### PR TITLE
fix(lora): support attention-output-gated fused QKV in CanonicalLoRA

### DIFF
--- a/miles_plugins/megatron_bridge/__init__.py
+++ b/miles_plugins/megatron_bridge/__init__.py
@@ -68,6 +68,14 @@ except Exception as _e:  # best-effort; Qwen3-VL may be unavailable in some envs
     logger.warning("miles Qwen3-VL THD packed mRoPE patch not applied: %s", _e)
 
 
+try:
+    from miles_plugins.megatron_bridge.canonical_lora_gated_qkv import install_canonical_lora_gated_qkv_patch
+
+    install_canonical_lora_gated_qkv_patch()
+except Exception as _e:  # best-effort
+    logger.warning("miles bridge shim install_canonical_lora_gated_qkv_patch not applied: %s", _e)
+
+
 # Model-specific bridge subclasses. Each submodule self-installs on import.
 # Keep imports here so merely importing ``miles_plugins.megatron_bridge`` is
 # enough to pick up every miles bridge (mirrors ``miles_plugins.mbridge``).

--- a/miles_plugins/megatron_bridge/canonical_lora_gated_qkv.py
+++ b/miles_plugins/megatron_bridge/canonical_lora_gated_qkv.py
@@ -7,7 +7,9 @@ the wrapped projection and the first forward fails with a shape mismatch. The pa
 gives ``adapter_q`` per-head [Q; gate] rows (the HF ``q_proj`` layout, as in
 ``miles_plugins/mbridge/qwen3_5.py``) and packs adapter output per query group as
 [Q heads, gate heads, K, V] (Megatron's fused layout). Non-gated modules keep the
-original behavior. Drop once the Megatron-Bridge pin includes the fix upstream.
+original behavior. Like upstream's non-gated ``_interleave_qkv``, the interleave uses
+global head counts, so fused-QKV canonical LoRA remains TP=1-only for now. Drop once
+the Megatron-Bridge pin includes the fix upstream.
 """
 
 from __future__ import annotations
@@ -58,6 +60,7 @@ def install_canonical_lora_gated_qkv_patch() -> None:
         ParallelLinearAdapter,
         get_adapter_attributes_from_linear,
         get_effective_lora_dim,
+        is_modelopt_linear,
     )
     from torch import nn
 
@@ -100,7 +103,8 @@ def install_canonical_lora_gated_qkv_patch() -> None:
             ),
         )
         gated = bool(getattr(getattr(m, "config", None), "attention_output_gate", False))
-        if name != "linear_qkv" or already_wrapped or isinstance(m, nn.Linear) or not gated:
+        plain_linear = isinstance(m, nn.Linear) and not is_modelopt_linear(m)
+        if name != "linear_qkv" or already_wrapped or plain_linear or not gated:
             return _original_transform(self, m, name, prefix)
 
         if (ans := self.match(m, name, prefix)) is None:

--- a/miles_plugins/megatron_bridge/canonical_lora_gated_qkv.py
+++ b/miles_plugins/megatron_bridge/canonical_lora_gated_qkv.py
@@ -1,0 +1,146 @@
+"""CanonicalLoRA support for attention-output-gated fused QKV (radixark/miles#2008).
+
+Megatron-Bridge's ``CanonicalLoRA`` sizes the ``linear_qkv`` adapter for grouped
+Q/K/V rows; providers with ``attention_output_gate=True`` (Qwen3.5/3.6, gated
+``linear_qkv`` of Qwen3-Next) pack Q/Gate/K/V rows, so the adapter is narrower than
+the wrapped projection and the first forward fails with a shape mismatch. The patch
+gives ``adapter_q`` per-head [Q; gate] rows (the HF ``q_proj`` layout, as in
+``miles_plugins/mbridge/qwen3_5.py``) and packs adapter output per query group as
+[Q heads, gate heads, K, V] (Megatron's fused layout). Non-gated modules keep the
+original behavior. Drop once the Megatron-Bridge pin includes the fix upstream.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import torch
+
+logger = logging.getLogger(__name__)
+
+
+def interleave_gated_qkv(
+    query_and_gate: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    *,
+    num_attention_heads: int,
+    num_query_groups: int,
+    head_size: int,
+) -> torch.Tensor:
+    """Pack per-head [Q; gate] adapter output plus K/V into Megatron's grouped Q/Gate/K/V order."""
+    if num_attention_heads % num_query_groups != 0:
+        raise ValueError("num_attention_heads must be divisible by num_query_groups.")
+    if query_and_gate.size(-1) != 2 * num_attention_heads * head_size:
+        raise ValueError("Gated query projection size must equal 2 * num_attention_heads * head_size.")
+
+    heads_per_group = num_attention_heads // num_query_groups
+    leading_shape = query_and_gate.shape[:-1]
+    query_and_gate = query_and_gate.reshape(-1, num_attention_heads, 2, head_size)
+    query = query_and_gate[:, :, 0, :]
+    gate = query_and_gate[:, :, 1, :]
+    key = key.reshape(-1, num_query_groups, head_size)
+    value = value.reshape(-1, num_query_groups, head_size)
+
+    qkv_chunks = []
+    for group in range(num_query_groups):
+        q_group = query[:, group * heads_per_group : (group + 1) * heads_per_group, :]
+        gate_group = gate[:, group * heads_per_group : (group + 1) * heads_per_group, :]
+        qkv_chunks.extend([q_group, gate_group, key[:, group : group + 1, :], value[:, group : group + 1, :]])
+
+    return torch.cat(qkv_chunks, dim=1).reshape(*leading_shape, -1)
+
+
+def install_canonical_lora_gated_qkv_patch() -> None:
+    """Teach ``CanonicalLoRA`` the Q/Gate/K/V fused-QKV contract. Idempotent."""
+    from megatron.bridge.peft import canonical_lora as _canonical_lora
+    from megatron.bridge.peft.utils import (
+        ParallelLinearAdapter,
+        get_adapter_attributes_from_linear,
+        get_effective_lora_dim,
+    )
+    from torch import nn
+
+    if getattr(_canonical_lora.CanonicalLoRA, "_miles_gated_qkv_patch_installed", False):
+        return
+
+    class LoRALinearSplitGatedQKV(_canonical_lora.LoRALinearSplitQKV):
+        """``linear_qkv`` wrapper for gated attention: ``adapter_q`` carries Q and gate rows."""
+
+        def forward(self, x, *args, **kwargs):
+            linear_output, bias, layernorm_output = self.base_linear_forward(x, *args, **kwargs)
+            if not self._adapter_enabled:
+                return linear_output, bias
+            query_and_gate = self.adapter_forward(self.adapter.adapter_q, layernorm_output, *args, **kwargs)
+            key = self.adapter_forward(self.adapter.adapter_k, layernorm_output, *args, **kwargs)
+            value = self.adapter_forward(self.adapter.adapter_v, layernorm_output, *args, **kwargs)
+
+            config = self.to_wrap.config
+            adapter_output = interleave_gated_qkv(
+                query_and_gate,
+                key,
+                value,
+                num_attention_heads=config.num_attention_heads,
+                num_query_groups=config.num_query_groups,
+                head_size=config.kv_channels,
+            )
+            return linear_output + adapter_output, bias
+
+    _original_transform = _canonical_lora.CanonicalLoRA.transform
+
+    def transform(self, m, name=None, prefix=None):
+        already_wrapped = isinstance(
+            m,
+            (
+                _canonical_lora.LinearAdapter,
+                _canonical_lora.LoRALinear,
+                _canonical_lora.LoRALinearSplitQKV,
+                _canonical_lora.LoRALinearSplitFC1UpGate,
+                _canonical_lora.LoRATopKRouter,
+            ),
+        )
+        gated = bool(getattr(getattr(m, "config", None), "attention_output_gate", False))
+        if name != "linear_qkv" or already_wrapped or isinstance(m, nn.Linear) or not gated:
+            return _original_transform(self, m, name, prefix)
+
+        if (ans := self.match(m, name, prefix)) is None:
+            return m
+        match, full_name = ans
+
+        # linear_qkv is never an expert linear, so the expert adapter variants do not apply.
+        attrs = get_adapter_attributes_from_linear(m, is_expert=False)
+        dim = get_effective_lora_dim(m, dim=self.dim, normalize_moe_lora=self.normalize_moe_lora, is_expert=False)
+        adapter_kwargs = dict(
+            dim=dim,
+            base_linear_name=full_name,
+            activation="identity",
+            column_init_method=self.lora_A_init_method,
+            row_init_method=self.lora_B_init_method,
+            input_is_parallel=attrs.input_is_parallel,
+            dropout=self.dropout,
+            dropout_position=self.dropout_position,
+            model_parallel_config=m.config,
+            alpha=self.alpha,
+            base_linear_is_parallel=attrs.base_linear_is_parallel,
+            is_expert=False,
+            disable_tensor_parallel_comm=attrs.disable_tensor_parallel_comm,
+            disable_sequence_parallel_comm=attrs.disable_sequence_parallel_comm,
+        )
+
+        canonical_submodules = self.canonical_mapping[match]
+        logger.info(f"Adding lora to: {full_name} ({canonical_submodules}, attention_output_gate)")
+        q_out_features = 2 * m.config.kv_channels * m.config.num_attention_heads
+        kv_out_features = m.config.kv_channels * m.config.num_query_groups
+        adapter_q, adapter_k, adapter_v = None, None, None
+        if "linear_q" in canonical_submodules:
+            adapter_q = ParallelLinearAdapter(attrs.in_features, q_out_features, **adapter_kwargs)
+        if "linear_k" in canonical_submodules:
+            adapter_k = ParallelLinearAdapter(attrs.in_features, kv_out_features, **adapter_kwargs)
+        if "linear_v" in canonical_submodules:
+            adapter_v = ParallelLinearAdapter(attrs.in_features, kv_out_features, **adapter_kwargs)
+        adapters = _canonical_lora.ModuleDict({"adapter_q": adapter_q, "adapter_k": adapter_k, "adapter_v": adapter_v})
+        return LoRALinearSplitGatedQKV(m, adapters)
+
+    _canonical_lora.CanonicalLoRA.transform = transform
+    _canonical_lora.CanonicalLoRA._miles_gated_qkv_patch_installed = True
+    logger.info("Patched CanonicalLoRA.transform for attention_output_gate fused QKV")

--- a/tests/fast/test_canonical_lora_gated_qkv.py
+++ b/tests/fast/test_canonical_lora_gated_qkv.py
@@ -129,18 +129,32 @@ class _FakeParallelLinearAdapter(nn.Module):
         return self.linear(x)
 
 
+def _gated_qkv_out_features(config):
+    heads, groups, head_size = config.num_attention_heads, config.num_query_groups, config.kv_channels
+    return (2 * heads + 2 * groups) * head_size
+
+
 class _FakeGatedQKVLinear(nn.Module):
     """Fused Q/Gate/K/V parallel linear with a megatron-style (output, bias) forward."""
 
     def __init__(self, config):
         super().__init__()
         self.config = config
-        heads, groups, head_size = config.num_attention_heads, config.num_query_groups, config.kv_channels
-        out_features = (2 * heads + 2 * groups) * head_size
-        self.linear = nn.Linear(config.hidden_size, out_features, bias=False)
+        self.linear = nn.Linear(config.hidden_size, _gated_qkv_out_features(config), bias=False)
+        self.out_features = self.linear.out_features
 
     def forward(self, x):
         return self.linear(x), None
+
+
+class _FakeModelOptGatedQKVLinear(nn.Linear):
+    """ModelOpt-quantized fused gated QKV: an nn.Linear subclass that must still get the gated wrapper."""
+
+    _is_modelopt = True
+
+    def __init__(self, config):
+        super().__init__(config.hidden_size, _gated_qkv_out_features(config), bias=False)
+        self.config = config
 
 
 class _FakeCanonicalLoRABase:
@@ -182,13 +196,14 @@ def patched_canonical_lora(monkeypatch):
     utils_module.ParallelLinearAdapter = _FakeParallelLinearAdapter
     utils_module.get_adapter_attributes_from_linear = lambda m, is_expert: SimpleNamespace(
         in_features=m.config.hidden_size,
-        out_features=m.linear.out_features,
+        out_features=m.out_features,
         input_is_parallel=False,
         base_linear_is_parallel=True,
         disable_tensor_parallel_comm=False,
         disable_sequence_parallel_comm=False,
     )
     utils_module.get_effective_lora_dim = lambda m, dim, normalize_moe_lora, is_expert: dim
+    utils_module.is_modelopt_linear = lambda m: getattr(m, "_is_modelopt", False)
 
     megatron_module = types.ModuleType("megatron")
     bridge_module = types.ModuleType("megatron.bridge")
@@ -257,6 +272,30 @@ def test_gated_forward_places_adapter_rows_in_megatron_order(patched_canonical_l
         head_size=config.kv_channels,
     )
     assert torch.allclose(output, expected)
+
+
+def test_modelopt_gated_linear_qkv_gets_gated_wrapper(patched_canonical_lora):
+    # ModelOpt linears subclass nn.Linear but must not fall through to the non-gated path.
+    config = _make_config()
+    lora = patched_canonical_lora.CanonicalLoRA()
+    wrapped = patched_canonical_lora.CanonicalLoRA.transform(
+        lora, _FakeModelOptGatedQKVLinear(config), name="linear_qkv"
+    )
+
+    assert isinstance(wrapped, _FakeAdapterWrapperBase)
+    assert lora.original_transform_calls == []
+    assert wrapped.adapter["adapter_q"].out_features == 2 * 4 * 8
+
+
+def test_plain_linear_gated_qkv_delegates_to_original_transform(patched_canonical_lora):
+    config = _make_config()
+    lora = patched_canonical_lora.CanonicalLoRA()
+    module = nn.Linear(config.hidden_size, _gated_qkv_out_features(config))
+    module.config = config
+    result = patched_canonical_lora.CanonicalLoRA.transform(lora, module, name="linear_qkv")
+
+    assert result is module
+    assert lora.original_transform_calls == ["linear_qkv"]
 
 
 def test_non_gated_linear_qkv_delegates_to_original_transform(patched_canonical_lora):

--- a/tests/fast/test_canonical_lora_gated_qkv.py
+++ b/tests/fast/test_canonical_lora_gated_qkv.py
@@ -1,0 +1,296 @@
+"""CanonicalLoRA on attention-output-gated fused QKV (radixark/miles#2008):
+gated row allocation, grouped Q/Gate/K/V interleave, unchanged non-gated behavior."""
+
+import sys
+import types
+from types import SimpleNamespace
+
+import pytest
+import torch
+from torch import nn
+
+from miles_plugins.megatron_bridge.canonical_lora_gated_qkv import interleave_gated_qkv
+
+# ---------------------------------------------------------------------------
+# Pure interleave / allocation math (no megatron needed)
+# ---------------------------------------------------------------------------
+
+
+def _make_config(**overrides):
+    config = SimpleNamespace(
+        num_attention_heads=4,
+        num_query_groups=2,
+        kv_channels=8,
+        hidden_size=32,
+        attention_output_gate=True,
+    )
+    for key, value in overrides.items():
+        setattr(config, key, value)
+    return config
+
+
+def test_gated_packed_width_matches_wrapped_projection_qwen3_6_27b():
+    # The 14336-vs-8192 mismatch from the issue.
+    heads, groups, head_size = 24, 4, 256
+    query_and_gate = torch.zeros(1, 2 * heads * head_size)
+    key = torch.zeros(1, groups * head_size)
+    value = torch.zeros(1, groups * head_size)
+    packed = interleave_gated_qkv(
+        query_and_gate, key, value, num_attention_heads=heads, num_query_groups=groups, head_size=head_size
+    )
+    assert packed.shape[-1] == 14336
+
+
+def test_interleave_matches_megatron_split_contract():
+    # Splitting the packed output the way get_query_key_value_tensors does must
+    # recover exactly the per-head Q/gate and per-group K/V.
+    heads, groups, head_size = 4, 2, 3
+    heads_per_group = heads // groups
+
+    query_and_gate = torch.arange(2 * heads * head_size, dtype=torch.float32).unsqueeze(0)
+    key = 1000 + torch.arange(groups * head_size, dtype=torch.float32).unsqueeze(0)
+    value = 2000 + torch.arange(groups * head_size, dtype=torch.float32).unsqueeze(0)
+
+    packed = interleave_gated_qkv(
+        query_and_gate, key, value, num_attention_heads=heads, num_query_groups=groups, head_size=head_size
+    )
+
+    per_head = query_and_gate.view(heads, 2, head_size)
+    grouped = packed.view(groups, (2 * heads_per_group + 2) * head_size)
+    q_split, gate_split, k_split, v_split = torch.split(
+        grouped,
+        [heads_per_group * head_size, heads_per_group * head_size, head_size, head_size],
+        dim=-1,
+    )
+
+    for group in range(groups):
+        head_lo = group * heads_per_group
+        head_hi = head_lo + heads_per_group
+        assert torch.equal(q_split[group].view(heads_per_group, head_size), per_head[head_lo:head_hi, 0])
+        assert torch.equal(gate_split[group].view(heads_per_group, head_size), per_head[head_lo:head_hi, 1])
+        assert torch.equal(k_split[group], key.view(groups, head_size)[group])
+        assert torch.equal(v_split[group], value.view(groups, head_size)[group])
+
+
+def test_interleave_preserves_leading_dims():
+    heads, groups, head_size = 4, 2, 3
+    sq, b = 5, 2
+    query_and_gate = torch.randn(sq, b, 2 * heads * head_size)
+    key = torch.randn(sq, b, groups * head_size)
+    value = torch.randn(sq, b, groups * head_size)
+    packed = interleave_gated_qkv(
+        query_and_gate, key, value, num_attention_heads=heads, num_query_groups=groups, head_size=head_size
+    )
+    assert packed.shape == (sq, b, (2 * heads + 2 * groups) * head_size)
+
+
+def test_interleave_rejects_mismatched_query_width():
+    with pytest.raises(ValueError, match="2 \\* num_attention_heads \\* head_size"):
+        interleave_gated_qkv(
+            torch.zeros(1, 24),  # not 2 * 4 * 8
+            torch.zeros(1, 16),
+            torch.zeros(1, 16),
+            num_attention_heads=4,
+            num_query_groups=2,
+            head_size=8,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Patched CanonicalLoRA.transform (megatron.bridge stubbed out)
+# ---------------------------------------------------------------------------
+
+
+class _FakeAdapterWrapperBase(nn.Module):
+    """Stands in for megatron.bridge's AdapterWrapper + LoRALinearSplitQKV."""
+
+    def __init__(self, to_wrap, adapter):
+        super().__init__()
+        self.to_wrap = to_wrap
+        self.adapter = adapter
+        self._adapter_enabled = True
+
+    def base_linear_forward(self, x, *args, **kwargs):
+        linear_output, bias = self.to_wrap(x)
+        return linear_output, bias, x
+
+    def adapter_forward(self, adapter, x, *args, **kwargs):
+        return adapter(x)
+
+
+class _FakeParallelLinearAdapter(nn.Module):
+    def __init__(self, in_features, out_features, **kwargs):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.linear = nn.Linear(in_features, out_features, bias=False)
+
+    def forward(self, x):
+        return self.linear(x)
+
+
+class _FakeGatedQKVLinear(nn.Module):
+    """Fused Q/Gate/K/V parallel linear with a megatron-style (output, bias) forward."""
+
+    def __init__(self, config):
+        super().__init__()
+        self.config = config
+        heads, groups, head_size = config.num_attention_heads, config.num_query_groups, config.kv_channels
+        out_features = (2 * heads + 2 * groups) * head_size
+        self.linear = nn.Linear(config.hidden_size, out_features, bias=False)
+
+    def forward(self, x):
+        return self.linear(x), None
+
+
+class _FakeCanonicalLoRABase:
+    dim = 4
+    alpha = 8
+    dropout = 0.0
+    dropout_position = "pre"
+    lora_A_init_method = "xavier"
+    lora_B_init_method = "zero"
+    normalize_moe_lora = False
+
+    def __init__(self):
+        self.canonical_mapping = {"linear_qkv": {"linear_q", "linear_k", "linear_v"}}
+        self.original_transform_calls = []
+
+    def match(self, m, name=None, prefix=None):
+        if name in self.canonical_mapping:
+            return name, f"decoder.layers.0.self_attention.{name}"
+        return None
+
+    def transform(self, m, name=None, prefix=None):
+        self.original_transform_calls.append(name)
+        return m
+
+
+@pytest.fixture
+def patched_canonical_lora(monkeypatch):
+    """Install the shim against stub megatron.bridge modules; fresh CanonicalLoRA subclass per test."""
+    canonical_lora_module = types.ModuleType("megatron.bridge.peft.canonical_lora")
+    canonical_lora_module.CanonicalLoRA = type("CanonicalLoRA", (_FakeCanonicalLoRABase,), {})
+    canonical_lora_module.LoRALinearSplitQKV = _FakeAdapterWrapperBase
+    canonical_lora_module.LoRALinearSplitFC1UpGate = type("LoRALinearSplitFC1UpGate", (nn.Module,), {})
+    canonical_lora_module.LinearAdapter = type("LinearAdapter", (nn.Module,), {})
+    canonical_lora_module.LoRALinear = type("LoRALinear", (nn.Module,), {})
+    canonical_lora_module.LoRATopKRouter = type("LoRATopKRouter", (nn.Module,), {})
+    canonical_lora_module.ModuleDict = nn.ModuleDict
+
+    utils_module = types.ModuleType("megatron.bridge.peft.utils")
+    utils_module.ParallelLinearAdapter = _FakeParallelLinearAdapter
+    utils_module.get_adapter_attributes_from_linear = lambda m, is_expert: SimpleNamespace(
+        in_features=m.config.hidden_size,
+        out_features=m.linear.out_features,
+        input_is_parallel=False,
+        base_linear_is_parallel=True,
+        disable_tensor_parallel_comm=False,
+        disable_sequence_parallel_comm=False,
+    )
+    utils_module.get_effective_lora_dim = lambda m, dim, normalize_moe_lora, is_expert: dim
+
+    megatron_module = types.ModuleType("megatron")
+    bridge_module = types.ModuleType("megatron.bridge")
+    peft_module = types.ModuleType("megatron.bridge.peft")
+    megatron_module.bridge = bridge_module
+    bridge_module.peft = peft_module
+    peft_module.canonical_lora = canonical_lora_module
+    peft_module.utils = utils_module
+
+    for name, module in {
+        "megatron": megatron_module,
+        "megatron.bridge": bridge_module,
+        "megatron.bridge.peft": peft_module,
+        "megatron.bridge.peft.canonical_lora": canonical_lora_module,
+        "megatron.bridge.peft.utils": utils_module,
+    }.items():
+        monkeypatch.setitem(sys.modules, name, module)
+
+    from miles_plugins.megatron_bridge.canonical_lora_gated_qkv import install_canonical_lora_gated_qkv_patch
+
+    install_canonical_lora_gated_qkv_patch()
+    yield canonical_lora_module
+
+
+def test_gated_linear_qkv_gets_double_width_query_adapter(patched_canonical_lora):
+    config = _make_config()
+    lora = patched_canonical_lora.CanonicalLoRA()
+    wrapped = patched_canonical_lora.CanonicalLoRA.transform(lora, _FakeGatedQKVLinear(config), name="linear_qkv")
+
+    assert isinstance(wrapped, _FakeAdapterWrapperBase)
+    assert lora.original_transform_calls == []
+    assert wrapped.adapter["adapter_q"].out_features == 2 * 4 * 8
+    assert wrapped.adapter["adapter_k"].out_features == 2 * 8
+    assert wrapped.adapter["adapter_v"].out_features == 2 * 8
+
+
+def test_gated_forward_output_matches_wrapped_projection_width(patched_canonical_lora):
+    config = _make_config()
+    lora = patched_canonical_lora.CanonicalLoRA()
+    base = _FakeGatedQKVLinear(config)
+    wrapped = patched_canonical_lora.CanonicalLoRA.transform(lora, base, name="linear_qkv")
+
+    x = torch.randn(5, 2, config.hidden_size)
+    output, bias = wrapped(x)
+    assert output.shape == (5, 2, base.linear.out_features)
+    assert bias is None
+
+
+def test_gated_forward_places_adapter_rows_in_megatron_order(patched_canonical_lora):
+    config = _make_config()
+    lora = patched_canonical_lora.CanonicalLoRA()
+    base = _FakeGatedQKVLinear(config)
+    with torch.no_grad():
+        base.linear.weight.zero_()
+    wrapped = patched_canonical_lora.CanonicalLoRA.transform(lora, base, name="linear_qkv")
+
+    x = torch.randn(3, config.hidden_size)
+    with torch.no_grad():
+        output, _ = wrapped(x)
+    expected = interleave_gated_qkv(
+        wrapped.adapter["adapter_q"](x),
+        wrapped.adapter["adapter_k"](x),
+        wrapped.adapter["adapter_v"](x),
+        num_attention_heads=config.num_attention_heads,
+        num_query_groups=config.num_query_groups,
+        head_size=config.kv_channels,
+    )
+    assert torch.allclose(output, expected)
+
+
+def test_non_gated_linear_qkv_delegates_to_original_transform(patched_canonical_lora):
+    config = _make_config(attention_output_gate=False)
+    lora = patched_canonical_lora.CanonicalLoRA()
+    module = _FakeGatedQKVLinear(config)
+    result = patched_canonical_lora.CanonicalLoRA.transform(lora, module, name="linear_qkv")
+
+    assert result is module
+    assert lora.original_transform_calls == ["linear_qkv"]
+
+
+def test_non_qkv_modules_delegate_to_original_transform(patched_canonical_lora):
+    lora = patched_canonical_lora.CanonicalLoRA()
+    module = nn.Linear(4, 4)
+    result = patched_canonical_lora.CanonicalLoRA.transform(lora, module, name="linear_fc1")
+
+    assert result is module
+    assert lora.original_transform_calls == ["linear_fc1"]
+
+
+def test_already_wrapped_module_delegates_to_original_transform(patched_canonical_lora):
+    config = _make_config()
+    lora = patched_canonical_lora.CanonicalLoRA()
+    wrapped = patched_canonical_lora.CanonicalLoRA.transform(lora, _FakeGatedQKVLinear(config), name="linear_qkv")
+    result = patched_canonical_lora.CanonicalLoRA.transform(lora, wrapped, name="linear_qkv")
+
+    assert result is wrapped
+    assert lora.original_transform_calls == ["linear_qkv"]
+
+
+def test_install_is_idempotent(patched_canonical_lora):
+    from miles_plugins.megatron_bridge.canonical_lora_gated_qkv import install_canonical_lora_gated_qkv_patch
+
+    first = patched_canonical_lora.CanonicalLoRA.transform
+    install_canonical_lora_gated_qkv_patch()
+    assert patched_canonical_lora.CanonicalLoRA.transform is first


### PR DESCRIPTION
## Motivation

Fixes #2008.

`CanonicalLoRA` in Megatron-Bridge assumes every fused `linear_qkv` has the grouped Q/K/V output layout. Providers with `TransformerConfig.attention_output_gate=True` (Qwen3.5, Qwen3.6, and the gated `linear_qkv` of Qwen3-Next) pack Q/Gate/K/V rows instead, so the canonical adapter output is narrower than the wrapped projection and the first forward — or the trainer-to-SGLang LoRA publication — fails with a tensor shape mismatch (14336 vs 8192 on Qwen3.6-27B full-attention layers).

## Modifications

Following the fix proposed in the issue, this adds a Miles-side Megatron-Bridge shim (`miles_plugins/megatron_bridge/canonical_lora_gated_qkv.py`, installed from the plugin package `__init__` like the existing bridge shims) that patches `CanonicalLoRA.transform` for attention-output-gated fused QKV:

- The query-side canonical adapter is allocated with `2 * kv_channels * num_attention_heads` output rows so it represents both Q and gate, using the HF `q_proj` row contract for gated attention (per head: `head_size` Q rows, then `head_size` gate rows). This matches the base-weight mapping in `miles_plugins/mbridge/qwen3_5.py`.
- The wrapper's forward packs adapter output in Megatron's grouped order — per query group: all Q heads, all gate heads, K, V — matching `get_query_key_value_tensors` in Megatron-LM.
- Non-gated `linear_qkv` and every other module delegate to the original `transform`, so ordinary Q/K/V behavior is unchanged.

The shim is idempotent and best-effort (a missing `megatron` import degrades to a warning), and can be dropped once the Megatron-Bridge pin includes the fix upstream.

## Checklist

- `pre-commit run --all-files` clean.
- New CPU regression tests in `tests/fast/test_canonical_lora_gated_qkv.py` (auto-registered in `stage-a-cpu`, verified with `run_suite.py --list-only`): gated row allocation, exact grouped Q/Gate/K/V interleaving against Megatron's split contract, forward output width matching the wrapped projection, and delegation/unchanged behavior for non-gated modules.
