### PR TITLE
dashboard: resolve CP/PP-sharded train dumps offline and fix a partition-reader race

### DIFF
--- a/miles/backends/training_utils/cp_utils.py
+++ b/miles/backends/training_utils/cp_utils.py
@@ -21,13 +21,20 @@ def get_logits_and_tokens_offset_with_cp(
     response_length: int,
     qkv_format: str = "thd",
     max_seq_len: int | None = None,
+    cp_rank: int | None = None,
+    cp_size: int | None = None,
 ):
     """
     All offsets start from the begining of the prompt.
+
+    ``cp_rank`` / ``cp_size`` default to this process's parallel state. Pass them
+    explicitly to compute another rank's offsets outside the process group, which
+    is how an offline reader reassembles a sample from per-rank dumps.
     """
-    parallel_state = get_parallel_state()
-    cp_rank = parallel_state.cp.rank
-    cp_size = parallel_state.cp.size
+    if cp_rank is None or cp_size is None:
+        parallel_state = get_parallel_state()
+        cp_rank = parallel_state.cp.rank
+        cp_size = parallel_state.cp.size
     assert cp_size > 1
 
     prompt_length = total_length - response_length
@@ -429,6 +436,43 @@ def slice_log_prob_with_cp(
         return chunk_1 + chunk_2
     else:
         return torch.cat([chunk_1, chunk_2], dim=0)
+
+
+def assemble_log_prob_from_cp(
+    chunks: dict[int, torch.Tensor],
+    total_length: int,
+    response_length: int,
+    cp_size: int,
+    qkv_format: str = "thd",
+    max_seq_len: int | None = None,
+) -> torch.Tensor:
+    """Inverse of `slice_log_prob_with_cp`: per-rank slices back to one response.
+
+    `chunks` maps cp_rank to that rank's slice. Every rank of the group must be
+    present -- a partial group cannot be filled, since the missing positions are
+    not zeros but unknowns. Offsets come from the same helper the forward split
+    uses, so the two stay in step by construction.
+    """
+    assert cp_size > 1, "no reassembly needed at cp_size=1"
+    missing = sorted(set(range(cp_size)) - set(chunks))
+    assert not missing, f"cp ranks {missing} missing; cannot reassemble a partial group"
+
+    prompt_length = total_length - response_length
+    out = torch.zeros(response_length, dtype=next(iter(chunks.values())).dtype)
+    for cp_rank, chunk in chunks.items():
+        _, _, logits_offset, _ = get_logits_and_tokens_offset_with_cp(
+            total_length, response_length, qkv_format, max_seq_len, cp_rank=cp_rank, cp_size=cp_size
+        )
+        taken = 0
+        for lo, hi in logits_offset:
+            start, stop = lo - (prompt_length - 1), hi - (prompt_length - 1)
+            width = stop - start
+            if width <= 0:
+                continue
+            out[start:stop] = chunk[taken : taken + width]
+            taken += width
+        assert taken == len(chunk), f"cp rank {cp_rank}: consumed {taken} of {len(chunk)} values"
+    return out
 
 
 def build_gdn_cp_context(module: nn.Module, cu_seqlens: torch.Tensor, device: torch.device):

--- a/miles/backends/training_utils/cp_utils.py
+++ b/miles/backends/training_utils/cp_utils.py
@@ -27,9 +27,8 @@ def get_logits_and_tokens_offset_with_cp(
     """
     All offsets start from the begining of the prompt.
 
-    ``cp_rank`` / ``cp_size`` default to this process's parallel state. Pass them
-    explicitly to compute another rank's offsets outside the process group, which
-    is how an offline reader reassembles a sample from per-rank dumps.
+    ``cp_rank`` / ``cp_size`` default to this process's parallel state; pass them
+    explicitly to compute another rank's offsets outside the process group.
     """
     if cp_rank is None or cp_size is None:
         parallel_state = get_parallel_state()
@@ -448,10 +447,8 @@ def assemble_log_prob_from_cp(
 ) -> torch.Tensor:
     """Inverse of `slice_log_prob_with_cp`: per-rank slices back to one response.
 
-    `chunks` maps cp_rank to that rank's slice. Every rank of the group must be
-    present -- a partial group cannot be filled, since the missing positions are
-    not zeros but unknowns. Offsets come from the same helper the forward split
-    uses, so the two stay in step by construction.
+    `chunks` maps cp_rank to that rank's slice; every rank must be present.
+    Offsets come from the same helper the forward split uses.
     """
     assert cp_size > 1, "no reassembly needed at cp_size=1"
     missing = sorted(set(range(cp_size)) - set(chunks))

--- a/miles/dashboard/advisory.py
+++ b/miles/dashboard/advisory.py
@@ -246,6 +246,19 @@ def _rollout_advisories(reader: DumpReader, args: dict) -> list[Advisory]:
                 "the per-turn cap is usually the binding limit, not the context length"
             )
         out.append(Advisory(level="warning", message=message))
+
+    if "alignment_failed" in summary.columns and bool(summary["alignment_failed"].any()):
+        unreadable = int(summary["alignment_failed"].sum())
+        out.append(
+            Advisory(
+                level="info",
+                message=(
+                    f"per-token columns are blank for {unreadable} samples in rollout {rollout_id}: their "
+                    "context-parallel slices could not be placed, because this dump predates the cp_rank/cp_size "
+                    "fields. Blank here means unreadable, not undumped"
+                ),
+            )
+        )
     return out
 
 

--- a/miles/dashboard/dump_reader.py
+++ b/miles/dashboard/dump_reader.py
@@ -573,6 +573,9 @@ class DumpReader:
         cover only its overlap with the response region (stat ``i`` maps to
         token position ``prompt_len + a + i``). ``response_offset`` is the
         index within the returned token slice where the response begins.
+        Stat values are null at loss-masked positions (tool output, injected
+        turns): the engine never scored those tokens and the dump stores
+        placeholders, so only mask=1 entries carry real numbers.
         """
         columns = self._rollout_columns(rollout_id, sample_index, evaluation=evaluation)
         row = None if evaluation else self._train_row_lazy(rollout_id, sample_index)
@@ -586,19 +589,23 @@ class DumpReader:
         a = max(0, start - prompt_len)
         b = max(0, end - prompt_len)
 
-        def response_slice(values) -> list[float] | None:
-            return None if values is None else [float(v) for v in values[a:b]]
-
-        token_ids = [int(t) for t in columns["tokens"][start:end]]
         # A dump carries no rollout log-prob for positions the loss ignores (tool
         # output, masked turns): the inference engine never generated them, so
-        # 0.0 is stored. Blank the trainer side the same way, otherwise lp_diff
-        # and imp_ratio score a real log-prob against that placeholder and report
-        # a disagreement of tens of nats on tokens that never train.
-        train_log_probs = None if row is None else _zero_masked(row.log_probs, row.loss_mask > 0)
+        # 0.0 is stored and every per-token stat is undefined there. Those
+        # positions serialize as null — a placeholder rendered as 0 (imp_ratio
+        # 1) is indistinguishable from a genuinely small value on a generated
+        # token.
+        mask = None if row is None else row.loss_mask > 0
+
+        def response_slice(values) -> list[float | None] | None:
+            if values is None:
+                return None
+            return [float(values[i]) if mask is None or bool(mask[i]) else None for i in range(a, b)]
+
+        token_ids = [int(t) for t in columns["tokens"][start:end]]
         lp_diff = (
-            train_log_probs - row.rollout_log_probs
-            if row is not None and train_log_probs is not None and row.rollout_log_probs is not None
+            row.log_probs - row.rollout_log_probs
+            if row is not None and row.log_probs is not None and row.rollout_log_probs is not None
             else None
         )
         return dict(
@@ -618,7 +625,7 @@ class DumpReader:
                 else response_slice(row.rollout_log_probs) if row is not None else None
             ),
             loss_mask=None if row is None else [int(v) for v in row.loss_mask[a:b]],
-            train_log_probs=response_slice(train_log_probs),
+            train_log_probs=None if row is None else response_slice(row.log_probs),
             ref_log_probs=None if row is None else response_slice(row.ref_log_probs),
             lp_diff=response_slice(lp_diff),
             imp_ratio=None if lp_diff is None else response_slice(lp_diff.exp()),
@@ -747,13 +754,6 @@ def _masked(values: torch.Tensor | None, mask: torch.Tensor) -> torch.Tensor | N
         return None
     selected = values[mask]
     return selected.float() if selected.numel() else None
-
-
-def _zero_masked(values: torch.Tensor | None, mask: torch.Tensor) -> torch.Tensor | None:
-    """Zero the loss-masked positions of a per-token array, keeping its length so
-    it stays aligned with the token slice it annotates (the token view needs
-    every position; only the summary statistics can drop them)."""
-    return None if values is None else torch.where(mask, values, torch.zeros_like(values))
 
 
 def _mean(values: torch.Tensor | None) -> float | None:

--- a/miles/dashboard/dump_reader.py
+++ b/miles/dashboard/dump_reader.py
@@ -98,8 +98,7 @@ class TrainRow:
     raw_reward: Any
     truncated: int | None
     weight_versions: list[str] | None
-    # set when a per-token field was dropped because its cp slices could not
-    # be placed; distinguishes 'not dumped' from 'dumped but unreadable'
+    # cp slices could not be placed: dumped but unreadable, not merely absent
     alignment_failed: bool = False
 
     @classmethod
@@ -129,9 +128,7 @@ class TrainRow:
         )
 
 
-# Response-aligned per-token fields: full length at cp_size 1, this rank's slice
-# otherwise. Everything else a shard carries (tokens, masks, lengths, rewards) is
-# full-length on every rank.
+# Per-token fields stored as the rank's cp slice; everything else is full-length.
 _CP_SHARDED_FIELDS = (
     "log_probs",
     "rollout_log_probs",
@@ -146,13 +143,8 @@ _CP_SHARDED_FIELDS = (
 def _cp_layout(
     handles: list[dict], locations: list[tuple[int, int]], total_length: int, response_length: int
 ) -> tuple[int, dict[int, int], bool]:
-    """This sample's shard -> cp_rank mapping, and the group's cp size.
-
-    The layout is a property of the shards, not of any one field, so it is
-    resolved once and then applied to every field. Returns `(cp_size, {shard:
-    cp_rank}, ok)`; `ok` is False when slices exist but the layout could not be
-    established.
-    """
+    """Resolve `(cp_size, {shard: cp_rank}, ok)` once per sample and reuse it for
+    every field; `ok` is False when slices exist but could not be placed."""
     recorded = {
         shard: int(handles[shard]["cp_rank"]) for shard, _ in locations if handles[shard].get("cp_rank") is not None
     }
@@ -167,18 +159,9 @@ def _recover_cp_layout_legacy(
 ) -> tuple[int, dict[int, int], bool]:
     """Infer the layout for dumps written before cp_rank/cp_size were recorded.
 
-    `rollout_log_probs` is the probe: every rank carries it, and its values vary
-    along the sequence, so equal slices really are the same slice. Fields that
-    are constant within a sample -- GRPO advantages, say -- could never be told
-    apart on their own, which is why the layout is established once here and
-    then reused rather than inferred per field.
-
-    Ranks are ordered tp-fastest then cp, so a group's lowest rank increases with
-    cp_rank and first appearance gives the order. The widths are then checked
-    against `get_logits_and_tokens_offset_with_cp`, the same function the
-    training side split with; a layout that does not reproduce them is refused.
-
-    Deletable once every dump in circulation carries the layout.
+    `rollout_log_probs` is the probe (present on every rank, varies along the
+    sequence); slice widths must reproduce `get_logits_and_tokens_offset_with_cp`
+    or the layout is refused. Deletable once all dumps carry the fields.
     """
     probe = "rollout_log_probs"
     holders = sorted(
@@ -209,12 +192,8 @@ def _recover_cp_layout_legacy(
 
 
 def _cp_widths_match(widths: list[int], total_length: int, response_length: int, cp_size: int) -> bool:
-    """Do the observed slice widths reproduce what this cp layout would produce?
-
-    The chunk size is derived from the *total* length, prompt included, so the
-    prompt cannot be elided here -- it is what makes rank 0's slice shorter
-    than its siblings'.
-    """
+    """Chunk size derives from the total length, prompt included -- which is what
+    makes rank 0's slice shorter than its siblings'."""
     if sum(widths) != response_length:
         return False
     for cp_rank, width in enumerate(widths):
@@ -227,20 +206,13 @@ def _cp_widths_match(widths: list[int], total_length: int, response_length: int,
 
 
 def _build_train_row(handles: list[dict], locations: list[tuple[int, int]], *, raw_reward) -> TrainRow:
-    """One sample's train row, assembled across whatever parallelism wrote it.
-
-    Full-length columns come from any shard holding the sample -- every rank
-    records them identically. The per-token fields are resolved one at a time,
-    because which ranks carry a field depends on the field: pipeline parallelism
-    decides who computed it, context parallelism decides who holds which slice.
-    """
+    """One sample's train row: per-token fields resolve per field, since PP decides
+    who computed a field and CP who holds which slice."""
     shard, row_no = locations[0]
     columns = handles[shard]["rollout_data"]
     for other_shard, other_row in locations[1:]:
         other = handles[other_shard]["rollout_data"]
-        # Length is a property of the sample, identical on every rank that holds
-        # it whatever the parallelism; a disagreement means mixed or corrupt
-        # dumps, not a different slice.
+        # lengths are identical on every rank; disagreement means mixed or corrupt dumps
         assert (
             other["response_lengths"][other_row] == columns["response_lengths"][row_no]
             and other["total_lengths"][other_row] == columns["total_lengths"][row_no]
@@ -284,9 +256,7 @@ def _resolve_per_token_fields(row: TrainRow, handles: list[dict], locations: lis
         chunks: dict[int, torch.Tensor] = {}
         for shard, row_no in holders:
             if shard in layout:
-                # setdefault, not assignment: tensor-parallel peers share a
-                # cp_rank, and which replica answers must not depend on the
-                # order the shards happened to be listed in.
+                # setdefault: TP peers share a cp_rank; keep the replica choice order-independent
                 chunks.setdefault(layout[shard], handles[shard]["rollout_data"][field][row_no])
         if cp_size == 1:
             setattr(row, field, next(iter(chunks.values()), None))
@@ -303,8 +273,7 @@ def _resolve_per_token_fields(row: TrainRow, handles: list[dict], locations: lis
             ),
         )
 
-    # Last guard: a field that is not response-aligned would be scored against a
-    # full-length mask.
+    # a field that is not response-aligned would be scored against a full-length mask
     for field in _CP_SHARDED_FIELDS:
         values = getattr(row, field)
         if values is not None and len(values) != row.response_length:
@@ -573,9 +542,8 @@ class DumpReader:
         cover only its overlap with the response region (stat ``i`` maps to
         token position ``prompt_len + a + i``). ``response_offset`` is the
         index within the returned token slice where the response begins.
-        Stat values are null at loss-masked positions (tool output, injected
-        turns): the engine never scored those tokens and the dump stores
-        placeholders, so only mask=1 entries carry real numbers.
+        Stat values are null at loss-masked positions: the engine never scored
+        those tokens.
         """
         columns = self._rollout_columns(rollout_id, sample_index, evaluation=evaluation)
         row = None if evaluation else self._train_row_lazy(rollout_id, sample_index)
@@ -589,12 +557,7 @@ class DumpReader:
         a = max(0, start - prompt_len)
         b = max(0, end - prompt_len)
 
-        # A dump carries no rollout log-prob for positions the loss ignores (tool
-        # output, masked turns): the inference engine never generated them, so
-        # 0.0 is stored and every per-token stat is undefined there. Those
-        # positions serialize as null — a placeholder rendered as 0 (imp_ratio
-        # 1) is indistinguishable from a genuinely small value on a generated
-        # token.
+        # mask=0 positions hold 0.0 placeholders the engine never scored; serialize as null
         mask = None if row is None else row.loss_mask > 0
 
         def response_slice(values) -> list[float | None] | None:
@@ -661,12 +624,7 @@ class DumpReader:
             weight_version=sample.weight_versions[-1] if sample.weight_versions else None,
             weight_version_min=_min_numeric_version(sample.weight_versions),
             mixed_version=len(set(sample.weight_versions)) > 1 if sample.weight_versions else None,
-            # Weight updates between the policy that generated this sample's
-            # oldest turn and the rollout consuming it -- the same
-            # `current_version - group_oldest` the fully-async buffer reports as
-            # rollout/fully_async/avg_staleness, per sample rather than averaged.
-            # Verified against it: the mean of this column reproduces the metric
-            # exactly, which the rollout view's own box did not (it was +1).
+            # rollout_id - oldest weight version: rollout/fully_async/avg_staleness per sample
             staleness=(
                 None if (oldest := _min_numeric_version(sample.weight_versions)) is None else rollout_id - oldest
             ),

--- a/miles/dashboard/dump_reader.py
+++ b/miles/dashboard/dump_reader.py
@@ -26,6 +26,7 @@ from typing import Any, ClassVar
 import polars as pl
 import torch
 
+from miles.backends.training_utils.cp_utils import assemble_log_prob_from_cp, get_logits_and_tokens_offset_with_cp
 from miles.utils.types import Sample
 
 
@@ -97,6 +98,9 @@ class TrainRow:
     raw_reward: Any
     truncated: int | None
     weight_versions: list[str] | None
+    # set when a per-token field was dropped because its cp slices could not
+    # be placed; distinguishes 'not dumped' from 'dumped but unreadable'
+    alignment_failed: bool = False
 
     @classmethod
     def from_columns(cls, columns: dict, row: int, *, rank: int, raw_reward) -> TrainRow:
@@ -125,6 +129,190 @@ class TrainRow:
         )
 
 
