### PR TITLE
docs: add serial commas throughout the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@
 Miles is a high-performance, enterprise-ready reinforcement learning framework for
 **large-scale model post-training**. It pairs [SGLang](https://github.com/sgl-project/sglang)
 for high-throughput rollout with [Megatron-LM](https://github.com/NVIDIA/Megatron-LM) for
-scalable training, and ships the precision, stability and observability features an RL run
+scalable training, and ships the precision, stability, and observability features an RL run
 needs at trillion-parameter scale. A PyTorch FSDP2 backend is available for runs that would
-rather train the HuggingFace implementation as-is, though the recipes, the parallelism and
+rather train the HuggingFace implementation as-is, though the recipes, the parallelism, and
 the largest models all live on Megatron-LM. See
 [Training Backends](https://miles.radixark.com/docs/user-guide/training-backend).
 
@@ -46,7 +46,7 @@ the largest models all live on Megatron-LM. See
   off-policy schedules, a pipeline tuned for fewer bubbles, and customizable async rollout
   and eval modes. See [Fully Async RL](https://miles.radixark.com/docs/user-guide/fully-async).
 - **Fast agentic rollout.** Generation runs on [SGLang](https://github.com/sgl-project/sglang)
-  behind a router that spreads requests across engines, preserves per-request metadata and
+  behind a router that spreads requests across engines, preserves per-request metadata, and
   health-checks the fleet. Tuned for multi-turn agentic workloads.
 - **Fast weight updates.** New weights reach the engines in-loop in seconds, even on a
   trillion-parameter model such as Kimi-K2.6, with
@@ -54,7 +54,7 @@ the largest models all live on Megatron-LM. See
   for disaggregated setups.
 - **Low-precision training.** [MXFP8 and NVFP4](https://miles.radixark.com/docs/advanced/low-precision)
   training with a numerically stable RL recipe that reduces precision-induced divergence.
-  FP8, [INT4 QAT](https://miles.radixark.com/docs/advanced/int4-qat), BF16 and FP16 are also
+  FP8, [INT4 QAT](https://miles.radixark.com/docs/advanced/int4-qat), BF16, and FP16 are also
   supported.
 - **LoRA and multi-LoRA.** [Low-rank adapters](https://miles.radixark.com/docs/advanced/lora)
   train frontier-scale models on a fraction of the GPUs, and the same adapters load straight
@@ -79,18 +79,18 @@ the largest models all live on Megatron-LM. See
 
 ### What Miles runs
 
-- **Day-0 model support.** DeepSeek-V4, Kimi-K3, GLM-5.2, Inkling and Nemotron landed on
+- **Day-0 model support.** DeepSeek-V4, Kimi-K3, GLM-5.2, Inkling, and Nemotron landed on
   release day. Beyond day 0, nearly every frontier model runs on Miles, including Kimi-K2.6
   and Qwen3.5. See [Models](https://miles.radixark.com/docs/models).
-- **Extensive hardware support.** NVIDIA GB300, GB200, B300, B200, H200, H100 and A100, and
-  AMD MI300X, MI325, MI350 and MI355X via ROCm. See
+- **Extensive hardware support.** NVIDIA GB300, GB200, B300, B200, H200, H100, and A100, and
+  AMD MI300X, MI325, MI350, and MI355X via ROCm. See
   [Installation](https://miles.radixark.com/docs/getting-started/installation#hardware-requirements)
   for per-GPU status and the container image for each.
-- **Wide recipe support.** GRPO, GSPO, PPO and REINFORCE++ for RL, plus SFT and
+- **Wide recipe support.** GRPO, GSPO, PPO, and REINFORCE++ for RL, plus SFT and
   [on-policy distillation](https://miles.radixark.com/docs/advanced/on-policy-distillation).
 - **Agentic environments.** Train coding and computer-use agents through connectors for
-  Harbor, HUD, NeMo Gym, OpenEnv, Verifiers and more, each plugging into the rollout
-  layer that fits it, with task sandboxes on AgentENV, Daytona, E2B or Modal. See
+  Harbor, HUD, NeMo Gym, OpenEnv, Verifiers, and more, each plugging into the rollout
+  layer that fits it, with task sandboxes on AgentENV, Daytona, E2B, or Modal. See
   [Agentic Environments](https://miles.radixark.com/docs/user-guide/environments).
 
 ## Getting Started
@@ -108,7 +108,7 @@ the largest models all live on Megatron-LM. See
 
 Miles was forked from [slime](https://github.com/THUDM/slime), and integrates
 [SGLang](https://github.com/sgl-project/sglang),
-[Megatron-LM](https://github.com/NVIDIA/Megatron-LM) and
+[Megatron-LM](https://github.com/NVIDIA/Megatron-LM), and
 [torch_memory_saver](https://github.com/fzyzcjy/torch_memory_saver).
 
 ## Citation

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ the largest models all live on Megatron-LM. See
 
 - **Token-in-token-out (TITO).** Supported for
   [every model and every black-box harness](https://miles.radixark.com/docs/user-guide/agentic-rollout),
-  with no detokenize and retokenize round-trip between rollout and training.
+  with no detokenize/retokenize round-trip between rollout and training.
 - **Rollout Routing Replay (R3).** Expert routing recorded during rollout is
   [replayed in the trainer's forward pass](https://miles.radixark.com/docs/advanced/miles-router),
   removing the MoE routing mismatch that destabilizes large runs, with compute and


### PR DESCRIPTION
## Summary

Copy-edit pass over the repo README:

- **Serial (Oxford) commas** added consistently across the nine lists that were missing them: the About paragraph (precision/stability/observability; recipes/parallelism/largest-models), the router bullet's verb series, the low-precision dtype list, the day-0 model list, both hardware lists (NVIDIA and AMD), the RL recipe list, the environments connector and sandbox lists, and the Acknowledgment integration list. The one list that already had its serial comma (the fully-async bullet) is untouched.

- **One phrasing fix**: the TITO bullet's "no detokenize and retokenize round-trip" reads as a mis-parsed list; now "no detokenize/retokenize round-trip", matching the docs homepage wording.

While auditing, every docs link in the README (17 routes plus the `#hardware-requirements` anchor) was checked against `docs/docs.json` and the target pages, and all external URLs (9 LMSYS blog posts, the logo asset) were liveness-checked — everything resolves, so no link fixes were needed. No factual issues found. (`https://slack.sglang.ai` answers 403 to non-browser clients — it appears to be bot protection on the invite redirect, but worth a one-click browser check.)

## Test plan

- [ ] README renders unchanged apart from punctuation
