### PR TITLE
docs: document release workflow

### DIFF
--- a/.github/workflows/bot-bump-miles-version.yml
+++ b/.github/workflows/bot-bump-miles-version.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
     inputs:
       new_version:
-        description: 'New miles version (e.g., 0.3.0 or 0.3.0rc0)'
+        description: 'Base Miles version (X.Y.Z only; e.g., 0.3.0)'
         required: true
         type: string
 

--- a/.github/workflows/bot-bump-miles-version.yml
+++ b/.github/workflows/bot-bump-miles-version.yml
@@ -1,3 +1,4 @@
+# doc-dev: docs/ci/04-release.md
 name: Bot Bump Miles Version
 # Optional convenience for release step ①: a hand-opened PR editing setup.py's
 # version line (via .github/scripts/release/bump_miles_version.py) is fully equivalent

--- a/.github/workflows/bot-cherry-pick.yml
+++ b/.github/workflows/bot-cherry-pick.yml
@@ -1,3 +1,4 @@
+# doc-dev: docs/ci/04-release.md
 name: Bot Cherry Pick to Release Branch
 # Picks a merged main PR (or a raw commit) onto a release branch. Re-dispatch
 # release-branch-cut.yml on the branch afterwards to re-run the full CI.

--- a/.github/workflows/pr-test-rocm.yml
+++ b/.github/workflows/pr-test-rocm.yml
@@ -7,8 +7,8 @@ name: PR Test (ROCm)
 #
 # Test selection is explicit rather than inherited from the CUDA suites. The
 # shared CI policy selects matching register_rocm_ci() labels for PR/nightly
-# runs and the full label scope for weekly; manual dispatch keeps the full
-# regular MI350 suite.
+# runs and the full scope for weekly or explicitly called release runs; manual
+# dispatch keeps the full regular MI350 suite.
 #
 # The MI350 host is split into two 4-GPU runners, so this stage is 4-GPU.
 # CUDA tests that need 8 GPUs get a standalone test_amd_<name>.py with its