+# Response-aligned per-token fields: full length at cp_size 1, this rank's slice
+# otherwise. Everything else a shard carries (tokens, masks, lengths, rewards) is
+# full-length on every rank.
+_CP_SHARDED_FIELDS = (
+    "log_probs",
+    "rollout_log_probs",
+    "ref_log_probs",
+    "entropy",
+    "ref_entropy",
+    "advantages",
+    "returns",
+)
+
+
+def _cp_layout(
+    handles: list[dict], locations: list[tuple[int, int]], total_length: int, response_length: int
+) -> tuple[int, dict[int, int], bool]:
+    """This sample's shard -> cp_rank mapping, and the group's cp size.
+
+    The layout is a property of the shards, not of any one field, so it is
+    resolved once and then applied to every field. Returns `(cp_size, {shard:
+    cp_rank}, ok)`; `ok` is False when slices exist but the layout could not be
+    established.
+    """
+    recorded = {
+        shard: int(handles[shard]["cp_rank"]) for shard, _ in locations if handles[shard].get("cp_rank") is not None
+    }
+    if recorded:
+        cp_size = int(handles[locations[0][0]].get("cp_size", 1) or 1)
+        return cp_size, recorded, len(set(recorded.values())) == cp_size
+    return _recover_cp_layout_legacy(handles, locations, total_length, response_length)
+
+
+def _recover_cp_layout_legacy(
+    handles: list[dict], locations: list[tuple[int, int]], total_length: int, response_length: int
+) -> tuple[int, dict[int, int], bool]:
+    """Infer the layout for dumps written before cp_rank/cp_size were recorded.
+
+    `rollout_log_probs` is the probe: every rank carries it, and its values vary
+    along the sequence, so equal slices really are the same slice. Fields that
+    are constant within a sample -- GRPO advantages, say -- could never be told
+    apart on their own, which is why the layout is established once here and
+    then reused rather than inferred per field.
+
+    Ranks are ordered tp-fastest then cp, so a group's lowest rank increases with
+    cp_rank and first appearance gives the order. The widths are then checked
+    against `get_logits_and_tokens_offset_with_cp`, the same function the
+    training side split with; a layout that does not reproduce them is refused.
+
+    Deletable once every dump in circulation carries the layout.
+    """
+    probe = "rollout_log_probs"
+    holders = sorted(
+        (int(handles[shard].get("rank", shard)), shard, row)
+        for shard, row in locations
+        if handles[shard]["rollout_data"].get(probe) is not None
+    )
+    if not holders:
+        return 1, {shard: 0 for shard, _ in locations}, True
+
+    layout: dict[int, int] = {}
+    seen: list[torch.Tensor] = []
+    for _rank, shard, row in holders:
+        values = handles[shard]["rollout_data"][probe][row]
+        match = next(
+            (i for i, other in enumerate(seen) if len(values) == len(other) and torch.equal(values, other)), None
+        )
+        if match is None:
+            match = len(seen)
+            seen.append(values)
+        layout[shard] = match
+    cp_size = len(seen)
+    if cp_size == 1:
+        return 1, layout, True
+    if not _cp_widths_match([len(v) for v in seen], total_length, response_length, cp_size):
+        return cp_size, {}, False
+    return cp_size, layout, True
+
+
+def _cp_widths_match(widths: list[int], total_length: int, response_length: int, cp_size: int) -> bool:
+    """Do the observed slice widths reproduce what this cp layout would produce?
+
+    The chunk size is derived from the *total* length, prompt included, so the
+    prompt cannot be elided here -- it is what makes rank 0's slice shorter
+    than its siblings'.
+    """
+    if sum(widths) != response_length:
+        return False
+    for cp_rank, width in enumerate(widths):
+        _, _, logits_offset, _ = get_logits_and_tokens_offset_with_cp(
+            total_length, response_length, "thd", None, cp_rank=cp_rank, cp_size=cp_size
+        )
+        if sum(max(0, hi - lo) for lo, hi in logits_offset) != width:
+            return False
+    return True
+
+
+def _build_train_row(handles: list[dict], locations: list[tuple[int, int]], *, raw_reward) -> TrainRow:
+    """One sample's train row, assembled across whatever parallelism wrote it.
+
+    Full-length columns come from any shard holding the sample -- every rank
+    records them identically. The per-token fields are resolved one at a time,
+    because which ranks carry a field depends on the field: pipeline parallelism
+    decides who computed it, context parallelism decides who holds which slice.
+    """
+    shard, row_no = locations[0]
+    columns = handles[shard]["rollout_data"]
+    for other_shard, other_row in locations[1:]:
+        other = handles[other_shard]["rollout_data"]
+        # Length is a property of the sample, identical on every rank that holds
+        # it whatever the parallelism; a disagreement means mixed or corrupt
+        # dumps, not a different slice.
+        assert (
+            other["response_lengths"][other_row] == columns["response_lengths"][row_no]
+            and other["total_lengths"][other_row] == columns["total_lengths"][row_no]
+        ), (
+            f"rank {handles[other_shard].get('rank', other_shard)} disagrees with "
+            f"rank {handles[shard].get('rank', shard)} on sample "
+            f"{columns['sample_indices'][row_no]} lengths"
+        )
+    row = TrainRow.from_columns(
+        columns,
+        row_no,
+        rank=int(handles[shard].get("rank", shard)),
+        raw_reward=raw_reward,
+    )
+    return _resolve_per_token_fields(row, handles, locations)
+
+
+def _resolve_per_token_fields(row: TrainRow, handles: list[dict], locations: list[tuple[int, int]]) -> TrainRow:
+    """Fill every per-token field of `row` at full response length.
+
+    One place decides which shard answers for a field, so pipeline parallelism
+    (who computed it), tensor parallelism (redundant copies) and context
+    parallelism (who holds which slice) are handled once instead of once per
+    view with a different accidental rule.
+    """
+    cp_size, layout, ok = _cp_layout(handles, locations, row.total_length, row.response_length)
+    row.alignment_failed = not ok
+
+    primary = handles[locations[0][0]]["rollout_data"]
+    qkv_format = handles[locations[0][0]].get("qkv_format", "thd")
+    max_seq_lens = primary.get("max_seq_lens")
+    max_seq_len = None if max_seq_lens is None else int(max_seq_lens[locations[0][1]])
+
+    for field in _CP_SHARDED_FIELDS:
+        holders = [
+            (shard, row_no) for shard, row_no in locations if handles[shard]["rollout_data"].get(field) is not None
+        ]
+        if not holders:
+            setattr(row, field, None)  # pipeline parallelism: only the last stage computes it
+            continue
+        chunks: dict[int, torch.Tensor] = {}
+        for shard, row_no in holders:
+            if shard in layout:
+                # setdefault, not assignment: tensor-parallel peers share a
+                # cp_rank, and which replica answers must not depend on the
+                # order the shards happened to be listed in.
+                chunks.setdefault(layout[shard], handles[shard]["rollout_data"][field][row_no])
+        if cp_size == 1:
+            setattr(row, field, next(iter(chunks.values()), None))
+            continue
+        if len(chunks) != cp_size:
+            setattr(row, field, None)
+            row.alignment_failed = True
+            continue
+        setattr(
+            row,
+            field,
+            assemble_log_prob_from_cp(
+                chunks, row.total_length, row.response_length, cp_size, qkv_format=qkv_format, max_seq_len=max_seq_len
+            ),
+        )
+
+    # Last guard: a field that is not response-aligned would be scored against a
+    # full-length mask.
+    for field in _CP_SHARDED_FIELDS:
+        values = getattr(row, field)
+        if values is not None and len(values) != row.response_length:
+            setattr(row, field, None)
+            row.alignment_failed = True
+    return row
+
+
 @dataclass
 class JoinedRollout:
     rollout_id: int
