### PR TITLE
openenv: stop the episode at a length-truncated turn

### DIFF
--- a/examples/experimental/openenv/openenv_agent_function.py
+++ b/examples/experimental/openenv/openenv_agent_function.py
@@ -300,6 +300,9 @@ async def multi_turn(
             # (extras like reasoning_content included).
             convo.append(message.model_dump(exclude_none=True))
 
+            if completion.choices[0].finish_reason == "length":
+                break
+
             command = _strip_fence(reply) if "```" in reply else reply.strip()
             if not command or command.upper().startswith("TASK_COMPLETE"):
                 break

--- a/examples/experimental/openenv/openenv_agent_function.py
+++ b/examples/experimental/openenv/openenv_agent_function.py
@@ -288,7 +288,8 @@ async def multi_turn(
                 model=model_name, messages=convo, extra_body=request_kwargs
             )
             gen_times.append(time.monotonic() - t0)
-            message = completion.choices[0].message
+            choice = completion.choices[0]
+            message = choice.message
             reply = message.content or ""
             # Echo the assistant turn back verbatim. The session server stores the
             # message exactly as SGLang emitted it -- content plus reasoning_content
@@ -300,7 +301,7 @@ async def multi_turn(
             # (extras like reasoning_content included).
             convo.append(message.model_dump(exclude_none=True))
 
-            if completion.choices[0].finish_reason == "length":
+            if choice.finish_reason == "length":
                 break
 
             command = _strip_fence(reply) if "```" in reply else reply.strip()

--- a/tests/fast/examples/experimental/openenv/test_openenv_agent_function.py
+++ b/tests/fast/examples/experimental/openenv/test_openenv_agent_function.py
@@ -160,9 +160,8 @@ class _TruncatedPolicy:
 
 def test_truncated_turn_ends_the_episode(monkeypatch):
     """A finish_reason="length" turn closes the trainable sample — collection
-    keeps nothing past it, so the loop must stop instead of burning up to
-    max_turns of engine time on discarded tokens. The cut-off command must not
-    be executed either; scoring still runs."""
+    keeps nothing past it, so the loop stops there. The cut-off command is not
+    executed; scoring still runs."""
     monkeypatch.setattr(oaf, "load_tbench2", lambda: _CLASSES)
 
     async def spying_with_env(env_cls, env_url, body):

--- a/tests/fast/examples/experimental/openenv/test_openenv_agent_function.py
+++ b/tests/fast/examples/experimental/openenv/test_openenv_agent_function.py
@@ -80,7 +80,7 @@ class _FakePolicy:
         msg = types.SimpleNamespace(
             content=text, model_dump=lambda exclude_none=True: {"role": "assistant", "content": text}
         )
-        return types.SimpleNamespace(choices=[types.SimpleNamespace(message=msg)])
+        return types.SimpleNamespace(choices=[types.SimpleNamespace(message=msg, finish_reason="stop")])
 
 
 _CLASSES = {"env": _FakeEnv, "action": _FakeAction}
@@ -140,3 +140,43 @@ def test_old_server_reward_is_not_trusted(monkeypatch):
     )
     assert reward is None
     assert metrics["turns"] == 2  # the episode itself completed; only scoring was rejected
+
+
+class _TruncatedPolicy:
+    """Every turn returns a command cut off by the per-turn cap."""
+
+    def __init__(self):
+        self.n = 0
+        self.chat = types.SimpleNamespace(completions=types.SimpleNamespace(create=self._create))
+
+    async def _create(self, **kw):
+        self.n += 1
+        text = "```bash\nmake -j && ./run_all_the"
+        msg = types.SimpleNamespace(
+            content=text, model_dump=lambda exclude_none=True: {"role": "assistant", "content": text}
+        )
+        return types.SimpleNamespace(choices=[types.SimpleNamespace(message=msg, finish_reason="length")])
+
+
+def test_truncated_turn_ends_the_episode(monkeypatch):
+    """A finish_reason="length" turn closes the trainable sample — collection
+    keeps nothing past it, so the loop must stop instead of burning up to
+    max_turns of engine time on discarded tokens. The cut-off command must not
+    be executed either; scoring still runs."""
+    monkeypatch.setattr(oaf, "load_tbench2", lambda: _CLASSES)
+
+    async def spying_with_env(env_cls, env_url, body):
+        return await body(env_cls())
+
+    monkeypatch.setattr(oaf, "_with_env", spying_with_env)
+
+    policy = _TruncatedPolicy()
+    reward, metrics = run_async(
+        oaf.run_episode(policy, "m", [{"role": "system", "content": "s"}], {}, {"task_id": "t1"})
+    )
+    assert policy.n == 1, "the loop must stop at the truncated turn"
+    actions = _FakeEnv.last_actions
+    execs = [a for a in actions if a.action_type == "exec"]
+    assert all("/tmp/tbench2_env_runs" in (a.command or "") for a in execs), execs
+    assert any(a.action_type == "evaluate" for a in actions), "scoring still runs"
+    assert reward == 1.0 and metrics["turns"] == 1


### PR DESCRIPTION
## Problem

In the tbench2 agent loop, a turn that hits `--rollout-max-response-len` comes back with `finish_reason="length"` and closes the trainable sample at that turn — sample collection keeps nothing past a truncated turn. The agent loop did not know that: it executed the cut-off command and kept generating until `OPENENV_MAX_TURNS` (or the episode wall-clock), entirely on tokens training will discard.

Measured on a GB300 16-node GLM-5.2 run (6469 episodes): the post-truncation ghost tail consumed **22.7% of all episode wall-clock** (144.7h of 638h), concentrated at the longest contexts of the run — so its share of engine *compute* is higher still. One concrete sample: truncated at turn 22, then 8 more turns over 16.4 minutes (73% of its episode), all discarded. Samples that rode the tail to the wall-clock cap came back ABORTED and took their whole group with them via `check_no_aborted`.

The tail is invisible in the dashboard's batch anatomy (tool/gen spans after the final policy call cannot be derived from request gaps), which is how it went unnoticed: it renders as a long "queue/waiting" band after the last visible activity.

Secondary effect: ghost turns lengthen episodes, which fattens the fully-async whole-group staleness tail — the carrier population of the train/rollout divergence documented in the smoke-test report.

## Fix

Break the turn loop when `finish_reason == "length"`; skip the truncated turn's cut-off command (mid-stream garbage); scoring (`evaluate`) still runs so the episode is graded as-is.

## Tests

- `_FakePolicy` now carries `finish_reason` like the real SDK response.
- New `test_truncated_turn_ends_the_episode`: one policy call, no exec of the cut-off command, evaluate still runs, `turns == 1`.
- `tests/fast/examples/experimental/openenv/`: 103 passed, 2 skipped (arm64 container).
