### PR TITLE
docs: lead environments bullet with training value, not connector mechanics

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,10 +88,10 @@ the largest models all live on Megatron-LM. See
   for per-GPU status and the container image for each.
 - **Wide recipe support.** GRPO, GSPO, PPO and REINFORCE++ for RL, plus SFT and
   [on-policy distillation](https://miles.radixark.com/docs/advanced/on-policy-distillation).
-- **Agentic environments.** Train coding and computer-use agents through connectors for
-  Harbor, HUD, NeMo Gym, OpenEnv, Verifiers and more, each plugging into the rollout
-  layer that fits it, with task sandboxes on AgentENV, Daytona, E2B or Modal. See
-  [Agentic Environments](https://miles.radixark.com/docs/user-guide/environments).
+- **Agentic environments.** Train coding and computer-use agent models on environments
+  from Harbor, HUD, NeMo Gym, OpenEnv, Verifiers and more: each ecosystem has a connector
+  at the rollout layer that fits it. Task sandboxes run on AgentENV, Daytona, E2B or
+  Modal. See [Agentic Environments](https://miles.radixark.com/docs/user-guide/environments).
 
 ## Getting Started
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -58,10 +58,10 @@ the largest models all live on Megatron-LM. See
   MI355X via ROCm. See [Supported hardware](#supported-hardware).
 - **Wide recipe support.** GRPO, GSPO, PPO and REINFORCE++ for RL, plus SFT and
   [on-policy distillation](/advanced/on-policy-distillation).
-- **Agentic environments.** Train coding and computer-use agents through connectors for
-  Harbor, HUD, NeMo Gym, OpenEnv, Verifiers and more, each plugging into the rollout
-  layer that fits it, with task sandboxes on AgentENV, Daytona, E2B or Modal. See
-  [Agentic Environments](/user-guide/environments).
+- **Agentic environments.** Train coding and computer-use agent models on environments
+  from Harbor, HUD, NeMo Gym, OpenEnv, Verifiers and more: each ecosystem has a connector
+  at the rollout layer that fits it. Task sandboxes run on AgentENV, Daytona, E2B or
+  Modal. See [Agentic Environments](/user-guide/environments).
 - **Comprehensive CI.** Unit suites run on every pull request, and tag-triggered end-to-end
   GPU training tests cover the supported model families on both NVIDIA and AMD runners.
 


### PR DESCRIPTION
## Summary

Follow-up to #2533, which was merged before this refinement landed on the branch.

Reword the **Agentic environments** bullet in the README and docs index so it leads with what the user gets rather than how the integration works:

> **Agentic environments.** Train coding and computer-use agent models on environments from Harbor, HUD, NeMo Gym, OpenEnv, Verifiers and more: each ecosystem has a connector at the rollout layer that fits it. Task sandboxes run on AgentENV, Daytona, E2B or Modal.

- "through connectors for X" put the mechanism in the main clause; "train … agent models on environments from X" says what you train and on what, and the connector moves to the supporting clause. "Agent models" rather than "agents": RL updates the model's weights, while the agent harness stays a black box — which is the point of TITO.
- "each plugging into the rollout layer" → "a connector **at** the rollout layer", matching the docs table's "Plugs in at" wording.
- The dangling "with task sandboxes on …" becomes its own sentence, "Task sandboxes run on …" — sandbox providers are a separate axis from the connector list, so they don't share the connector clause's colon.

Same wording applied to `README.md` and its mirror `docs/index.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)