@@ -146,7 +334,7 @@ class DumpReader:
     FRESH_SECONDS: ClassVar[float] = 60.0
 
     # bump to invalidate summary parquet caches when their columns change
-    SUMMARY_VERSION: ClassVar[int] = 2  # v2: staleness/turns/tool columns
+    SUMMARY_VERSION: ClassVar[int] = 4  # v4: per-sample staleness
 
     def __init__(self, dump_dir: Path | str, *, cache_dir: Path | str | None = None, tensor_lru: int = 2):
         self.dump_dir = Path(dump_dir)
@@ -186,7 +374,10 @@ class DumpReader:
 
         train_rows: dict[int, TrainRow] = {}
         if not evaluation:
-            for path in self._train_paths(rollout_id):
+            handles: list[dict] = []
+            index: dict[int, list[tuple[int, int]]] = {}
+            raw_reward_column = None
+            for shard, path in enumerate(self._train_paths(rollout_id)):
                 rank_pack = self._torch_load(path)
                 columns = rank_pack["rollout_data"]
                 raw_rewards = columns.get("raw_reward")
@@ -195,23 +386,19 @@ class DumpReader:
                         f"{path}: raw_reward must be batch-global "
                         f"(expected {len(samples)} entries, got {len(raw_rewards)})"
                     )
