### PR TITLE
[AMD][P2P][1/N] Honor Mooncake transfer configuration

### DIFF
--- a/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/p2p_transfer_utils.py
+++ b/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/p2p_transfer_utils.py
@@ -10,6 +10,7 @@ import torch
 import torch.distributed as dist
 from mooncake.engine import TransferEngine
 from ray.actor import ActorHandle
+from sglang.srt.environ import envs
 from sglang.srt.server_args import ServerArgs
 from miles.backends.training_utils.parallel import get_parallel_state
 
@@ -208,7 +209,14 @@ def register_cpu_memory(params_dict: dict, transfer_engine) -> dict:
 def create_transfer_engine():
     transfer_engine = TransferEngine()
     local_ip = ray._private.services.get_node_ip_address()
-    transfer_engine.initialize(local_ip, "P2PHANDSHAKE", "rdma", "")
+    ret = transfer_engine.initialize(
+        local_ip,
+        "P2PHANDSHAKE",
+        envs.MOONCAKE_PROTOCOL.get(),
+        envs.MOONCAKE_DEVICE.get(),
+    )
+    if ret != 0:
+        raise RuntimeError(f"Mooncake TransferEngine initialization failed, error: {ret}")
     return transfer_engine
 
 


### PR DESCRIPTION
## Summary

Use `MOONCAKE_PROTOCOL` and `MOONCAKE_DEVICE` when initializing the trainer-side Mooncake `TransferEngine`, and fail immediately if initialization is unsuccessful.

## Problem

The rollout receiver already uses the Mooncake protocol and device configured through SGLang environment variables. The trainer instead hard-coded:

- protocol: `rdma`
- device: empty string, enabling automatic device discovery

As a result, the trainer and rollout receiver could use different Mooncake configurations.

During AMD MI355X bring-up, setting `MOONCAKE_DEVICE=ionic_0` constrained the receiver but had no effect on the trainer. The trainer continued using automatic HCA discovery, which could select unintended Ionic devices and later fail with RDMA retry-exhaustion errors.

The trainer also ignored the return value from `TransferEngine.initialize()`, so an initialization failure was reported only later as an opaque transfer failure.

## Change

- Read the trainer-side protocol from `MOONCAKE_PROTOCOL`.
- Read the trainer-side device list from `MOONCAKE_DEVICE`.
- Raise a clear error when Mooncake initialization returns a non-zero status.

## Compatibility

The existing defaults remain unchanged:

- `MOONCAKE_PROTOCOL=rdma`
- `MOONCAKE_DEVICE=""`

Therefore, configurations that do not set these variables retain the same behavior.

No AMD device names or platform-specific policy are hard-coded.

## Validation

Validated on an AMD MI355X node inside the Miles ROCm container.

Local checks confirmed that:

- The configured protocol and device are passed to `TransferEngine.initialize()`.
- A non-zero initialization result raises immediately.