### PR TITLE
glm52_tbench2: collapse levers and launch fixes from the GB300 16-node smoke runs

### DIFF
--- a/examples/experimental/openenv/eval_tbench2_via_api.py
+++ b/examples/experimental/openenv/eval_tbench2_via_api.py
@@ -123,7 +123,7 @@ async def main() -> None:
         env_desc = os.getenv("OPENENV_ENV_URL", oaf._DEFAULT_ENV_URL)
     print(f"policy={model} @ {base_url} | env={env_desc} | " f"{len(rows)} tasks | concurrency={args.concurrency}")
 
-    policy = AsyncOpenAI(base_url=base_url, api_key=api_key)
+    policy = AsyncOpenAI(base_url=base_url, api_key=api_key, timeout=3600.0, max_retries=0)
     request_kwargs = {"temperature": args.temperature}
     sem = asyncio.Semaphore(args.concurrency)
 

--- a/examples/experimental/openenv/glm52_tbench2/README.md
+++ b/examples/experimental/openenv/glm52_tbench2/README.md
@@ -26,12 +26,12 @@ ranks at `--async-max-concurrent-samples 128`).
 
 | | |
 |---|---|
-| Training | 8 nodes, TP2 / CP4 / PP4 (18-20-20-20 layer split) / EP8. CP4 splits `--max-seq-len` (default 131k) to ~33k per rank; DP1 leaves optimizer state unsharded, so `--stream-optimizer-state-to-disk` is mandatory, not an optimization |
+| Training | 8 nodes, TP2 / CP4 / PP4 (18-20-20-20 layer split) / EP8. CP4 splits `--max-seq-len` (default 65k) to ~16k per rank; DP1 leaves optimizer state unsharded, so `--stream-optimizer-state-to-disk` is mandatory, not an optimization |
 | Inference | 8 nodes, one 4-GPU engine each: dp-attention (dp=4) + deepep, EAGLE 1/1/2, fp8 KV. `--sglang-config low-latency` switches to one TP8 engine per node pair with EAGLE 5/1/6 |
 | KV budget | `--sglang-mem-fraction-static 0.85` → ~553k KV tokens per dp rank. At the older 0.75 the pool was 26k tokens: trajectories hard-failed past ~26k input, 84% of samples truncated, and one long trajectory saturated a rank |
 | Async | `train_async.py` + `FullyAsyncRolloutFn`; 128 in-flight trajectories decoupled from the 64-sample train batch; `--rollout-submission-granularity sample` frees a submission slot per finished sample rather than per finished group |
 | Routing | dp-attention implies dp-aware routing (set automatically); without it, requests pile onto one dp rank per engine while the other three idle |
-| Episodes | 30 turns, 3600 s wall clock, 16k tokens/turn, 131k session (`--max-seq-len`); thinking at GLM-5.2's default `Reasoning Effort: Max` |
+| Episodes | 30 turns, 3600 s wall clock, 8k tokens/turn, 65k session (`--max-seq-len`); thinking at GLM-5.2's default `Reasoning Effort: Max` |
 | Eval | every 10 rollouts over a held-out tbench2 split, on the shared rollout engines (the producer pauses). 20 tasks x 2 samples has σ≈0.08 — single-eval movements below that are noise; raise `--n-samples-per-eval-prompt` to tighten |
 | Sandboxes | one per episode, deleted at episode end; labelled `openenv-tbench2-task` / `openenv-launcher` / `openenv-run-id` |
 

--- a/examples/experimental/openenv/glm52_tbench2/README.md
+++ b/examples/experimental/openenv/glm52_tbench2/README.md
@@ -26,12 +26,12 @@ ranks at `--async-max-concurrent-samples 128`).
 
 | | |
 |---|---|