+                    raw_reward_column = raw_rewards
                 for row, sample_index in enumerate(columns["sample_indices"]):
                     assert (
                         sample_index in batch_position
                     ), f"{path} references sample_index {sample_index} absent from the rollout dump"
-                    if (existing := train_rows.get(sample_index)) is not None:
-                        # TP-duplicate rank carrying the same DP shard.
-                        assert existing.response_length == columns["response_lengths"][row], (
-                            f"rank {rank_pack['rank']} disagrees with rank {existing.rank} "
-                            f"on sample {sample_index} in rollout {rollout_id}"
-                        )
-                        continue
-                    train_rows[sample_index] = TrainRow.from_columns(
-                        columns,
-                        row,
-                        rank=rank_pack["rank"],
-                        raw_reward=None if raw_rewards is None else raw_rewards[batch_position[sample_index]],
-                    )
+                    index.setdefault(int(sample_index), []).append((shard, row))
+                handles.append(rank_pack)
+            for sample_index, locations in index.items():
+                train_rows[sample_index] = _build_train_row(
+                    handles,
+                    locations,
+                    raw_reward=None if raw_reward_column is None else raw_reward_column[batch_position[sample_index]],
+                )
 
         return JoinedRollout(rollout_id=rollout_id, evaluation=evaluation, samples=samples, train_rows=train_rows)
 
@@ -254,7 +441,10 @@ class DumpReader:
             return pl.read_parquet(cache_path)
 
         joined = self.joined(rollout_id, evaluation=evaluation)
-        df = pl.DataFrame([self._summary_row(s, joined.train_rows.get(s.index)) for s in joined.samples], strict=False)
+        df = pl.DataFrame(
+            [self._summary_row(s, joined.train_rows.get(s.index), rollout_id=rollout_id) for s in joined.samples],
+            strict=False,
+        )
         self.cache_dir.mkdir(parents=True, exist_ok=True)
         df.write_parquet(cache_path)
         sources_path.write_text(json.dumps(sources))
