### PR TITLE
[multi-lora] tinker frontend: add native GSPO loss

### DIFF
--- a/docs/examples/tinker-backend.md
+++ b/docs/examples/tinker-backend.md
@@ -190,8 +190,9 @@ quotas are future work.
 ## v1 compatibility matrix
 
 Supported: text-only input; the synchronous training loop; 1-D shifted
-targets; `loss_fn ∈ {cross_entropy, importance_sampling, ppo}` (per-op clip
-config); per-call AdamParams; multi-chunk gradient accumulation with
+targets; `loss_fn ∈ {cross_entropy, importance_sampling, ppo, gspo}` (per-op
+clip config; GSPO-token uses sequence-level ratios and requires `weights`);
+per-call AdamParams; multi-chunk gradient accumulation with
 independent `optim_step`; latest-only sampler weights behind the publish
 barrier; named immutable `save_state` / `load_state` (create-from-checkpoint
 included, shape-fenced); optional `num_step` auto-retirement.

--- a/examples/tinker_backend/README.md
+++ b/examples/tinker_backend/README.md
@@ -187,8 +187,9 @@ quotas are future work.
 ## v1 compatibility matrix
 
 Supported: text-only input; the synchronous training loop; 1-D shifted
-targets; `loss_fn ∈ {cross_entropy, importance_sampling, ppo}` (per-op clip
-config); per-call AdamParams; multi-chunk gradient accumulation with
+targets; `loss_fn ∈ {cross_entropy, importance_sampling, ppo, gspo}` (per-op
+clip config; GSPO-token uses sequence-level ratios and requires `weights`);
+per-call AdamParams; multi-chunk gradient accumulation with
 independent `optim_step`; latest-only sampler weights behind the publish
 barrier; named immutable `save_state` / `load_state` (create-from-checkpoint
 included, shape-fenced); optional `num_step` auto-retirement.

--- a/miles/backends/training_utils/loss_hub/losses.py
+++ b/miles/backends/training_utils/loss_hub/losses.py
@@ -517,7 +517,7 @@ def tinker_loss_function(
     BatchPlan, keyed by the sample's batch-local ``operation lane`` (never by
     trainer slot — ``adapter_slots`` only routes the Multi-LoRA forward):
     linear cross-entropy ``Σ(-logp·w)``, importance sampling ``-Σ(ratio·A)``,
-    or the PPO clipped surrogate. Reduction is a plain token sum — chunk
+    PPO, or GSPO-token clipped surrogates. Reduction is a plain token sum — chunk
     additive, so K accumulated forward_backward operations produce the same
     gradient as one, and the client's ``loss_weights`` own the scale (no
     1/count normalization ever applies to tinker operations).
