### PR TITLE
lora: refresh optimizer main params after restoring an adapter

### DIFF
--- a/miles/backends/megatron_utils/lora_utils.py
+++ b/miles/backends/megatron_utils/lora_utils.py
@@ -573,6 +573,15 @@ def load_lora_adapter(
                     loaded += 1
         logger.info(f"Loaded {loaded} adapter tensors from Megatron-native checkpoint: {native_path}")
 
+        if optimizer is not None:
+            # The copies above changed the parameters outside the optimizer. With a
+            # main-params optimizer (fp16/bf16, precision-aware) the fp32 masters
+            # were built from the randomly initialised adapter, and the first step()
+            # writes those stale masters back over the weights just restored.
+            # Refresh them; when a training_state file is present the state restore
+            # below overwrites the masters again, so the call is correct either way.
+            optimizer.reload_model_params()
+
         iteration = _load_training_state(adapter_dir, optimizer, opt_param_scheduler)
         return True, iteration
 


### PR DESCRIPTION
## Motivation

`load_lora_adapter` restores the adapter by writing straight into `param.data`, which changes the parameters outside the optimizer. With a main-params optimizer (fp16/bf16, and anything precision-aware) the fp32 masters were built when the optimizer was constructed — from the randomly initialised adapter — and are never told about the load.

When a `training_state_rank*.pt` is restored alongside, `optimizer.load_state_dict` repairs the masters. On an **adapter-only restore** — no training-state file, or a rank layout that no longer matches the per-rank files — nothing does. The first optimizer step then writes the stale masters back over the restored adapter, the weight sync pushes that to the rollout engine, and the next rollout dies with

```
Assertion `probability tensor contains either `inf`, `nan` or element < 0` failed
CUDA error: device-side assert triggered
```

one rollout after the first training step, on every such resume. The signature is visible before the crash: `train_rollout_kl` ~3x a fresh run's on the first step (2.26e-3 vs 7.4e-4, reproducible to three significant figures across two runs) while `grad_norm` stays small — the gradients are fine, the damage is the master overwrite. Fresh runs are unaffected because masters and model start from the same initialisation.

## What this does

Call `optimizer.reload_model_params()` right after the adapter copies. Megatron documents it as "call whenever the parameters are changed outside of the optimizer", and `_load_checkpoint_hf` already does exactly this after loading HF weights; the LoRA path simply omitted it. When training state is present, the state restore that follows overwrites the masters again, so the call is correct in both paths. (`miles_plugins/models/inkling` already carries the identical call for its own adapter-load path — this brings the generic path in line.)

## Testing

- `tests/fast/backends/megatron_utils/test_lora_utils.py`, `test_lora_checkpoint_helpers.py`, `tests/fast/utils/test_lora_arguments.py` pass locally (87 passed).
- Root-caused and verified downstream on Qwen3.6-35B-A3B LoRA resumes: with the refresh, resume-from-adapter runs match fresh-run `train_rollout_kl` and no longer hit the sampler assert.
