### PR TITLE
feat(session): return 410 for a session the trainer already reclaimed

### DIFF
--- a/miles/rollout/session/core.py
+++ b/miles/rollout/session/core.py
@@ -18,9 +18,9 @@ from starlette.responses import Response
 from miles.rollout.generate_utils.sample_utils import merge_samples
 from miles.rollout.session.errors import (
     MessageValidationError,
-    SessionNotFoundError,
     TokenizationError,
     UpstreamResponseError,
+    reclaimed_error,
 )
 from miles.rollout.session.linear_trajectory import SessionRegistry
 from miles.rollout.session.samples.codec import encode_samples
@@ -342,7 +342,7 @@ class SessionCore:
     async def delete_session(self, session_id: str) -> Response:
         session = self.registry.get_session(session_id)
         if session.closing:
-            raise SessionNotFoundError(f"session not found: session_id={session_id}")
+            raise reclaimed_error(session_id)
         session.closing = True
         # Acquire the lock so an in-flight chat finishes before we drop the session.
         await session.lock.acquire()
@@ -365,12 +365,12 @@ class SessionCore:
         request_timestamp = time.time()
         session = self.registry.get_session(session_id)
         if session.closing:
-            raise SessionNotFoundError(f"session not found: session_id={session_id}")
+            raise reclaimed_error(session_id)
 
         # --- Phase 1: prepare request (lock held briefly) ---
         async with session.lock:
             if session.closing:
