### PR TITLE
rollout: defer image decoding, and optionally hand the engine paths

### DIFF
--- a/miles/rollout/sglang_rollout.py
+++ b/miles/rollout/sglang_rollout.py
@@ -150,11 +150,33 @@ async def generate(args: Namespace, sample: Sample, sampling_params: dict[str, A
         sample.status == Sample.Status.PENDING or sample.status == Sample.Status.ABORTED
     ), f"Sample status is {sample.status}"
 
+    # Resolve media the dataset deferred. This is the only place the decoded
+    # images are needed -- here for the processor, and below for the payload --
+    # so they are built now and become garbage when this call returns, rather
+    # than being held for the life of the run.
+    deferred_refs = (sample.metadata or {}).get("_deferred_media_refs")
+    _media_key = None
+    if state.processor and deferred_refs and not sample.multimodal_inputs:
+        from miles.utils.processing_utils import (
+            deferred_media_cache_key,
+            resolve_deferred_media,
+        )
+
+        _media_key = deferred_media_cache_key(deferred_refs)
+        sample.multimodal_inputs = resolve_deferred_media(deferred_refs, state.processor)
+
     if state.processor and (
         isinstance(sample.prompt, (list, tuple))
         or (sample.multimodal_inputs and any(v is not None for v in sample.multimodal_inputs.values()))
     ):
-        processor_output = call_processor(state.processor, sample.prompt, sample.multimodal_inputs)
+        if _media_key is not None:
+            from miles.utils.processing_utils import call_processor_cached
+
+            processor_output = call_processor_cached(
+                state.processor, sample.prompt, sample.multimodal_inputs, _media_key
+            )
+        else:
+            processor_output = call_processor(state.processor, sample.prompt, sample.multimodal_inputs)
         prompt_ids = processor_output["input_ids"][0]
         prompt_ids = prompt_ids.tolist() if hasattr(prompt_ids, "tolist") else list(prompt_ids)
         sample.multimodal_train_inputs = extract_multimodal_train_inputs(processor_output)
@@ -204,7 +226,24 @@ async def generate(args: Namespace, sample: Sample, sampling_params: dict[str, A
     if getattr(args, "use_rollout_indexer_replay", False):
         payload["return_indexer_topk"] = True
 
-    if sample.multimodal_inputs and sample.multimodal_inputs["images"]:
+    if deferred_refs and deferred_refs.get("image"):
+        if getattr(args, "rollout_media_payload_paths", False):
+            # The engine sees the dataset's filesystem, so hand it the paths.
+            # Re-encoding the decoded PIL back to PNG costs ~84 ms per page on
+            # the same asyncio thread that submits requests, and inflates each
+            # request to megabytes of base64. The engine applies the identical
+            # smart_resize to whatever it receives, so the pixels reaching the
+            # model are the same either way.
+            payload["image_data"] = list(deferred_refs["image"])
+        else:
+            payload["image_data"] = [
+                encode_image_for_rollout_engine(image) for image in sample.multimodal_inputs["images"]
+            ]
+        # Tensors are what training consumes from here; the images are
+        # reproducible from the refs, so drop the reference to them rather than
+        # let deepcopy duplicate them once per sample in the group.
+        sample.multimodal_inputs = None
+    elif sample.multimodal_inputs and sample.multimodal_inputs["images"]:
         image_data = sample.multimodal_inputs["images"]
         payload["image_data"] = [encode_image_for_rollout_engine(image) for image in image_data]
 

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -736,6 +736,18 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 ),
             )
             parser.add_argument(
+                "--rollout-media-payload-paths",
+                action="store_true",
+                default=False,
+                help=(
+                    "Send local image paths to the rollout engine in image_data instead of re-encoding "
+                    "decoded media to base64. Skips a per-page PNG encode on the request path and shrinks "
+                    "each request from megabytes to bytes. Requires every rollout engine to be able to "
+                    "open the dataset's media paths, i.e. colocated engines or a filesystem shared with "
+                    "the dataset."
+                ),
+            )
+            parser.add_argument(
                 "--custom-rollout-log-function-path",
                 type=str,
                 default=None,

--- a/miles/utils/data.py
+++ b/miles/utils/data.py
@@ -230,12 +230,24 @@ class Dataset:
                 output_prompt = prompt
 
             if processor:
-                from miles.utils.processing_utils import process_vision_info
+                from miles.utils.processing_utils import (
+                    extract_deferrable_media_refs,
+                    process_vision_info,
+                )
 
                 assert isinstance(
                     prompt, list
                 ), f"prompt must be a list when processor is not None, got {type(prompt)} instead"
-                multimodal_inputs = process_vision_info(prompt, processor)
+                # When every image is a reopenable reference, keep the reference
+                # and let generate() resolve it. No window or eviction policy is
+                # needed here: reopening is just Image.open. Anything else is
+                # decoded now, so inline base64 / URLs behave exactly as before.
+                refs = extract_deferrable_media_refs(prompt, processor)
+                if refs is not None:
+                    metadata = {**metadata, "_deferred_media_refs": refs}
+                    multimodal_inputs = None
+                else:
+                    multimodal_inputs = process_vision_info(prompt, processor)
             else:
                 multimodal_inputs = None
 

--- a/miles/utils/processing_utils.py
+++ b/miles/utils/processing_utils.py
@@ -3,6 +3,8 @@ import inspect
 import io
 import logging
 import os
+import threading
+from collections import OrderedDict
 from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
@@ -180,6 +182,130 @@ def process_vision_info(prompt, processor):
     images, videos = qwen_process_vision_info(prompt, image_patch_size=image_patch_size)
     multimodal_inputs = {"images": images, "videos": videos}
     return multimodal_inputs
+
+
+_DEFERRED_MEDIA_CACHE: "OrderedDict[tuple, dict]" = OrderedDict()
+_DEFERRED_MEDIA_CACHE_MAX = int(os.getenv("MILES_MEDIA_CACHE_ENTRIES", "16"))
+_DEFERRED_MEDIA_LOCK = threading.Lock()
+
+
+def extract_deferrable_media_refs(prompt, processor) -> dict | None:
+    """Return {media_type: [ref, ...]} when every media item is cheap to reopen.
+
+    "Cheap" means a local file: `file://...` or a bare path, which can be
+    resolved at use time for the price of an Image.open. Decoding when the
+    Dataset is built instead costs memory proportional to the corpus -- a decoded
+    RGB page is ~5.75 MB, so a 51k-page dataset pins ~295 GB for the whole run --
+    even though the result is only read inside sglang_rollout.generate(), for one
+    sample, and is dead afterwards.
+
+    Inline base64 and remote URLs are NOT cheap to re-resolve, so this returns
+    None for them and the caller decodes eagerly, exactly as before. The same
+    bail-out covers a processor with its own ``extract_media`` (it may consume
+    modalities or context this function does not model) and any content part
+    type other than text/image/video, so anything this function cannot
+    faithfully re-resolve takes the eager path unchanged. Returns None rather
+    than {} when there is no media, so the caller can distinguish "defer this"
+    from "nothing to defer".
+    """
+    if not isinstance(prompt, list):
+        return None
+    if hasattr(processor, "extract_media"):
+        return None
+    refs: dict[str, list] = {}
+    found = False
+    for message in prompt:
+        content = message.get("content") if isinstance(message, dict) else None
+        if not isinstance(content, list):
+            continue
+        for part in content:
+            if not isinstance(part, dict):
+                continue
+            kind = part.get("type")
+            if kind == "text":
+                continue
+            if kind not in ("image", "video"):
+                # image_url, audio, anything unknown: not modelled here, so do
+                # not defer -- a partial refs dict would silently drop media.
+                return None
+            value = part.get(kind)
+            found = True
+            if not isinstance(value, str):
+                return None
+            # A data: URI carries the bytes inline, so "re-resolving" one means
+            # holding the whole payload anyway. It also contains no "://", so it
+            # must be rejected before the bare-path test below.
+            if value.startswith("data:"):
+                return None
+            if not (value.startswith("file://") or "://" not in value):
+                return None
+            refs.setdefault(kind, []).append(value)
+    return refs if found else None
+
+
+def deferred_media_cache_key(refs: dict) -> tuple:
+    """Hashable identity for a set of refs -- the same paths mean the same media."""
+    return tuple((kind, tuple(items)) for kind, items in sorted(refs.items()))
+
+
+def resolve_deferred_media(refs: dict, processor) -> dict:
+    """Turn refs back into media, reusing the result across a GRPO group.
+
+    Rebuilds the minimal conversation process_vision_info expects, so the output
+    is identical to what the eager path would have produced: same fetch_image,
+    same to_rgb, same smart_resize.
+
+    The n samples of a group are deepcopies of one prompt and therefore share
+    refs, so without the cache this decodes the same pages n times. Entries are
+    evicted oldest-first and only groups in flight can hit, so a handful suffices.
+    """
+    key = deferred_media_cache_key(refs)
+    with _DEFERRED_MEDIA_LOCK:
+        hit = _DEFERRED_MEDIA_CACHE.get(key)
+        if hit is not None:
+            _DEFERRED_MEDIA_CACHE.move_to_end(key)
+            return hit
+
+    content = [{"type": kind, kind: ref} for kind, items in refs.items() for ref in items]
+    resolved = process_vision_info([{"role": "user", "content": content}], processor)
+
+    with _DEFERRED_MEDIA_LOCK:
+        _DEFERRED_MEDIA_CACHE[key] = resolved
+        _DEFERRED_MEDIA_CACHE.move_to_end(key)
+        while len(_DEFERRED_MEDIA_CACHE) > _DEFERRED_MEDIA_CACHE_MAX:
+            _DEFERRED_MEDIA_CACHE.popitem(last=False)
+    return resolved
+
+
+_PROCESSOR_OUTPUT_CACHE: "OrderedDict[tuple, object]" = OrderedDict()
+_PROCESSOR_OUTPUT_LOCK = threading.Lock()
+
+
+def call_processor_cached(processor, text, multimodal_inputs, cache_key):
+    """call_processor, memoised on (prompt text, media identity).
+
+    pixel_values depends only on the prompt and the images, and every sample in a
+    GRPO group has both identical -- so this runs once per group instead of once
+    per sample. That removes the redundant processor passes and, because the
+    result is shared, shrinks what Ray has to serialise to the trainer by the
+    same factor (measured: ~23 GB -> ~2.9 GB per step, a 24s stall in
+    torch._legacy_save).
+    """
+    key = (text if isinstance(text, str) else str(text), cache_key)
+    with _PROCESSOR_OUTPUT_LOCK:
+        hit = _PROCESSOR_OUTPUT_CACHE.get(key)
+        if hit is not None:
+            _PROCESSOR_OUTPUT_CACHE.move_to_end(key)
+            return hit
+
+    out = call_processor(processor, text, multimodal_inputs)
+
+    with _PROCESSOR_OUTPUT_LOCK:
+        _PROCESSOR_OUTPUT_CACHE[key] = out
+        _PROCESSOR_OUTPUT_CACHE.move_to_end(key)
+        while len(_PROCESSOR_OUTPUT_CACHE) > _DEFERRED_MEDIA_CACHE_MAX:
+            _PROCESSOR_OUTPUT_CACHE.popitem(last=False)
+    return out
 
 
 def encode_image_for_rollout_engine(image) -> str:

--- a/tests/fast/utils/test_deferred_media.py
+++ b/tests/fast/utils/test_deferred_media.py
@@ -1,0 +1,114 @@
+from tests.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=20, suite="stage-a-cpu", labels=[])
+
+from types import SimpleNamespace
+
+from PIL import Image
+
+from miles.utils.processing_utils import (
+    call_processor_cached,
+    deferred_media_cache_key,
+    extract_deferrable_media_refs,
+    resolve_deferred_media,
+)
+
+
+class _QwenStyleProcessor:
+    """No extract_media, patch-size image_processor: takes the qwen_vl_utils path."""
+
+    image_processor = SimpleNamespace(patch_size=14)
+
+
+def _prompt_with(*parts):
+    return [{"role": "user", "content": list(parts)}]
+
+
+def _image_part(value):
+    return {"type": "image", "image": value}
+
+
+def test_defers_local_paths_and_file_uris():
+    prompt = _prompt_with(
+        {"type": "text", "text": "describe"},
+        _image_part("/data/page_1.png"),
+        _image_part("file:///data/page_2.png"),
+    )
+    refs = extract_deferrable_media_refs(prompt, _QwenStyleProcessor())
+    assert refs == {"image": ["/data/page_1.png", "file:///data/page_2.png"]}
+
+
+def test_no_media_returns_none_not_empty_dict():
+    prompt = _prompt_with({"type": "text", "text": "just text"})
+    assert extract_deferrable_media_refs(prompt, _QwenStyleProcessor()) is None
+    assert extract_deferrable_media_refs("a plain string prompt", _QwenStyleProcessor()) is None
+
+
+def test_inline_and_remote_media_decode_eagerly():
+    for value in (
+        "data:image/png;base64,iVBORw0KGgo=",
+        "https://example.com/page.png",
+        Image.new("RGB", (4, 4)),  # already-decoded object, nothing to reopen
+    ):
+        prompt = _prompt_with(_image_part(value))
+        assert extract_deferrable_media_refs(prompt, _QwenStyleProcessor()) is None
+
+
+def test_unmodelled_part_types_decode_eagerly():
+    # A partial refs dict would silently drop the unmodelled media, so any
+    # image_url / audio / unknown part must send the whole prompt eager.
+    for part in (
+        {"type": "image_url", "image_url": {"url": "https://example.com/x.png"}},
+        {"type": "audio", "audio": "/data/clip.wav"},
+    ):
+        prompt = _prompt_with(_image_part("/data/page_1.png"), part)
+        assert extract_deferrable_media_refs(prompt, _QwenStyleProcessor()) is None
+
+
+def test_extract_media_processor_decodes_eagerly():
+    class _ExtractMediaProcessor:
+        def extract_media(self, prompt):
+            raise AssertionError("must not be reached from the extractor")
+
+    prompt = _prompt_with(_image_part("/data/page_1.png"))
+    assert extract_deferrable_media_refs(prompt, _ExtractMediaProcessor()) is None
+
+
+def test_resolve_matches_eager_output_and_caches_per_media_identity(tmp_path):
+    from miles.utils.processing_utils import process_vision_info
+
+    path = tmp_path / "page.png"
+    Image.new("RGB", (64, 64), color=(200, 10, 10)).save(path)
+
+    prompt = _prompt_with({"type": "text", "text": "describe"}, _image_part(str(path)))
+    processor = _QwenStyleProcessor()
+    refs = extract_deferrable_media_refs(prompt, processor)
+
+    resolved = resolve_deferred_media(refs, processor)
+    eager = process_vision_info(prompt, processor)
+    assert len(resolved["images"]) == len(eager["images"]) == 1
+    assert resolved["images"][0].size == eager["images"][0].size
+
+    # The n samples of a GRPO group share refs; the resolve must be shared too.
+    assert resolve_deferred_media(refs, processor) is resolved
+    assert resolve_deferred_media(dict(refs), processor) is resolved
+
+
+def test_call_processor_cached_runs_once_per_group():
+    calls = []
+
+    def processor(text, **kwargs):
+        calls.append(text)
+        return {"input_ids": [[1, 2, 3]], "pixel_values": object()}
+
+    refs = {"image": ["/data/page_1.png"]}
+    key = deferred_media_cache_key(refs)
+    inputs = {"images": [object()]}
+
+    first = call_processor_cached(processor, "prompt-text", inputs, key)
+    second = call_processor_cached(processor, "prompt-text", inputs, key)
+    assert first is second
+    assert len(calls) == 1
+
+    call_processor_cached(processor, "other-prompt", inputs, key)
+    assert len(calls) == 2


### PR DESCRIPTION
## Motivation

`Dataset` decodes every image at construction time and keeps the decoded PIL alive for the whole run, even though the result is only read inside `sglang_rollout.generate()`, for one sample, and is dead afterwards. Memory cost is proportional to the corpus: a decoded RGB page is ~5.75 MB, so a 51k-page multimodal dataset pins ~295 GB for the run. On top of that, every sample of a GRPO group deepcopies the images, runs its own processor pass, and re-encodes the same pages to base64 per request.

## What this does

- **Defer decoding to use time.** When every media part in a prompt is a local file (`file://...` or a bare path), the dataset stores the refs and `generate()` resolves them where they are needed — once for the processor, once for the payload — after which they become garbage.
- **Share work across a GRPO group.** The n samples of a group are deepcopies of one prompt, so the media resolve and the processor pass are memoised on the media identity and run once per group instead of once per sample. Sharing the processor output also shrinks what Ray serialises to the trainer by the same factor (measured on the workload above: ~23 GB → ~2.9 GB per step, removing a 24 s stall in `torch._legacy_save`).
- **Optionally skip base64 entirely.** With `--rollout-media-payload-paths` (default off), deferred samples put the file paths in `image_data` instead of re-encoding decoded PIL to PNG (~84 ms/page on the same asyncio thread that submits requests, megabytes per request). The engine applies the identical `smart_resize` either way, so the pixels reaching the model are unchanged. Off by default because it requires every rollout engine to be able to open the dataset's media paths (colocated engines or a shared filesystem).

## Behaviour is unchanged for everything else

The deferred path is taken only when it can be re-resolved faithfully. All of these decode eagerly, exactly as before:

- inline base64 (`data:` URIs) and remote URLs
- already-decoded media objects
- processors with their own `extract_media`
- any content part type this code does not model (`image_url`, `audio`, unknown) — a partial refs dict would silently drop media, so the whole prompt goes eager

## Testing

- New `tests/fast/utils/test_deferred_media.py` covers the defer/eager decision table, resolve-vs-eager output equivalence, and the once-per-group caching for both the media resolve and the processor pass.
- `tests/fast/utils/test_processing_utils.py`, `tests/fast/utils/test_arguments.py`, `tests/fast/utils/test_lora_arguments.py`, `tests/fast/rollout/generate_hub` all pass locally (268 passed, 17 skipped).
- Trained with this on a 2-node Megatron+SGLang LoRA run over a 51k-page image-only dataset (Qwen3.6-35B-A3B); rollout/training numbers above are from that workload.