-| Training | 8 nodes, TP2 / CP4 / PP4 (18-20-20-20 layer split) / EP8. CP4 splits the 131k max sequence to ~33k per rank; DP1 leaves optimizer state unsharded, so `--stream-optimizer-state-to-disk` is mandatory, not an optimization |
+| Training | 8 nodes, TP2 / CP4 / PP4 (18-20-20-20 layer split) / EP8. CP4 splits `--max-seq-len` (default 131k) to ~33k per rank; DP1 leaves optimizer state unsharded, so `--stream-optimizer-state-to-disk` is mandatory, not an optimization |
 | Inference | 8 nodes, one 4-GPU engine each: dp-attention (dp=4) + deepep, EAGLE 1/1/2, fp8 KV. `--sglang-config low-latency` switches to one TP8 engine per node pair with EAGLE 5/1/6 |
 | KV budget | `--sglang-mem-fraction-static 0.85` → ~553k KV tokens per dp rank. At the older 0.75 the pool was 26k tokens: trajectories hard-failed past ~26k input, 84% of samples truncated, and one long trajectory saturated a rank |
 | Async | `train_async.py` + `FullyAsyncRolloutFn`; 128 in-flight trajectories decoupled from the 64-sample train batch; `--rollout-submission-granularity sample` frees a submission slot per finished sample rather than per finished group |
 | Routing | dp-attention implies dp-aware routing (set automatically); without it, requests pile onto one dp rank per engine while the other three idle |
-| Episodes | 30 turns, 3600 s wall clock, 16k tokens/turn, 131k session; thinking at GLM-5.2's default `Reasoning Effort: Max` |
+| Episodes | 30 turns, 3600 s wall clock, 16k tokens/turn, 131k session (`--max-seq-len`); thinking at GLM-5.2's default `Reasoning Effort: Max` |
 | Eval | every 10 rollouts over a held-out tbench2 split, on the shared rollout engines (the producer pauses). 20 tasks x 2 samples has σ≈0.08 — single-eval movements below that are noise; raise `--n-samples-per-eval-prompt` to tighten |
 | Sandboxes | one per episode, deleted at episode end; labelled `openenv-tbench2-task` / `openenv-launcher` / `openenv-run-id` |
 
@@ -95,6 +95,7 @@ that id selects the per-episode sandbox image.
 export MILES_ROOT=...  CONTAINER_IMAGE=...  CONTAINER_MOUNTS=...
 export DAYTONA_ENV_FILE=~/.daytona_env
 export OPENENV_TB2_TASKS_DIR=...
+export FABRIC_PREFIX=10.4.          # leading octets of the compute-fabric IP
 export WANDB_API_KEY=...            # optional
 
 sbatch --export=ALL examples/experimental/openenv/glm52_tbench2/launch_16node_slurm.sh \
