### PR TITLE
fix: use wandb.sdk.lib.runid.generate_id for the wandb group suffix

### DIFF
--- a/miles/utils/tracking_utils/wandb_utils.py
+++ b/miles/utils/tracking_utils/wandb_utils.py
@@ -3,6 +3,7 @@ import os
 from copy import deepcopy
 
 import wandb
+from wandb.sdk.lib.runid import generate_id
 
 from miles.utils.env_report import decode_env_report
 
@@ -49,7 +50,7 @@ def init_wandb_primary(args):
     # Prepare wandb init parameters
     # add random 6 length string with characters
     if args.wandb_random_suffix:
-        group = args.wandb_group + "_" + wandb.util.generate_id()
+        group = args.wandb_group + "_" + generate_id()
         run_name = f"{group}-RANK_{args.rank}"
     else:
         group = args.wandb_group


### PR DESCRIPTION
## What this fixes

Every run launched with `--use-wandb` currently crashes during startup on recent wandb builds:

```
AttributeError: module 'wandb.util' has no attribute 'generate_id'
  miles/utils/tracking_utils/wandb_utils.py:52
```

`wandb` no longer exposes `wandb.util.generate_id`. The helper still exists at
`wandb.sdk.lib.runid.generate_id`, so this switches the import to that path.

## Why it matters

The crash happens inside `init_tracking`, **before any model or checkpoint is loaded**, so the
Ray job dies within a minute and the surrounding `CalledProcessError` makes it look like a
launcher or argument problem rather than a dependency mismatch.

It fires whenever `args.wandb_random_suffix` is set, which is the default path for the
`examples/` launchers — so in practice it blocks every wandb-tracked training run on an image
that has picked up a newer wandb.

`wandb` is not pinned: it appears in `pyproject.toml` only inside isort's `known_third_party`
and has no `uv.lock` entry, so nothing currently constrains which version an image installs.

## Verification

Reproduced and then fixed on a live 8x H200 run (GLM-4.7-Flash agentic RL). Before the change
the job died at init; after it, wandb initialised normally and the run trained.

Checked on the image that hit this (wandb 0.28.2):

```
wandb version: 0.28.2
has wandb.util.generate_id: False
signature: (length: int = 8) -> str
source module: wandb.sdk.lib.runid
samples: ['by6yph4n', 'd4agqavq', 'zs1fezg8'] len: [8, 8, 8]
charset ok: True
unique: 2000
```

Same `(length: int = 8) -> str` signature and same 8-character alphanumeric output as the old
helper, so group naming is unchanged. 2000/2000 generated ids were unique.

`grep` confirms this was the only `wandb.util` reference in the repository, so there is no
other call site to migrate. `black` (line-length 119) and `isort` (repo settings) both pass.

## Follow-up worth considering (not in this PR)

Adding an explicit `wandb` pin to `pyproject.toml` / `uv.lock` would stop the next base-image
rebuild from reintroducing a break like this. That is a separate decision about which version
to pin, so I have left it out rather than bundle it here.
