### PR TITLE
fix: skip rollout construction for debug replay

### DIFF
--- a/miles/ray/actor_group.py
+++ b/miles/ray/actor_group.py
@@ -121,7 +121,7 @@ class RayTrainGroup:
         if self.args.debug_train_only or self.args.debug_rollout_only:
             return
 
-        if self.args.use_fault_tolerance:
+        if self.args.use_fault_tolerance and "rollout" in self.args.ft_components:
             await self.rollout_manager.recover_updatable_engines.remote()
 
         info = await self.rollout_manager.get_updatable_engines_and_lock.remote()

--- a/miles/ray/rollout/eval_fleet.py
+++ b/miles/ray/rollout/eval_fleet.py
@@ -24,6 +24,7 @@ class EvalFleet:
     def __init__(self, args: Namespace, *, srv):
         self.args = args
         self._srv = srv
+        self._rollout_ft_enabled = args.use_fault_tolerance and "rollout" in args.ft_components
         self._state = GenerateState(self._fleet_args())
 
     async def pin(self, checkpoint_dir: str, weight_version: str) -> GenerateState:
@@ -32,7 +33,7 @@ class EvalFleet:
         On the manager's event loop: keep everything here awaiting rather than blocking.
         """
         try:
-            if not self.args.use_fault_tolerance:
+            if not self._rollout_ft_enabled:
                 # Otherwise RolloutHealthMonitor owns the probing for these engines.
                 await self._srv.probe_and_mark_dead()
             await self._srv.recover()

--- a/miles/ray/rollout/rollout_manager.py
+++ b/miles/ray/rollout/rollout_manager.py
@@ -71,14 +71,18 @@ class RolloutManager:
 
         self.use_legacy_rollout_v1 = use_legacy_rollout_v1()
         if not self.use_legacy_rollout_v1:
-            input = RolloutFnConstructorInput(args=args, data_source=self.data_source)
-            self.generate_rollout = load_rollout_function(input, self.args.rollout_function_path)
-            if self.args.eval_function_path == self.args.rollout_function_path:
-                # Reuse the instance so train and eval share one state (and stateful
-                # rollout fns like FullyAsyncRolloutFn are not constructed twice).
-                self.eval_generate_rollout = self.generate_rollout
+            if self.args.load_debug_rollout_data is not None:
+                self.generate_rollout = None
+                self.eval_generate_rollout = None
             else:
-                self.eval_generate_rollout = load_rollout_function(input, self.args.eval_function_path)
+                input = RolloutFnConstructorInput(args=args, data_source=self.data_source)
+                self.generate_rollout = load_rollout_function(input, self.args.rollout_function_path)
+                if self.args.eval_function_path == self.args.rollout_function_path:
+                    # Reuse the instance so train and eval share one state (and stateful
+                    # rollout fns like FullyAsyncRolloutFn are not constructed twice).
+                    self.eval_generate_rollout = self.generate_rollout
+                else:
+                    self.eval_generate_rollout = load_rollout_function(input, self.args.eval_function_path)
         else:
             self.generate_rollout = load_function(self.args.rollout_function_path)
             self.eval_generate_rollout = load_function(self.args.eval_function_path)
@@ -88,8 +92,9 @@ class RolloutManager:
         self.custom_convert_samples_to_train_data_func = None
         if (x := self.args.custom_convert_samples_to_train_data_path) is not None:
             self.custom_convert_samples_to_train_data_func = load_function(x)
-        logger.info(f"import {self.args.rollout_function_path} as generate_rollout function.")
-        logger.info(f"import {self.args.eval_function_path} as eval_generate_rollout function.")
+        if self.generate_rollout is not None:
+            logger.info(f"import {self.args.rollout_function_path} as generate_rollout function.")
+            logger.info(f"import {self.args.eval_function_path} as eval_generate_rollout function.")
 
         if self.args.debug_train_only:
             self.servers: dict[str, RolloutServer] = {}
@@ -234,7 +239,7 @@ class RolloutManager:
         log_eval_skip(rollout_id, self.args, reason)
 
     async def _get_rollout_data(self, rollout_id):
-        if self.args.load_debug_rollout_data:
+        if self.args.load_debug_rollout_data is not None:
             data, metadata = load_debug_rollout_data(self.args, rollout_id=rollout_id)
             metrics = None
         else:

--- a/miles/ray/rollout/rollout_manager.py
+++ b/miles/ray/rollout/rollout_manager.py
@@ -112,13 +112,15 @@ class RolloutManager:
 
         # TODO will be replaced by full ft, thus temporarily leave it without modifications
         self._health_monitors = []
-        if not self.args.debug_train_only and self.args.use_fault_tolerance:
+        self._rollout_ft_enabled = self.args.use_fault_tolerance and "rollout" in self.args.ft_components
+        self._ci_fault_injection_pending = False
+        if not self.args.debug_train_only and self._rollout_ft_enabled:
             for srv in self.servers.values():
                 for group in srv.server_groups:
                     monitor = RolloutHealthMonitor(group, args)
                     monitor.start()
                     self._health_monitors.append(monitor)
-            self._ci_fault_injection_pending = self.args.ci_test and "rollout" in self.args.ft_components
+            self._ci_fault_injection_pending = self.args.ci_test
 
     # -------------------------- lifecycle -----------------------------
     # TODO: may have a `async def init` here later
@@ -143,7 +145,7 @@ class RolloutManager:
         start_time = time.time()
         self.rollout_id = rollout_id
         self._health_monitoring_resume()
-        if self.args.ci_test and self.args.use_fault_tolerance and rollout_id >= 2:
+        if self.args.ci_test and self._rollout_ft_enabled and rollout_id >= 2:
             self._try_ci_fault_injection()
         dashboard_hooks.register_engines(self.servers)
         if (get_buffer_length := getattr(self.data_source, "get_buffer_length", None)) is not None:

--- a/tests/fast/ray/rollout/real_ray/test_rollout_manager.py
+++ b/tests/fast/ray/rollout/real_ray/test_rollout_manager.py
@@ -138,6 +138,57 @@ async def _assert_engine_dies(actor_handle, *, deadline_s: float = 15.0, poll_in
 
 @pytest.mark.asyncio
 class TestRolloutManagerInit:
+    async def test_debug_rollout_replay_skips_class_based_rollout_construction(
+        self,
+        ray_local_mode,
+        tmp_path,
+        patch_low_level,
+        monkeypatch,
+    ):
+        import miles.ray.rollout.rollout_manager as rmgr
+
+        args = _make_test_args(tmp_path, models=[("actor", True)])
+        args.debug_train_only = True
+        args.load_debug_rollout_data = str(tmp_path / "rollout-{rollout_id}.pt")
+        args.rollout_num_gpus = None
+        monkeypatch.delenv("MILES_USE_LEGACY_ROLLOUT_V1", raising=False)
+
+        def fail_if_loaded(*args, **kwargs):
+            pytest.fail("debug rollout replay must not construct rollout functions")
+
+        monkeypatch.setattr(rmgr, "load_rollout_function", fail_if_loaded)
+
+        manager = _make_manager(args, pg=None)
+
+        assert manager.generate_rollout is None
+        assert manager.eval_generate_rollout is None
+
+    async def test_debug_train_only_without_replay_constructs_rollout_function(
+        self,
+        ray_local_mode,
+        tmp_path,
+        patch_low_level,
+        monkeypatch,
+    ):
+        import miles.ray.rollout.rollout_manager as rmgr
+
+        args = _make_test_args(tmp_path, models=[("actor", True)])
+        args.debug_train_only = True
+        monkeypatch.delenv("MILES_USE_LEGACY_ROLLOUT_V1", raising=False)
+        loaded_paths: list[str] = []
+
+        def record_load(input, path):
+            loaded_paths.append(path)
+            return lambda *args, **kwargs: None
+
+        monkeypatch.setattr(rmgr, "load_rollout_function", record_load)
+
+        manager = _make_manager(args, pg=None)
+
+        assert loaded_paths == [args.rollout_function_path, args.eval_function_path]
+        assert manager.generate_rollout is not None
+        assert manager.eval_generate_rollout is not None
+
     async def test_init_creates_live_mock_engines_via_real_start_rollout_servers(
         self,
         ray_local_mode,

--- a/tests/fast/ray/rollout/real_ray/test_rollout_manager.py
+++ b/tests/fast/ray/rollout/real_ray/test_rollout_manager.py
@@ -138,6 +138,52 @@ async def _assert_engine_dies(actor_handle, *, deadline_s: float = 15.0, poll_in
 
 @pytest.mark.asyncio
 class TestRolloutManagerInit:
+    @pytest.mark.parametrize(
+        ("ft_components", "expected_monitor_count", "expected_injection_pending"),
+        [
+            (["train"], 0, False),
+            (["rollout"], 1, True),
+        ],
+    )
+    async def test_rollout_ft_lifecycle_follows_selected_component(
+        self,
+        ray_local_mode,
+        placement_group_factory,
+        tmp_path,
+        patch_low_level,
+        monkeypatch,
+        ft_components,
+        expected_monitor_count,
+        expected_injection_pending,
+    ):
+        import miles.ray.rollout.rollout_manager as rmgr
+
+        started_monitors = []
+
+        class FakeMonitor:
+            def __init__(self, group, args):
+                self.group = group
+
+            def start(self):
+                started_monitors.append(self)
+
+            def stop(self):
+                pass
+
+        monkeypatch.setattr(rmgr, "RolloutHealthMonitor", FakeMonitor)
+        args = _make_test_args(tmp_path, models=[("actor", True)])
+        args.use_fault_tolerance = True
+        args.ft_components = ft_components
+        args.ci_test = True
+        args.ci_metric_checker_key = None
+        pg = placement_group_factory(2)
+
+        manager = _make_manager(args, pg)
+
+        assert len(started_monitors) == expected_monitor_count
+        assert len(manager._health_monitors) == expected_monitor_count
+        assert manager._ci_fault_injection_pending is expected_injection_pending
+
     async def test_debug_rollout_replay_skips_class_based_rollout_construction(
         self,
         ray_local_mode,

--- a/tests/fast/ray/rollout/test_eval_fleet.py
+++ b/tests/fast/ray/rollout/test_eval_fleet.py
@@ -18,6 +18,7 @@ def make_args(**overrides):
         eval_num_gpus=1,
         eval_num_gpus_per_engine=1,
         use_fault_tolerance=False,
+        ft_components=[],
         sglang_model_routers={"default": ("10.0.0.1", 30000), "eval": ("10.0.0.2", 31000)},
     )
     defaults.update(overrides)
@@ -160,12 +161,22 @@ async def test_fleet_recovers_before_pinning(fleet_env):
 
 
 async def test_fleet_leaves_probing_to_the_health_monitor(fleet_env):
-    """With --use-fault-tolerance a RolloutHealthMonitor already probes these engines."""
-    fleet = make_fleet(make_args(use_fault_tolerance=True), [FakeEngine([])])
+    """Rollout FT leaves probing to the RolloutHealthMonitor."""
+    fleet = make_fleet(make_args(use_fault_tolerance=True, ft_components=["rollout"]), [FakeEngine([])])
 
     await fleet.pin("/snap/step_5", "5")
 
     assert fleet._srv.probe_calls == 0
+    assert fleet._srv.recover_calls == 1
+
+
+async def test_fleet_probes_with_train_only_fault_tolerance(fleet_env):
+    """Train-only FT has no RolloutHealthMonitor, so the fleet must probe itself."""
+    fleet = make_fleet(make_args(use_fault_tolerance=True, ft_components=["train"]), [FakeEngine([])])
+
+    await fleet.pin("/snap/step_5", "5")
+
+    assert fleet._srv.probe_calls == 1
     assert fleet._srv.recover_calls == 1
 
 

--- a/tests/fast/ray/test_actor_group_shared_ppo.py
+++ b/tests/fast/ray/test_actor_group_shared_ppo.py
@@ -17,6 +17,21 @@ class _Handle:
         self.train = _RemoteTrain(rank, calls)
 
 
+class _RemoteCall:
+    def __init__(self, name, calls, result=None):
+        self.name = name
+        self.calls = calls
+        self.result = result
+
+    def remote(self, *args, **kwargs):
+        self.calls.append((self.name, args, kwargs))
+
+        async def result():
+            return self.result
+
+        return result()
+
+
 async def test_train_routes_each_critic_payload_to_matching_actor_rank():
     from miles.ray.actor_group import RayTrainGroup
 
@@ -59,3 +74,30 @@ async def test_train_rejects_wrong_number_of_rank_payloads():
 
     with pytest.raises(ValueError, match="one payload per train worker"):
         await group.train(5, {"data_ref": "rollout"}, external_data=[{"values": []}])
+
+
+async def test_train_only_ft_does_not_recover_rollout_engines():
+    from types import SimpleNamespace
+    from unittest.mock import AsyncMock
+
+    from miles.ray.actor_group import RayTrainGroup
+
+    calls = []
+    group = object.__new__(RayTrainGroup)
+    group.args = SimpleNamespace(
+        debug_train_only=False,
+        debug_rollout_only=False,
+        use_fault_tolerance=True,
+        ft_components=["train"],
+    )
+    group.rollout_manager = SimpleNamespace(
+        recover_updatable_engines=_RemoteCall("recover", calls),
+        get_updatable_engines_and_lock=_RemoteCall("get_engines", calls, result="info"),
+        health_monitoring_pause=_RemoteCall("pause", calls),
+    )
+    group._broadcast = AsyncMock()
+
+    await group.update_weights(rollout_id=1)
+
+    assert [name for name, _, _ in calls] == ["get_engines", "pause"]
+    group._broadcast.assert_awaited_once_with("update_weights", info="info")


### PR DESCRIPTION
<!-- lint: profile=normal -->
## Summary

Fix debug replay initialization and keep train-only FT out of rollout lifecycle.

## Symptom & Reproduction

- **Symptom:** At revision `5330aadc0db911f97763fcde754ccaaf8d0e4819`, release run [31862426780](https://github.com/radixark/miles/actions/runs/31862426780) failed both `stage-c-8-gpu-h200` shards with `TypeError: unsupported operand type(s) for *: int and NoneType` from `GenerateState`.
- **Symptom:** At revision `ee0cd176e8222c9b4fd8b1f9c34ff22dab2a2327`, the unpinned main-stack [FT shard](https://github.com/radixark/miles/actions/runs/31931553316/job/95127749019) failed `test_trainer_ft_deterministic_dp2_cp2_real_rollout.py` with `MetricEvent comparison found 10 issue(s)`.
- **Reproduction:** Replay with `--load-debug-rollout-data`; separately run the deterministic real-rollout FT test with `--ft-components train`.

## Root Cause

1. `RolloutManager.__init__` constructed live rollout state before replay selection.
2. Replay intentionally leaves `rollout_num_gpus` unset.
3. `RolloutManager.__init__` only checked the master FT switch.
4. `--ft-components train` therefore activated target-only rollout lifecycle work.
5. `compare_metrics` observed the resulting baseline/target divergence.

## Fix

Skip class-based rollout construction when recorded rollout data is configured, while preserving ordinary train-only and SFT construction. Derive rollout FT enablement from both the master switch and the selected `rollout` component, then use it consistently for health monitors, CI fault injection, eval probing delegation, and legacy rollout recovery.

## Verification

- `python3 -m pytest -q tests/fast/ray/rollout/real_ray/test_rollout_manager.py tests/fast/ray/rollout/test_eval_fleet.py tests/fast/ray/test_actor_group_shared_ppo.py`: 31 passed on `698a91629491f6639beeb4fede70350548db245d`.
- `pre-commit run --files ...`: all applicable hooks passed on the six component-gating files.

## Review Focus

- `RolloutManager.__init__` / `_get_rollout_data`: replay construction and selection remain complementary.
- `_rollout_ft_enabled`: train-only FT never starts rollout monitors or fault injection.
- `EvalFleet.pin` / `RayTrainGroup.update_weights`: probing and recovery retain an owner for every FT mode.
