### PR TITLE
Do not abort in-flight requests when bumping the engine weight version

### DIFF
--- a/miles/backends/sglang_utils/sglang_engine.py
+++ b/miles/backends/sglang_utils/sglang_engine.py
@@ -644,7 +644,7 @@ class SGLangEngine(RayActor):
     def update_weight_version(self, weight_version: str):
         return self._make_request(
             "update_weight_version",
-            {"new_version": weight_version},
+            {"new_version": weight_version, "abort_all_requests": False},
         )
 
     def start_profile(


### PR DESCRIPTION
## Problem

Every weight update ends by aborting all in-flight rollout requests. The chain:

1. `_finalize_and_resume_engines` (mixin.py) calls `engine.update_weight_version(new_version)` — added so full-param and LoRA updates share one version bump. The July-era code passed `weight_version` inside the `update_weights_from_distributed` payload instead and never hit this endpoint.
2. The wrapper posts only `{"new_version": ...}` (`sglang_engine.py`).
3. sglang's `UpdateWeightVersionReqInput` defaults `abort_all_requests: bool = True`, and the `/update_weight_version` handler then runs `abort_request(abort_all=True)` — one step before `continue_generation`.

Under `pause_generation_mode=in_place` this defeats the pause itself: the scheduler's in-place pause deliberately leaves all running requests intact so they resume decoding under the new weights, and the version bump then destroys them.

Downstream, each aborted turn returns a partial message with `finish_reason: "abort"`. The agent extracts no command from the partial and ends the episode, the sample finishes ABORTED, and `check_no_aborted` drops the entire group.

## Measured impact (16-node GLM-5.2 agentic run, job 2403; July build as control)

- ~65 aborts per update ≈ the number of requests decoding when the update lands; abort timestamps sit 30–60s after each pause (after the ~44s transfer, at finalize), with none during the transfer window.
- 38% of all samples end ABORTED (July control: 0%). 11–18 groups (88–144 samples) discarded per step — about two thirds of rollout production.
- Consumable sample supply drops to ~64 per 450s while raw production is ~178 per step; `train_wait_time` 137–340s per step.
- The `abort_all` sweep racing `_wait_one_response` wake-ups is also the source of the `rid_to_state` KeyErrors logged during updates (343 in this run).
- Mixed-version turns disappear (0.11–0.56 mixed_version in the July control vs 0–9%): any turn spanning an update is killed instead of finishing under the new weights.

## Fix

Pass `abort_all_requests: False` from the wrapper. The pause mode has already decided the in-flight requests' fate by the time the version is bumped; under `in_place` they must stay alive. This restores the July behavior, under which a 99-step run trained with turns routinely finishing under mixed weights (the per-turn rollout log-probs record the actual sampling distribution either way, so importance correction is unaffected).

A follow-up candidate (not in this PR): the agent loop in `examples/experimental/openenv` does not inspect `finish_reason`, so any residual aborted turn still ends its episode; the session server's retry rollback (`prepare_pretokenized`) already supports re-issuing such a turn.