@@ -580,15 +580,32 @@ def tinker_loss_function(
         mask = local_masks[i].to(device=logp.device, dtype=logp.dtype)
         if loss_fn == "cross_entropy":
             sample_loss = -(logp * channel("loss_weights", i, loss_fn) * mask).sum()
-        elif loss_fn in ("importance_sampling", "ppo"):
-            ratio = torch.exp(logp - channel("rollout_log_probs", i, loss_fn))
+        elif loss_fn in ("importance_sampling", "ppo", "gspo"):
+            old_log_probs = channel("rollout_log_probs", i, loss_fn)
+            active_mask = mask
+            if loss_fn == "gspo":
+                active_mask = active_mask * channel("loss_weights", i, loss_fn)
+                full_logp = logp.detach()
+                full_old_log_probs = old_log_probs
+                full_active_mask = active_mask
+                if get_parallel_state().cp.size > 1:
+                    full_logp = all_gather_with_cp(full_logp, total_lengths[i], response_lengths[i])
+                    full_old_log_probs = all_gather_with_cp(old_log_probs, total_lengths[i], response_lengths[i])
+                    full_active_mask = all_gather_with_cp(active_mask, total_lengths[i], response_lengths[i])
+                sequence_log_ratio = (
+                    (full_logp - full_old_log_probs) * full_active_mask
+                ).sum() / full_active_mask.sum().clamp_min(1)
+                log_ratio = logp - logp.detach() + sequence_log_ratio.detach()
+                ratio = torch.exp(log_ratio.clamp(max=10))
+            else:
+                ratio = torch.exp(logp - old_log_probs)
             advantages = channel("advantages", i, loss_fn)
             surrogate = ratio * advantages
-            if loss_fn == "ppo":
+            if loss_fn in ("ppo", "gspo"):
                 low = config.get("clip_low_threshold", 0.8)
                 high = config.get("clip_high_threshold", 1.2)
                 surrogate = torch.minimum(surrogate, ratio.clamp(low, high) * advantages)
-            sample_loss = -(surrogate * mask).sum()
+            sample_loss = -(surrogate * active_mask).sum()
         else:
             raise ValueError(f"tinker operation in lane {operation_lanes[i]} requests unknown loss_fn '{loss_fn}'")
         loss = sample_loss if loss is None else loss + sample_loss

--- a/miles/ray/tinker_backend/backend.py
+++ b/miles/ray/tinker_backend/backend.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 
 # v1 compatibility matrix (README table mirrors this): anything outside is a
 # typed user error at enqueue time, never a GPU-side crash.
-SUPPORTED_LOSS_FNS = ("cross_entropy", "importance_sampling", "ppo")
+SUPPORTED_LOSS_FNS = ("cross_entropy", "importance_sampling", "ppo", "gspo")
 _ADAM_FIELDS = ("learning_rate", "beta1", "beta2", "eps", "weight_decay", "grad_clip_norm")
 _SAMPLE_TENSOR_FIELDS = ("loss_mask", "loss_weights", "advantages", "rollout_log_probs")
 # Channels each loss reads per token; a missing one must fail at enqueue, not
@@ -36,6 +36,7 @@ _LOSS_REQUIRED_CHANNELS = {
     "cross_entropy": ("loss_weights",),
     "importance_sampling": ("rollout_log_probs", "advantages"),
     "ppo": ("rollout_log_probs", "advantages"),
+    "gspo": ("rollout_log_probs", "advantages", "loss_weights"),
 }
 
 
@@ -553,6 +554,22 @@ def operation_result_metrics(payload: dict, logprobs: list[list[float]]) -> dict
         if loss_fn == "cross_entropy":
             weights = sample.get("loss_weights") or []
             total += sum(-lp * w * m for lp, w, m in zip(sample_logprobs, weights, mask, strict=False))
+        elif loss_fn == "gspo":
+            old = sample.get("rollout_log_probs") or []
+            advantages = sample.get("advantages") or []
+            weights = sample.get("loss_weights") or []
+            active = [m * w for m, w in zip(mask, weights, strict=False)]
+            denominator = max(sum(active), 1.0)
+            sequence_log_ratio = (
+                sum((lp - old_lp) * weight for lp, old_lp, weight in zip(sample_logprobs, old, active, strict=False))
+                / denominator
+            )
+            ratio = math.exp(min(sequence_log_ratio, 10.0))
+            low = config.get("clip_low_threshold", 0.8)
+            high = config.get("clip_high_threshold", 1.2)
+            for advantage, weight in zip(advantages, active, strict=False):
+                surrogate = min(ratio * advantage, min(max(ratio, low), high) * advantage)
+                total += -surrogate * weight
         else:
             old = sample.get("rollout_log_probs") or []
             advantages = sample.get("advantages") or []

--- a/miles/ray/tinker_backend/frontend/service.py
+++ b/miles/ray/tinker_backend/frontend/service.py
@@ -387,7 +387,10 @@ class TinkerFrontend:
         info = self.backend.service_info()
         # None until the engine context limit is configured or discovered.
         model = {"model_name": info.get("base_model"), "max_context_length": self._context_limit}
-        return {"supported_models": [model]}
+        return {
+            "supported_models": [model],
+            "supported_loss_fns": info.get("supported_loss_fns", []),
+        }
 
     def create_session(self, request: wire.CreateSessionRequest) -> dict:
         self._check_sdk_version(request.sdk_version)

--- a/miles/ray/tinker_backend/frontend/translation.py
+++ b/miles/ray/tinker_backend/frontend/translation.py
@@ -26,7 +26,7 @@ import math
 
 from miles.ray.tinker_backend.frontend import wire
 
-SUPPORTED_LOSS_FNS = ("cross_entropy", "importance_sampling", "ppo")
+SUPPORTED_LOSS_FNS = ("cross_entropy", "importance_sampling", "ppo", "gspo")
 
 # Official loss_fn_inputs channel -> backend per-token channel.
 _CHANNEL_TO_BACKEND = {
@@ -38,10 +38,16 @@ _REQUIRED_CHANNELS = {
     "cross_entropy": ("weights",),
     "importance_sampling": ("logprobs", "advantages"),
     "ppo": ("logprobs", "advantages"),
+    "gspo": ("logprobs", "advantages", "weights"),
 }
 # Which channel decides whether a position contributes loss (and therefore
 # must be a true next-token target).
-_ACTIVE_CHANNEL = {"cross_entropy": "weights", "importance_sampling": "advantages", "ppo": "advantages"}
+_ACTIVE_CHANNEL = {
+    "cross_entropy": "weights",
+    "importance_sampling": "advantages",
+    "ppo": "advantages",
+    "gspo": "weights",
+}
 
 
 class UserInputError(ValueError):

--- a/tests/fast/backends/training_utils/loss/test_tinker_loss.py
+++ b/tests/fast/backends/training_utils/loss/test_tinker_loss.py
@@ -1,5 +1,5 @@
 """Tinker per-operation-lane loss dispatch: linear CE / importance sampling /
-PPO, sum-reduction (chunk-additive), per-sample lane correlation, channel
+PPO / GSPO, sum-reduction (chunk-additive), per-sample lane correlation, channel
 validation, and homogeneous forward-only collection. The physical
 ``adapter_slots`` never appear here: they route the Multi-LoRA forward only."""
 
@@ -103,6 +103,45 @@ def test_importance_sampling_and_ppo_clip():
     assert torch.allclose(loss_ppo, expected_ppo)
     # Clipping binds somewhere, otherwise this test proves nothing.
     assert not torch.allclose(loss_ppo, loss)
+
+
+def test_gspo_uses_sequence_ratio_with_token_local_gradients():
+    args, batch, logits = make_batch(prompt_lens=(4,), response_lens=(3,))
+    batch["rollout_log_probs"] = [torch.tensor([-2.0, -1.0, -3.0])]
+    batch["advantages"] = [torch.tensor([1.0, -2.0, 0.5])]
+    batch["loss_weights"] = [torch.tensor([1.0, 1.0, 0.0])]
+    batch["tinker_loss_by_lane"] = {
+        0: {"loss_fn": "gspo", "loss_fn_config": {"clip_low_threshold": 0.5, "clip_high_threshold": 2.0}}
+    }
+
+    loss, _ = run(args, batch, logits)
+    logp = reference_log_probs(args, batch, logits)[0]
+    active = batch["loss_weights"][0]
+    sequence_log_ratio = ((logp.detach() - batch["rollout_log_probs"][0]) * active).sum() / active.sum()
+    token_log_ratio = logp - logp.detach() + sequence_log_ratio
+    ratio = torch.exp(token_log_ratio.clamp(max=10))
+    advantages = batch["advantages"][0]
+    expected = -(torch.minimum(ratio * advantages, ratio.clamp(0.5, 2.0) * advantages) * active).sum()
+
+    assert torch.allclose(loss, expected)
+    actual_grad = torch.autograd.grad(loss, logits, retain_graph=True)[0]
+    expected_grad = torch.autograd.grad(expected, logits)[0]
+    assert torch.allclose(actual_grad, expected_grad)
+
+
+def test_gspo_differs_from_token_ratio_ppo():
+    args, batch, logits = make_batch(prompt_lens=(4,), response_lens=(3,))
+    batch["rollout_log_probs"] = [torch.tensor([-5.0, 0.0, -1.0])]
+    batch["advantages"] = [torch.ones(3)]
+    batch["loss_weights"] = [torch.ones(3)]
+    config = {"clip_low_threshold": 0.9, "clip_high_threshold": 1.1}
+
+    batch["tinker_loss_by_lane"] = {0: {"loss_fn": "gspo", "loss_fn_config": config}}
+    gspo_loss, _ = run(args, batch, logits)
+    batch["tinker_loss_by_lane"] = {0: {"loss_fn": "ppo", "loss_fn_config": config}}
+    ppo_loss, _ = run(args, batch, logits)
+
+    assert not torch.allclose(gspo_loss, ppo_loss)
 
 
 def test_mixed_lanes_dispatch_independently():

--- a/tests/fast/ray/tinker_backend/frontend/test_sdk_contract.py
+++ b/tests/fast/ray/tinker_backend/frontend/test_sdk_contract.py
@@ -157,7 +157,7 @@ class TestTrainingChain:
         assert len(result.loss_fn_outputs) == count
         assert result.metrics["unmasked_tokens:sum"] == pytest.approx(2.0 * count)
 
-    def test_importance_sampling_and_ppo(self, service_client):
+    def test_importance_sampling_ppo_and_gspo(self, service_client):
         client = service_client.create_lora_training_client(base_model=BASE, rank=4)
         datum = types.Datum(
             model_input=types.ModelInput.from_ints([1, 2, 3]),
@@ -173,6 +173,14 @@ class TestTrainingChain:
             [datum], "ppo", loss_fn_config={"clip_low_threshold": 0.8, "clip_high_threshold": 1.2}
         ).result()
         assert "loss:sum" in ppo_result.metrics
+        gspo_datum = types.Datum(
+            model_input=datum.model_input,
+            loss_fn_inputs={**datum.loss_fn_inputs, "weights": [0.0, 1.0, 1.0]},
+        )
+        gspo_result = client.forward_backward(
+            [gspo_datum], "gspo", loss_fn_config={"clip_low_threshold": 0.8, "clip_high_threshold": 1.2}
+        ).result()
+        assert "loss:sum" in gspo_result.metrics
 
     def test_user_error_is_typed_and_leaves_no_gap(self, service_client):
         client = service_client.create_lora_training_client(base_model=BASE, rank=4)

--- a/tests/fast/ray/tinker_backend/frontend/test_service.py
+++ b/tests/fast/ray/tinker_backend/frontend/test_service.py
@@ -635,6 +635,12 @@ class TestLifecycle:
             assert stack.frontend.health() == {"status": "ok"}
             capabilities = stack.frontend.capabilities()
             assert capabilities["supported_models"][0]["model_name"] == BASE
+            assert capabilities["supported_loss_fns"] == [
+                "cross_entropy",
+                "importance_sampling",
+                "ppo",
+                "gspo",
+            ]
             config = stack.frontend.client_config(wire.ClientConfigRequest(sdk_version="0.24.1"))
             assert config["proto_write_fwdbwd"] is False and config["pjwt_auth_enabled"] is False
             assert stack.frontend.session_heartbeat(wire.SessionHeartbeatRequest(session_id=stack.session_id)) == {

--- a/tests/fast/ray/tinker_backend/frontend/test_translation.py
+++ b/tests/fast/ray/tinker_backend/frontend/test_translation.py
@@ -65,6 +65,23 @@ class TestDatumToSample:
         assert sample["advantages"] == [0.0, 1.0]
         assert "loss_weights" not in sample
 
+    def test_gspo_requires_and_maps_sequence_mask(self):
+        d = datum(
+            [1, 2],
+            [2, 5],
+            logprobs=[-0.5, -0.5],
+            advantages=[0.0, 1.0],
+            weights=[0.0, 1.0],
+        )
+        sample = translation.datum_to_sample(0, d, "gspo")
+        assert sample["rollout_log_probs"] == [-0.5, -0.5]
+        assert sample["advantages"] == [0.0, 1.0]
+        assert sample["loss_weights"] == [0.0, 1.0]
+
+        del d.loss_fn_inputs["weights"]
+        with pytest.raises(UserInputError, match="requires loss_fn_inputs\\['weights'\\]"):
+            translation.datum_to_sample(0, d, "gspo")
+
     def test_missing_required_channel_is_rejected(self):
         with pytest.raises(UserInputError, match="requires loss_fn_inputs\\['weights'\\]"):
             translation.datum_to_sample(0, datum([1, 2], [2, 3]), "cross_entropy")

--- a/tests/fast/ray/tinker_backend/test_backend.py
+++ b/tests/fast/ray/tinker_backend/test_backend.py
@@ -439,7 +439,7 @@ def test_service_info_reports_the_v1_matrix():
     assert info["base_model"] == "Qwen/Qwen3-0.6B"
     assert info["lora_rank_max"] == 32 and info["n_adapters"] == 4
     assert info["occupied_slots"] == [0] and info["ready_adapters"] == ["X"]
-    assert info["supported_loss_fns"] == ["cross_entropy", "importance_sampling", "ppo"]
+    assert info["supported_loss_fns"] == ["cross_entropy", "importance_sampling", "ppo", "gspo"]
 
 
 def test_engine_aborts_go_through_the_inference_admin_port():

--- a/tests/fast/ray/tinker_backend/test_metrics_contract.py
+++ b/tests/fast/ray/tinker_backend/test_metrics_contract.py
@@ -56,6 +56,23 @@ class TestMetricsValues:
         assert metrics_ppo["loss:sum"] == pytest.approx(expected)
         assert metrics_ppo["loss:sum"] != pytest.approx(metrics["loss:sum"])
 
+    def test_gspo_uses_one_sequence_ratio_and_weights(self):
+        sample = {
+            "tokens": [1, 1, 1, 1],
+            "response_length": 3,
+            "rollout_log_probs": [-1.0, -1.0, -1.0],
+            "advantages": [1.0, -2.0, 4.0],
+            "loss_weights": [1.0, 1.0, 0.0],
+        }
+        logprobs = [[-0.5, -1.5, 4.0]]
+        spec = {"loss_fn": "gspo", "loss_fn_config": {"clip_low_threshold": 0.9, "clip_high_threshold": 1.1}}
+
+        metrics = operation_result_metrics({"samples": [sample], "loss": spec}, logprobs)
+
+        ratio = math.exp(0.0)
+        expected = -min(ratio, 1.1) - min(ratio * -2.0, 0.9 * -2.0)
+        assert metrics["loss:sum"] == pytest.approx(expected)
+
     def test_degenerate_ratio_cannot_overflow_the_recompute(self):
         # exp(1000) would raise OverflowError AFTER the GPU work landed,
         # leaving the operation without a terminal result; the recompute clamps.


### PR DESCRIPTION
## Summary

- Add native GSPO loss to the Tinker-compatible backend.
- Calculate one masked sequence ratio on the server. Keep client-defined loss normalization.
- Add `supported_loss_fns` to the capabilities response. Clients use native GSPO only when the server lists it.

## B300 benchmark

Test configuration: one node with eight B300 GPUs, Qwen3.8-27B, batch size 16, and group size 32. The table gives median values for updates 1 through 4.

| Miles GSPO path | Training time per update | Total time per update | Unconditional action tokens per second |
| --- | ---: | ---: | ---: |
| Client-side | 941 s | 965 s | 849 |
| Native | 729 s | 762 s | 1,250 |

Native GSPO decreased training time by 22.5%. It decreased total update time by 21.1%. It increased action-token throughput by 47.2%.

## Testing

```text
pytest --confcutdir=tests/fast/ray/tinker_backend \
  tests/fast/ray/tinker_backend/test_metrics_contract.py \
  tests/fast/ray/tinker_backend/test_backend.py \
  tests/fast/ray/tinker_backend/frontend/test_translation.py \
  tests/fast/ray/tinker_backend/frontend/test_service.py \
  tests/fast/ray/tinker_backend/frontend/test_sdk_contract.py -q
```

All 114 tests passed. These tests cover loss metrics, request translation, service behavior, backend behavior, and the `tinker==0.24.1` SDK contract.

A B300 run completed five optimizer updates. The loss and gradient norm stayed finite.

```text
uv run python scripts/tools/sync_example_docs.py --check
```

The documentation check passed. Ruff and Black also passed for all changed Python files.