--- a/.github/workflows/release-branch-cut.yml
+++ b/.github/workflows/release-branch-cut.yml
@@ -100,8 +100,7 @@ jobs:
           SGLANG_SHA=$(git ls-remote https://github.com/sgl-project/sglang refs/heads/sglang-miles | cut -f1)
           MEGATRON_SHA=$(git ls-remote https://github.com/radixark/Megatron-LM refs/heads/miles-main | cut -f1)
 
-          # Prefer the latest timestamped dev tag; the implementation falls back
-          # to mutable dev if none exists, which the maintainer runbook forbids.
+          # Prefer the latest timestamped dev tag; fall back to mutable dev if none exists.
           DEV_IMAGE_TAG=$(curl -s "https://hub.docker.com/v2/repositories/radixark/miles/tags/?page_size=100&name=dev-" \
             | python3 -c "import sys, json, re; names = [t['name'] for t in json.load(sys.stdin)['results']]; c = sorted(n for n in names if re.fullmatch(r'dev-\d{12}', n)); print(c[-1] if c else 'dev')")
 

--- a/.github/workflows/release-branch-cut.yml
+++ b/.github/workflows/release-branch-cut.yml
@@ -1,16 +1,17 @@
+# doc-dev: docs/ci/04-release.md
 name: Release Branch Cut
-# The branch name is stamped into run-name so release-tag.yml can find this
-# run by title when it verifies the CI gate.
+# The branch name in run-name identifies the operator run; release-tag.yml
+# gates on the per-SHA release-ci commit status, not on this title.
 run-name: Release Branch Cut ${{ inputs.branch_name }}
 #
 # Creates a release/vX.Y.Z branch from main, freezes the dependency triplet
-# into release-lock.json on that branch, then runs the full-scope (weekly
-# cadence) CI suites against it. Re-dispatching on an existing branch skips
+# into release-lock.json on that branch, then runs the full-scope release
+# cadence CI suites against it. Re-dispatching on an existing branch skips
 # creation and just re-runs the tests (e.g. after a cherry-pick).
 #
-# A miles version is a frozen triplet (miles + sglang-miles + miles-main), not
-# one repo — see docs/developer/versions.md. The lockfile is what makes the
-# tested combination and the released image the same combination.
+# A Miles version freezes the repository commit plus the SGLang and Megatron-LM
+# commits; see docs/developer/versions.md. The lockfile also names the CUDA CI
+# image, while wheel fingerprints are audit records and ROCm remains smoke-only.
 
 on:
   workflow_dispatch:
@@ -99,7 +100,8 @@ jobs:
           SGLANG_SHA=$(git ls-remote https://github.com/sgl-project/sglang refs/heads/sglang-miles | cut -f1)
           MEGATRON_SHA=$(git ls-remote https://github.com/radixark/Megatron-LM refs/heads/miles-main | cut -f1)
 
-          # Latest timestamped dev tag = a frozen image for the release CI run.
+          # Prefer the latest timestamped dev tag; the implementation falls back
+          # to mutable dev if none exists, which the maintainer runbook forbids.
           DEV_IMAGE_TAG=$(curl -s "https://hub.docker.com/v2/repositories/radixark/miles/tags/?page_size=100&name=dev-" \
             | python3 -c "import sys, json, re; names = [t['name'] for t in json.load(sys.stdin)['results']]; c = sorted(n for n in names if re.fullmatch(r'dev-\d{12}', n)); print(c[-1] if c else 'dev')")
 
@@ -133,9 +135,9 @@ jobs:
             echo "## Release Branch Cut"
             echo "- Branch: \`${{ github.event.inputs.branch_name }}\`"
             echo "- CI image: \`radixark/miles:${{ steps.freeze.outputs.ci_image_tag }}\`"
-            echo "- Full-scope CI runs below. Once this run is fully green, tag with:"
-            echo "  \`gh workflow run release-tag.yml -f version=X.Y.Z -f ref=${{ github.event.inputs.branch_name }}\`"
-            echo "  (release-tag checks the release-ci commit status this run stamps on the tested commit)"
+            echo "- Once fully green, confirm the branch still points to the tested SHA, keep it frozen, then tag:"
+            echo "  \`gh workflow run release-tag.yml -f version=X.Y.Z -f ref=${{ steps.freeze.outputs.tested_sha }}\`"
+            echo "  (release-tag checks release-ci on this SHA but does not compare the remote branch tip)"
           } >> "$GITHUB_STEP_SUMMARY"
 
   run-tests-cuda:

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -1,11 +1,14 @@
+# doc-dev: docs/ci/04-release.md
 name: Release Docker Images
 #
-# Triggered by a vX.Y.Z tag push (from release-tag.yml). Builds and publishes:
+# release-tag.yml dispatches this workflow explicitly after its GITHUB_TOKEN
+# tag push; independently pushed matching tags and manual retries also run it.
+# Builds and publishes:
 #   - radixark/miles:v{version}        (cu13, amd64+arm64)
 #   - radixark/miles:v{version}-cu12   (cu12.9, amd64)
-# Every dependency build-arg is pinned from the tag's release-lock.json, and
-# MILES_COMMIT is the tagged SHA — so the image is the frozen triplet the
-# release branch CI tested, not the branch heads at build time.
+# SGLANG_COMMIT and MEGATRON_COMMIT come from release-lock.json; MILES_COMMIT
+# is the checked-out SHA. Wheel release tags remain rolling inputs whose
+# lockfile fingerprints are audit records, not restored build inputs.
 
 on:
   push:

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -1,6 +1,7 @@
+# doc-dev: docs/ci/04-release.md
 name: Release Tag
-# Creates the vX.Y.Z tag that triggers release-docker.yml. Use after the
-# release branch's full CI (a release-branch-cut.yml run) is green.
+# Creates an annotated v<exact-version> tag, then explicitly dispatches
+# release-docker.yml. Use after release-branch-cut.yml is green.
 #
 # Unlike sglang's release-tag.yml, this one refuses to tag blind. It requires
 # a green `release-ci` commit status on the exact commit being tagged — the

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,7 @@
 # doc-dev: docs/ci/02-docker-build.md
-# Build via docker/build.py (single source of truth for build-args, platforms,
-# and tags) — see docs/ci/02-docker-build.md. Examples:
+# Build via docker/build.py (single source of truth for variant defaults,
+# platforms, tags, and build-arg ordering); callers may append explicit
+# build-arg overrides. See docs/ci/02-docker-build.md. Examples:
 #       python docker/build.py --variant cu13     --image-tag dev --push   # radixark/miles:dev      (amd64+arm64)
 #       python docker/build.py --variant cu13-x86 --image-tag dev --push   # radixark/miles:dev (amd64)
 #       python docker/build.py --variant cu13-aarch64 --image-tag dev --push   # radixark/miles:dev (arm64)

--- a/docker/build.py
+++ b/docker/build.py
@@ -7,7 +7,6 @@ Usage:
     python docker/build.py --variant cu13-x86 --image-tag dev --push      # single arch
     python docker/build.py --variant cu12-x86 --image-tag latest
     python docker/build.py --variant cu13 --image-tag dev --dry-run
-    python docker/build.py --variant cu13 --image-tag custom --custom-tag release-test --build-arg MILES_COMMIT=FULL_SHA --dry-run
 """
 
 import os

--- a/docker/build.py
+++ b/docker/build.py
@@ -7,6 +7,7 @@ Usage:
     python docker/build.py --variant cu13-x86 --image-tag dev --push      # single arch
     python docker/build.py --variant cu12-x86 --image-tag latest
     python docker/build.py --variant cu13 --image-tag dev --dry-run
+    python docker/build.py --variant cu13 --image-tag custom --custom-tag release-test --build-arg MILES_COMMIT=FULL_SHA --dry-run
 """
 
 import os

--- a/docs/ci/00-stage.md
+++ b/docs/ci/00-stage.md
@@ -6,7 +6,7 @@ A *stage* is one CI job in a Miles CI workflow. A *suite* is the `suite=` value 
 
 ## Suite → stage mapping
 
-The canonical suite list is `CI_SUITES` in `tests/ci/run_suite.py`, grouped by hardware backend (CPU / CUDA / ROCm). Cadence does not change this inventory: regular, nightly, and weekly runs use the same stages. Every CPU and CUDA entry has one matching job in `pr-test.yml`; `stage-c-4-gpu-mi350` has its matching job in `pr-test-rocm.yml`; the 2-GPU and 8-GPU MI350 suites are owned by the external nightly described below. A test picks its stage purely by `suite=`; the stage job runs `run_suite.py --suite <name>`, which collects exactly the tests carrying that suite.
+The canonical suite list is `CI_SUITES` in `tests/ci/run_suite.py`, grouped by hardware backend (CPU / CUDA / ROCm). Cadence does not change this inventory: regular, nightly, weekly, and release runs use the same stages. Every CPU and CUDA entry has one matching job in `pr-test.yml`; `stage-c-4-gpu-mi350` has its matching job in `pr-test-rocm.yml`; the 2-GPU and 8-GPU MI350 suites are owned by the external nightly described below. A test picks its stage purely by `suite=`; the stage job runs `run_suite.py --suite <name>`, which collects exactly the tests carrying that suite.
 
 The mapping is kept in sync by hand on both sides:
 - A `suite=` with no matching job never runs.
@@ -31,9 +31,15 @@ In `pr-test.yml`, `tier a` (CPU fast) gates the NVIDIA GPU fleet after both reso
 
 `pr-test.yml` treats `pull_request.closed` as cancellation-only: the close event shares the PR's concurrency group, cancels any queued or running `PR Test` run, and starts no resolver or test jobs.
 
+Both PR workflows are also reusable `workflow_call` entry points for release CI. Called runs group concurrency by `inputs.ref`, so redispatching the same release branch cancels the older run; literal `pr-test-` and `pr-test-rocm-` prefixes keep the CUDA and ROCm groups from cancelling each other under the same branch-cut caller.
+
 ## What each stage does
 
-**Image resolution (`resolve-ci-image`).** In `pr-test.yml`, a small `ubuntu-latest` job reads `ci-image-tag:` from the PR description (or the `ci_image_tag` dispatch input), defaults to `dev`, validates it is a bare tag, and outputs `radixark/miles:<tag>`. The ROCm resolver uses only its dispatch input, defaults to its undated `rocm/sgl-dev` tag, and uses that same default for PR, nightly, and weekly runs. Distinct from this, the **`run-ci-image` label** selects the image scope — every enabled tag except `long`, `ft-short`, and `ft-long` — which validates an image bump without selecting those domains implicitly.
+**Image resolution (`resolve-ci-image`).** In `pr-test.yml`, a small `ubuntu-latest` job takes the called workflow's `image_tag` first, then reads `ci-image-tag:` from the PR description or the `ci_image_tag` dispatch input, defaults to `dev`, validates the result is a bare tag, and outputs `radixark/miles:<tag>`. `release-branch-cut.yml` passes the prune-exempt `release-vX.Y.Z-ci` tag recorded in `release-lock.json`.
+
+The ROCm resolver uses only its dispatch input, defaults to its undated `rocm/sgl-dev` tag, and uses that default for called release runs too.
+
+Distinct from image selection, the **`run-ci-image` label** selects the test scope — every enabled tag except `long`, `ft-short`, and `ft-long` — which validates an image bump without selecting those domains implicitly.
 
 **Policy resolution (`resolve-ci-policy`).**
 
@@ -42,32 +48,37 @@ In `pr-test.yml`, `tier a` (CPU fast) gates the NVIDIA GPU fleet after both reso
 - A PR `nightly` label maps to nightly cadence.
 - A scheduled run maps its exact UTC `github.event.schedule` cron: `0 15 * * 0-5` maps to nightly and `0 15 * * 6` maps to weekly; an unknown cron fails.
 - A manual dispatch keeps regular cadence and has no PR labels. `pr-test.yml` therefore runs the ordinary always-on selection, while the dedicated ROCm dispatch adds `--match-all-labels` to preserve its full regular MI350 run.
+- A reusable `workflow_call` supplies an explicit cadence override because the called workflow inherits the caller's event name. Policy resolution deliberately runs the caller commit's `ci_policy.py`; only suite jobs check out the requested release ref.
 
-A **nightly** policy selects every enabled tag except `long` and `ft-long`, admits both regular and `nightly=True` registrations, and disables fast-fail. A **weekly** policy selects every enabled tag, including `long` and `ft-long`, admits both registration types, and disables fast-fail. Regular cadence admits only regular registrations. All three cadences use the same stage inventory.
+A **nightly** policy selects every enabled tag except `long` and `ft-long`, admits both regular and `nightly=True` registrations, and disables fast-fail. **Weekly** and **release** select every enabled tag, admit both registration types, and disable fast-fail; release differs by never writing the rolling performance baseline. Regular cadence admits only regular registrations. All four cadences use the same stage inventory.
 
-`run-ci-all` selects the full domain-tag set without changing cadence. `run-ci-image` selects every enabled tag except `long`, `ft-short`, and `ft-long`. If scope signals overlap, the precedence is `run-ci-all` > weekly > nightly > `run-ci-image`. The resolved cadence and raw/synthetic labels are passed to `run_suite.py`, which computes one run policy (see [Labels](/ci/01-label) for the subtraction semantics).
+`run-ci-all` selects the full domain-tag set without changing cadence. `run-ci-image` selects every enabled tag except `long`, `ft-short`, and `ft-long`. If scope signals overlap, the precedence is `run-ci-all` > weekly/release full scope > nightly > `run-ci-image`. The resolved cadence and raw/synthetic labels are passed to `run_suite.py`, which computes one run policy (see [Labels](/ci/01-label) for the subtraction semantics).
 
-**Dependencies / gating.** In `pr-test.yml`, both CPU stages require both resolvers. Its GPU stages also require both resolvers and, by default, a successful `stage-a-cpu`, so a CPU-test failure short-circuits the expensive NVIDIA fleet. Resolved nightly or weekly cadence and the `bypass-fastfail` PR label relax only the `stage-a-cpu` failure gate and make each suite continue after a test failure; none bypasses resolver failure.
+**Dependencies / gating.** In `pr-test.yml`, both CPU stages require both resolvers. Its GPU stages also require both resolvers and, by default, a successful `stage-a-cpu`, so a CPU-test failure short-circuits the expensive NVIDIA fleet. Resolved nightly, weekly, or release cadence and the `bypass-fastfail` PR label relax only the `stage-a-cpu` failure gate and make each suite continue after a test failure; none bypasses resolver failure.
 
 **Runner selection.** CUDA stages request runners by label via `runs_on`, a JSON list passed through to `runs-on` — a runner must carry **all** listed labels (GPU class + count). CPU stages call `_run-cpu-ci.yml`, whose only job runs on GitHub-hosted `ubuntu-latest`, so they don't occupy GPU-fleet slots.
 
 **Dependency boundary.** CUDA stages start from dependencies baked into `radixark/miles`, reconcile Miles runtime dependencies from `requirements.txt`, update the SGLang and Megatron-LM checkouts to the selected refs, and expose all three source trees through `PYTHONPATH`; they do not rebuild or install the Miles, SGLang, or Megatron-LM source trees after the container starts. The hosted CPU stages install dependencies from `requirements.txt` and the fully pinned `tests/ci/requirements-ci-cpu.txt`, then expose the Miles, SGLang, and Megatron-LM source trees through `PYTHONPATH` without editable installs or inline package lists. The ROCm stage instead uses the SGLang and Megatron-LM versions baked into `rocm/sgl-dev`.
 
+CUDA and CPU dependency refs resolve in this order: explicit dispatch input or PR-body directive, committed `release-lock.json`, then the moving `sglang-miles` / `miles-main` branch heads. A called release run therefore checks out its requested Miles `ref` and consumes the lockfile on that ref unless an explicit override exists. ROCm checks out the requested Miles ref but keeps the dependencies baked into its image.
+
 **Launch.** Each CPU/CUDA stage is a thin caller of one hardware-specific reusable workflow: CPU stages use `_run-cpu-ci.yml`, while CUDA stages use `_run-ci.yml`. Each reusable workflow declares only its matching job, so GitHub does not add a skipped CPU sibling to CUDA stages or a skipped CUDA sibling to CPU stages.
 
-Both workflows receive `execute_command`; CUDA callers additionally pass `runs_on` and `container_image`. The reusable workflows own runner setup, dependency and source resolution, and the two command invocations (first `--list-only`, then the real run); each stage owns only which runner class, image, and command to select.
+Both workflows receive `execute_command` and an optional `ref`; CUDA callers additionally pass `runs_on` and `container_image`. The reusable workflows own checkout, runner setup, dependency and source resolution, and the two command invocations (first `--list-only`, then the real run); each stage owns only which runner class, image, ref, and command to select.
 
 **Secrets.** CPU/CUDA stages call their reusable workflow with `secrets: inherit`. The ROCm caller passes `WANDB_API_KEY` explicitly; GitHub withholds it from fork `pull_request` runs.
 
 **Sharding.** A stage with a `partition_id` matrix splits its tests across N shards; `run_suite.py` balances the shards by each test's `est_time`. Each shard is an independent job instance running the same `execute_command` with a different `--auto-partition-id`.
 
-Weekly runs keep the same shards but set each GPU matrix's `max-parallel` to one, so each stage occupies at most one matching runner. Stages remain independent: `stage-b-2-gpu-h200` and `stage-c-2-gpu-h200` may each occupy one 2-GPU runner at the same time. PR and nightly runs retain their existing matrix parallelism.
+Weekly runs keep the same shards but set each GPU matrix's `max-parallel` to one, so each stage occupies at most one matching runner. Stages remain independent: `stage-b-2-gpu-h200` and `stage-c-2-gpu-h200` may each occupy one 2-GPU runner at the same time. PR, nightly, and release runs retain their existing matrix parallelism.
 
-## ROCm PR/nightly/weekly mirror
+## ROCm PR/nightly/weekly/release mirror
 
-`pr-test-rocm.yml` has `pull_request`, exact nightly and weekly crons, and `workflow_dispatch` entry points. PR runs use the same low-trust merge-commit model as `pr-test.yml`. It runs `stage-c-4-gpu-mi350` through `_run-ci-rocm.yml` on two 4-GPU MI350 runners, resolves `rocm/sgl-dev:<tag>` (defaulting to the undated `miles-rocm720-mi35x` tag each nightly image build overwrites), and splits tests into two `est_time`-balanced shards. Weekly limits that matrix to one runner at a time. It runs no CPU tests. SGLang and Megatron-LM come from the image, so manual dispatch exposes no dependency-ref inputs.
+`pr-test-rocm.yml` exposes `pull_request`, exact nightly and weekly crons, `workflow_dispatch`, and `workflow_call`. PR runs use the same low-trust merge-commit model as `pr-test.yml`. It runs `stage-c-4-gpu-mi350` through `_run-ci-rocm.yml` on two 4-GPU MI350 runners and splits tests into two `est_time`-balanced shards; weekly alone limits the matrix to one runner at a time. It runs no CPU tests.
 
-Only tests registered with `register_rocm_ci(suite="stage-c-4-gpu-mi350", ...)` run; CUDA registrations are not inherited. PR, nightly, and weekly runs consume the shared cadence and label policy: `run-ci-amd` selects the `amd`-labelled subset of the suite; the remaining MI350 registrations carry only topic labels and are picked up by manual dispatch or the external nightly. Other `run-ci-*` labels can select matching subsets, nightly admits regular plus `nightly=True` registrations, and weekly selects all enabled registrations. Manual dispatch adds `--match-all-labels` and runs the full regular suite.
+A called release run checks out the supplied Miles `ref` with `cadence=release` but resolves the same undated `rocm/sgl-dev:miles-rocm720-mi35x` image as the other automatic paths. SGLang and Megatron-LM remain baked into that image, so release ROCm is a smoke signal and manual dispatch exposes no dependency-ref inputs.
+
+Only tests registered with `register_rocm_ci(suite="stage-c-4-gpu-mi350", ...)` run; CUDA registrations are not inherited. PR, nightly, weekly, and release runs consume the shared cadence and label policy: `run-ci-amd` selects the `amd`-labelled subset, other `run-ci-*` labels select matching subsets, nightly admits regular plus `nightly=True` registrations, and weekly or release selects every enabled registration. Manual dispatch adds `--match-all-labels` and runs the full regular 4-GPU suite. The external nightly coverage of all three MI350 suites is described below.
 
 Fork PRs use GitHub's standard `pull_request` protections: checkout tests the merge commit, repository secrets are withheld, and held runs follow the shared maintainer approval flow described in [`01-label.md`](01-label.md).
 

--- a/docs/ci/01-label.md
+++ b/docs/ci/01-label.md
@@ -35,24 +35,27 @@ To add one: add the entry to `KNOWN_LABELS`, then create the matching `run-ci-<k
 
 ## Cadence eligibility
 
-There are three CI cadences: `regular`, the ordinary mode; `nightly`, which admits `nightly=True` tests, broadens the default scope, and bypasses fast-fail; and `weekly`, which also admits `nightly=True` tests, selects every enabled tag, and bypasses fast-fail.
+There are four CI cadences: `regular`, the ordinary mode; `nightly`, which admits `nightly=True` tests and broadens scope; `weekly`, which admits those tests and selects every enabled tag; and `release`, an explicit called-workflow cadence with weekly's selection but no rolling performance-baseline writes. Nightly, weekly, and release all bypass fast-fail.
 
-`register_*_ci(nightly=True)` means the test is eligible under nightly and weekly cadence, but not regular cadence. It does not create a separate suite inventory and does not replace domain-label filtering. A regular run selects regular registrations only; nightly and weekly select regular plus `nightly=True` registrations, then apply their own domain-label scopes. For example, a `nightly=True` test carrying only `ft-long` remains outside the nightly scope unless `run-ci-ft-long` or `run-ci-all` explicitly includes it, while weekly includes it automatically.
+`register_*_ci(nightly=True)` means the test is eligible under nightly, weekly, and release cadence, but not regular cadence. It does not create a separate suite inventory and does not replace domain-label filtering. A regular run selects regular registrations only; nightly, weekly, and release select regular plus `nightly=True` registrations, then apply their own domain-label scopes. For example, a `nightly=True` test carrying only `ft-long` remains outside the nightly scope unless `run-ci-ft-long` or `run-ci-all` explicitly includes it, while weekly and release include it automatically.
 
 ## Broad CI scopes
 
-The workflow's `resolve-ci-policy` job forwards trigger-specific facts to `tests/ci/ci_policy.py`; that module adapts them into explicit cadence and label inputs, then its shared `resolve_policy` maps those inputs to one effective include-label set and fast-fail policy. `run_suite.py` consumes the same resolved-policy function and never derives policy from `schedule` or `workflow_dispatch` event names. A broad scope is just a large include set (every registered label minus the scope's subtractions).
+The workflow's `resolve-ci-policy` job forwards trigger-specific facts or a called workflow's explicit cadence override to `tests/ci/ci_policy.py`; that module adapts them into cadence and label inputs, then its shared `resolve_policy` maps those inputs to one effective include-label set and fast-fail policy. `run_suite.py` consumes the same resolved-policy function and never derives policy from `schedule`, `workflow_dispatch`, or the caller's inherited event name. A broad scope is just a large include set (every registered label minus the scope's subtractions).
 
 | Scope | Explicit source | Runs | Subtracts | Fast-fail |
 |---|---|---|---|---|
 | all | `run-ci-all` label | every enabled tag | — | determined by cadence |
 | weekly | exact weekly cron | every enabled tag | — | disabled on both levels |
+| release | `release-branch-cut.yml` calling with `cadence=release` | every enabled tag | — | disabled on both levels |
 | nightly | resolved nightly cadence from the PR label, exact nightly cron, or local `--nightly` | every enabled tag except `long` and `ft-long`, incl. `ft-short` | `long`, `ft-long` | disabled on both levels (within-stage only for local runs) |
 | image | `run-ci-image` label | every enabled tag except `long` and FT tags | `long`, `ft-short`, `ft-long` | determined by cadence |
 
-Rows are in precedence order: when scope signals overlap, the higher row wins (`run-ci-all` > weekly > nightly > `run-ci-image`, the branch order of `resolve_policy`). `run-ci-all` widens only the domain scope; regular cadence still does not admit `nightly=True` registrations.
+Release and weekly have the same selection and fast-fail policy. Release is separate because frozen release refs must never write the rolling performance baseline; see [Metric history & regression gate](/ci/03-metric-history-gate#trust-cleanup-who-writes).
 
-The generic triggers carry no policy. All scheduled runs use UTC: nightly is identified by the exact cron `0 15 * * 0-5`, and weekly by `0 15 * * 6`. Saturday weekly replaces that day's nightly rather than starting alongside it. A manual dispatch uses regular cadence and no PR labels, so it receives only the ordinary always-on scope; its existing operation inputs do not imply all, nightly, or weekly.
+Rows are in precedence order: when scope signals overlap, the higher row wins (`run-ci-all` > weekly/release full scope > nightly > `run-ci-image`, the branch order of `resolve_policy`). `run-ci-all` widens only the domain scope; regular cadence still does not admit `nightly=True` registrations.
+
+The generic triggers carry no policy. All scheduled runs use UTC: nightly is identified by the exact cron `0 15 * * 0-5`, and weekly by `0 15 * * 6`. Saturday weekly replaces that day's nightly rather than starting alongside it. A manual dispatch uses regular cadence and no PR labels, so it receives only the ordinary always-on scope; its operation inputs do not imply all, nightly, weekly, or release. A called workflow instead supplies its cadence explicitly, which is how `release-branch-cut.yml` selects release.
 
 A subtraction is not a per-test veto — it only stops that label from granting inclusion. A test carrying a subtracted label still runs when another of its labels is in the set, so a test that must stay outside the standard nightly scope must carry only labels that nightly subtracts.
 
@@ -81,7 +84,7 @@ The `bypass-fastfail` PR label turns both off so one run surfaces every failure:
 - Cross-stage: each GPU stage consumes the shared `bypass_fastfail` policy output, so GPU stages run even after `stage-a-cpu` fails.
 - Within-stage: `run_suite.py` derives continue-on-error from the same resolved policy (drops `pytest -x`; sets `continue_on_error=True` for CUDA). The stage still ends red — it changes coverage, not the verdict.
 
-A resolved nightly or weekly cadence bypasses fast-fail on both levels so a scheduled broad run surfaces every failure rather than stopping at the first. For nightly this applies equally whether the cadence came from the PR `nightly` label or the explicitly mapped nightly cron. Local `--nightly` applies the same nightly selection and within-stage behavior; cross-stage gating does not exist in a local invocation.
+A resolved nightly, weekly, or release cadence bypasses fast-fail on both levels so a broad run surfaces every failure rather than stopping at the first. For nightly this applies equally whether the cadence came from the PR `nightly` label or the explicitly mapped nightly cron; release comes from the called workflow's explicit override. Local `--nightly` applies the same nightly selection and within-stage behavior; cross-stage gating does not exist in a local invocation.
 
 Like the scope labels, `bypass-fastfail` is a workflow-only input and is not in `KNOWN_LABELS`.
 

--- a/docs/ci/02-docker-build.md
+++ b/docs/ci/02-docker-build.md
@@ -1,15 +1,15 @@
 ---
 title: Docker build
-description: The Dockerfiles, the build script, the remote build workflow, and how to build & push manually.
+description: The Dockerfiles, the build script, rolling and release build workflows, and how to build and push manually.
 ---
-GPU CI runs inside `radixark/miles`. This doc maps which Dockerfiles exist, the script that builds them, the PR-side build check, how the remote build is triggered, and how to build & push manually.
+GPU CI runs inside `radixark/miles`. This doc maps which Dockerfiles exist, the script that builds them, the PR-side build check, the rolling and versioned release workflows, and manual build and push behavior.
 
 ## Dockerfiles
 
 
 | Path                     | Builds                   | Wired into                             |
 | ------------------------ | ------------------------ | -------------------------------------- |
-| `docker/Dockerfile`      | `radixark/miles` (CUDA)  | `docker-build.yml`                     |
+| `docker/Dockerfile`      | `radixark/miles` (CUDA)  | `docker-build.yml`, `release-docker.yml` |
 | `docker/Dockerfile.rocm` | AMD ROCm (MI30x / MI35x) | `docker-build.yml` (`rocm-*` variants) |
 
 
@@ -26,16 +26,16 @@ The Dockerfile is the build recipe: it provides the cu13 defaults and emits one 
 | `ENABLE_CUDA_13`                                                                                       | `1` = CUDA 13 (default) and installs the Mooncake wheel from the selected wheels release; `0` = CUDA 12.9 and keeps the base image's Mooncake                                                                                                                                                                                                         |
 | `WHEELS_REPO`                                                                                          | prebuilt-wheels GitHub repo (`yueming-yuan/miles-wheels`)                                                                                                                                                                                                                                                                                           |
 | `WHEELS_TAG_X86` / `WHEELS_TAG_ARM64`                                                                  | the two **complete** wheels release tags selected by `TARGETARCH` and installed **verbatim**. cu13 uses the rolling `cu130-x86_64` / `cu130-aarch64` releases; cu12-x86 overrides `WHEELS_TAG_X86` with the rolling `cu129-x86_64` release                                                                                                                                                                                              |
-| `SGLANG_BRANCH` / `SGLANG_COMMIT`, `MEGATRON_REPO` / `MEGATRON_BRANCH`, `MILES_COMMIT`, `SGL_ROUTER_*` | source pins for the layered repos                                                                                                                                                                                                                                                                                                                   |
+| `SGLANG_BRANCH` / `SGLANG_COMMIT`, `MEGATRON_REPO` / `MEGATRON_BRANCH` / `MEGATRON_COMMIT`, `MILES_COMMIT`, `SGL_ROUTER_*` | source pins for the layered repos; empty commit args follow their branch, while release builds provide exact SHAs |
 
 
-**Output** — one `radixark/miles` image for the platform buildx targets: the sglang base, then the Python dependencies declared in `requirements.txt`, Megatron-LM (`radixark/Megatron-LM@miles-main`), miles, and the prebuilt wheels (`sgl-router` among them). A multi-arch build is one `buildx` run executed once per platform — `TARGETARCH` differs each time, so each arch installs its own wheels — and buildx pushes the two as a single manifest.
+**Output** — one `radixark/miles` image for the platform buildx targets: the SGLang base, then the Python dependencies declared in `requirements.txt`, Megatron-LM at its branch default or caller-pinned commit, Miles, and the prebuilt wheels (`sgl-router` among them). A multi-arch build is one `buildx` run executed once per platform — `TARGETARCH` differs each time, so each arch installs its own wheels — and buildx pushes the two as a single manifest.
 
 `docker/Dockerfile.rocm` is the ROCm counterpart (build-args `GPU_ARCH` + a ROCm `SGLANG_IMAGE_TAG`; the 7.2 variants also set `APPLY_ROCR_VMMFIX=1`, which downloads the ROCr VMM-pause fix `.so` from the `WHEELS_TAG_ROCM` release and installs it — ROCm 7.0 has no such regression and leaves it off).
 
 ## Build script
 
-`docker/build.py` builds and pushes the images. Select a build with `--variant` and a tag mode with `--image-tag {dev,latest,custom}`. A single `VARIANTS` table is the source of truth for each variant's image, target platforms, Dockerfile, and build-args.
+`docker/build.py` builds and pushes the images. Select a build with `--variant` and a tag mode with `--image-tag {dev,latest,custom}`. The `VARIANTS` table is the source of truth for each variant's image, target platforms, Dockerfile, and default build-args. Repeatable `--build-arg KEY=VALUE` options are appended after those defaults, so an explicit caller override wins.
 
 
 | `--variant`    | Tag (`--image-tag dev`)            | Platforms                     | Notes                                          |
@@ -52,7 +52,7 @@ The cu13 variants share one multi-arch CUDA base image and differ only in platfo
 
 The **Tag** column is for `--image-tag dev`, which also pushes a timestamped `dev-<YYYYMMDDHHMM>` sibling; `latest` swaps the prefix to `latest`, `custom` uses `--custom-tag`. `cu13` / `cu13-x86` / `cu13-aarch64` intentionally share `radixark/miles:dev` — the daily build runs `cu13` (multi-arch), while a single-arch variant overwrites `dev` with one arch when run alone.
 
-A multi-arch build (`cu13`) needs Buildx's `docker-container` driver and is push-only — buildx writes the manifest straight to the registry, it can't load into the local image store. Use `cu13-x86` / `cu13-aarch64` (single-platform; the arm64 one cross-builds via QEMU on an x86 host) for local single-arch iteration. Other flags: `--push`, `--dry-run`, `--dockerfile`, `--custom-tag`.
+A multi-arch build (`cu13`) needs Buildx's `docker-container` driver and is push-only — buildx writes the manifest straight to the registry, it can't load into the local image store. Use `cu13-x86` / `cu13-aarch64` (single-platform; the arm64 one cross-builds via QEMU on an x86 host) for local single-arch iteration. Other flags: `--push`, `--dry-run`, `--dockerfile`, `--custom-tag`, and repeatable `--build-arg KEY=VALUE`.
 
 ## PR build check (in `pr-test.yml`)
 
@@ -68,9 +68,9 @@ When a PR touches `docker/Dockerfile`, `docker/build.py`, `docker/verify_transfo
 
 Non-docker PRs are untouched: `docker-paths` reports no change, `docker-build` skips, and the matrix runs on `dev` as before.
 
-## Remote docker build (`docker-build.yml`)
+## Rolling Docker build (`docker-build.yml`)
 
-The only automated builder of `radixark/miles`. Two jobs:
+This workflow owns the rolling `dev` and `latest` image families. It has two jobs:
 
 - **`check-upstream`** (schedule / `simulate_schedule` only) — polls the inputs the image bakes: the HEAD SHA of sglang `sglang-miles` (`sgl-project/sglang`) and Megatron-LM `miles-main` (`radixark/Megatron-LM`) — the source branches it builds — plus a fingerprint of the selected `yueming-yuan/miles-wheels` rolling release, so a rebuilt sgl-router or other wheel also triggers a build (re-uploads to the same tag are caught by fingerprint, not commit SHA). It compares against the values cached from the last build and sets `should_build=true` if any moved. `miles` itself is intentionally not polled — that would rebuild far too often. This is what stops the 12-hour cron from rebuilding an unchanged image, with one staleness bound: because the image also bakes a `miles` checkout, `should_build` is forced to `true` once the last triggered build is **24h** old, so `dev` never drifts more than a day behind the `miles` repo even when sglang / Megatron / wheels are quiet. (The cache file's last line records the epoch of the last triggered build; it is only re-saved when a build fires.)
 - **`build-and-push`** (self-hosted `docker-build` runner) — calls `docker/build.py` to build + push, then conditionally points `latest` at the new `dev` and prunes old timestamped tags.
@@ -138,10 +138,23 @@ Pushes use a Docker Hub credential, not your identity:
 - **Remote (CI)** — the workflow logs in with repo secrets `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN`, so you don't hold the key — you just trigger the run, which needs repo **Write** access. No approval gate, but `build-and-push` runs on a `self-hosted` runner, so it only fires when one is online.
 - **Local** — `build.py --push` uses your own `docker login`; you need push rights to the target namespace (`radixark/miles`, or `rocm/sgl-dev` for ROCm).
 
+## Versioned release build (`release-docker.yml`)
+
+An exact `vX.Y.Z`, `vX.Y.ZrcN`, or `vX.Y.Z.postN` tag push starts this workflow; `release-tag.yml` also dispatches it explicitly because a tag pushed with `GITHUB_TOKEN` does not trigger another workflow. A manual retry accepts `version` and `ref`, which must identify the same immutable tag.
+
+The workflow checks out the release ref, requires its committed `release-lock.json`, and passes the locked SGLang and Megatron-LM commits plus the checked-out Miles SHA to `docker/build.py` as final build-arg overrides. It publishes two official images:
+
+| Variant | Published tag |
+|---|---|
+| `cu13` | `radixark/miles:v<exact-version>` (`linux/amd64` + `linux/arm64`) |
+| `cu12-x86` | `radixark/miles:v<exact-version>-cu12` (`linux/amd64`) |
+
+This workflow does not move or prune any rolling `dev` or `latest` tag. See [Release a Version](/ci/04-release) for the guarded maintainer procedure and manual retry boundary.
+
 ### Pinning specific repo versions
 
-`docker/Dockerfile` already takes `MEGATRON_BRANCH` / `SGLANG_COMMIT` / `MILES_COMMIT` build-args, but `build.py` does not yet forward arbitrary build-args and `workflow_dispatch` exposes no input for them — so commit-pinning from the workflow needs two changes first: a passthrough in `build.py` and matching inputs in `docker-build.yml`.
+`docker/build.py` accepts repeatable `--build-arg KEY=VALUE` options and appends them after variant defaults. `release-docker.yml` uses that ordering to supply `SGLANG_COMMIT`, `MEGATRON_COMMIT`, and `MILES_COMMIT` from the checked-out tag and its `release-lock.json`; the rolling `docker-build.yml` continues to use branch defaults.
 
 ## Image retention (open)
 
-`docker-build.yml` prunes `dev-<timestamp>` and `dev-cu12-<timestamp>` as separate series, keeping the newest 20 of each; `dev` / `latest` and `dev-cu12` / `latest-cu12` move forward. So there is no durable record of which image a past CI run used — reproducing an old run needs retention / immutable tagging, which is a separate, unsolved design.
+`docker-build.yml` prunes `dev-<timestamp>` and `dev-cu12-<timestamp>` as separate series, keeping the newest 20 of each; `dev` / `latest` and `dev-cu12` / `latest-cu12` move forward. Ordinary PR, nightly, and weekly CI therefore has no durable image record. A release branch cut is the exception: it prefers the newest timestamped `dev` image, falls back to mutable `dev` if none exists, retags the result as prune-exempt `release-vX.Y.Z-ci`, and records that tag in `release-lock.json`. The maintainer runbook requires a verified timestamped image before cutting.

--- a/docs/ci/02-docker-build.md
+++ b/docs/ci/02-docker-build.md
@@ -58,7 +58,7 @@ A multi-arch build (`cu13`) needs Buildx's `docker-container` driver and is push
 
 Dockerfile changes are build-tested on the PR itself, before merge — `docker-build.yml` only runs after a push to `main`, so without this breakage lands on `main` first.
 
-When a PR touches `docker/Dockerfile`, `docker/build.py`, `docker/verify_transformer_engine.py`, `docker/patch/**`, or `requirements.txt` (detected by the `docker-paths` job), `pr-test.yml` inserts a build in front of the test matrix:
+When a PR touches `docker/Dockerfile`, `docker/build.py`, `docker/install-kube-tools.sh`, `docker/verify_transformer_engine.py`, `docker/patch/**`, or `requirements.txt` (detected by the `docker-paths` job), `pr-test.yml` inserts a build in front of the test matrix:
 
 | Job | What it does |
 | --- | --- |
@@ -79,14 +79,16 @@ This workflow owns the rolling `dev` and `latest` image families. It has two job
 
 ### Triggers: automatic vs manual
 
-- **Automatic** (no human) — the **schedule** (cron 00:00 / 12:00 UTC, gated by `check-upstream`) and any **push to `main` that touches `docker/Dockerfile`, `docker/verify_transformer_engine.py`, or `requirements.txt`**. Both leave `--variant` empty and build **two images**: `cu13` → `radixark/miles` (multi-arch) and `cu12-x86` → `radixark/miles:dev-cu12`.
+- **Automatic** (no human) — the **schedule** (cron 00:00 / 12:00 UTC, gated by `check-upstream`) and any **push to `main` that touches `docker/Dockerfile`, `docker/install-kube-tools.sh`, `docker/verify_transformer_engine.py`, or `requirements.txt`**. Both leave `--variant` empty and build **two images**: `cu13` → `radixark/miles` (multi-arch) and `cu12-x86` → `radixark/miles:dev-cu12`.
 - **Manual** — `workflow_dispatch` (pick one variant — see Trigger a build yourself below) or running `docker/build.py` locally. Only the `rocm-*` images have **no automatic path** (`cu13-x86` / `cu13-aarch64` just rebuild the same `dev` image single-arch).
+
+`docker/build.py` and `docker/patch/**` participate in PR image validation but are not `main`-push triggers; [Release a Version](/ci/04-release) treats them as manual preflight cases.
 
 
 | Trigger                                     | `check-upstream`                   | builds                | `latest` move     | prune      |
 | ------------------------------------------- | ---------------------------------- | --------------------- | ----------------- | ---------- |
 | schedule (cron 00:00 / 12:00 UTC)           | runs; build if upstream moved or last build ≥ 24h ago | `cu13` + `cu12-x86`   | yes (both)        | yes (both) |
-| push to `main` touching `docker/Dockerfile`, `docker/verify_transformer_engine.py`, or `requirements.txt` | skipped                            | `cu13` + `cu12-x86`   | no                | no         |
+| push to `main` touching `docker/Dockerfile`, `docker/install-kube-tools.sh`, `docker/verify_transformer_engine.py`, or `requirements.txt` | skipped                            | `cu13` + `cu12-x86`   | no                | no         |
 | `workflow_dispatch`                         | skipped                            | the one input variant | no                | no         |
 | `workflow_dispatch` + `simulate_schedule`   | runs                               | the one input variant | no                | no         |
 
@@ -140,21 +142,8 @@ Pushes use a Docker Hub credential, not your identity:
 
 ## Versioned release build (`release-docker.yml`)
 
-An exact `vX.Y.Z`, `vX.Y.ZrcN`, or `vX.Y.Z.postN` tag push starts this workflow; `release-tag.yml` also dispatches it explicitly because a tag pushed with `GITHUB_TOKEN` does not trigger another workflow. A manual retry accepts `version` and `ref`, which must identify the same immutable tag.
-
-The workflow checks out the release ref, requires its committed `release-lock.json`, and passes the locked SGLang and Megatron-LM commits plus the checked-out Miles SHA to `docker/build.py` as final build-arg overrides. It publishes two official images:
-
-| Variant | Published tag |
-|---|---|
-| `cu13` | `radixark/miles:v<exact-version>` (`linux/amd64` + `linux/arm64`) |
-| `cu12-x86` | `radixark/miles:v<exact-version>-cu12` (`linux/amd64`) |
-
-This workflow does not move or prune any rolling `dev` or `latest` tag. See [Release a Version](/ci/04-release) for the guarded maintainer procedure and manual retry boundary.
-
-### Pinning specific repo versions
-
-`docker/build.py` accepts repeatable `--build-arg KEY=VALUE` options and appends them after variant defaults. `release-docker.yml` uses that ordering to supply `SGLANG_COMMIT`, `MEGATRON_COMMIT`, and `MILES_COMMIT` from the checked-out tag and its `release-lock.json`; the rolling `docker-build.yml` continues to use branch defaults.
+`release-docker.yml` checks out the supplied release ref, requires its committed `release-lock.json`, and passes the locked SGLang and Megatron-LM commits plus the checked-out Miles SHA as final `--build-arg` overrides. Rolling `docker-build.yml` keeps the branch defaults. Published tags and the guarded dispatch and retry procedure are documented in [Release a Version](/ci/04-release).
 
 ## Image retention (open)
 
-`docker-build.yml` prunes `dev-<timestamp>` and `dev-cu12-<timestamp>` as separate series, keeping the newest 20 of each; `dev` / `latest` and `dev-cu12` / `latest-cu12` move forward. Ordinary PR, nightly, and weekly CI therefore has no durable image record. A release branch cut is the exception: it prefers the newest timestamped `dev` image, falls back to mutable `dev` if none exists, retags the result as prune-exempt `release-vX.Y.Z-ci`, and records that tag in `release-lock.json`. The maintainer runbook requires a verified timestamped image before cutting.
+`docker-build.yml` prunes `dev-<timestamp>` and `dev-cu12-<timestamp>` as separate series, keeping the newest 20 of each; `dev` / `latest` and `dev-cu12` / `latest-cu12` move forward. Ordinary PR, nightly, and weekly CI therefore has no durable image record. A release branch cut instead retags the newest timestamped `dev` image, or mutable `dev` when none exists, as prune-exempt `release-vX.Y.Z-ci` and records that tag in `release-lock.json`. The guarded preflight is documented in [Release a Version](/ci/04-release).

--- a/docs/ci/03-metric-history-gate.md
+++ b/docs/ci/03-metric-history-gate.md
@@ -204,7 +204,7 @@ Use $neon-access to show the 10 most recent metric-history runs for tests/e2e/me
 
 - A run is `trusted` iff it passed **all** active gates. A drifting run is still recorded, with `trusted = false`, so it can't drag the baseline. A test that fails then passes on **retry** is gated on its passing attempt's metrics and trusted normally — needing a retry is not itself a trust penalty.
 - **Clean a bad point**: `mark_untrusted` = `UPDATE runs SET trusted = false` on the run. The next gate read excludes it immediately — no rebaseline, no row deletion.
-- **Nightly and weekly runs write baselines** — either an explicitly mapped `schedule` cron (on `main`, post-merge) **or** a PR carrying the `nightly` label (the PR's own pre-merge code). Provenance (`event_name`, `pr_number`) records whether a writer was scheduled or PR-triggered, so a label-PR baseline can be `mark_untrusted`'d if it turns out bad. Ordinary (unlabeled) PR runs are read-only and only shadow.
+- **Nightly and weekly runs write baselines** — either an explicitly mapped `schedule` cron (on `main`, post-merge) **or** a PR carrying the `nightly` label (the PR's own pre-merge code). Provenance (`event_name`, `pr_number`) records whether a writer was scheduled or PR-triggered, so a label-PR baseline can be `mark_untrusted`'d if it turns out bad. Ordinary PR runs and explicitly called release runs are read-only and only shadow; frozen release dependency SHAs must not enter the rolling baseline.
 - **What one baseline-writing run writes** — one `runs` row plus one `metric_values` row per value coordinate: two specs sharing a coordinate (identical `steps` + `constraint` literals, differing only in policy metadata) collapse to a single row, so a duplicated declaration cannot double-weight the baseline mean; and a file that declares no gate writes nothing at all — `run_gate_hook` skips the write instead of leaving an empty `runs` row.
 
 
@@ -220,7 +220,7 @@ Shadow-first: collect, store, and evaluate, but **never block a PR** initially �
 **Goal:** record accepted caveats and open questions beside the behavior they qualify; planned-but-unimplemented work lives in TODO below.
 
 - A test-file edit does not reset the series: `test_file_hash` was dropped from the run-series identity because a tiny edit to a test kept wiping its whole history. A test change that genuinely shifts a metric's expected level surfaces as gate failures instead; the reset levers are manual — `mark_untrusted` the stale runs, or edit the declaration literals (new `steps_key` / `constraint_key` ⇒ fresh coordinate).
-- Baseline writing is selected by the resolved CI policy rather than inferred from `GITHUB_EVENT_NAME`; nightly and weekly write, while regular runs stay shadow-only.
+- Baseline writing is selected by the resolved CI policy rather than inferred from `GITHUB_EVENT_NAME`; nightly and weekly write, while regular and release runs stay shadow-only.
 - Open: should a brand-new test's first baselines need human confirmation before counting as trusted? (v1: no.)
 
 

--- a/docs/ci/04-release.md
+++ b/docs/ci/04-release.md
@@ -118,4 +118,3 @@ gh workflow run release-docker.yml -f version="${EXACT_VERSION}" -f ref="v${EXAC
 ```
 
 The current manual interface does not cross-check `version` against `ref`; a mismatch could publish one ref's source under another official version tag.
-

--- a/docs/ci/04-release.md
+++ b/docs/ci/04-release.md
@@ -1,0 +1,121 @@
+---
+title: Release a Version
+description: Cut a versioned Miles release branch, run release CI, tag an exact release, and publish the official Docker images.
+---
+
+This runbook is for maintainers publishing an official Miles version from `radixark/miles`. It covers the supported path from a base-version bump through the two published Docker tags. The version vocabulary and pin ownership live in [Versions and Images](/developer/versions); CI selection details live in [Stage](/ci/00-stage) and [Labels](/ci/01-label).
+
+## Before you start
+
+- Authenticate `gh` to `radixark/miles` with permission to run workflows, push release refs, and open pull requests.
+- Choose a base version `X.Y.Z` and an exact release version. The exact version may be `X.Y.Z`, `X.Y.ZrcN`, or `X.Y.Z.postN`; the release branch and `setup.py` always use the base version.
+- Keep the release branch unchanged from the start of release CI until the tag workflow successfully pushes the tag. The called suite jobs currently check out the branch name independently, so a moving branch can invalidate which SHA the final status represents; the tag workflow also does not prove that a supplied SHA is still the branch tip.
+- Treat `force=true` on the tag workflow as an audited emergency bypass, never as the normal path.
+
+The commands below use deliberately invalid placeholders. Replace them before dispatching anything:
+
+```bash
+BASE_VERSION=X.Y.Z
+EXACT_VERSION=X.Y.Z
+RELEASE_BRANCH="release/v${BASE_VERSION}"
+```
+
+For a release candidate, keep `BASE_VERSION=X.Y.Z` and set `EXACT_VERSION=X.Y.ZrcN`. A post release similarly uses `EXACT_VERSION=X.Y.Z.postN`.
+
+## 1. Merge the base-version bump
+
+Run the helper workflow, or open an equivalent pull request that changes the single `version="..."` assignment in `setup.py`:
+
+```bash
+gh workflow run bot-bump-miles-version.yml -f new_version="${BASE_VERSION}"
+```
+
+Pass only `X.Y.Z` here. `setup.py` and the release branch carry the base version; prerelease and post-release suffixes belong only in `EXACT_VERSION` at tag time.
+
+The workflow opens a PR against `main`. A PR created with `GITHUB_TOKEN` does not trigger `pr-test.yml`; close and reopen that PR once to start normal CI, then merge it. Do not cut the release branch until `main` contains the base version.
+
+## 2. Cut the release branch and run release CI
+
+Before dispatching, follow the image-affecting-change guidance in [Docker build](/ci/02-docker-build) and confirm that the latest successful timestamped CUDA 13 development image contains every required image-layer change. If a required build has not run, dispatch it and wait for success:
+
+```bash
+gh workflow run docker-build.yml -f variant=cu13 -f image_tag=dev
+```
+
+`release-branch-cut.yml` selects the newest `dev-<YYYYMMDDHHMM>` tag and falls back to mutable `dev` if none exists. Stop rather than accepting that fallback.
+
+Dispatch the branch-cut workflow:
+
+```bash
+gh workflow run release-branch-cut.yml -f branch_name="${RELEASE_BRANCH}"
+```
+
+Add `-f commit_sha=FULL_MAIN_SHA` to cut from a specific commit already on `main`; otherwise the workflow uses the checked-out `main` tip. On the first dispatch, it creates `release/vX.Y.Z`, records the SGLang and Megatron-LM commits in `release-lock.json`, retags the preflighted development image as `release-vX.Y.Z-ci`, and commits the lockfile on the release branch. Re-dispatching an existing branch preserves its lockfile and tests its current tip.
+
+While this run is active, do not push or cherry-pick anything onto the release branch. The workflow runs full-scope CUDA, CPU, and ROCm jobs with `cadence=release`, then records a `release-ci` commit status. [Stage](/ci/00-stage) and [Labels](/ci/01-label) own the cadence details; ROCm is a smoke signal because its dependencies remain baked into the image.
+
+After the run is green, resolve the branch tip and copy the first column as `RELEASE_SHA`:
+
+```bash
+git ls-remote https://github.com/radixark/miles.git "refs/heads/${RELEASE_BRANCH}"
+RELEASE_SHA=FULL_RELEASE_SHA
+gh api "repos/radixark/miles/commits/${RELEASE_SHA}/status" --jq '[.statuses[] | select(.context == "release-ci")][0].state'
+```
+
+The final command must print `success`. Keep using this immutable SHA for the tag step.
+
+## 3. Apply a release hotfix, if needed
+
+Fixes land on `main` first. Cherry-pick exactly one merged PR or one commit already reachable from `main`:
+
+```bash
+gh workflow run bot-cherry-pick.yml -f pr_number=PR_NUMBER -f target_branch="${RELEASE_BRANCH}"
+# Or use exactly one commit:
+gh workflow run bot-cherry-pick.yml -f commit_sha=FULL_MAIN_SHA -f target_branch="${RELEASE_BRANCH}"
+```
+
+The workflow rejects commits that touch frozen image-layer files because release CI would still run inside the previously retagged CI image; `requirements.txt` is allowed because CI installs it at runtime and the release build bakes it. If a required fix is rejected for touching an image layer, publish it through a new base-version bump and a fresh branch cut instead of forcing it onto the existing branch.
+
+After every successful cherry-pick, repeat step 2, keep the branch frozen during that run, and replace `RELEASE_SHA` with the newly verified tip. An older green status never authorizes the new commit.
+
+## 4. Tag the verified SHA
+
+Re-read the remote branch tip immediately before dispatch and require it to equal the verified SHA, then dispatch the tag workflow with that immutable SHA:
+
+```bash
+REMOTE_RELEASE_SHA=$(git ls-remote https://github.com/radixark/miles.git "refs/heads/${RELEASE_BRANCH}" | cut -f1)
+if [ "${REMOTE_RELEASE_SHA}" != "${RELEASE_SHA}" ]; then
+  echo "release branch moved; rerun release CI on the new tip" >&2
+  exit 1
+fi
+gh workflow run release-tag.yml -f version="${EXACT_VERSION}" -f ref="${RELEASE_SHA}"
+```
+
+The workflow checks the version grammar, verifies that `setup.py` contains the base version, requires `release-ci=success` on the checked-out SHA, creates annotated tag `v${EXACT_VERSION}`, and explicitly dispatches the Docker release. Passing an immutable SHA fixes the checkout target, but it does not prove that SHA is still the release branch tip. Keep the branch frozen until this workflow succeeds; the comparison above is an operator check because the workflow does not repeat it immediately before pushing the tag.
+
+Do not use `force=true` to bypass missing or failed release CI. If the status is absent, the branch changed or the release run has not finished; rerun step 2 on the final branch tip.
+
+## 5. Verify the published images
+
+`release-docker.yml` builds from `v${EXACT_VERSION}` and publishes:
+
+- `radixark/miles:v${EXACT_VERSION}` for CUDA 13 on `linux/amd64` and `linux/arm64`.
+- `radixark/miles:v${EXACT_VERSION}-cu12` for CUDA 12.9 on `linux/amd64`.
+
+Verify both manifests after the workflow succeeds:
+
+```bash
+docker buildx imagetools inspect "radixark/miles:v${EXACT_VERSION}"
+docker buildx imagetools inspect "radixark/miles:v${EXACT_VERSION}-cu12"
+```
+
+The versioned release does not move `dev`, `dev-cu12`, `latest`, or `latest-cu12`.
+
+If the automatic Docker dispatch must be retried, keep its two manual inputs paired to the same immutable tag:
+
+```bash
+gh workflow run release-docker.yml -f version="${EXACT_VERSION}" -f ref="v${EXACT_VERSION}"
+```
+
+The current manual interface does not cross-check `version` against `ref`; a mismatch could publish one ref's source under another official version tag.
+

--- a/docs/ci/contributor-guide.md
+++ b/docs/ci/contributor-guide.md
@@ -56,7 +56,7 @@ If your file does **not** show up, check, in order:
 - `labels=[]` (or omitted) → **always-on** within the eligible cadence; with the default `nightly=False`, this includes every PR.
 - `labels=["megatron"]` → runs only when the PR carries the GitHub label **`run-ci-megatron`** (the `run-ci-` prefix is added on the PR side). This keeps the heavy GPU matrix off unrelated PRs.
 
-Cadence is independent of labels: `nightly=True` excludes a registration from regular cadence, while nightly and weekly runs include both ordinary and `nightly=True` registrations.
+Cadence is independent of labels: `nightly=True` excludes a registration from regular cadence, while nightly, weekly, and release runs include both ordinary and `nightly=True` registrations.
 
 So if your test is gated and you don't see it run, add the matching `run-ci-<label>` label to your PR. To force the full suite regardless of labels, a maintainer can add `run-ci-all`. Valid labels live in `tests/ci/labels.py`; using one outside that list is a hard error at collection time.
 

--- a/docs/developer/contributor-guide.md
+++ b/docs/developer/contributor-guide.md
@@ -125,7 +125,7 @@ Current sentinels, so you know when you have walked into one:
 |---|---|
 | `.github/workflows/pr-test.yml`, `pr-test-rocm.yml` | `docs/ci/00-stage.md`, `docs/ci/01-label.md` |
 | `.github/workflows/bot-bump-miles-version.yml`, `bot-cherry-pick.yml`, `release-*.yml` | `docs/ci/04-release.md` |
-| `docker/Dockerfile`, `docker/Dockerfile.rocm`, `docker/build.py` | `docs/ci/02-docker-build.md` |
+| `docker/build.py` | `docs/ci/02-docker-build.md` |
 | `tests/ci/metric_history/**` | `docs/ci/03-metric-history-gate.md` |
 
 Grep for `doc-dev:` before editing anything under `.github/workflows/` or `docker/`. A

--- a/docs/developer/contributor-guide.md
+++ b/docs/developer/contributor-guide.md
@@ -124,7 +124,8 @@ Current sentinels, so you know when you have walked into one:
 | File | Governing document |
 |---|---|
 | `.github/workflows/pr-test.yml`, `pr-test-rocm.yml` | `docs/ci/00-stage.md`, `docs/ci/01-label.md` |
-| `docker/build.py` | `docs/ci/02-docker-build.md` |
+| `.github/workflows/bot-bump-miles-version.yml`, `bot-cherry-pick.yml`, `release-*.yml` | `docs/ci/04-release.md` |
+| `docker/Dockerfile`, `docker/Dockerfile.rocm`, `docker/build.py` | `docs/ci/02-docker-build.md` |
 | `tests/ci/metric_history/**` | `docs/ci/03-metric-history-gate.md` |
 
 Grep for `doc-dev:` before editing anything under `.github/workflows/` or `docker/`. A
@@ -161,10 +162,7 @@ register_cuda_ci(
 )
 ```
 
-`register_cpu_ci`, `register_cuda_ci` and `register_rocm_ci` share that signature, plus
-`nightly=True` (nightly and weekly cadence only) and `disabled="<reason + issue link>"` (reported as
-skipped rather than deleted). The calls are parsed from the AST, so they must be
-top-level, literal, and unaliased.
+`register_cpu_ci`, `register_cuda_ci` and `register_rocm_ci` share that signature, plus `nightly=True` (nightly, weekly, and release cadence only) and `disabled="<reason + issue link>"` (reported as skipped rather than deleted). The calls are parsed from the AST, so they must be top-level, literal, and unaliased.
 
 The runner scans `tests/fast`, `tests/fast-gpu`, `tests/e2e` and `tests/ci` for
 `test_*.py`, and a file outside `tests/fast/` with no registration fails collection with

--- a/docs/developer/versions.md
+++ b/docs/developer/versions.md
@@ -1,6 +1,6 @@
 ---
 title: Versions and Images
-description: How the Miles, SGLang, and Megatron-LM trees fit together, what the Docker images pin, and the principle for bumping any of them.
+description: How the Miles, SGLang, and Megatron-LM trees fit together, which artifact owns each release identity, and what the Docker images pin.
 ---
 A Miles run is three Python source trees on one `PYTHONPATH`. Understanding which tree owns
 a given behavior, and which file pins its version, is most of what you need to debug a
@@ -16,17 +16,13 @@ version problem or land a bump.
 
 Two things follow from that table.
 
-**Neither dependency is a released version.** Both are branches that carry patches Miles
-needs before they land upstream, which is why installing stock `sglang` or upstream
-Megatron-LM next to Miles does not work. The Docker image exists to make one coherent
-triplet, not merely to save you a `pip install`.
+**The dependency branches are moving development sources.** Both carry patches Miles needs before they land upstream, which is why installing stock `sglang` or upstream Megatron-LM next to Miles does not work. Ordinary `dev` images follow those branches; a versioned release records their exact commits in `release-lock.json`.
 
 **All three are editable installs.** Nothing is copied into `site-packages`, so changing a
 file in any of the three trees changes the next run. That is also what lets CI move the
 SGLang and Megatron-LM checkouts to a different ref without reinstalling anything.
 
-The `version` in `setup.py` (`0.2.1`) is packaging metadata. Miles is consumed from a
-checkout plus an image tag, not from a version number.
+The `version` in `setup.py` owns the base Miles release version `X.Y.Z`. Release candidates and post releases keep that base in `setup.py` and add `rcN` or `.postN` only to the exact Git and Docker tags.
 
 ## Where each pin is written
 
@@ -34,6 +30,7 @@ checkout plus an image tag, not from a version number.
 docker/Dockerfile     the image recipe and its default build-args
 docker/build.py       the variant table: which build-args each variant overrides
 requirements.txt      Miles' own Python dependencies
+release-lock.json     generated on a release branch: dependency commits, CI image tag, and audit fingerprints
 ```
 
 The default build-args are the version surface:
@@ -43,7 +40,7 @@ The default build-args are the version surface:
 | `SGLANG_IMAGE_TAG` | `v0.5.16` | The `lmsysorg/sglang` base image, which brings torch, CUDA and Transformer Engine |
 | `SGLANG_BRANCH` | `sglang-miles` | The branch fetched into the base image's SGLang checkout |
 | `SGLANG_COMMIT` | empty | Empty means the branch HEAD at build time; set it to freeze one commit |
-| `MEGATRON_REPO` / `MEGATRON_BRANCH` | `radixark/Megatron-LM` / `miles-main` | The Megatron-LM checkout |
+| `MEGATRON_REPO` / `MEGATRON_BRANCH` / `MEGATRON_COMMIT` | `radixark/Megatron-LM` / `miles-main` / empty | The Megatron-LM checkout; an empty commit follows branch HEAD, while a release build supplies the locked commit |
 | `MILES_COMMIT` | `main` | The Miles checkout baked into the image |
 | `ENABLE_CUDA_13` | `1` | CUDA 13 plus the Mooncake structured-object-store wheel; `0` selects the CUDA 12.9 path |
 | `WHEELS_REPO` | `yueming-yuan/miles-wheels` | The prebuilt-wheels repository |
@@ -66,6 +63,22 @@ carries its reason inline**: `transformers==5.12.1` names the HF-native weight c
 an SGLang collision, `blake3` / `xxhash` / `zstandard` name the disk-delta weight sync,
 `onnxscript` records that TE 2.17 imports it at import time. Follow that when you add one.
 
+## Release identities and source ownership
+
+Release values represent different facts. Each row below names the canonical source that workflows derive or consume.
+
+| Fact | Authoritative source | Derived or consumed values |
+|---|---|---|
+| Base Miles version | `setup.py` | Release branch `release/vX.Y.Z`; base-version check before tagging |
+| Exact published version | Annotated Git tag `v<exact-version>` | CUDA image tags `v<exact-version>` and `v<exact-version>-cu12` |
+| Frozen dependency selection | `release-lock.json` committed on the release branch | SGLang commit, Megatron-LM commit, and the CUDA image tag used by release CI |
+
+For example, base version `0.3.0` owns branch `release/v0.3.0`; that branch can produce exact tags `v0.3.0rc0`, `v0.3.0`, and `v0.3.0.post1` without changing `setup.py` between tags.
+
+`release-lock.json` freezes the two dependency source commits and names the prune-exempt CUDA image used by release CI. Miles itself is frozen by the release commit and final Git tag. Wheels asset fingerprints are audit records, not content-addressed inputs.
+
+Use [Release a Version](/ci/04-release) for the maintainer procedure. That runbook owns workflow order, inputs, success signals, and recovery; this page owns the identity and pinning model.
+
 ## The images
 
 CUDA variants are published to [`radixark/miles`](https://hub.docker.com/r/radixark/miles)
@@ -81,10 +94,7 @@ fleet's image is.
 | `cu12-x86` | `radixark/miles:dev-cu12` | `linux/amd64`, CUDA 12.9 legacy |
 | `rocm-mi300` / `rocm-mi350` | `rocm/sgl-dev:miles-rocm7xx-mi3xx` | Native |
 
-Every build also pushes a timestamped sibling (`dev-<YYYYMMDDHHMM>`), which is what you pin
-to when you need a frozen image. Only the scheduled build advances `latest` and prunes old
-timestamped tags, keeping the newest 20 per series; a manual dispatch writes its own tag and
-never moves `latest`.
+`--image-tag dev` also publishes a timestamped sibling. Scheduled retention and manual tag behavior are documented in [Docker build](/ci/02-docker-build).
 
 Build one yourself with `docker/build.py`:
 
@@ -95,6 +105,8 @@ python docker/build.py --variant cu13-x86 --image-tag custom --custom-tag my-exp
 [Docker build](/ci/02-docker-build) is the full reference for the build script, the
 workflow and the tag rules.
 
+Official versioned releases add `radixark/miles:v<exact-version>` for the CUDA 13 multi-arch image and `radixark/miles:v<exact-version>-cu12` for the CUDA 12.9 image. Publishing them does not move the rolling `dev` or `latest` families.
+
 ## What CI moves, and what it does not
 
 This is the part that decides whether your change needs a new image. A CUDA CI job starts
@@ -104,8 +116,7 @@ from `radixark/miles:<tag>` and then:
    restore is not cosmetic: TE's fused attention needs a newer cuDNN than torch pins, a
    plain resolve drags it back down, and the symptom is a fused-attention backward failing
    with `CUDNN_STATUS_BAD_PARAM`.
-2. Resets both dependency checkouts and fetches the selected refs, defaulting to
-   `sglang-miles` and `miles-main`.
+2. Resets both dependency checkouts and fetches the selected refs. Explicit dispatch or PR-body overrides win first, `release-lock.json` commits win when no override exists, and the moving `sglang-miles` / `miles-main` heads are the final defaults.
 3. Sets `PYTHONPATH` to the Miles workspace plus both source roots.
 
 It never reinstalls the three source trees, because they are editable installs. So:
@@ -117,8 +128,7 @@ It never reinstalls the three source trees, because they are editable installs. 
 | SGLang or Megatron-LM code | No. Point CI at a ref instead |
 | Miles code | No |
 
-The ROCm stage is the exception: it takes SGLang and Megatron-LM from `rocm/sgl-dev` and
-exposes no ref inputs, so the only way to move them there is a new ROCm image.
+The ROCm stage is the exception: it takes SGLang and Megatron-LM from `rocm/sgl-dev` and exposes no dependency-ref inputs, so the only way to move them there is a new ROCm image. A release call can select the Miles ref, but its baked dependencies still make the run a smoke signal rather than a lock-accurate check.
 
 ## Bumping principle
 
@@ -127,9 +137,7 @@ exposes no ref inputs, so the only way to move them there is a new ROCm image.
 moves in `docker/build.py`. If a bump needs edits in two of the three, one of them is in the
 wrong place.
 
-**Prefer moving the branch to pinning a commit.** `SGLANG_COMMIT` is empty by default, so
-the image follows `sglang-miles` HEAD and the pair advances together. Pin a commit only to
-freeze a known-good state deliberately, and expect to unpin it.
+**Prefer moving the branch to pinning a commit during rolling development.** `SGLANG_COMMIT` and `MEGATRON_COMMIT` are empty by default, so ordinary images follow `sglang-miles` and `miles-main` together. A versioned release is the deliberate exception: its lockfile supplies both exact commits to CI and the final image build.
 
 **Validate an image-affecting bump on the PR that makes it.** A PR touching
 `docker/Dockerfile`, `docker/build.py`, `docker/verify_transformer_engine.py`,
@@ -169,11 +177,12 @@ that to stop moving underneath you, pin `ci-image-tag:` to a timestamped tag.
 | Build fails with "TE patch did not apply cleanly" | A `docker/patch/cu13/*.patch` no longer matches the new TE; rebase the patch or drop it if upstream fixed it |
 | TE triplet assertion at build time | The base image moved TE off `2.17.0`; update `docker/verify_transformer_engine.py` together with whatever depends on it |
 | `mooncake.structured_object_store` import fails | A CUDA 12 image; that wheel is only installed on the cu13 path |
-| A test passes locally but fails in CI, or the reverse | Compare the three refs: the image tag, and the two branch heads CI resolved. Every job logs all three |
+| A test passes locally but fails in CI, or the reverse | Compare the image tag and the two dependency refs or commits CI resolved. Every job logs all three |
 
 ## Related
 
 - [Installation](/getting-started/installation) for pulling and running the image.
+- [Release a Version](/ci/04-release) for the maintainer release runbook.
 - [Contributing](/developer/contributor-guide) for the CI labels and PR-description
   directives.
 - [Docker build](/ci/02-docker-build) for the build script, workflow triggers and tag

--- a/docs/developer/versions.md
+++ b/docs/developer/versions.md
@@ -65,12 +65,12 @@ an SGLang collision, `blake3` / `xxhash` / `zstandard` name the disk-delta weigh
 
 ## Release identities and source ownership
 
-Release values represent different facts. Each row below names the canonical source that workflows derive or consume.
+Release values represent different facts. Each row below names the source used by the supported automatic path.
 
 | Fact | Authoritative source | Derived or consumed values |
 |---|---|---|
 | Base Miles version | `setup.py` | Release branch `release/vX.Y.Z`; base-version check before tagging |
-| Exact published version | Annotated Git tag `v<exact-version>` | CUDA image tags `v<exact-version>` and `v<exact-version>-cu12` |
+| Exact published version | `version` input to `release-tag.yml`, persisted as annotated Git tag `v<exact-version>` | CUDA image tags `v<exact-version>` and `v<exact-version>-cu12` |
 | Frozen dependency selection | `release-lock.json` committed on the release branch | SGLang commit, Megatron-LM commit, and the CUDA image tag used by release CI |
 
 For example, base version `0.3.0` owns branch `release/v0.3.0`; that branch can produce exact tags `v0.3.0rc0`, `v0.3.0`, and `v0.3.0.post1` without changing `setup.py` between tags.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -267,7 +267,8 @@
        "ci/00-stage",
        "ci/01-label",
        "ci/02-docker-build",
-       "ci/03-metric-history-gate"
+       "ci/03-metric-history-gate",
+       "ci/04-release"
       ]
      }
     ]


### PR DESCRIPTION
## Summary

Document the maintainer release workflow introduced by PR #2538.

## Motivation

PR #2538 adds branch-cut, release-CI, tagging, and image-publishing interfaces, but their governing documentation did not evolve with them. Maintainers otherwise have to infer version/ref pairing and recovery gates from workflow YAML, while future edits can silently drift from the supported release path.

## Usage

Maintainers follow `docs/ci/04-release.md` from the base-version bump through image verification, using the checked release SHA for tagging:

```bash
gh workflow run release-tag.yml -f version="${EXACT_VERSION}" -f ref="${RELEASE_SHA}"
```

## Design Notes

- `docs/ci/04-release.md` owns workflow order, operator inputs, success signals, safety checks, and recovery.
- `docs/developer/versions.md` retains release identity ownership instead of duplicating that contract in the runbook.
- `docs/ci/00-stage.md` through `03-metric-history-gate.md` retain CI behavior ownership instead of duplicating those contracts in the runbook.
- Five public release workflows carry `doc-dev: docs/ci/04-release.md`; internal release helpers remain implementation details.
- Known workflow validation gaps remain code-review findings; this documentation supplies the safe supported procedure without changing release behavior.

## Verification

- `pre-commit run --files <release-doc surface>`: all applicable hooks passed.
- `python3 scripts/tools/sync_example_docs.py --check`: exited 0.
- Workflow YAML and `docs/docs.json` parsing: passed.
- `pytest -q tests/ci/test/test_run_suite.py`: 83 passed.

## Review Focus

- `docs/ci/04-release.md`: verify every command, success signal, and recovery path against the five bound workflows.
- Documentation ownership: confirm operator procedure appears once while version, CI, Docker, cadence, and baseline details remain in their canonical pages.