@@ -356,22 +546,21 @@ class DumpReader:
         only its pickle graph; slicing a row faults in ~contiguous KBs."""
         if rollout_id not in self._shard_cache:
             handles: list[dict] = []
-            index: dict[int, tuple[int, int]] = {}
+            index: dict[int, list[tuple[int, int]]] = {}
             for shard_no, path in enumerate(self._train_paths(rollout_id)):
-                columns = self._torch_load(path, mmap=True)["rollout_data"]
-                for row_no, si in enumerate(columns["sample_indices"]):
-                    index[int(si)] = (shard_no, row_no)
-                handles.append(columns)
+                pack = self._torch_load(path, mmap=True)
+                for row_no, si in enumerate(pack["rollout_data"]["sample_indices"]):
+                    index.setdefault(int(si), []).append((shard_no, row_no))
+                handles.append(pack)
             self._shard_cache[rollout_id] = (handles, index)
             while len(self._shard_cache) > 4:
                 self._shard_cache.popitem(last=False)
         self._shard_cache.move_to_end(rollout_id)
         handles, index = self._shard_cache[rollout_id]
-        location = index.get(sample_index)
-        if location is None:
+        locations = index.get(sample_index)
+        if not locations:
             return None
-        shard_no, row_no = location
-        return TrainRow.from_columns(handles[shard_no], row_no, rank=shard_no, raw_reward=None)
+        return _build_train_row(handles, locations, raw_reward=None)
 
     # ------------------------------- L2 view --------------------------------
 
@@ -451,7 +640,7 @@ class DumpReader:
         paths = [rollout_path] + ([] if evaluation else self._train_paths(rollout_id))
         return {"_summary_version": self.SUMMARY_VERSION, **{p.name: p.stat().st_mtime for p in paths}}
 
-    def _summary_row(self, sample: Sample, row: TrainRow | None) -> dict:
+    def _summary_row(self, sample: Sample, row: TrainRow | None, *, rollout_id: int) -> dict:
         spec = sample.spec_info
         cache_info = sample.prefix_cache_info
         entry = dict(
@@ -465,6 +654,15 @@ class DumpReader:
             weight_version=sample.weight_versions[-1] if sample.weight_versions else None,
             weight_version_min=_min_numeric_version(sample.weight_versions),
             mixed_version=len(set(sample.weight_versions)) > 1 if sample.weight_versions else None,
+            # Weight updates between the policy that generated this sample's
+            # oldest turn and the rollout consuming it -- the same
+            # `current_version - group_oldest` the fully-async buffer reports as
+            # rollout/fully_async/avg_staleness, per sample rather than averaged.
+            # Verified against it: the mean of this column reproduces the metric
+            # exactly, which the rollout view's own box did not (it was +1).
+            staleness=(
+                None if (oldest := _min_numeric_version(sample.weight_versions)) is None else rollout_id - oldest
+            ),
             turns=len(sample.weight_versions) if sample.weight_versions else None,
             tool_calls=_tool_call_count(sample),
             non_generation_time=sample.non_generation_time,
@@ -492,6 +690,7 @@ class DumpReader:
                     "return_mean",
                 )
             )
+            train_columns["alignment_failed"] = False
             train_columns["truncated"] = sample.status == Sample.Status.TRUNCATED
             return entry | train_columns
 
@@ -516,6 +715,7 @@ class DumpReader:
             adv_mean=_mean(advantages),
             adv_std=_std(advantages),
             return_mean=_mean(_masked(row.returns, mask)),
+            alignment_failed=row.alignment_failed,
         )
 
     def _train_paths(self, rollout_id: int) -> list[Path]:

--- a/miles/dashboard/serve.py
+++ b/miles/dashboard/serve.py
@@ -88,8 +88,10 @@ def main(argv: list[str] | None = None) -> None:
     )
 
     if args.follow:
-        # Append-only streams + GIL-atomic list appends make concurrent reads
-        # from request handlers safe; a reader may just miss the newest records.
+        # Sync handlers run in a threadpool, so this races them. Safe for the
+        # append-only streams (GIL-atomic appends; a reader may just miss the
+        # newest records) and for the partitioned block caches, which take
+        # their own lock.
         def _tail() -> None:
             while True:
                 time.sleep(FOLLOW_INTERVAL_SECONDS)

--- a/miles/dashboard/serve.py
+++ b/miles/dashboard/serve.py
@@ -88,10 +88,7 @@ def main(argv: list[str] | None = None) -> None:
     )
 
     if args.follow:
-        # Sync handlers run in a threadpool, so this races them. Safe for the
-        # append-only streams (GIL-atomic appends; a reader may just miss the
-        # newest records) and for the partitioned block caches, which take
-        # their own lock.
+        # races the threadpool handlers: list appends are GIL-atomic, partition caches lock
         def _tail() -> None:
             while True:
                 time.sleep(FOLLOW_INTERVAL_SECONDS)

--- a/miles/dashboard/static/charts.js
+++ b/miles/dashboard/static/charts.js
@@ -46,16 +46,25 @@ export function drawChart(canvas, points, opts = {}) {
     bucketed = true;
     const size = Math.ceil(pts.length / MAX_RAW_POINTS);
     const buckets = [];
-    for (let i = 0; i < pts.length; i += size) {
-      const bucket = pts.slice(i, i + size);
-      const y = bucket.reduce((sum, p) => sum + p.y, 0) / bucket.length;
+    // a bucket never spans a gap: merging points from both sides of a null
+    // run would put the bucket-to-bucket line straight across the hole
+    let cur = [];
+    const flush = () => {
+      if (!cur.length) return;
+      const y = cur.reduce((sum, p) => sum + p.y, 0) / cur.length;
       buckets.push({
-        x: bucket[0].x,
+        x: cur[0].x,
         y,
-        gap: bucket.some((p) => p.gap),
-        label: `${fmt(bucket[0].x)}–${fmt(bucket.at(-1).x)}\nmean = ${fmt(y)} (${bucket.length} pts)`,
+        gap: cur[0].gap,
+        label: `${fmt(cur[0].x)}–${fmt(cur.at(-1).x)}\nmean = ${fmt(y)} (${cur.length} pts)`,
       });
+      cur = [];
+    };
+    for (const p of pts) {
+      if (cur.length && (p.gap || cur.length >= size)) flush();
+      cur.push(p);
     }
+    flush();
     pts = buckets;
   }
   const { ctx, width, height } = setupCanvas(canvas);

--- a/miles/dashboard/static/charts.js
+++ b/miles/dashboard/static/charts.js
@@ -46,8 +46,7 @@ export function drawChart(canvas, points, opts = {}) {
     bucketed = true;
     const size = Math.ceil(pts.length / MAX_RAW_POINTS);
     const buckets = [];
-    // a bucket never spans a gap: merging points from both sides of a null
-    // run would put the bucket-to-bucket line straight across the hole
+    // a bucket spanning a gap would draw the line straight across the hole
     let cur = [];
     const flush = () => {
       if (!cur.length) return;
@@ -91,8 +90,7 @@ export function drawChart(canvas, points, opts = {}) {
   } else {
     const xs = pts.map((p) => p.x);
     [xMin, xMax] = [Math.min(...xs), Math.max(...xs)];
-    // bands mark regions without points (prompt, masked turns): widen the
-    // domain so they render as visible space instead of being cropped away
+    // bands cover point-free regions: widen the domain so they stay visible
     for (const b of bands) {
       xMin = Math.min(xMin, b.x0);
       xMax = Math.max(xMax, b.x1);
@@ -148,8 +146,7 @@ export function drawChart(canvas, points, opts = {}) {
     ctx.strokeStyle = colMain;
     ctx.lineWidth = 1.5;
     ctx.beginPath();
-    // a gap marks the first point after a null run: lift the pen so masked
-    // spans read as holes instead of being bridged by a fake segment
+    // gap = first point after a null run: lift the pen
     linePts.forEach((p, i) => (i && !p.gap ? ctx.lineTo(X(p.x), Y(p.y)) : ctx.moveTo(X(p.x), Y(p.y))));
     ctx.stroke();
   }

--- a/miles/dashboard/static/charts.js
+++ b/miles/dashboard/static/charts.js
@@ -52,6 +52,7 @@ export function drawChart(canvas, points, opts = {}) {
       buckets.push({
         x: bucket[0].x,
         y,
+        gap: bucket.some((p) => p.gap),
         label: `${fmt(bucket[0].x)}–${fmt(bucket.at(-1).x)}\nmean = ${fmt(y)} (${bucket.length} pts)`,
       });
     }
@@ -74,12 +75,19 @@ export function drawChart(canvas, points, opts = {}) {
     return;
   }
 
+  const bands = opts.bands ?? [];
   let xMin, xMax;
   if (zoom?.x) {
     [xMin, xMax] = zoom.x;
   } else {
     const xs = pts.map((p) => p.x);
     [xMin, xMax] = [Math.min(...xs), Math.max(...xs)];
+    // bands mark regions without points (prompt, masked turns): widen the
+    // domain so they render as visible space instead of being cropped away
+    for (const b of bands) {
+      xMin = Math.min(xMin, b.x0);
+      xMax = Math.max(xMax, b.x1);
+    }
   }
   if (xMin === xMax) [xMin, xMax] = [xMin - 0.5, xMax + 0.5];
   let yMin, yMax;
@@ -116,12 +124,24 @@ export function drawChart(canvas, points, opts = {}) {
   ctx.beginPath();
   ctx.rect(MARGIN.left, MARGIN.top, plotW, plotH);
   ctx.clip();
+  for (const b of bands) {
+    ctx.globalAlpha = b.strong ? 0.3 : 0.14;
+    ctx.fillStyle = colBorder;
+    ctx.fillRect(X(b.x0), MARGIN.top, Math.max(X(b.x1) - X(b.x0), 1), plotH);
+    ctx.globalAlpha = 1;
+    if (b.label && X(b.x1) - X(b.x0) > 44) {
+      ctx.fillStyle = colText;
+      ctx.fillText(b.label, X(b.x0) + 4, MARGIN.top + 12);
+    }
+  }
   if (opts.line !== false) {
     const linePts = bucketed ? pts : points;
     ctx.strokeStyle = colMain;
     ctx.lineWidth = 1.5;
     ctx.beginPath();
-    linePts.forEach((p, i) => (i ? ctx.lineTo(X(p.x), Y(p.y)) : ctx.moveTo(X(p.x), Y(p.y))));
+    // a gap marks the first point after a null run: lift the pen so masked
+    // spans read as holes instead of being bridged by a fake segment
+    linePts.forEach((p, i) => (i && !p.gap ? ctx.lineTo(X(p.x), Y(p.y)) : ctx.moveTo(X(p.x), Y(p.y))));
     ctx.stroke();
   }
   if (!bucketed) {

--- a/miles/dashboard/static/views_rollout.js
+++ b/miles/dashboard/static/views_rollout.js
@@ -21,8 +21,7 @@ const DEFAULT_COLUMNS = [
   "non_generation_time",
 ];
 
-// staleness span rendered as one sortable-ish string column; mixed-version
-// samples are exactly what --use-tis corrects, so they must not blend in
+// one string column so mixed-version samples stay visibly distinct
 function versionSpan(row) {
   if (row.weight_version === null || row.weight_version === undefined) return null;
   const lo = row.weight_version_min;

--- a/miles/dashboard/static/views_rollout.js
+++ b/miles/dashboard/static/views_rollout.js
@@ -11,6 +11,7 @@ const DEFAULT_COLUMNS = [
   "response_length",
   "truncated",
   "versions",
+  "staleness",
   "turns",
   "tool_calls",
   "mean_abs_lp_diff",
@@ -117,14 +118,9 @@ export async function renderRollout(view, meta, route) {
     statBox("truncated frac", mean(rows.map((r) => (r.truncated ? 1 : 0)))),
     statBox("zero-std groups", `${zeroStdGroups}/${groups.rows.length}`),
     statBox("mixed-version frac", mean(rows.map((r) => (r.mixed_version === null ? null : +r.mixed_version)).filter((v) => v !== null))),
-    // staleness = trainer version at consume − generation version; the engine
-    // counter is 1 after the startup push and +1 per train step, so the
-    // trainer holds v(step+1) when consuming step N
     statBox(
       "avg staleness",
-      evaluation
-        ? null
-        : mean(rows.map((r) => (r.weight_version_min == null ? null : rolloutId + 1 - r.weight_version_min)).filter((v) => v !== null)),
+      evaluation ? null : mean(rows.map((r) => r.staleness).filter((v) => v !== null && v !== undefined)),
     ),
     statBox("mean |lp diff|", mean(rows.map((r) => r.mean_abs_lp_diff).filter((v) => v !== null))),
     statBox("mean entropy", mean(rows.map((r) => r.mean_entropy).filter((v) => v !== null))),

--- a/miles/dashboard/static/views_tokens.js
+++ b/miles/dashboard/static/views_tokens.js
@@ -190,8 +190,7 @@ async function loadTokensPane(root, rolloutId, sampleIndex, evaluation) {
       points.push({ x: pos, y: v, gap: afterGap, label: `pos ${pos}\n${chartMetric} = ${fmtNum(v)}` });
       afterGap = false;
     });
-    // shade what the policy did not generate: the prompt, and mask=0 runs
-    // inside the response (tool output, injected turns)
+    // shade the prompt and mask=0 runs: regions the policy did not generate
     const bands = [{ x0: 0, x1: chartData.prompt_len, strong: true, label: "prompt" }];
     const mask = chartData.loss_mask;
     if (mask) {

--- a/miles/dashboard/static/views_tokens.js
+++ b/miles/dashboard/static/views_tokens.js
@@ -99,7 +99,13 @@ export async function renderTokens(view, meta, route) {
   };
 
   if (conversationRow === null) {
-    view.replaceChildren(...panels, tokensPane);
+    view.replaceChildren(
+      ...panels,
+      el("p", { class: "muted" }, [
+        "No conversation recorded for this sample — aborted before any model call, or the step's trajectory sidecar is not written yet. Token view only.",
+      ]),
+      tokensPane,
+    );
     startTokens();
     return;
   }
@@ -174,12 +180,32 @@ async function loadTokensPane(root, rolloutId, sampleIndex, evaluation) {
     );
     const values = chartData[chartMetric];
     const points = [];
+    let afterGap = false;
     values.forEach((v, i) => {
-      if (v === null) return;
+      if (v === null) {
+        afterGap = true;
+        return;
+      }
       const pos = chartData.prompt_len + i;
-      points.push({ x: pos, y: v, label: `pos ${pos}\n${chartMetric} = ${fmtNum(v)}` });
+      points.push({ x: pos, y: v, gap: afterGap, label: `pos ${pos}\n${chartMetric} = ${fmtNum(v)}` });
+      afterGap = false;
     });
-    queueMicrotask(() => drawChart(chartCanvas, points));
+    // shade what the policy did not generate: the prompt, and mask=0 runs
+    // inside the response (tool output, injected turns)
+    const bands = [{ x0: 0, x1: chartData.prompt_len, strong: true, label: "prompt" }];
+    const mask = chartData.loss_mask;
+    if (mask) {
+      let runStart = null;
+      mask.forEach((m, i) => {
+        if (m === 0 && runStart === null) runStart = i;
+        if (m !== 0 && runStart !== null) {
+          bands.push({ x0: chartData.prompt_len + runStart, x1: chartData.prompt_len + i });
+          runStart = null;
+        }
+      });
+      if (runStart !== null) bands.push({ x0: chartData.prompt_len + runStart, x1: chartData.prompt_len + mask.length });
+    }
+    queueMicrotask(() => drawChart(chartCanvas, points, { bands }));
   }
 
   async function loadChart() {

--- a/miles/dashboard/store.py
+++ b/miles/dashboard/store.py
@@ -297,6 +297,7 @@ class _PartitionReader:
         self._max_blocks = max_blocks
         self._blocks: OrderedDict[str, Any] = OrderedDict()
         self._offsets: dict[str, int] = {}
+        self._lock = threading.Lock()
 
     def files(self) -> list[tuple[str, Path]]:
         out = [(self.LEGACY_KEY, self.legacy_path)] if self.legacy_path.exists() else []
@@ -331,27 +332,34 @@ class _PartitionReader:
         return added
 
     def _block(self, key: str, path: Path) -> Any:
-        offset = self._offsets.get(key, 0)
-        if key in self._blocks and path.stat().st_size <= offset:
+        # Serialized: the offset read, the parse, and the append back are one
+        # transaction. Reading and parsing release the GIL, so an unlocked
+        # follow tick racing a request handler re-reads from the same stale
+        # offset and appends the same byte range twice — duplicate records with
+        # identical timestamps, which every downstream aggregate silently
+        # double-counts.
+        with self._lock:
+            offset = self._offsets.get(key, 0)
+            if key in self._blocks and path.stat().st_size <= offset:
+                self._blocks.move_to_end(key)
+                return self._blocks[key]
+            with open(path, "rb") as f:
+                f.seek(offset)
+                chunk = f.read()
+            end = chunk.rfind(b"\n")
+            if end >= 0:
+                new = self._parse(chunk[: end + 1], path, offset)
+                pieces = [self._blocks[key], new] if key in self._blocks else [new]
+                self._blocks[key] = self._concat([piece for piece in pieces if self._length(piece)])
+                self._offsets[key] = offset + end + 1
+            elif key not in self._blocks:
+                self._blocks[key] = self._concat([])
+                self._offsets[key] = offset
             self._blocks.move_to_end(key)
+            while len(self._blocks) > self._max_blocks:
+                evicted, _ = self._blocks.popitem(last=False)
+                self._offsets.pop(evicted, None)
             return self._blocks[key]
-        with open(path, "rb") as f:
-            f.seek(offset)
-            chunk = f.read()
-        end = chunk.rfind(b"\n")
-        if end >= 0:
-            new = self._parse(chunk[: end + 1], path, offset)
-            pieces = [self._blocks[key], new] if key in self._blocks else [new]
-            self._blocks[key] = self._concat([piece for piece in pieces if self._length(piece)])
-            self._offsets[key] = offset + end + 1
-        elif key not in self._blocks:
-            self._blocks[key] = self._concat([])
-            self._offsets[key] = offset
-        self._blocks.move_to_end(key)
-        while len(self._blocks) > self._max_blocks:
-            evicted, _ = self._blocks.popitem(last=False)
-            self._offsets.pop(evicted, None)
-        return self._blocks[key]
 
     def edge_stamps(self) -> list[float]:
         """Global-range candidates from the first line of the oldest file and

