### PR TITLE
fix(ci): honor nightly fast-fail bypass

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -123,7 +123,7 @@ jobs:
       github.event.action != 'closed' &&
       needs.resolve-ci-policy.result == 'success' &&
       (needs.stage-a-cpu.result == 'success' ||
-         (needs.stage-a-cpu.result == 'failure' && needs.resolve-ci-policy.outputs.bypass_fastfail == 'true'))
+         needs.resolve-ci-policy.outputs.bypass_fastfail == 'true')
     uses: ./.github/workflows/_build-pr-ci-image.yml
     secrets: inherit
 
@@ -200,7 +200,7 @@ jobs:
       needs.resolve-ci-image.result == 'success' &&
       !contains(fromJSON(needs.resolve-ci-policy.outputs.skipped_stages || '[]'), 'stage-b-2-gpu-h200') &&
       (needs.stage-a-cpu.result == 'success' ||
-        (needs.stage-a-cpu.result == 'failure' && needs.resolve-ci-policy.outputs.bypass_fastfail == 'true'))
+        needs.resolve-ci-policy.outputs.bypass_fastfail == 'true')
     uses: ./.github/workflows/_run-ci.yml
     with:
       runs_on: '["h200", "2gpu"]'
@@ -221,7 +221,7 @@ jobs:
       needs.resolve-ci-image.result == 'success' &&
       !contains(fromJSON(needs.resolve-ci-policy.outputs.skipped_stages || '[]'), 'stage-c-8-gpu-h100') &&
       (needs.stage-a-cpu.result == 'success' ||
-        (needs.stage-a-cpu.result == 'failure' && needs.resolve-ci-policy.outputs.bypass_fastfail == 'true'))
+        needs.resolve-ci-policy.outputs.bypass_fastfail == 'true')
     strategy:
       fail-fast: false
       max-parallel: ${{ needs.resolve-ci-policy.outputs.cadence == 'weekly' && 1 || 2 }}
@@ -248,7 +248,7 @@ jobs:
       needs.resolve-ci-image.result == 'success' &&
       !contains(fromJSON(needs.resolve-ci-policy.outputs.skipped_stages || '[]'), 'stage-c-8-gpu-h200') &&
       (needs.stage-a-cpu.result == 'success' ||
-        (needs.stage-a-cpu.result == 'failure' && needs.resolve-ci-policy.outputs.bypass_fastfail == 'true'))
+        needs.resolve-ci-policy.outputs.bypass_fastfail == 'true')
     strategy:
       fail-fast: false
       max-parallel: ${{ needs.resolve-ci-policy.outputs.cadence == 'weekly' && 1 || 2 }}
@@ -275,7 +275,7 @@ jobs:
       needs.resolve-ci-image.result == 'success' &&
       !contains(fromJSON(needs.resolve-ci-policy.outputs.skipped_stages || '[]'), 'stage-c-4-gpu-h200') &&
       (needs.stage-a-cpu.result == 'success' ||
-        (needs.stage-a-cpu.result == 'failure' && needs.resolve-ci-policy.outputs.bypass_fastfail == 'true'))
+        needs.resolve-ci-policy.outputs.bypass_fastfail == 'true')
     strategy:
       fail-fast: false
       max-parallel: ${{ needs.resolve-ci-policy.outputs.cadence == 'weekly' && 1 || 3 }}
@@ -302,7 +302,7 @@ jobs:
       needs.resolve-ci-image.result == 'success' &&
       !contains(fromJSON(needs.resolve-ci-policy.outputs.skipped_stages || '[]'), 'stage-c-2-gpu-h200') &&
       (needs.stage-a-cpu.result == 'success' ||
-        (needs.stage-a-cpu.result == 'failure' && needs.resolve-ci-policy.outputs.bypass_fastfail == 'true'))
+        needs.resolve-ci-policy.outputs.bypass_fastfail == 'true')
     strategy:
       fail-fast: false
       max-parallel: ${{ needs.resolve-ci-policy.outputs.cadence == 'weekly' && 1 || 2 }}

--- a/tests/ci/test/test_run_suite.py
+++ b/tests/ci/test/test_run_suite.py
@@ -316,8 +316,8 @@ class TestWorkflowScopeSeam:
         assert "github.event.action != 'closed'" in caller
         assert "needs.resolve-ci-policy.result == 'success'" in caller
         assert "needs.stage-a-cpu.result == 'success'" in caller
-        assert "needs.stage-a-cpu.result == 'failure'" in caller
         assert "needs.resolve-ci-policy.outputs.bypass_fastfail == 'true'" in caller
+        assert "needs.stage-a-cpu.result == 'failure'" not in caller
         assert "stage-b-cpu" not in caller
         assert "uses: ./.github/workflows/_build-pr-ci-image.yml" in caller
         assert "secrets: inherit" in caller
@@ -401,6 +401,7 @@ class TestWorkflowScopeSeam:
         assert gpu_stages.count(bypass_gate) == 5
         assert gpu_stages.count("needs.resolve-ci-policy.result == 'success'") == 5
         assert gpu_stages.count("needs.resolve-ci-image.result == 'success'") == 5
+        assert "needs.stage-a-cpu.result == 'failure'" not in gpu_stages
 
     def test_each_cuda_stage_consumes_the_fail_open_skip_list(self):
         workflow = self._workflow()


### PR DESCRIPTION
## Summary

Honor the nightly fast-fail bypass when Stage A cannot produce a normal failure result.

## Symptom & Reproduction

- **Symptom:** [Nightly run 32041342404](https://github.com/radixark/miles/actions/runs/32041342404) skipped `docker-build` despite policy output `bypass_fastfail=true`.
- **Evidence:** `stage-a-cpu` failed while setting up `astral-sh/setup-uv@v5`, and every GPU stage was skipped.
- **Reproduction:** Run `PR Test` on the weekday schedule with a Stage A setup failure. Downstream image and GPU jobs stop instead of honoring nightly policy.

## Root Cause

1. `jobs.docker-build.if` and the GPU job gates nested `bypass_fastfail` behind `needs.stage-a-cpu.result == 'failure'`.
2. The reusable-matrix setup failure did not satisfy `needs.stage-a-cpu.result == 'failure'` at the caller gate.

## Fix

Treat `bypass_fastfail=true` as an independent alternative to Stage A success in `docker-build` and all five GPU gates. Cancellation, policy-success, image-success, and stage-selection guards remain unchanged.

## Verification

- `pytest -q tests/ci/test/test_run_suite.py tests/ci/test/test_ci_policy.py`: `103 passed`
- `git diff --check`: passed
- Commit hooks, including YAML validation: passed

## Review Focus

- `.github/workflows/pr-test.yml`: Confirm bypass overrides every Stage A non-success without bypassing cancellation, policy failure, image failure, or stage selection.
- `tests/ci/test/test_run_suite.py`: Confirm seam assertions reject reintroducing an exact Stage A `failure` requirement.
