### PR TITLE
release: bump miles version to 0.1.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ class bdist_wheel(_bdist_wheel):
 setup(
     author="miles Team",
     name="miles",
-    version="0.2.1",
+    version="0.1.0",
     packages=find_packages(include=["miles*", "miles_plugins*"]),
     include_package_data=True,
     package_data={"miles.dashboard": ["static/*"]},


### PR DESCRIPTION
Release step ① for the first miles release, v0.1.0.

Resets `setup.py`'s version line from 0.2.1 → 0.1.0: the 0.2.x numbering was inherited from slime and nothing was ever published under it as miles, so there is no ordering conflict — v0.1.0 starts the miles version line.

After this merges: `release-branch-cut.yml` (branch `release/v0.1.0`, lockfile freeze + full CI) → `release-tag.yml` (v0.1.0, gated on the `release-ci` commit status) → images `radixark/miles:v0.1.0` / `v0.1.0-cu12`. The tag gate verifies setup.py carries 0.1.0, which is what this PR provides.