### PR TITLE
Install tmux into the training image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -41,7 +41,7 @@ WORKDIR /root/
 
 RUN apt update
 # ethtool for network diagnostics
-RUN apt install -y nvtop rsync dnsutils ethtool
+RUN apt install -y nvtop rsync dnsutils ethtool tmux
 
 # nccl-tests for diagnostics
 RUN git clone https://github.com/NVIDIA/nccl-tests.git /tmp/nccl-tests && \


### PR DESCRIPTION
A run that outlives its ssh session needs a multiplexer to come back to, and the image ships none, so every long training or debugging session on a devbox starts by apt-installing one by hand.

One word on one `apt install` line. Split out of the deliver-2 chain (#2542) so it can land on its own — it is the only change there that touches `docker/`, and its presence forces a full multi-arch image rebuild on every push to that chain.