-                raise SessionNotFoundError(f"session not found: session_id={session_id}")
+                raise reclaimed_error(session_id)
 
             request_body, client_stream, tito_tokenizer = prepare_chat_request(
                 body, self.args, self.registry.tito_tokenizer

--- a/miles/rollout/session/errors.py
+++ b/miles/rollout/session/errors.py
@@ -4,6 +4,7 @@ Hierarchy
 ---------
 SessionError (base)
 ├── SessionNotFoundError       → 404  session does not exist
+├── SessionReclaimedError      → 410  session existed and was released by the trainer
 ├── MessageValidationError     → 400  messages structure/content invalid
 ├── TruncatedGenerationError   → 409  extending a length-truncated generation (v2)
 ├── TokenizationError          → 500  TITO tokenizer / prefix mismatch
@@ -21,6 +22,32 @@ class SessionNotFoundError(SessionError):
     """Raised when the requested session ID does not exist."""
 
     status_code: int = 404
+
+
+class SessionReclaimedError(SessionError):
+    """Raised when the session existed but the trainer already released it.
+
+    This is the "your run was abandoned" signal, distinct from the 404 a
+    never-existent session ID gets. It happens when the trainer stops waiting
+    for an agent -- for example the agent-server call exceeded
+    ``AGENT_TRIAL_TIMEOUT`` -- collects whatever samples exist and deletes the
+    session, while the agent is still running and still issuing requests.
+
+    410 rather than 404 so the caller can tell "the trainer moved on without
+    me" apart from a genuine bad-ID bug or a model-side fault; both otherwise
+    surface through OpenAI-compatible clients as an indistinguishable
+    NotFoundError.
+    """
+
+    status_code: int = 410
+
+
+def reclaimed_error(session_id: str) -> SessionReclaimedError:
+    """Build the canonical "the trainer moved on without you" error."""
+    return SessionReclaimedError(
+        f"session reclaimed: session_id={session_id} "
+        "(the trainer released this session and is no longer waiting for the agent)"
+    )
 
 
 class MessageValidationError(SessionError):

--- a/miles/rollout/session/linear_trajectory.py
+++ b/miles/rollout/session/linear_trajectory.py
@@ -1,10 +1,17 @@
 import asyncio
 import logging
+import time
 import uuid
+from collections import OrderedDict
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, NoReturn
 
-from miles.rollout.session.errors import MessageValidationError, SessionNotFoundError, TokenizationError
+from miles.rollout.session.errors import (
+    MessageValidationError,
+    SessionNotFoundError,
+    TokenizationError,
+    reclaimed_error,
+)
 from miles.rollout.session.types import SessionRecord
 from miles.utils.chat_template_utils.message_matcher_hub import (
     SessionMessageMatcher,
@@ -19,6 +26,13 @@ logger = logging.getLogger(__name__)
 # TODO: hardcoded to 1 for now; if multi-step rollback is actually needed,
 #  raise this limit or make it configurable and remove the restriction.
 MAX_ASSISTANT_ROLLBACK_STEPS = 1
+
+# How long a deleted session ID keeps answering 410 instead of 404, and how many
+# such IDs are retained. An abandoned agent only needs to survive long enough to
+# make one more request and read the reason, so this is deliberately short and
+# bounded -- it is a diagnostic breadcrumb, not a record of the run.
+RECLAIMED_TOMBSTONE_TTL_S = 3600.0
+RECLAIMED_TOMBSTONE_MAX = 4096
 
 
 def assert_pretokenized_prefix(
@@ -303,6 +317,8 @@ class SessionRegistry:
         message_matcher: SessionMessageMatcher | None = None,
     ):
         self.sessions: dict[str, LinearTrajectory] = {}
+        # session_id -> monotonic timestamp of the delete that reclaimed it.
+        self._reclaimed: OrderedDict[str, float] = OrderedDict()
         self.args = args
         self.tokenizer = tokenizer
         self.tito_tokenizer = tito_tokenizer
@@ -319,12 +335,45 @@ class SessionRegistry:
     def get_session(self, session_id: str) -> LinearTrajectory:
         session = self.sessions.get(session_id)
         if session is None:
-            raise SessionNotFoundError(f"session not found: session_id={session_id}")
+            self.raise_for_missing(session_id)
         return session
 
     def remove_session(self, session_id: str) -> None:
         if self.sessions.pop(session_id, None) is None:
-            raise SessionNotFoundError(f"session not found: session_id={session_id}")
+            self.raise_for_missing(session_id)
+        self._note_reclaimed(session_id)
+
+    def raise_for_missing(self, session_id: str) -> NoReturn:
+        """Raise the error that explains why ``session_id`` is not serviceable.
+
+        A session the trainer deleted gets 410 rather than 404 so an agent that
+        outlived its trainer-side deadline can tell it was abandoned, instead of
+        seeing the same NotFoundError a bogus ID would produce.
+        """
+        if self._was_reclaimed(session_id):
+            raise reclaimed_error(session_id)
+        raise SessionNotFoundError(f"session not found: session_id={session_id}")
+
+    def _note_reclaimed(self, session_id: str) -> None:
+        now = time.monotonic()
+        self._reclaimed[session_id] = now
+        self._reclaimed.move_to_end(session_id)
+        # Timestamps only increase, so the oldest entry is always leftmost.
+        cutoff = now - RECLAIMED_TOMBSTONE_TTL_S
+        while self._reclaimed:
+            _, stamp = next(iter(self._reclaimed.items()))
+            if stamp >= cutoff and len(self._reclaimed) <= RECLAIMED_TOMBSTONE_MAX:
+                break
+            self._reclaimed.popitem(last=False)
+
+    def _was_reclaimed(self, session_id: str) -> bool:
+        stamp = self._reclaimed.get(session_id)
+        if stamp is None:
+            return False
+        if time.monotonic() - stamp > RECLAIMED_TOMBSTONE_TTL_S:
+            del self._reclaimed[session_id]
+            return False
+        return True
 
     def compute_session_mismatch(self, session: LinearTrajectory) -> list[dict] | None:
         """Compare accumulated token IDs against canonical chat template output.

--- a/miles/rollout/session/v2/core.py
+++ b/miles/rollout/session/v2/core.py
@@ -15,7 +15,7 @@ from miles.rollout.session.core import (
     prepare_chat_request,
     proxy_result_to_response,
 )
-from miles.rollout.session.errors import SessionNotFoundError, TokenizationError
+from miles.rollout.session.errors import TokenizationError, reclaimed_error
 from miles.rollout.session.samples.codec import COMPUTED_FIELDS_V2, encode_samples
 from miles.rollout.session.types import GetSessionResponse, SessionRecord
 from miles.rollout.session.v2.session_state import (
@@ -139,12 +139,12 @@ class SessionCoreV2(SessionCore):
         request_timestamp = time.time()
         session = self.registry.get_session(session_id)
         if session.closing:
-            raise SessionNotFoundError(f"session not found: session_id={session_id}")
+            raise reclaimed_error(session_id)
 
         # --- Phase 1: prepare request (lock held briefly) ---
         async with session.lock:
             if session.closing:
-                raise SessionNotFoundError(f"session not found: session_id={session_id}")
+                raise reclaimed_error(session_id)
 
             request_body, client_stream, tito_tokenizer = prepare_chat_request(
                 body, self.args, self.registry.tito_tokenizer

--- a/tests/fast/router/test_linear_trajectory.py
+++ b/tests/fast/router/test_linear_trajectory.py
@@ -4,6 +4,7 @@ Tests the session registry CRUD and the trajectory pretokenized state management
 logic in isolation (no HTTP server, no real tokenizer).
 """
 
+import time
 from dataclasses import dataclass
 from types import SimpleNamespace
 from typing import Any
@@ -11,7 +12,13 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from miles.rollout.session.errors import MessageValidationError, SessionNotFoundError, TokenizationError
+from miles.rollout.session import linear_trajectory
+from miles.rollout.session.errors import (
+    MessageValidationError,
+    SessionNotFoundError,
+    SessionReclaimedError,
+    TokenizationError,
+)
 from miles.rollout.session.linear_trajectory import SessionRegistry
 from miles.rollout.session.types import SessionRecord
 from miles.utils.chat_template_utils.tito_tokenizer import ALL_APPEND_ROLES, FixedTemplate, TITOTokenizer
@@ -117,7 +124,8 @@ class TestSessionCRUD:
         session_id = registry.create_session()
         registry.remove_session(session_id)  # no raise = success
         assert session_id not in registry.sessions
-        with pytest.raises(SessionNotFoundError):
+        # Reclaimed, not unknown: the ID did exist, so it gets 410 not 404.
+        with pytest.raises(SessionReclaimedError):
             registry.remove_session(session_id)
 
     def test_append_record(self, registry: SessionRegistry):
@@ -140,6 +148,59 @@ class TestSessionCRUD:
     def test_append_record_missing_session(self, registry: SessionRegistry):
         with pytest.raises(SessionNotFoundError):
             registry.get_session("missing")
+
+
+class TestReclaimedSessions:
+    """A deleted session answers 410 for a while, so an agent that outlived its
+    trainer-side deadline learns it was abandoned instead of getting the same
+    404 a bogus ID produces."""
+
+    def test_get_after_remove_is_reclaimed(self, registry: SessionRegistry):
+        session_id = registry.create_session()
+        registry.remove_session(session_id)
+        with pytest.raises(SessionReclaimedError, match="session reclaimed"):
+            registry.get_session(session_id)
+
+    def test_unknown_id_is_still_not_found(self, registry: SessionRegistry):
+        with pytest.raises(SessionNotFoundError, match="session not found"):
+            registry.get_session("never-existed")
+
+    def test_status_codes_are_distinguishable(self, registry: SessionRegistry):
+        assert SessionNotFoundError.status_code == 404
+        assert SessionReclaimedError.status_code == 410
+        # Siblings, not parent/child: catching one must not swallow the other.
+        assert not issubclass(SessionReclaimedError, SessionNotFoundError)
+        assert not issubclass(SessionNotFoundError, SessionReclaimedError)
+
+    def test_tombstone_expires_back_to_not_found(self, registry: SessionRegistry, monkeypatch):
+        session_id = registry.create_session()
+        registry.remove_session(session_id)
+
+        now = time.monotonic() + linear_trajectory.RECLAIMED_TOMBSTONE_TTL_S + 1.0
+        monkeypatch.setattr(linear_trajectory.time, "monotonic", lambda: now)
+
+        with pytest.raises(SessionNotFoundError):
+            registry.get_session(session_id)
+        # The expired entry is dropped rather than left to accumulate.
+        assert session_id not in registry._reclaimed
+
+    def test_tombstones_are_bounded(self, registry: SessionRegistry, monkeypatch):
+        monkeypatch.setattr(linear_trajectory, "RECLAIMED_TOMBSTONE_MAX", 4)
+
+        removed = []
+        for _ in range(10):
+            session_id = registry.create_session()
+            registry.remove_session(session_id)
+            removed.append(session_id)
+
+        assert len(registry._reclaimed) == 4
+        # Newest survive as 410; the evicted oldest degrade to 404, never leak.
+        for session_id in removed[-4:]:
+            with pytest.raises(SessionReclaimedError):
+                registry.get_session(session_id)
+        for session_id in removed[:-4]:
+            with pytest.raises(SessionNotFoundError):
+                registry.get_session(session_id)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/fast/router/test_session_state.py
+++ b/tests/fast/router/test_session_state.py
@@ -11,7 +11,12 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from miles.rollout.session.errors import MessageValidationError, SessionNotFoundError, TokenizationError
+from miles.rollout.session.errors import (
+    MessageValidationError,
+    SessionNotFoundError,
+    SessionReclaimedError,
+    TokenizationError,
+)
 from miles.rollout.session.types import SessionRecord
 from miles.rollout.session.v2.session_state import (
     SessionRegistryV2,
@@ -141,7 +146,8 @@ class TestSessionCRUD:
         session_id = registry.create_session()
         registry.remove_session(session_id)  # no raise = success
         assert session_id not in registry.sessions
-        with pytest.raises(SessionNotFoundError):
+        # V2 inherits the v1 registry's reclaimed-session bookkeeping.
+        with pytest.raises(SessionReclaimedError):
             registry.remove_session(session_id)
 
     def test_committed_generation_carries_its_record(self, registry: SessionRegistryV2):

--- a/tests/fast/router/test_sessions.py
+++ b/tests/fast/router/test_sessions.py
@@ -130,7 +130,37 @@ class TestSessionRoutes:
         assert delete_resp.status_code == 204
         assert delete_resp.text == ""
 
-        assert requests.delete(f"{router_env.url}/sessions/{session_id}", timeout=5.0).status_code == 404
+        # Deleted, not unknown: 410 Gone so an agent still running against this
+        # session can tell it was abandoned rather than mistyped.
+        second = requests.delete(f"{router_env.url}/sessions/{session_id}", timeout=5.0)
+        assert second.status_code == 410
+        assert "session reclaimed" in second.json()["error"]
+
+    def test_chat_after_delete_reports_reclaimed(self, router_env):
+        """The bug this guards: a trial outliving its trainer-side deadline used
+        to get a bare 404, indistinguishable from a bad ID or a model fault."""
+        session_id = requests.post(f"{router_env.url}/sessions", timeout=5.0).json()["session_id"]
+        assert requests.delete(f"{router_env.url}/sessions/{session_id}", timeout=5.0).status_code == 204
+
+        response = requests.post(
+            f"{router_env.url}/sessions/{session_id}/v1/chat/completions",
+            json={"model": "test", "messages": [{"role": "user", "content": "hi"}]},
+            timeout=5.0,
+        )
+        assert response.status_code == 410
+        assert response.json()["error"] == (
+            f"session reclaimed: session_id={session_id} "
+            "(the trainer released this session and is no longer waiting for the agent)"
+        )
+
+    def test_chat_on_unknown_session_still_404(self, router_env):
+        """Never-existed IDs keep 404; only reclaimed ones become 410."""
+        response = requests.post(
+            f"{router_env.url}/sessions/nonexistent/v1/chat/completions",
+            json={"model": "test", "messages": [{"role": "user", "content": "hi"}]},
+            timeout=5.0,
+        )
+        assert response.status_code == 404
 
     def test_delete_session_not_found(self, router_env):
         response = requests.delete(f"{router_env.url}/sessions/nonexistent", timeout=5.0)


### PR DESCRIPTION
## What this changes

A session the trainer has deleted currently answers `404`, exactly like a session ID that
never existed. Through an OpenAI-compatible client both arrive as an indistinguishable
`NotFoundError`.

This adds a bounded, short-lived record of reclaimed session IDs and answers **`410 Gone`**
for them, with a message saying the trainer released the session. Unknown IDs keep their
`404`, so the two cases stay distinguishable.

## Why

The two cases really do both happen, and telling them apart matters.

When the trainer stops waiting for an agent — for example the agent-server call exceeds
`AGENT_TRIAL_TIMEOUT` — `agentic_tool_call.generate` runs `collect_samples` in its `finally`,
and that deletes the session. But `asyncio.wait_for` only cancels the *local* request; the
agent server is never told, so the agent can still be running and still issuing requests.
Every one of those then `404`s.

On a long agentic RL run this produced a sustained ~18% of trials failing with a generic
`NotFoundError` that was reported as a plain agent error — indistinguishable from a bad ID
or a model-side fault. Working out that these were abandoned sessions rather than genuine
agent failures took reconstructing the HTTP access log by hand. A distinct status code makes
that a one-line grep, and lets the agent side classify the outcome as infrastructure
abandonment instead of a model failure.

This is a diagnosability change only. It does **not** fix the underlying race — the trainer
still reclaims sessions out from under live agents, and there is still no per-trial
cancellation. It makes that failure legible so it can be measured and attributed.

## Scope note

`SessionRegistryV2` subclasses `SessionRegistry` and inherits `get_session` / `remove_session`,
so v1 and v2 both pick this up from a single change point.

The tombstone is capped at 4096 IDs and one hour. It only has to outlive an abandoned agent's
next request, so it is a diagnostic breadcrumb rather than a record of the run, and it cannot
grow without bound. Expired entries are dropped on lookup and evicted oldest-first on insert.

## Wire-contract change — please weigh this

Two responses change status code:

- a chat/samples/get request against a **deleted** session: `404` -> `410`
- a second `DELETE` of an already-deleted session: `404` -> `410`

A request against a never-existent ID is unchanged at `404`. `SessionReclaimedError` is a
sibling of `SessionNotFoundError`, not a subclass, so catching one will not swallow the other;
nothing in the tree catches `SessionNotFoundError` today (the only consumer is the
`SessionError` base handler, which reads `status_code`), so this is contained.

Three existing tests encoded the old behaviour and are updated accordingly.

## Verification

Executed, not just read — on a machine with the full runtime:

- `tests/fast/router/test_linear_trajectory.py` + `test_session_state.py` — **101 passed**
- `tests/fast/router/test_sessions.py` — **29 passed** (this is the HTTP-level suite, so the
  `410` and its body are asserted over the real wire, including that an unknown ID still
  returns `404`)
- `black` (line-length 119) and `isort` (repo settings) clean on all seven touched files

New tests cover: reclaimed vs unknown discrimination, both status codes, the sibling-not-subclass
relationship, TTL expiry falling back to `404` without leaking the entry, and bounded eviction
where the oldest tombstones degrade to `404`.