--- a/miles/dashboard/store.py
+++ b/miles/dashboard/store.py
@@ -332,12 +332,7 @@ class _PartitionReader:
         return added
 
     def _block(self, key: str, path: Path) -> Any:
-        # Serialized: the offset read, the parse, and the append back are one
-        # transaction. Reading and parsing release the GIL, so an unlocked
-        # follow tick racing a request handler re-reads from the same stale
-        # offset and appends the same byte range twice — duplicate records with
-        # identical timestamps, which every downstream aggregate silently
-        # double-counts.
+        # read+parse release the GIL; two fills from one stale offset append the bytes twice
         with self._lock:
             offset = self._offsets.get(key, 0)
             if key in self._blocks and path.stat().st_size <= offset:

--- a/miles/utils/train_dump_utils.py
+++ b/miles/utils/train_dump_utils.py
@@ -24,11 +24,8 @@ def save_debug_train_data(args, *, rollout_id, rollout_data):
 def save_debug_train_data_for_rank(args, *, rollout_id, rollout_data, rank, cp_rank=0, cp_size=1):
     """Write one rank's slice of a rollout.
 
-    ``cp_rank`` / ``cp_size`` describe how this rank's per-token tensors were
-    split, and are passed in for the same reason ``rank`` is: this runs outside
-    the process group in tests and offline tools. They are what an offline reader
-    cannot recover -- under context parallelism several ranks hold equal-length
-    pieces of the same sample, while the masks stay full-length everywhere.
+    ``cp_rank`` / ``cp_size`` are passed in for the same reason ``rank`` is:
+    this runs outside the process group in tests and offline tools.
     """
     if (path_template := args.save_debug_train_data) is not None:
         path = Path(path_template.format(rollout_id=rollout_id, rank=rank))

