### PR TITLE
fix(docker): pin cutlass-dsl 4.6.2 and flashinfer 0.6.15.post1 over the sglang base

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -291,6 +291,47 @@ p = inspect.signature(k.make_kwargs_wrapper).parameters; \
 assert 'map_dataclass_to_tuple' in p, \
   'apache-tvm-ffi resolves to a build too old for nvidia-cutlass-dsl 4.6.0: %s' % list(p)"
 
+# ==================== Pin nvidia-cutlass-dsl to 4.6.2 ====================
+# The sglang v0.5.16 base ships nvidia-cutlass-dsl 4.6.0, whose 4.6.0/4.6.1 runtime
+# hangs FA4 CuTe backward forever on sm_103 (B300/GB300): the first training backward
+# spins at 100% GPU in _bwd_postprocess_convert and never returns
+# (https://github.com/Dao-AILab/flash-attention/issues/2797). 4.6.2 is fixed and passes
+# FA4's own SM100 forward/backward checks. The meta-package alone does NOT move what a
+# process loads — the -libs-cu12/-libs-cu13 wheels carry the actual runtime — so pin
+# every component and fail the build loudly if any of them slips.
+RUN pip install --force-reinstall --no-deps \
+      "nvidia-cutlass-dsl==4.6.2" \
+      "nvidia-cutlass-dsl-libs-base==4.6.2" \
+      "nvidia-cutlass-dsl-libs-core==4.6.2" \
+      "nvidia-cutlass-dsl-libs-cu12==4.6.2" \
+      "nvidia-cutlass-dsl-libs-cu13==4.6.2" && \
+    python3 -c "from importlib.metadata import version as v; \
+libs = ['nvidia-cutlass-dsl', 'nvidia-cutlass-dsl-libs-base', 'nvidia-cutlass-dsl-libs-core', \
+        'nvidia-cutlass-dsl-libs-cu12', 'nvidia-cutlass-dsl-libs-cu13']; \
+bad = {p: v(p) for p in libs if v(p) != '4.6.2'}; \
+assert not bad, 'nvidia-cutlass-dsl components not at 4.6.2: %s' % bad"
+
+# ==================== Pin flashinfer to 0.6.15.post1 ====================
+# The sglang v0.5.16 base ships flashinfer 0.6.14, whose trtllm MoE cubins can hang
+# 2CTA kernels on Blackwell (regression since 0.6.8, fixed cubins in 0.6.15;
+# https://github.com/flashinfer-ai/flashinfer/pull/3973). 0.6.15.post1 additionally
+# fixes the host-side MLA/MoE dispatch overhead that got the plain 0.6.15 bump
+# reverted upstream (sgl-project/sglang#31625 -> #31927). The python + cubin + jit-cache
+# trio must move together; jit-cache wheels live on flashinfer's own index, per CUDA line.
+RUN FI_CUDA_INDEX=$([ "${ENABLE_CUDA_13}" = "1" ] && echo cu130 || echo cu129) && \
+    pip install --force-reinstall --no-deps \
+      --extra-index-url "https://flashinfer.ai/whl" \
+      --extra-index-url "https://flashinfer.ai/whl/${FI_CUDA_INDEX}" \
+      "flashinfer-python==0.6.15.post1" \
+      "flashinfer-cubin==0.6.15.post1" \
+      "flashinfer-jit-cache==0.6.15.post1" && \
+    python3 -c "from importlib.metadata import version as v; \
+vers = {p: v(p) for p in ['flashinfer-python', 'flashinfer-cubin', 'flashinfer-jit-cache']}; \
+bad = {p: x for p, x in vers.items() if not x.startswith('0.6.15.post1')}; \
+assert not bad, 'flashinfer components not at 0.6.15.post1: %s' % bad"
+# The sglang base exports FLASHINFER_VERSION=0.6.14; keep the marker in step.
+ENV FLASHINFER_VERSION=0.6.15.post1
+
 RUN rm -rf /tmp/wheels
 
 # The cu130 sglang base ships its baked Rust toolchain outside the default PATH.


### PR DESCRIPTION
## Problem

Two dependency bugs baked into the `lmsysorg/sglang:v0.5.16` base image (and therefore every miles image, including `release-v0.1.0-ci`):

1. **nvidia-cutlass-dsl 4.6.0 hangs FA4 backward on B300/GB300 (sm_103).** The first training backward spins at 100% GPU forever in FA4 CuTe `_bwd_postprocess_convert` (Dao-AILab/flash-attention#2797). Reproduced on a B300 devbox with bare `flash_attn.cute` fwd+bwd: hangs on 4.6.0, completes on 4.6.2. sm_100 (B200/GB200) and Hopper are unaffected, which is why existing CI never caught it. qwen3-30b nvfp4 training on B300 hung 9.5h in the first train step; with 4.6.2 the same run trains normally.
2. **flashinfer 0.6.14 trtllm MoE cubins can hang 2CTA kernels on Blackwell** (regression since 0.6.8, fixed in 0.6.15 via flashinfer-ai/flashinfer#3973; 0.6.15.post1 also fixes the host-overhead regressions that got the plain 0.6.15 bump reverted upstream, sgl-project/sglang#31625 → #31927).

## Fix

Two pin-override layers in `docker/Dockerfile`, same pattern as the existing apache-tvm-ffi reconcile: force-reinstall after every other install + loud build-time assert.

- cutlass-dsl: all five components pinned 4.6.2 — the meta-package alone does not move the loaded runtime (the `-libs-cu12`/`-libs-cu13` wheels carry it). Wheels exist for cu12/cu13 × x86_64/aarch64, so every image variant is covered.
- flashinfer: python + cubin + jit-cache trio pinned 0.6.15.post1 (jit-cache from flashinfer's per-CUDA index, selected by `ENABLE_CUDA_13`), plus the `FLASHINFER_VERSION` env marker.

## Notes

- sglang-miles code-side companion for the flashinfer bump (upstream sgl-project/sglang#31927: cutedsl MoE API compat + MLA handling) is tracked separately; Qwen paths (trtllm_routed/trtllm_mha, deep_gemm/deepep) do not depend on it.
- quack-kernels 0.6.1 metadata pins cutlass-dsl==4.6.0, so `pip check` reports a conflict; sglang srt does not import quack directly.
- Image-layer change: per release rules this cannot be cherry-picked into an existing release branch; it ships via a fresh cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)