### PR TITLE
[AMD][P2P][4/N] Backport upstream Mooncake ROCm P2P fixes

### DIFF
--- a/docker/Dockerfile.rocm
+++ b/docker/Dockerfile.rocm
@@ -64,6 +64,8 @@ ENV CMAKE_PREFIX_PATH=/opt/rocm:/opt/rocm/hip:/usr/local:/usr
 # Patches + requirements consumed below.
 # TODO: remove these patches once the changes are merged into the main codebase.
 COPY docker/amd_patch/latest/megatron.patch /tmp/amd_patch/megatron.patch
+COPY docker/amd_patch/latest/mooncake_rocm_p2p.patch /tmp/amd_patch/mooncake_rocm_p2p.patch
+COPY docker/amd_patch/latest/mooncake_rdma_mr_split.patch /tmp/amd_patch/mooncake_rdma_mr_split.patch
 COPY docker/amd_patch/latest/tile_kernels.patch /tmp/amd_patch/tile_kernels.patch
 COPY docker/amd_patch/latest/tilelang_hip_fp8.patch /tmp/amd_patch/tilelang_hip_fp8.patch
 COPY requirements.txt /tmp/requirements.txt
@@ -106,6 +108,31 @@ RUN pip install /tmp/wheels/flash_attn-*.whl
 RUN pip install --no-deps --target=/tmp/mc "mooncake-transfer-engine-non-cuda==${MOONCAKE_VERSION}" && \
     cp -n /tmp/mc/mooncake/*.py "$(python3 -c 'import mooncake, os; print(os.path.dirname(mooncake.__file__))')" && \
     rm -rf /tmp/mc
+
+# The ROCm base image's Mooncake native module does not include this upstream HIP DMA-BUF fix:
+# https://github.com/kvcache-ai/Mooncake/commit/45b84d36cfac14d5b6016a4d37832ff64d4c4293
+# Apply it and rebuild only the Python TransferEngine module so MI355X VRAM can be registered
+# for RDMA weight updates. The second patch backports upstream Mooncake commits
+# 7a938fb3 (max-MR chunking) and 4c2fa8ab (MR-boundary transfer slicing).
+RUN if git -C /sgl-workspace/Mooncake apply --check /tmp/amd_patch/mooncake_rocm_p2p.patch; then \
+      git -C /sgl-workspace/Mooncake apply /tmp/amd_patch/mooncake_rocm_p2p.patch; \
+    elif git -C /sgl-workspace/Mooncake apply --reverse --check /tmp/amd_patch/mooncake_rocm_p2p.patch; then \
+      echo "Mooncake ROCm P2P fix is already present"; \
+    else \
+      echo "Mooncake ROCm P2P patch does not apply cleanly" >&2; exit 1; \
+    fi && \
+    if git -C /sgl-workspace/Mooncake apply --check /tmp/amd_patch/mooncake_rdma_mr_split.patch; then \
+      git -C /sgl-workspace/Mooncake apply /tmp/amd_patch/mooncake_rdma_mr_split.patch; \
+    elif git -C /sgl-workspace/Mooncake apply --reverse --check /tmp/amd_patch/mooncake_rdma_mr_split.patch; then \
+      echo "Mooncake RDMA MR splitting fix is already present"; \
+    else \
+      echo "Mooncake RDMA MR splitting patch does not apply cleanly" >&2; exit 1; \
+    fi && \
+    cmake -S /sgl-workspace/Mooncake -B /sgl-workspace/Mooncake/build \
+      -DUSE_HIP=ON -DUSE_HIP_DMABUF=ON && \
+    cmake --build /sgl-workspace/Mooncake/build --target engine -j${MAX_JOBS} && \
+    cp /sgl-workspace/Mooncake/build/mooncake-integration/engine*.so \
+      "$(python3 -c 'import mooncake, os; print(os.path.dirname(mooncake.__file__))')/"
 
 RUN pip install flash-linear-attention==0.4.2
 

--- a/docker/amd_patch/latest/mooncake_rdma_mr_split.patch
+++ b/docker/amd_patch/latest/mooncake_rdma_mr_split.patch
@@ -1,0 +1,256 @@
+diff --git a/mooncake-transfer-engine/include/transport/rdma_transport/rdma_transport.h b/mooncake-transfer-engine/include/transport/rdma_transport/rdma_transport.h
+index e7a171b8..59cd3556 100644
+--- a/mooncake-transfer-engine/include/transport/rdma_transport/rdma_transport.h
++++ b/mooncake-transfer-engine/include/transport/rdma_transport/rdma_transport.h
+@@ -144,6 +144,8 @@ class RdmaTransport : public Transport {
+     // local_server_name_ keeps the TCP-reachable address for P2P routing.
+     std::string rdma_server_name_;
+     std::mutex local_desc_lock_;
++    std::mutex chunk_map_mutex_;
++    std::unordered_map<uint64_t, std::vector<void *>> chunk_map_;
+ };
+ 
+ using TransferRequest = Transport::TransferRequest;
+diff --git a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp
+index 71fdcc93..26f44590 100644
+--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp
++++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp
+@@ -347,9 +347,11 @@ int RdmaContext::registerMemoryRegionInternal(void *addr, size_t length,
+                                               int access,
+                                               MemoryRegionMeta &mrMeta) {
+     if (length > (size_t)globalConfig().max_mr_size) {
+-        PLOG(WARNING) << "The buffer length exceeds device max_mr_size, "
+-                      << "shrink it to " << globalConfig().max_mr_size;
+-        length = (size_t)globalConfig().max_mr_size;
++        LOG(ERROR) << "Buffer length " << length
++                   << " exceeds device max_mr_size "
++                   << globalConfig().max_mr_size
++                   << " and should have been split before registration";
++        return ERR_INVALID_ARGUMENT;
+     }
+ #if defined(USE_MLU) || defined(USE_MACA) || defined(USE_CUDA)
+     // Implement register memory in a way that does not assume the presence of
+diff --git a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_transport.cpp b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_transport.cpp
+index 9b76dacb..2b26e78a 100644
+--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_transport.cpp
++++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_transport.cpp
+@@ -18,6 +18,7 @@
+ #include <sys/mman.h>
+ #include <sys/time.h>
+ 
++#include <algorithm>
+ #include <cassert>
+ #include <chrono>
+ #include <cstddef>
+@@ -52,6 +53,70 @@ static std::string resolveBufferLocation(
+     return location;
+ }
+ 
++// Backport of Mooncake#3198: cap a transfer slice at the source and target
++// memory-region boundaries created by Mooncake#2017.
++static uint64_t bytesUntilBufferEnd(
++    const TransferMetadata::SegmentDesc *segment_desc, uint64_t address,
++    bool require_remote_key, size_t *last_buffer_idx = nullptr) {
++    if (!segment_desc || segment_desc->buffers.empty()) return 0;
++
++    auto is_valid_buffer = [&](const TransferMetadata::BufferDesc &buffer) {
++#ifdef ENABLE_MULTI_PROTOCOL
++        if (!buffer.protocol.empty() && buffer.protocol != "rdma") return false;
++#endif
++        if (require_remote_key ? buffer.rkey.empty() : buffer.lkey.empty())
++            return false;
++        return address >= buffer.addr &&
++               address - buffer.addr < buffer.length;
++    };
++
++    if (last_buffer_idx && *last_buffer_idx < segment_desc->buffers.size()) {
++        const auto &buffer = segment_desc->buffers[*last_buffer_idx];
++        if (is_valid_buffer(buffer)) {
++            return buffer.length - (address - buffer.addr);
++        }
++    }
++
++    uint64_t max_remaining = 0;
++    for (size_t i = 0; i < segment_desc->buffers.size(); ++i) {
++        const auto &buffer = segment_desc->buffers[i];
++        if (!is_valid_buffer(buffer)) continue;
++        uint64_t remaining = buffer.length - (address - buffer.addr);
++        if (remaining > max_remaining) {
++            max_remaining = remaining;
++            if (last_buffer_idx) *last_buffer_idx = i;
++        }
++    }
++    return max_remaining;
++}
++
++struct SliceLengthCalculator {
++    const Transport::TransferRequest &request;
++    size_t block_size;
++    size_t fragment_size;
++    const TransferMetadata::SegmentDesc *local_desc;
++    const TransferMetadata::SegmentDesc *target_desc;
++    size_t src_buffer_idx = 0;
++    size_t tgt_buffer_idx = 0;
++
++    size_t calculate(uint64_t offset) {
++        const size_t remaining = request.length - offset;
++        size_t slice_length =
++            remaining <= block_size + fragment_size ? remaining : block_size;
++        const uint64_t src_remaining = bytesUntilBufferEnd(
++            local_desc, reinterpret_cast<uint64_t>(request.source) + offset,
++            false, &src_buffer_idx);
++        if (src_remaining > 0)
++            slice_length = std::min<uint64_t>(slice_length, src_remaining);
++        const uint64_t target_remaining = bytesUntilBufferEnd(
++            target_desc, request.target_offset + offset, true,
++            &tgt_buffer_idx);
++        if (target_remaining > 0)
++            slice_length = std::min<uint64_t>(slice_length, target_remaining);
++        return slice_length;
++    }
++};
++
+ // Mode definition for MC_IB_PCI_RELAXED_ORDERING env.
+ // 0 - disabled, 1 - enabled if supported, 2 - auto (default, same as 1 today).
+ static int getIbRelaxedOrderingMode() {
+@@ -213,6 +278,48 @@ int RdmaTransport::registerLocalMemoryInternal(void *addr, size_t length,
+                                                bool update_metadata,
+                                                bool force_sequential) {
+     (void)remote_accessible;
++    const size_t max_mr_size = (size_t)globalConfig().max_mr_size;
++    if (max_mr_size > 0 && length > max_mr_size) {
++        std::vector<void *> chunks;
++        size_t offset = 0;
++        while (offset < length) {
++            void *chunk_addr = static_cast<char *>(addr) + offset;
++            size_t chunk_length = std::min(max_mr_size, length - offset);
++            int ret = registerLocalMemoryInternal(
++                chunk_addr, chunk_length, name, remote_accessible,
++                false, force_sequential);
++            if (ret != 0) {
++                for (void *registered_addr : chunks) {
++                    unregisterLocalMemoryInternal(registered_addr, false,
++                                                  force_sequential);
++                }
++                return ret;
++            }
++            chunks.push_back(chunk_addr);
++            offset += chunk_length;
++        }
++
++        if (update_metadata) {
++            int ret = metadata_->updateLocalSegmentDesc();
++            if (ret != 0) {
++                for (void *registered_addr : chunks) {
++                    unregisterLocalMemoryInternal(registered_addr, false,
++                                                  force_sequential);
++                }
++                return ret;
++            }
++        }
++
++        {
++            std::lock_guard<std::mutex> lock(chunk_map_mutex_);
++            chunk_map_[(uint64_t)addr] = chunks;
++        }
++        LOG(INFO) << "Split RDMA memory registration at " << addr << " ("
++                  << length << " bytes) into " << chunks.size()
++                  << " chunks of at most " << max_mr_size << " bytes";
++        return 0;
++    }
++
+     BufferDesc buffer_desc;
+     const int kBaseAccessRights = IBV_ACCESS_LOCAL_WRITE |
+                                   IBV_ACCESS_REMOTE_WRITE |
+@@ -337,6 +444,29 @@ int RdmaTransport::unregisterLocalMemory(void *addr, bool update_metadata) {
+ int RdmaTransport::unregisterLocalMemoryInternal(void *addr,
+                                                  bool update_metadata,
+                                                  bool force_sequential) {
++    std::vector<void *> chunks;
++    {
++        std::lock_guard<std::mutex> lock(chunk_map_mutex_);
++        auto iter = chunk_map_.find((uint64_t)addr);
++        if (iter != chunk_map_.end()) {
++            chunks = std::move(iter->second);
++            chunk_map_.erase(iter);
++        }
++    }
++    if (!chunks.empty()) {
++        int first_error = 0;
++        for (void *chunk_addr : chunks) {
++            int ret = unregisterLocalMemoryInternal(chunk_addr, false,
++                                                    force_sequential);
++            if (ret != 0 && first_error == 0) first_error = ret;
++        }
++        if (update_metadata) {
++            int ret = metadata_->updateLocalSegmentDesc();
++            if (ret != 0 && first_error == 0) first_error = ret;
++        }
++        return first_error;
++    }
++
+     int rc = metadata_->removeLocalMemoryBuffer(addr, update_metadata);
+     if (rc) return rc;
+ 
+@@ -535,6 +665,8 @@ Status RdmaTransport::submitTransferTask(
+     const std::vector<TransferTask *> &task_list) {
+     std::unordered_map<std::shared_ptr<RdmaContext>, std::vector<Slice *>>
+         slices_to_post;
++    std::unordered_map<SegmentID, std::shared_ptr<SegmentDesc>>
++        target_segment_descs;
+     auto local_segment_desc = metadata_->getSegmentDescByID(LOCAL_SEGMENT_ID);
+     assert(local_segment_desc.get());
+     const size_t kBlockSize = globalConfig().slice_size;
+@@ -549,6 +681,14 @@ Status RdmaTransport::submitTransferTask(
+         nr_slices = 0;
+         assert(task.request);
+         auto &request = *task.request;
++        auto target_desc_it = target_segment_descs.find(request.target_id);
++        if (target_desc_it == target_segment_descs.end()) {
++            target_desc_it =
++                target_segment_descs
++                    .emplace(request.target_id,
++                             metadata_->getSegmentDescByID(request.target_id))
++                    .first;
++        }
+ 
+         auto request_buffer_id = -1, request_device_id = -1;
+         if (selectDevice(local_segment_desc.get(), (uint64_t)request.source,
+@@ -558,20 +698,19 @@ Status RdmaTransport::submitTransferTask(
+             request_device_id = -1;
+         }
+ 
+-        for (uint64_t offset = 0; offset < request.length;
+-             offset += kBlockSize) {
++        SliceLengthCalculator slice_calc{
++            request, kBlockSize, kFragmentSize, local_segment_desc.get(),
++            target_desc_it->second.get()};
++        for (uint64_t offset = 0; offset < request.length;) {
++            const size_t slice_length = slice_calc.calculate(offset);
+             Slice *slice = getSliceCache().allocate();
+             assert(slice);
+             if (!slice->from_cache) {
+                 nr_slices++;
+             }
+ 
+-            bool merge_final_slice =
+-                request.length - offset <= kBlockSize + kFragmentSize;
+-
+             slice->source_addr = (char *)request.source + offset;
+-            slice->length =
+-                merge_final_slice ? request.length - offset : kBlockSize;
++            slice->length = slice_length;
+             slice->source_location.clear();
+             slice->opcode = request.opcode;
+             slice->rdma.dest_addr = request.target_offset + offset;
+@@ -646,9 +785,7 @@ Status RdmaTransport::submitTransferTask(
+                 nr_slices = 0;
+             }
+ 
+-            if (merge_final_slice) {
+-                break;
+-            }
++            offset += slice->length;
+         }
+     }
+ 

--- a/docker/amd_patch/latest/mooncake_rocm_p2p.patch
+++ b/docker/amd_patch/latest/mooncake_rocm_p2p.patch
@@ -1,0 +1,81 @@
+diff --git a/mooncake-transfer-engine/src/CMakeLists.txt b/mooncake-transfer-engine/src/CMakeLists.txt
+index b151901f..86123552 100644
+--- a/mooncake-transfer-engine/src/CMakeLists.txt
++++ b/mooncake-transfer-engine/src/CMakeLists.txt
+@@ -107,7 +107,16 @@ if(USE_HIP)
+   if(USE_HIP_DMABUF)
+     find_package(hsa-runtime64 CONFIG)
+     if(hsa-runtime64_FOUND)
+-      target_compile_definitions(transfer_engine PRIVATE USE_HIP_DMABUF)
++      # The dmabuf MR-registration code lives in rdma_context.cpp, which is
++      # compiled in the rdma_transport OBJECT library and pulled into
++      # transfer_engine via $<TARGET_OBJECTS:transport>. A PRIVATE define on
++      # transfer_engine never reaches that object compilation, so the dmabuf
++      # path is silently compiled out and GPU MRs fall back to plain
++      # ibv_reg_mr (EINVAL on device memory). Put the define (and the hsa
++      # include/link usage requirements) on the target that actually compiles
++      # rdma_context.cpp.
++      target_compile_definitions(rdma_transport PRIVATE USE_HIP_DMABUF)
++      target_link_libraries(rdma_transport PUBLIC hsa-runtime64::hsa-runtime64)
+       target_link_libraries(transfer_engine PUBLIC hsa-runtime64::hsa-runtime64)
+       message(STATUS "HIP dmabuf MR registration enabled (hsa-runtime64 found)")
+     else()
+diff --git a/mooncake-transfer-engine/src/multi_transport.cpp b/mooncake-transfer-engine/src/multi_transport.cpp
+index fdb6a5c9..30475ede 100644
+--- a/mooncake-transfer-engine/src/multi_transport.cpp
++++ b/mooncake-transfer-engine/src/multi_transport.cpp
+@@ -14,6 +14,7 @@
+ 
+ #include "multi_transport.h"
+ #include <algorithm>
++#include <cstdlib>
+ #include <sstream>
+ #include <string>
+ 
+@@ -465,7 +466,10 @@ Status MultiTransport::selectTransport(const TransferRequest& entry,
+     // priority instead of relying on buffer registration order.
+     if (proto.find(',') != std::string::npos) {
+         auto protocol_priority = [](const std::string& p) {
+-            if (p == "hip") return 4;
++            // hip is intra-node GPU-IPC only. On a cross-node request a
++            // hip+rdma segment must fall through to rdma; allow deployments
++            // that know they need the cross-node path to de-prioritize hip.
++            if (p == "hip") return std::getenv("MC_DISABLE_HIP") ? 0 : 4;
+             if (p == "cxl") return 3;
+             if (p == "rdma") return 2;
+             if (p == "tcp") return 1;
+diff --git a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_transport.cpp b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_transport.cpp
+index e02b4348..9b76dacb 100644
+--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_transport.cpp
++++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_transport.cpp
+@@ -777,6 +777,17 @@ int RdmaTransport::selectDevice(SegmentDesc *desc, uint64_t offset,
+          ++buffer_id) {
+         const auto &buffer = buffers[buffer_id];
+ 
++#ifdef ENABLE_MULTI_PROTOCOL
++        // The RDMA transport must only bind buffers registered under the rdma
++        // protocol. Device (hip) buffers alias the same GPU addresses but carry
++        // no lkey/rkey, so picking one yields an empty-lkey out-of-bounds read
++        // in the submit path. The !empty() guard leaves legacy single-protocol
++        // descriptors (empty protocol field) unaffected.
++        if (!buffer.protocol.empty() && buffer.protocol != "rdma") {
++            continue;
++        }
++#endif
++
+         // Check if offset is within buffer range
+         if (offset < buffer.addr || length > buffer.length ||
+             offset - buffer.addr > buffer.length - length) {
+@@ -816,6 +827,12 @@ int RdmaTransport::selectDeviceByLocalHca(SegmentDesc *desc, uint64_t offset,
+          ++buffer_id) {
+         const auto &buffer = buffers[buffer_id];
+ 
++#ifdef ENABLE_MULTI_PROTOCOL
++        if (!buffer.protocol.empty() && buffer.protocol != "rdma") {
++            continue;
++        }
++#endif
++
+         if (offset < buffer.addr || length > buffer.length ||
+             offset - buffer.addr > buffer.length - length) {
+             continue;


### PR DESCRIPTION
## Summary

Temporarily backport three existing upstream Mooncake fixes required for P2P weight transfer in the Miles ROCm image.

The fixes have already been merged into Mooncake’s main branch, but no published Mooncake release currently contains all three. Therefore, updating the pinned package version is not yet an option.

These backports can be removed once Mooncake publishes a release containing the fixes and that release is consumed by the Miles ROCm image.

## Problem

The ROCm image currently uses Mooncake `0.3.12.post1`, which predates three fixes required for reliable P2P weight transfer on MI355X. Although all three fixes are available upstream, they are not yet available together in a published release.

First, the HIP DMA-BUF registration path was not compiled into Mooncake’s RDMA transport. GPU memory registration therefore fell back to the standard RDMA registration path, which fails for MI355X device memory. Mooncake’s `rdma+hip` selection could also choose invalid HIP metadata for a cross-node RDMA transfer.

This is fixed upstream by:

- [Fix cross-node RDMA transfer under `rdma+hip` on AMD](https://github.com/kvcache-ai/Mooncake/commit/45b84d36cfac14d5b6016a4d37832ff64d4c4293)

Second, buffers larger than the HCA’s maximum memory-region size were not fully registered. Mooncake truncated the registration instead of dividing the buffer into valid regions.

This is fixed upstream by:

- [Automatically split registrations at the HCA maximum MR size](https://github.com/kvcache-ai/Mooncake/commit/7a938fb359883838c65a1605f777257789cc1522)

Finally, transfers crossing one of those MR boundaries were not divided at the boundary, which could cause RDMA submission failures.

This is fixed upstream by:

- [Split RDMA transfers at MR boundaries](https://github.com/kvcache-ai/Mooncake/commit/4c2fa8ab368bfc6376932ca6df45e9d162fb5784)

Without these fixes, Mooncake cannot reliably register and transfer the MI355X rollout weight buffers.

## Change

Add two temporary patch files containing the upstream fixes.

The ROCm Docker build now:

1. Checks whether each patch is already present.
2. Applies it only when needed.
3. Fails clearly if the source is incompatible with the patch.
4. Rebuilds only Mooncake’s Python `TransferEngine` module with HIP DMA-BUF enabled.
5. Installs the rebuilt module into the existing Mooncake package.

The first patch is patch-equivalent to the upstream AMD fix. The second is a focused backport of the MR registration and transfer-boundary fixes.

## Compatibility

The change is limited to `Dockerfile.rocm`; NVIDIA images and runtime code are unchanged.

All runtime changes come from existing upstream Mooncake fixes. The backports and rebuild step can be removed once the ROCm image consumes a Mooncake release containing them.

## Validation

Validated in the MI355X Miles environment.

- Both patches apply cleanly to the Mooncake source in the current ROCm image.
- Mooncake builds successfully with HIP DMA-BUF enabled.
- GPU memory registration succeeds.
- Registration and transfer across the HCA MR-size boundary succeed.
- Qwen3-30B-A3B completed P2P weight updates with the patched engine.