--- a/miles/utils/train_dump_utils.py
+++ b/miles/utils/train_dump_utils.py
@@ -3,17 +3,33 @@ from pathlib import Path
 
 import torch
 
+from miles.backends.training_utils.parallel import get_parallel_state
+
 logger = logging.getLogger(__name__)
 
 
 def save_debug_train_data(args, *, rollout_id, rollout_data):
     if args.save_debug_train_data is not None:
+        parallel_state = get_parallel_state()
         save_debug_train_data_for_rank(
-            args, rollout_id=rollout_id, rollout_data=rollout_data, rank=torch.distributed.get_rank()
+            args,
+            rollout_id=rollout_id,
+            rollout_data=rollout_data,
+            rank=torch.distributed.get_rank(),
+            cp_rank=parallel_state.cp.rank,
+            cp_size=parallel_state.cp.size,
         )
 
 
-def save_debug_train_data_for_rank(args, *, rollout_id, rollout_data, rank):
+def save_debug_train_data_for_rank(args, *, rollout_id, rollout_data, rank, cp_rank=0, cp_size=1):
+    """Write one rank's slice of a rollout.
+
+    ``cp_rank`` / ``cp_size`` describe how this rank's per-token tensors were
+    split, and are passed in for the same reason ``rank`` is: this runs outside
+    the process group in tests and offline tools. They are what an offline reader
+    cannot recover -- under context parallelism several ranks hold equal-length
+    pieces of the same sample, while the masks stay full-length everywhere.
+    """
     if (path_template := args.save_debug_train_data) is not None:
         path = Path(path_template.format(rollout_id=rollout_id, rank=rank))
         logger.info(f"Save debug train data to {path}")
@@ -23,6 +39,9 @@ def save_debug_train_data_for_rank(args, *, rollout_id, rollout_data, rank):
                 rollout_id=rollout_id,
                 rank=rank,
                 rollout_data=rollout_data,
+                cp_rank=cp_rank,
+                cp_size=cp_size,
+                qkv_format=args.qkv_format,
             ),
             path,
         )

--- a/tests/fast/backends/training_utils/test_cp_log_prob_assembly.py
+++ b/tests/fast/backends/training_utils/test_cp_log_prob_assembly.py
@@ -2,11 +2,8 @@
 
 import pytest
 import torch
-from tests.ci.ci_register import register_cpu_ci
 
 from miles.backends.training_utils.cp_utils import assemble_log_prob_from_cp, get_logits_and_tokens_offset_with_cp
-
-register_cpu_ci(est_time=10, suite="stage-a-cpu", labels=[])
 
 
 def _split(

--- a/tests/fast/backends/training_utils/test_cp_log_prob_assembly.py
+++ b/tests/fast/backends/training_utils/test_cp_log_prob_assembly.py
@@ -1,10 +1,4 @@
-"""`assemble_log_prob_from_cp` must invert the CP split exactly.
-
-The split is what a training rank applies before dumping its slice; the assembly
-is what an offline reader (the dashboard) applies to put a sample back together.
-Both sides call `get_logits_and_tokens_offset_with_cp`, so this pins that they
-stay in step.
-"""
+"""`assemble_log_prob_from_cp` must invert the CP split exactly."""
 
 import pytest
 import torch

--- a/tests/fast/backends/training_utils/test_cp_log_prob_assembly.py
+++ b/tests/fast/backends/training_utils/test_cp_log_prob_assembly.py
@@ -1,0 +1,68 @@
+"""`assemble_log_prob_from_cp` must invert the CP split exactly.
+
+The split is what a training rank applies before dumping its slice; the assembly
+is what an offline reader (the dashboard) applies to put a sample back together.
+Both sides call `get_logits_and_tokens_offset_with_cp`, so this pins that they
+stay in step.
+"""
+
+import pytest
+import torch
+from tests.ci.ci_register import register_cpu_ci
+
+from miles.backends.training_utils.cp_utils import assemble_log_prob_from_cp, get_logits_and_tokens_offset_with_cp
+
+register_cpu_ci(est_time=10, suite="stage-a-cpu", labels=[])
+
+
+def _split(
+    values: torch.Tensor,
+    total_length: int,
+    response_length: int,
+    cp_size: int,
+    qkv_format: str = "thd",
+    max_seq_len: int | None = None,
+) -> dict[int, torch.Tensor]:
+    """What each cp rank keeps, mirroring `slice_log_prob_with_cp` without a process group."""
+    prompt_length = total_length - response_length
+    chunks = {}
+    for cp_rank in range(cp_size):
+        _, _, logits_offset, _ = get_logits_and_tokens_offset_with_cp(
+            total_length, response_length, qkv_format, max_seq_len, cp_rank=cp_rank, cp_size=cp_size
+        )
+        parts = [values[lo - (prompt_length - 1) : hi - (prompt_length - 1)] for lo, hi in logits_offset]
+        chunks[cp_rank] = torch.cat(parts, dim=0)
+    return chunks
+
+
+@pytest.mark.parametrize("cp_size", [2, 4, 8])
+@pytest.mark.parametrize("total_length,response_length", [(34017, 33789), (2630, 2402), (1024, 512), (97, 96)])
+def test_split_then_assemble_is_identity_thd(cp_size, total_length, response_length):
+    values = torch.arange(response_length, dtype=torch.float32)
+    chunks = _split(values, total_length, response_length, cp_size)
+    assert sum(len(c) for c in chunks.values()) == response_length, "the slices must tile the response exactly"
+
+    restored = assemble_log_prob_from_cp(chunks, total_length, response_length, cp_size)
+    torch.testing.assert_close(restored, values)
+
+
+@pytest.mark.parametrize("cp_size", [2, 4])
+@pytest.mark.parametrize("total_length,response_length,max_seq_len", [(1024, 512, 2048), (700, 640, 1024)])
+def test_split_then_assemble_is_identity_bshd(cp_size, total_length, response_length, max_seq_len):
+    """bshd partitions the padded maximum, not the sequence, so the chunk size
+    comes from `max_seq_len` and the two sides must agree on which one."""
+    values = torch.arange(response_length, dtype=torch.float32)
+    chunks = _split(values, total_length, response_length, cp_size, qkv_format="bshd", max_seq_len=max_seq_len)
+    restored = assemble_log_prob_from_cp(
+        chunks, total_length, response_length, cp_size, qkv_format="bshd", max_seq_len=max_seq_len
+    )
+    torch.testing.assert_close(restored, values)
+
+
+def test_partial_group_is_rejected():
+    """A missing rank leaves holes that are unknown, not zero."""
+    values = torch.arange(512, dtype=torch.float32)
+    chunks = _split(values, 640, 512, 4)
+    del chunks[2]
+    with pytest.raises(AssertionError, match="missing"):
+        assemble_log_prob_from_cp(chunks, 640, 512, 4)

--- a/tests/fast/dashboard/dummy_dump.py
+++ b/tests/fast/dashboard/dummy_dump.py
@@ -156,6 +156,7 @@ def _make_args(dump_dir: Path, *, num_prompts: int, n_samples_per_prompt: int) -
         rollout_batch_size=num_prompts,
         n_samples_per_prompt=n_samples_per_prompt,
         reward_key=None,
+        qkv_format="thd",
     )
 
 

--- a/tests/fast/dashboard/test_dump_reader_views.py
+++ b/tests/fast/dashboard/test_dump_reader_views.py
@@ -115,16 +115,17 @@ def test_tokens_full_range(reader):
     assert payload["lp_diff"][0] == pytest.approx(float(row.log_probs[0] - row.rollout_log_probs[0]))
 
 
