### PR TITLE
[AMD][P2P][2/N] Propagate transfer failures and reset reconnect state

### DIFF
--- a/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/p2p.py
+++ b/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/p2p.py
@@ -171,6 +171,13 @@ class UpdateWeightP2P(DistBucketedWeightUpdateMixin):
     def mark_engine_connection_stale(self) -> None:
         self._connection_stale = True
 
+    def _reset_registration_state(self) -> None:
+        """Drop memory-registration state owned by the previous TransferEngine."""
+        self._model_registered = False
+        self._weight_memory_registry = {}
+        self._tensor_update_pending.clear()
+        self._staged_tensors.clear()
+
     def connect_rollout_engines(
         self,
         rollout_engines: Sequence[ActorHandle],
@@ -189,10 +196,11 @@ class UpdateWeightP2P(DistBucketedWeightUpdateMixin):
           weight format conversion before transfer.
         """
         self.rollout_engines = rollout_engines
-        self._connection_stale = False
+        self._connection_stale = True
         self.rollout_engine_lock = rollout_engine_lock
 
         if self._is_source:
+            self._reset_registration_state()
             self._group_name = f"miles-p2p_{self.transfer_plan._gathered_dp_rank}"
             targets = self.transfer_plan.plan_p2p()
             (
@@ -244,6 +252,8 @@ class UpdateWeightP2P(DistBucketedWeightUpdateMixin):
                 ]
 
                 self._transfer_engine_meta_list.append((model_replica, remote_infos))
+
+        self._connection_stale = False
 
     def _create_cpu_replica(
         self,

--- a/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/p2p_transfer_utils.py
+++ b/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/p2p_transfer_utils.py
@@ -173,13 +173,17 @@ class P2PTransferManager:
 
     def wait_transfers(self) -> None:
         """Wait for all submitted tasks to complete."""
+        errors = []
         for future in self.transfer_futures:
             try:
                 future.result(timeout=self.transfer_timeout)
             except Exception as e:
                 logger.error(f"[P2P] Transfer future failed: {e}")
+                errors.append(e)
 
         self.transfer_futures.clear()
+        if errors:
+            raise RuntimeError(f"{len(errors)} P2P transfer task(s) failed") from errors[0]
 
 
 def create_server_args_from_dict(data_dict: dict) -> ServerArgs:


### PR DESCRIPTION
## Summary

Propagate background P2P transfer failures to the caller and reset TransferEngine-owned registration state when reconnecting to rollout engines.

## Problem

Two correctness issues were identified while debugging AMD P2P transfer failures.

### Background failures were ignored

P2P writes run through background futures. `wait_transfers()` logged exceptions but did not propagate them.

This allowed the weight-update flow to continue even when one or more writes had failed, potentially resuming rollout with an incomplete weight update.

### Reconnect retained stale registration state

When rollout engines were reconnected, Miles created a new Mooncake `TransferEngine` but retained registration state associated with the previous engine.

In particular, `_model_registered` could remain `True`, causing Miles to skip memory registration for the new TransferEngine. Partially staged tensor state could also survive across the reconnect.

The connection was also marked fresh before reconnect initialization had completed.

## Change

- Collect and propagate background transfer exceptions after waiting for all submitted writes.
- Preserve the original exception as the raised error's cause.
- Reset model-registration and partially staged tensor state before creating a replacement TransferEngine.
- Keep the connection marked stale until reconnect initialization completes successfully.

## Compatibility

The successful transfer path is unchanged.

The behavior changes only when:

- A background transfer fails, in which case Miles now stops the update instead of only logging the error.
- Rollout engines reconnect, in which case memory is correctly registered with the new TransferEngine.

No AMD-specific devices, transports, or policies are introduced. Existing NVIDIA configurations retain the same successful-path behavior and receive the same correctness fixes.

This was discovered during AMD P2P enablement, but the fixes are platform-independent.

## Validation

Validated on an AMD MI355X node inside the Miles ROCm container.

Local checks confirmed that:

- A background write exception is propagated after all futures are collected.
- The original exception is preserved as the cause.
- The completed future list is cleared.
- Registration and partially staged tensor state are cleared for a new TransferEngine.