@@ -102,7 +103,8 @@ sbatch --export=ALL examples/experimental/openenv/glm52_tbench2/launch_16node_sl
 ```
 
 Anything after the launcher name goes to the recipe: `--num-rollout 10` for a
-short run, `--sglang-config low-latency`, `--eval-interval` to change cadence.
+short run, `--sglang-config low-latency`, `--eval-interval` to change cadence
+(`--eval-interval 0` turns eval off).
 Outside slurm, bring up your own Ray cluster and run the recipe command from
 the module docstring on the head node.
 

--- a/examples/experimental/openenv/glm52_tbench2/launch_16node_slurm.sh
+++ b/examples/experimental/openenv/glm52_tbench2/launch_16node_slurm.sh
@@ -16,6 +16,7 @@ set -uo pipefail
 : "${CONTAINER_IMAGE:?squashfs image with the miles runtime}"
 : "${CONTAINER_MOUNTS:?must expose the checkouts, model/data dirs and node-local scratch}"
 : "${DAYTONA_ENV_FILE:?file exporting DAYTONA_API_KEY (chmod 600, never in git)}"
+: "${FABRIC_PREFIX:?leading octets of the compute-fabric IP, e.g. 10.4.}"
 
 RECIPE=$MILES_ROOT/examples/experimental/openenv/glm52_tbench2/run_glm5_2_744b_a40b_daytona.py
 RECIPE_ARGS=$(printf '%q ' "$@")
@@ -24,8 +25,10 @@ COMMON="export PYTHONNOUSERSITE=1 RAY_memory_monitor_refresh_ms=0 PYTHONPATH=$MI
 
 nodes=( $(scontrol show hostnames "$SLURM_JOB_NODELIST") )
 # Compute-fabric IP: `hostname -I` ordering varies and the management subnet
-# is not routable between nodes, so select the fabric prefix explicitly.
-head_ip=$(srun --nodes=1 --ntasks=1 -w "${nodes[0]}" hostname -I | tr ' ' '\n' | grep -E "^${FABRIC_PREFIX:-10.}" | head -1)
+# is not routable between nodes; the prefix is required rather than defaulted
+# because a wrong one costs a silent hang (workers never reach the head GCS).
+head_ip=$(srun --nodes=1 --ntasks=1 -w "${nodes[0]}" hostname -I | tr ' ' '\n' | grep -E "^$FABRIC_PREFIX" | head -1)
+: "${head_ip:?no address matching $FABRIC_PREFIX on ${nodes[0]}}"
 ngpu_total=$(( ${#nodes[@]} * 4 ))
 echo "head=${nodes[0]} ($head_ip)  nodes=${#nodes[@]}  gpus=$ngpu_total"
 

--- a/examples/experimental/openenv/glm52_tbench2/launch_16node_slurm.sh
+++ b/examples/experimental/openenv/glm52_tbench2/launch_16node_slurm.sh
@@ -25,8 +25,7 @@ COMMON="export PYTHONNOUSERSITE=1 RAY_memory_monitor_refresh_ms=0 PYTHONPATH=$MI
 
 nodes=( $(scontrol show hostnames "$SLURM_JOB_NODELIST") )
 # Compute-fabric IP: `hostname -I` ordering varies and the management subnet
-# is not routable between nodes; the prefix is required rather than defaulted
-# because a wrong one costs a silent hang (workers never reach the head GCS).
+# is not routable between nodes; a wrong prefix hangs silently at Ray startup.
 head_ip=$(srun --nodes=1 --ntasks=1 -w "${nodes[0]}" hostname -I | tr ' ' '\n' | grep -E "^$FABRIC_PREFIX" | head -1)
 : "${head_ip:?no address matching $FABRIC_PREFIX on ${nodes[0]}}"
 ngpu_total=$(( ${#nodes[@]} * 4 ))

--- a/examples/experimental/openenv/glm52_tbench2/run_glm5_2_744b_a40b_daytona.py
+++ b/examples/experimental/openenv/glm52_tbench2/run_glm5_2_744b_a40b_daytona.py
@@ -55,7 +55,9 @@ class ScriptArgs(U.ExecuteTrainConfig):
     rollout_batch_size: int = 8
     n_samples_per_prompt: int = 8
     global_batch_size: int = 64
-    rollout_max_response_len: int = 16384
+    rollout_max_response_len: int = 8192
+    # whole-session budget; CP splits it, so it also sets per-rank activations
+    max_seq_len: int = 131072
     # Max concurrently generating trajectories, decoupled from the train batch;
     # also sizes the Daytona pool so every in-flight trajectory has a sandbox.
     async_max_concurrent_samples: int = 128
@@ -72,13 +74,15 @@ class ScriptArgs(U.ExecuteTrainConfig):
     openenv_max_rollout_time_seconds: int = int(os.environ.get("OPENENV_MAX_ROLLOUT_TIME_SECONDS", "3600"))
     openenv_tb2_tasks_dir: str = os.environ.get("OPENENV_TB2_TASKS_DIR", "")
     openenv_daytona_create_concurrency: int = int(os.environ.get("OPENENV_DAYTONA_CREATE_CONCURRENCY", "8"))
+    # jittered-backoff attempts (~30s cap); 8 is ~2 min, short next to a 30-turn episode
+    openenv_daytona_create_max_retries: int = int(os.environ.get("OPENENV_DAYTONA_CREATE_MAX_RETRIES", "8"))
     openenv_launcher: str = os.environ.get("OPENENV_LAUNCHER", os.environ.get("USER", "miles"))
     openenv_run_id: str = os.environ.get("OPENENV_RUN_ID", "")
 
     # Eval over a held-out tbench2 split on the shared rollout engines (the
     # producer pauses for the duration). A dedicated fleet would need GPUs
-    # this 8+8 split has none of. None disables.
-    eval_interval: int | None = 10
+    # this 8+8 split has none of. 0 disables.
+    eval_interval: int = 10
     eval_prompt_data: str = ""  # default: <data_dir>/tbench2_eval.jsonl
     n_samples_per_eval_prompt: int = 2
     daytona_api_key: str = os.environ.get("DAYTONA_API_KEY", "")
@@ -104,7 +108,7 @@ class ScriptArgs(U.ExecuteTrainConfig):
         assert self.daytona_api_key, "DAYTONA_API_KEY must be set in the environment"
         if not self.prompt_data:
             self.prompt_data = f"{self.data_dir}/tbench2_train.jsonl"
-        if self.eval_interval is not None and not self.eval_prompt_data:
+        if self.eval_interval and not self.eval_prompt_data:
             self.eval_prompt_data = f"{self.data_dir}/tbench2_eval.jsonl"
 
 
@@ -145,14 +149,14 @@ def _execute_train(args: ScriptArgs):
         f"--rollout-batch-size {args.rollout_batch_size} "
         f"--n-samples-per-prompt {args.n_samples_per_prompt} "
         f"--rollout-max-response-len {args.rollout_max_response_len} "
-        "--max-seq-len 131072 "
+        f"--max-seq-len {args.max_seq_len} "
         "--rollout-temperature 0.8 "
         f"--global-batch-size {args.global_batch_size} "
         "--balance-data "
     )
 
     eval_args = ""
-    if args.eval_interval is not None:
+    if args.eval_interval:
         eval_args = (
             f"--eval-interval {args.eval_interval} "
             f"--eval-prompt-data tbench2 {args.eval_prompt_data} "
@@ -171,7 +175,7 @@ def _execute_train(args: ScriptArgs):
         "--session-server-port 30000 "
     )
 
-    # 32-GPU training half. CP4 splits the 131k max sequence to ~33k per rank;
+    # 32-GPU training half. CP4 splits --max-seq-len across the CP ranks;
     # TP2 (not TP1) because at TP1 the per-rank non-expert weights alone
     # overflow 276GB at checkpoint load.
     perf_args = (
@@ -201,7 +205,7 @@ def _execute_train(args: ScriptArgs):
         "--eps-clip 0.2 "
         "--eps-clip-high 0.28 "
         "--use-tis "
-        "--tis-clip-low 0.5 "
+        "--tis-clip-low 0.0 "
         "--tis-clip 2.0 "
     )
 
@@ -321,6 +325,7 @@ def _execute_train(args: ScriptArgs):
         "OPENENV_MAX_ROLLOUT_TIME_SECONDS": str(args.openenv_max_rollout_time_seconds),
         "OPENENV_TB2_TASKS_DIR": args.openenv_tb2_tasks_dir,
         "OPENENV_DAYTONA_CREATE_CONCURRENCY": str(args.openenv_daytona_create_concurrency),
+        "OPENENV_DAYTONA_CREATE_MAX_RETRIES": str(args.openenv_daytona_create_max_retries),
         "OPENENV_LAUNCHER": args.openenv_launcher,
         "OPENENV_RUN_ID": args.openenv_run_id,
         "DAYTONA_API_KEY": args.daytona_api_key,

--- a/examples/experimental/openenv/glm52_tbench2/run_glm5_2_744b_a40b_daytona.py
+++ b/examples/experimental/openenv/glm52_tbench2/run_glm5_2_744b_a40b_daytona.py
@@ -56,7 +56,8 @@ class ScriptArgs(U.ExecuteTrainConfig):
     n_samples_per_prompt: int = 8
     global_batch_size: int = 64
     rollout_max_response_len: int = 8192
-    # whole-session budget; CP splits it, so it also sets per-rank activations
+    # whole-session budget; CP splits it, so it also sets per-rank activations.
+    # TODO(#2591): the agent loop cannot see this cut and generates past it.
     max_seq_len: int = 65536
     # Max concurrently generating trajectories, decoupled from the train batch;
     # also sizes the Daytona pool so every in-flight trajectory has a sandbox.

--- a/examples/experimental/openenv/glm52_tbench2/run_glm5_2_744b_a40b_daytona.py
+++ b/examples/experimental/openenv/glm52_tbench2/run_glm5_2_744b_a40b_daytona.py
@@ -74,14 +74,13 @@ class ScriptArgs(U.ExecuteTrainConfig):
     openenv_max_rollout_time_seconds: int = int(os.environ.get("OPENENV_MAX_ROLLOUT_TIME_SECONDS", "3600"))
     openenv_tb2_tasks_dir: str = os.environ.get("OPENENV_TB2_TASKS_DIR", "")
     openenv_daytona_create_concurrency: int = int(os.environ.get("OPENENV_DAYTONA_CREATE_CONCURRENCY", "8"))
-    # jittered-backoff attempts (~30s cap); 8 is ~2 min, short next to a 30-turn episode
+    # jittered-backoff attempts (~30s cap)
     openenv_daytona_create_max_retries: int = int(os.environ.get("OPENENV_DAYTONA_CREATE_MAX_RETRIES", "8"))
     openenv_launcher: str = os.environ.get("OPENENV_LAUNCHER", os.environ.get("USER", "miles"))
     openenv_run_id: str = os.environ.get("OPENENV_RUN_ID", "")
 
     # Eval over a held-out tbench2 split on the shared rollout engines (the
-    # producer pauses for the duration). A dedicated fleet would need GPUs
-    # this 8+8 split has none of. 0 disables.
+    # producer pauses for the duration). 0 disables.
     eval_interval: int = 10
     eval_prompt_data: str = ""  # default: <data_dir>/tbench2_eval.jsonl
     n_samples_per_eval_prompt: int = 2

--- a/examples/experimental/openenv/glm52_tbench2/run_glm5_2_744b_a40b_daytona.py
+++ b/examples/experimental/openenv/glm52_tbench2/run_glm5_2_744b_a40b_daytona.py
@@ -57,7 +57,7 @@ class ScriptArgs(U.ExecuteTrainConfig):
     global_batch_size: int = 64
     rollout_max_response_len: int = 8192
     # whole-session budget; CP splits it, so it also sets per-rank activations
-    max_seq_len: int = 131072
+    max_seq_len: int = 65536
     # Max concurrently generating trajectories, decoupled from the train batch;
     # also sizes the Daytona pool so every in-flight trajectory has a sandbox.
     async_max_concurrent_samples: int = 128

--- a/examples/experimental/openenv/openenv_agent_function.py
+++ b/examples/experimental/openenv/openenv_agent_function.py
@@ -300,6 +300,9 @@ async def multi_turn(
             # (extras like reasoning_content included).
             convo.append(message.model_dump(exclude_none=True))
 
+            if completion.choices[0].finish_reason == "length":
+                break
+
             command = _strip_fence(reply) if "```" in reply else reply.strip()
             if not command or command.upper().startswith("TASK_COMPLETE"):
                 break