-def test_tokens_blank_the_trainer_side_where_the_loss_is_masked(reader):
-    """A real dump holds no rollout log-prob for positions the loss ignores (tool
-    output, masked turns), so the trainer side is blanked to match instead of
-    reporting a disagreement against that placeholder. The removed sample is
-    masked end to end; an ordinary sample must keep every dumped value."""
+def test_tokens_null_the_stats_where_the_loss_is_masked(reader):
+    """A real dump holds no rollout log-prob for positions the loss ignores
+    (tool output, masked turns) — 0.0 placeholders. Every per-token stat is
+    undefined there and serializes as null: a placeholder rendered as 0
+    (imp_ratio 1) is indistinguishable from a genuinely small value on a
+    generated token. The removed sample is masked end to end; an ordinary
+    sample keeps every dumped value."""
     masked = reader.tokens(0, REMOVED[0])
     assert masked["loss_mask"] and set(masked["loss_mask"]) == {0}
-    assert masked["train_log_probs"] == [0.0] * len(masked["loss_mask"])
-    assert masked["lp_diff"] == pytest.approx([-v for v in masked["rollout_log_probs"]])
-    assert masked["ref_log_probs"] is not None  # left as dumped: no view diffs it
+    for key in ("train_log_probs", "rollout_log_probs", "lp_diff", "imp_ratio", "ref_log_probs", "advantages"):
+        assert masked[key] == [None] * len(masked["loss_mask"]), key
 
     row = reader.load_joined(0).train_rows[0]
     unmasked = reader.tokens(0, 0)

--- a/tests/fast/dashboard/test_dump_reader_views.py
+++ b/tests/fast/dashboard/test_dump_reader_views.py
@@ -116,12 +116,8 @@ def test_tokens_full_range(reader):
 
 
 def test_tokens_null_the_stats_where_the_loss_is_masked(reader):
-    """A real dump holds no rollout log-prob for positions the loss ignores
-    (tool output, masked turns) — 0.0 placeholders. Every per-token stat is
-    undefined there and serializes as null: a placeholder rendered as 0
-    (imp_ratio 1) is indistinguishable from a genuinely small value on a
-    generated token. The removed sample is masked end to end; an ordinary
-    sample keeps every dumped value."""
+    """mask=0 positions hold placeholders the engine never scored: they serialize
+    as null, never as numbers a chart would mistake for data."""
     masked = reader.tokens(0, REMOVED[0])
     assert masked["loss_mask"] and set(masked["loss_mask"]) == {0}
     for key in ("train_log_probs", "rollout_log_probs", "lp_diff", "imp_ratio", "ref_log_probs", "advantages"):

--- a/tests/fast/dashboard/test_partitions.py
+++ b/tests/fast/dashboard/test_partitions.py
@@ -1,4 +1,6 @@
 import json
+import threading
+import time
 
 import pytest
 from fastapi.testclient import TestClient
@@ -6,7 +8,7 @@ from tests.fast.dashboard.dummy_telemetry import dump_dummy_telemetry
 
 from miles.dashboard.dump_reader import DumpReader
 from miles.dashboard.server import make_app
-from miles.dashboard.store import GpuSample, Meta, MetricStore, PhaseEvent, Role, Stream, _hour_key
+from miles.dashboard.store import GpuSample, Meta, MetricStore, PhaseEvent, Role, Stream, _hour_key, _PartitionReader
 
 # hour-aligned base so partition boundaries land where the test says they do
 BASE = ((1_000_000 // 3600) + 1) * 3600.0
@@ -195,3 +197,56 @@ def test_open_marker_partitions_by_start_hour_and_is_found(tmp_path):
     # windowed query two hours later still sees the growing band (backward slack)
     phases = [p for p in store.phases_by_lane(t0=BASE + 2 * HOUR - 10, t1=BASE + 2 * HOUR) if p["name"] == "rollout"]
     assert phases and phases[0]["t1"] == BASE + 2 * HOUR  # clipped to the data edge
+
+
+def _counting_reader(tmp_path, *, parse_delay: float):
+    """A reader over one partition whose parse is slow enough to hold the
+    critical section open across a thread switch."""
+
+    def parse(raw, path, offset):
+        time.sleep(parse_delay)
+        return [int(line) for line in raw.splitlines()]
+
+    (tmp_path / "part").mkdir()
+    (tmp_path / "part" / "20260814_19.jsonl").write_text("".join(f"{i}\n" for i in range(100)))
+    return _PartitionReader(
+        tmp_path / "part",
+        tmp_path / "absent.jsonl",
+        parse=parse,
+        concat=lambda blocks: [row for block in blocks for row in block],
+        length=len,
+        line_stamps=lambda row: (row, row),
+        max_blocks=4,
+    )
+
+
+def test_concurrent_fill_does_not_duplicate_records(tmp_path):
+    """The follow thread and a request handler both enter `_block` at the same
+    stale offset; unserialized, each appends the same byte range and every
+    downstream aggregate double-counts."""
+    reader = _counting_reader(tmp_path, parse_delay=0.05)
+    results = []
+    threads = [threading.Thread(target=lambda: results.append(reader.window(None, None))) for _ in range(2)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+    assert [len(rows) for rows in results] == [100, 100]
+    assert reader.window(None, None) == list(range(100))
+
+
+def test_concurrent_refresh_does_not_duplicate_records(tmp_path):
+    """Same race through the follow tick's entry point, on an already-cached
+    block — the shape the live `--follow` server hits."""
+    reader = _counting_reader(tmp_path, parse_delay=0.05)
+    reader.window(None, None)
+    (tmp_path / "part" / "20260814_19.jsonl").open("a").write("".join(f"{i}\n" for i in range(100, 150)))
+    threads = [
+        threading.Thread(target=reader.refresh_cached),
+        threading.Thread(target=lambda: reader.window(None, None)),
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+    assert reader.window(None, None) == list(range(150))


### PR DESCRIPTION
## What was broken

Four user-visible dashboard bugs, all found while debugging a GB300 16-node GLM-5.2 run (TP2/CP4/PP4):

1. **Token view unusable under CP > 1.** Per-token train columns (`log_probs`, `lp_diff`, `imp_ratio`, ...) are dumped as this rank's CP slice, but nothing recorded which slice a rank held. The reader concatenated slices in file order, which is wrong for the zigzag CP split, so the view either crashed on length mismatch or silently showed misaligned values.
2. **Batch view per-token columns empty under PP.** Only the last pipeline stage dumps per-token outputs; the reader picked a rank file arbitrarily and found nothing.
3. **`avg staleness` stat off by one.** The frontend recomputed `rollout_id + 1 - weight_version_min` instead of using the backend value; measured 2.75 vs the native 1.75.
4. **`--follow` dashboards double-count records.** `PartitionedReader._block` is a read-modify-write spanning two GIL-releasing steps (file read, parse). The follow thread and the threadpool request handlers could both read from the same stale offset and append the same byte range twice. Duplicates carry identical timestamps, so every timestamp-based check passes while every count-based aggregate is inflated (observed: a lane rendering 147 segments whose ground truth is 49, shredding the batch-anatomy axis).

## Design

- `save_debug_train_data_for_rank` now records `cp_rank` / `cp_size` / `qkv_format` alongside `rank`, passed explicitly like `rank` is (dumpers stay parallel-state-free for tests).
- New `assemble_log_prob_from_cp` in `cp_utils` is the exact inverse of `slice_log_prob_with_cp`: both sides call the same `get_logits_and_tokens_offset_with_cp`, which now accepts explicit `cp_rank`/`cp_size` (defaulting to parallel state as before). Round-trip pinned by `test_cp_log_prob_assembly` for thd and bshd.
- For dumps that predate the metadata, the reader recovers the layout: group rank files by content (`rollout_log_probs` probe), then place slices by the deterministic per-`(total_length, cp_size)` width pattern. Verified widths must match exactly.
- A sample whose slices cannot be placed is reported (`alignment_failed`, surfaced as an advisory) instead of shown misaligned.
- Samples table gains a `staleness` column (`rollout_id - oldest weight version`); the stat box reads the backend value.
- `_block` takes a lock making offset-read -> parse -> append one transaction. Regression test drives the race deterministically with a delayed parser.

## Verification

- 241 dashboard tests pass; new: CP assembly round-trips (thd x3 sizes, bshd x2, partial-group rejection) and the concurrent-fill regression.
- Real TP2/CP4/PP4 dumps: 64/64 samples aligned (`alignment_failed` 0), token view and batch view fully populated.
- Race fix end-to-end: 24 concurrent `/api/rollout/15/trajectories` requests all return the ground-truth 49 segments (previously 147 = 3x after a follow-tick collision).
