### PR TITLE
r3: bind routing replay to live MoE routers, not list position

### DIFF
--- a/miles/backends/megatron_utils/replay_utils.py
+++ b/miles/backends/megatron_utils/replay_utils.py
@@ -2,6 +2,26 @@ from megatron.core.transformer.transformer_block import get_num_layers_to_build
 from megatron.core.transformer.transformer_layer import get_transformer_layer_offset
 
 
+def _live_moe_replays(models):
+    """Replay buffers of the MoE routers that are actually part of ``models``.
+
+    ``register_to_module`` appends to the manager's global replay list at router
+    construction time, so a router that is built and then discarded still leaves
+    its replay behind (e.g. a model provider that rebuilds the decoder after
+    ``GPTModel.__init__`` has already built one). Filling by list position then
+    lands recorded streams on dead routers while every live router keeps an
+    empty buffer, which surfaces later as ``pop_forward out of range`` in the
+    middle of the first forward. Binding by module identity keeps each stream on
+    the router that will actually run.
+    """
+    return [
+        replay
+        for model in models
+        for _, module in model.named_modules()
+        if (replay := getattr(module, "routing_replay", None)) is not None
+    ]
+
+
 def register_replay_list_moe(replay_list, replay_data, *, models, **_kwargs):
     """Map replay streams to Megatron MoE layers using the local model layout."""
     layer_indices = []
@@ -19,6 +39,10 @@ def register_replay_list_moe(replay_list, replay_data, *, models, **_kwargs):
                     continue
             layer_indices.append(layer_id)
 
-    for replay_idx, layer_idx in enumerate(layer_indices):
-        layer_data = replay_data[:, layer_idx]
-        replay_list[replay_idx].record(layer_data)
+    replays = _live_moe_replays(models)
+    assert len(replays) == len(layer_indices), (
+        f"routing replay: {len(replays)} live MoE routers on this rank but "
+        f"{len(layer_indices)} replay streams to fill"
+    )
+    for replay, layer_idx in zip(replays, layer_indices, strict=True):
+        replay.record(replay_data[:, layer_idx])


### PR DESCRIPTION
## Motivation

`register_replay_list_moe` fills replay buffers by list position: stream *i* of the recorded rollout routing lands on entry *i* of the manager's global replay list. That list is appended to at router construction time, so the pairing is really "construction order == layer order". In this tree the invariant currently holds — MTP routers skip registration (`is_mtp_layer` in the Megatron fork) and the critic keeps the manager disabled — but nothing enforces it, and when it breaks it breaks silently.

We hit exactly that downstream with a VL model provider that rebuilds the decoder after `GPTModel.__init__` has already built one: every recorded stream landed on the discarded decoder's routers, every live router kept an empty buffer, and the first `compute_log_prob` of step 0 raised

```
IndexError: pop_forward out of range: forward_index=0, len(top_indices_list)=0
```

with nothing pointing at the registration site.

## What this does

Walk the live module tree and record into the routers that will actually run (`module.routing_replay`, the attribute `register_to_module` installs). The stream-to-layer mapping is unchanged; only the objects it lands on are. A count assert makes any future mismatch fail at fill time with both numbers, instead of surfacing as an empty buffer mid-forward.

## Testing

- `tests/fast/utils/test_replay_base.py` passes.
- Verified downstream on Qwen3.6-35B-A3B (LoRA + EP8, 8xH200): two consecutive steps with `train_rollout_kl` 7.2e-4 / 7.6e-4 and `ess_ratio` 1.0, i.e. the replayed routing reproduces the rollout engine's routing both before and after a weight update.