@@ -413,7 +416,7 @@ async def run_for_training(
     session_url = _resolve_session_url(base_url)
     model_name = os.getenv("AGENT_MODEL_NAME", os.getenv("SWE_AGENT_MODEL_NAME", "model"))
 
-    policy = AsyncOpenAI(base_url=session_url, api_key="EMPTY")
+    policy = AsyncOpenAI(base_url=session_url, api_key="EMPTY", timeout=3600.0, max_retries=0)
     messages = _extract_messages(prompt)
 
     try:

--- a/examples/experimental/openenv/openenv_daytona_agent_function.py
+++ b/examples/experimental/openenv/openenv_daytona_agent_function.py
@@ -65,10 +65,8 @@ logger = logging.getLogger(__name__)
 # older install outright, and the shared agent loop's harness-marker guard
 # backstops it per episode.
 #
-# Daytona refuses a create either by rate-limiting it (ThrottlerException: Too
-# Many Requests) or by reporting the org out of capacity; the shared backend caps
-# in-flight creates process-wide and retries both with jittered exponential
-# backoff (knobs: OPENENV_DAYTONA_CREATE_*).
+# Creates are capped process-wide and retried with jittered backoff when Daytona
+# throttles (429) or reports the org out of capacity (OPENENV_DAYTONA_CREATE_* knobs).
 def _is_throttle_error(exc: BaseException) -> bool:
     """True when a sandbox create failed only because Daytona would not seat it yet.
 

--- a/examples/experimental/openenv/openenv_daytona_agent_function.py
+++ b/examples/experimental/openenv/openenv_daytona_agent_function.py
@@ -65,15 +65,21 @@ logger = logging.getLogger(__name__)
 # older install outright, and the shared agent loop's harness-marker guard
 # backstops it per episode.
 #
-# Daytona rate-limits sandbox creation (ThrottlerException: Too Many Requests);
-# the shared backend caps in-flight creates process-wide and retries throttled ones
-# with jittered exponential backoff (knobs: OPENENV_DAYTONA_CREATE_*).
+# Daytona refuses a create either by rate-limiting it (ThrottlerException: Too
+# Many Requests) or by reporting the org out of capacity; the shared backend caps
+# in-flight creates process-wide and retries both with jittered exponential
+# backoff (knobs: OPENENV_DAYTONA_CREATE_*).
 def _is_throttle_error(exc: BaseException) -> bool:
-    """True when a sandbox create failed only because Daytona rate-limited it.
+    """True when a sandbox create failed only because Daytona would not seat it yet.
 
     The SDK normalizes HTTP 429 to DaytonaRateLimitError; the text match is a
     fallback for older SDKs and server messages that only surface as text
     (e.g. "ThrottlerException: Too Many Requests").
+
+    Quota exhaustion ("Total CPU limit exceeded. Maximum allowed: 500.", and the
+    memory/disk wordings beside it) arrives as a DaytonaValidationError but is
+    just as transient in a shared org: an episode aborted before its first model
+    call makes check_no_aborted discard the whole group, so waiting beats failing.
     """
     # In-function import, deliberately: this is the class's only use site, it
     # only runs on the failure path (where daytona is already in sys.modules,
@@ -85,7 +91,7 @@ def _is_throttle_error(exc: BaseException) -> bool:
             return True
     except ImportError:  # pragma: no cover - only without the daytona SDK
         pass
-    return common.throttle_text(exc, "throttler")
+    return common.throttle_text(exc, "throttler", "limit exceeded")
 
 
 def _start_sandbox(task_id: str, tasks_dir: str) -> tuple[Any, str]:

--- a/tests/fast/examples/experimental/openenv/test_openenv_agent_function.py
+++ b/tests/fast/examples/experimental/openenv/test_openenv_agent_function.py
@@ -80,7 +80,7 @@ class _FakePolicy:
         msg = types.SimpleNamespace(
             content=text, model_dump=lambda exclude_none=True: {"role": "assistant", "content": text}
         )
-        return types.SimpleNamespace(choices=[types.SimpleNamespace(message=msg)])
+        return types.SimpleNamespace(choices=[types.SimpleNamespace(message=msg, finish_reason="stop")])
 
 
 _CLASSES = {"env": _FakeEnv, "action": _FakeAction}
@@ -112,6 +112,35 @@ def test_shared_leg_dispatch(monkeypatch):
     assert any("/tmp/tbench2_env_runs" in (a.command or "") for a in execs), "trial-dir purge missing"
     assert any(a.action_type == "evaluate" for a in actions)
     assert metrics["turns"] == 2 and metrics["tool_calls"] == 1
+
+
+class _TruncatingPolicy(_FakePolicy):
+    """Emits a command the model never finished writing."""
+
+    async def _create(self, **kw):
+        completion = await super()._create(**kw)
+        completion.choices[0].finish_reason = "length"
+        return completion
+
+
+def test_length_capped_turn_ends_the_episode(monkeypatch):
+    """A turn cut off by the token cap must not be executed: the command is
+    truncated, so running it would send an arbitrary prefix to the sandbox."""
+    monkeypatch.setattr(oaf, "load_tbench2", lambda: _CLASSES)
+
+    async def spying_with_env(env_cls, env_url, body):
+        return await body(env_cls())
+
+    monkeypatch.setattr(oaf, "_with_env", spying_with_env)
+
+    _, metrics = run_async(
+        oaf.run_episode(_TruncatingPolicy(), "m", [{"role": "system", "content": "s"}], {}, {"task_id": "t1"})
+    )
+
+    assert metrics["turns"] == 1
+    assert metrics["tool_calls"] == 0
+    execs = [a for a in _FakeEnv.last_actions if a.action_type == "exec"]
+    assert not [a for a in execs if "echo hi" in (a.command or "")], "ran a command the model never finished"
 
 
 def test_old_server_reward_is_not_trusted(monkeypatch):

--- a/tests/fast/examples/experimental/openenv/test_openenv_daytona_agent_function.py
+++ b/tests/fast/examples/experimental/openenv/test_openenv_daytona_agent_function.py
@@ -68,6 +68,14 @@ def test_is_throttle_error_classification():
     assert not odaf._is_throttle_error(RuntimeError("image build failed"))
 
 
+def test_is_throttle_error_quota_exhaustion():
+    """Org capacity errors are retryable: failing immediately aborts the episode
+    and discards the whole group."""
+    assert odaf._is_throttle_error(Exception("Failed to create sandbox: Total CPU limit exceeded. Max allowed: 500."))
+    assert odaf._is_throttle_error(Exception("Failed to create sandbox: Total memory limit exceeded."))
+    assert not odaf._is_throttle_error(RuntimeError("task.toml is missing docker_image"))
+
+
 def test_is_throttle_error_typed_daytona_class():
     """The SDK's typed rate-limit error is recognized even when its message
     carries no throttle keywords."""


### PR DESCRIPTION
The exact example-side configuration of the GB300 16-node smoke runs (jobs 2403/2415), extracted so the run is reproducible from main:

```
examples/experimental/openenv/glm52_tbench2/launch_16node_slurm.sh \
  --eval-interval 0 --max-seq-len 65536 --sglang-config low-latency
```

## Collapse levers

Two 16-node runs on unmodified main collapsed the same way: `train_rollout_kl` flat at ~0.02, then an exponential ratchet (57x over 30 steps) concentrated entirely on near-deterministic tokens, followed by response-length blowup, truncation ~0.9 and reward -> 0.03. Root cause chain, per-token forensics on the train dumps:

- Failed samples loop (polling/retry cycles), hit the per-turn cap, truncate, and carry negative advantage over 16k+ near-deterministic scaffolding tokens shared with successful samples.
- `--tis-clip-low 0.5` **clamps** a collapsed importance ratio (exp(-30)) up to 0.5 — manufacturing gradient exactly where importance sampling says there should be none. The recipe now uses the miles default `0.0`, i.e. standard truncated IS (`w = min(ratio, 2)`).
- `rollout_max_response_len` 16384 -> 8192: completed samples never touched the cap in any run; only degenerate loops did. 16384 doubles a capped loop's token mass for no benefit.
- The policy client used SDK defaults (600 s timeout, `max_retries=2`). Slow 16k-token turns time out, the SDK resubmits while the engine keeps decoding the original, and zombies accumulate — measured ~1000 engine-side running requests against 128 live samples (~85-90% of decode capacity wasted), at ~500 duplicate requests/hour. `timeout=3600` matches the episode wall-clock cap; `max_retries=0` because resending a generation is not idempotent.
- A turn whose `finish_reason` is `length` now ends the episode instead of feeding a truncated turn forward.

With these three levers the run holds `kl ~= 0.03`, `tis_clipfrac ~= 0.007`, healthy climbing reward, and zero retry lines for 70+ steps (2.7x the unfixed lifetime; a residual slower ratchet through in-band stale groups is being addressed separately via `--max-weight-staleness`).

## Operational fixes hit while bringing the run up

- `--eval-interval 0` disables eval from the CLI (`int | None` + typer could not express "off").
- `FABRIC_PREFIX` is required: the previous default silently selected an unroutable address and the launch hung 15 minutes with no error.
- `--max-seq-len` is a recipe flag instead of a hard-coded 131072.
- Daytona org-capacity errors ("Total CPU limit exceeded", memory/disk variants) retry with the same jittered backoff as rate limits: failing immediately aborts the episode before its first model call, and `check_no_aborted` then discards the whole group. Retry count configurable via `OPENENV_DAYTONA_CREATE_MAX_RETRIES`.
- README updated to match.
