### PR TITLE
fix(weight-sync): always resume rollout health monitoring

### DIFF
--- a/miles/ray/actor_group.py
+++ b/miles/ray/actor_group.py
@@ -126,8 +126,10 @@ class RayTrainGroup:
 
         info = await self.rollout_manager.get_updatable_engines_and_lock.remote()
         await self.rollout_manager.health_monitoring_pause.remote()
-
-        await self._broadcast("update_weights", info=info)
+        try:
+            await self._broadcast("update_weights", info=info)
+        finally:
+            await self.rollout_manager.health_monitoring_resume.remote()
 
     async def reconcile_adapters(self) -> None:
         """Multi-LoRA: reconcile loaded adapters with the controller's active set

--- a/miles/ray/rollout/rollout_manager.py
+++ b/miles/ray/rollout/rollout_manager.py
@@ -137,7 +137,7 @@ class RolloutManager:
     async def generate(self, rollout_id):
         start_time = time.time()
         self.rollout_id = rollout_id
-        self._health_monitoring_resume()
+        self.health_monitoring_resume()
         if self.args.ci_test and self.args.use_fault_tolerance and rollout_id >= 2:
             self._try_ci_fault_injection()
         dashboard_hooks.register_engines(self.servers)
@@ -171,7 +171,7 @@ class RolloutManager:
         if self.args.debug_train_only:
             # if debug train only, we don't generate evaluation data
             return
-        self._health_monitoring_resume()
+        self.health_monitoring_resume()
 
         if self.args.eval_uses_snapshots:
             return await self._eval_checkpoint(rollout_id, hf_dir, export_time_seconds, require_marker)
@@ -393,7 +393,7 @@ class RolloutManager:
         for monitor in self._health_monitors:
             monitor.pause()
 
-    def _health_monitoring_resume(self) -> None:
+    def health_monitoring_resume(self) -> None:
         for monitor in self._health_monitors:
             monitor.resume()
 

--- a/miles/ray/train/group.py
+++ b/miles/ray/train/group.py
@@ -260,11 +260,15 @@ class RayTrainGroup:
         # ranks observe a consistent engine set; the actor releases the lock itself.
         info = await self._rollout_manager.get_updatable_engines_and_lock.remote()
         await self._rollout_manager.health_monitoring_pause.remote()
-        # Catch with vanilla retry: cells w/ exceptions are auto marked errored, thus retry will find the next one
-        await retry(
-            lambda _: self._execute_first_alive("update_weights", info=info),
-            max_attempts=_RETRY_MAX_ATTEMPTS,
-        )
+        try:
+            # Catch with vanilla retry: cells w/ exceptions are auto marked
+            # errored, thus retry will find the next one.
+            await retry(
+                lambda _: self._execute_first_alive("update_weights", info=info),
+                max_attempts=_RETRY_MAX_ATTEMPTS,
+            )
+        finally:
+            await self._rollout_manager.health_monitoring_resume.remote()
 
         await self._maybe_log_inference_engine_weight_checksums(rollout_id=rollout_id)
 


### PR DESCRIPTION
## Summary

- resume rollout health monitoring after weight synchronization
- restore monitoring from `finally` for both Ray train-group implementations
- expose the existing resume operation through the rollout-manager actor API

## Root cause

Weight synchronization pauses rollout health monitoring to avoid checking engines while their weights are being updated. The pause was not paired with a resume, so monitoring remained disabled until another rollout or evaluation explicitly resumed it. If weight synchronization failed, it could remain disabled indefinitely.

## Impact

Health monitoring is restored after every weight-update attempt while preserving the original weight-sync exception.

## Validation

- `git diff --check`
- Attempted `uv run pytest tests/fast/ray/test_actor_group_shared_ppo.py tests/fast/ray/train/test_group.py -q`; collection could not start in the clean worktree because `torch` is not installed.
