### PR TITLE
fix: add H200, B200 and B300 to NUM_GPUS_OF_HARDWARE

### DIFF
--- a/miles/utils/external_utils/command_utils.py
+++ b/miles/utils/external_utils/command_utils.py
@@ -366,6 +366,8 @@ def encode_pseudo_file(text: str) -> str:
 
 NUM_GPUS_OF_HARDWARE = {
     "H100": 8,
+    "H200": 8,
+    "B300": 8,
     "GB200": 4,
     "GB300": 4,
     "MI350X": 8,

--- a/miles/utils/external_utils/command_utils.py
+++ b/miles/utils/external_utils/command_utils.py
@@ -367,6 +367,7 @@ def encode_pseudo_file(text: str) -> str:
 NUM_GPUS_OF_HARDWARE = {
     "H100": 8,
     "H200": 8,
+    "B200": 8,
     "B300": 8,
     "GB200": 4,
     "GB300": 4,


### PR DESCRIPTION
Running `scripts/run_qwen3_30b_a3b.py --hardware B300` without an explicit `--num-gpus-per-node` fails with `KeyError: 'B300'` in `ScriptArgs.__post_init__`, because `NUM_GPUS_OF_HARDWARE` only lists H100/GB200/GB300/MI350X/MI355X. Same for H200 and B200.

Add H200, B200 and B300 (8 GPUs per node) so `--hardware` alone works on these machines.

Found while smoke-testing release/v0.1.0 nvfp4 training on a B300 devbox.