### PR TITLE
docs: point at Miles-diffusion for diffusion post-training

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,9 @@ the largest models all live on Megatron-LM. See
   Harbor, HUD, NeMo Gym, OpenEnv, Verifiers and more, each plugging into the rollout
   layer that fits it, with task sandboxes on AgentENV, Daytona, E2B or Modal. See
   [Agentic Environments](https://miles.radixark.com/docs/user-guide/environments).
+- **Diffusion models.** Flow-GRPO, DiffusionNFT and SFT on an sglang-diffusion rollout
+  engine and an FSDP2 trainer, in
+  [Miles-diffusion](https://github.com/radixark/miles_diffusion).
 
 ## Getting Started
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -62,6 +62,9 @@ the largest models all live on Megatron-LM. See
   Harbor, HUD, NeMo Gym, OpenEnv, Verifiers and more, each plugging into the rollout
   layer that fits it, with task sandboxes on AgentENV, Daytona, E2B or Modal. See
   [Agentic Environments](/user-guide/environments).
+- **Diffusion models.** Flow-GRPO, DiffusionNFT and SFT on an sglang-diffusion rollout
+  engine and an FSDP2 trainer, in
+  [Miles-diffusion](https://github.com/radixark/miles_diffusion).
 - **Comprehensive CI.** Unit suites run on every pull request, and tag-triggered end-to-end
   GPU training tests cover the supported model families on both NVIDIA and AMD runners.
 


### PR DESCRIPTION
Diffusion post-training is developed in [radixark/miles_diffusion](https://github.com/radixark/miles_diffusion), not in this repository — nothing in the README or the docs overview said so.

Adds one bullet to the "What Miles runs" list in both places, naming what lives there so readers know when to follow the link:

> - **Diffusion models.** Flow-GRPO, DiffusionNFT and SFT on an sglang-diffusion rollout engine and an FSDP2 trainer, in [Miles-diffusion](https://github.com/radixark/miles_diffusion).

Note that miles_diffusion's own README is currently a "Coming soon" placeholder; the feature names above come from the diffusion team's write-up, so please correct them if anything has since changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)