### PR TITLE
glm52_tbench2: default the train set to the 69-task split

### DIFF
--- a/examples/experimental/openenv/glm52_tbench2/README.md
+++ b/examples/experimental/openenv/glm52_tbench2/README.md
@@ -82,7 +82,7 @@ $MODEL_DIR/GLM-5.2_torch_dist   # training; tools/convert_hf_to_torch_dist.py
 $MODEL_DIR/GLM-5.2_fp8          # rollout;  tools/convert_hf_to_fp8.py
 
 python examples/experimental/openenv/make_tbench2_data.py \
-    --tasks_dir $OPENENV_TB2_TASKS_DIR --output $DATA_DIR/tbench2_train.jsonl
+    --tasks_dir $OPENENV_TB2_TASKS_DIR --output $DATA_DIR/tbench2_train69.jsonl
 # hold out a disjoint task set as $DATA_DIR/tbench2_eval.jsonl for the eval
 ```
 

--- a/examples/experimental/openenv/glm52_tbench2/run_glm5_2_744b_a40b_daytona.py
+++ b/examples/experimental/openenv/glm52_tbench2/run_glm5_2_744b_a40b_daytona.py
@@ -69,7 +69,7 @@ class ScriptArgs(U.ExecuteTrainConfig):
     save_interval: int = 100000  # effectively: only the end-of-training save
 
     # OpenEnv / Daytona
-    prompt_data: str = ""  # default: <data_dir>/tbench2_train.jsonl
+    prompt_data: str = ""  # default: <data_dir>/tbench2_train69.jsonl
     agent_model_name: str = os.environ.get("AGENT_MODEL_NAME", "model")
     openenv_max_turns: int = int(os.environ.get("OPENENV_MAX_TURNS", "30"))
     openenv_max_rollout_time_seconds: int = int(os.environ.get("OPENENV_MAX_ROLLOUT_TIME_SECONDS", "3600"))
@@ -107,7 +107,7 @@ class ScriptArgs(U.ExecuteTrainConfig):
         ), "GB300 config: 8 train nodes plus inference nodes (4 GPUs each)"
         assert self.daytona_api_key, "DAYTONA_API_KEY must be set in the environment"
         if not self.prompt_data:
-            self.prompt_data = f"{self.data_dir}/tbench2_train.jsonl"
+            self.prompt_data = f"{self.data_dir}/tbench2_train69.jsonl"
         if self.eval_interval and not self.eval_prompt_data:
             self.eval_prompt_data = f"{self.data_dir}/tbench2_eval.jsonl"
 


### PR DESCRIPTION
## What

Default `prompt_data` for the glm52_tbench2 recipe to `tbench2_train69.jsonl` (69 tasks) instead of `tbench2_train.jsonl` (8 tasks), and align the README's data-prep command.

## Why

Direct A/B evidence from two fully-dumped GB300 16-node runs:

- **69 tasks, July stack (job 1794)**: 100 steps healthy — `train_rollout_kl` 0.022-0.054 with no trend, reward 0.72, truncation down to 0.02-0.19 late. This despite running the *worse* knobs on every other axis (16384 per-turn cap, 131k session, `tis-clip-low 0.5`).
- **8 tasks, current stack (jobs 2350/2403/2423)**: every run enters the same divergence — trainer log-probs walk away from the shared content of giant capped turns under repeated negative advantage, `train_rollout_kl` grows exponentially, then generation degenerates.

Per-token dump forensics localize the mechanism and the dataset's role in it. Giant near-cap turns are not inherently pathological: the healthy 69-task run carries 63-73 of them per step at 0.09-0.12 mean |lp_diff|, almost never inside negative-advantage samples, and the policy learns its way out of them (73 -> 2 by step 80). With 8 tasks, every step trains all 8 tasks again: the same failing build/loop tasks re-emit near-identical giant turns each step, each carrying consistent negative advantage, and the repeated same-direction updates on that shared content self-amplify (mean |lp_diff| on those turns 0.06 -> 0.88 -> 3.85 within three steps of ignition on job 2423).

An 8.6x larger task set dilutes exactly that repetition. It is the strongest single lever identified by the investigation, and the staged validation run uses this default.

## Notes

- Complements #2588 (collapse levers and launch fixes); no file overlap on the changed lines.
- The 69-task file is what `make_tbench2_data.py` produces over the full TB2 task dir minus the eval holdout; the README command now names it.
