### PR TITLE
fix(rollout): raise server readiness timeout to 120s

### DIFF
--- a/miles/ray/rollout/router_manager.py
+++ b/miles/ray/rollout/router_manager.py
@@ -14,6 +14,11 @@ from miles.utils.http_utils import wait_for_server_ready
 
 logger = logging.getLogger(__name__)
 
+# Readiness budget for the spawned router/session-server children. The spawn
+# context re-imports the heavy transformers/megatron chain (~13s typical in
+# CI), and transient CI stalls have pushed startup past a 30s budget.
+_SERVER_READY_TIMEOUT_SECS = 120
+
 
 def start_router(args, *, has_pd_disaggregation: bool = False, force_new: bool = False) -> tuple[str, int]:
     """Start sgl router or miles router and return (router_ip, router_port).
@@ -72,7 +77,7 @@ def start_router(args, *, has_pd_disaggregation: bool = False, force_new: bool =
     )
     process.daemon = True
     process.start()
-    wait_for_server_ready(router_ip, router_port, process, timeout=30)
+    wait_for_server_ready(router_ip, router_port, process, timeout=_SERVER_READY_TIMEOUT_SECS)
     logger.info(f"Router launched at {router_ip}:{router_port}")
     return router_ip, router_port
 
@@ -146,5 +151,5 @@ def start_session_server(args):
     # replacing the per-session /health probe.
     args.session_server_instance_ids = instance_ids
     for port, process in processes:
-        wait_for_server_ready(ip, port, process, timeout=30)
+        wait_for_server_ready(ip, port, process, timeout=_SERVER_READY_TIMEOUT_SECS)
     logger.info(f"Session servers launched at {ip}, ports {ports} ({len(ports)} instances)")


### PR DESCRIPTION
## Summary

Widen the spawned router/session-server readiness budget from a hardcoded 30s to a single 120s module constant so transient CI startup stalls no longer fail whole training runs.

## Symptom & Reproduction

- **Symptom:** `stage-c-2-gpu-h200 (0)` in run [32090638792](https://github.com/radixark/miles/actions/runs/32090638792/job/95573421128) failed `tests/e2e/megatron/model_scripts/test_glm5_744b_a40b_4layer_r3.py` with `RuntimeError: Server at 172.18.0.2:4077 not ready after 30s` raised from `start_router` → `wait_for_server_ready(..., timeout=30)`. 6/7 tests in the job passed.
- **Reproduction:** flaky by nature; any spawn-context stall >17s beyond the ~13s typical import time reproduces the failure window.

## Root Cause

1. The router child is spawned (not forked), so it re-imports the heavy transformers/megatron chain; all 6 successful launches in the same job took 12.5–13.5s of the 30s budget (~2.3× margin).
2. The failed child was alive but stalled >16s inside the import chain after the modelopt warning (successful launches traverse that segment in ~1.5s); the 30s deadline expired before it could bind.
3. Port collision is ruled out: no `EADDRINUSE`/stale-router error anywhere in the 81k-line log, and the next test drew the same 172.18.0.2:4077 (and prometheus 4905) ~2min later, becoming ready in 13.5s; port 4077 was reused successfully twice more.

## Fix

Introduce `_SERVER_READY_TIMEOUT_SECS = 120` in `miles/ray/rollout/router_manager.py` and use it for both `start_router` and `start_session_server` (same spawn + heavy-import launch pattern). Dead children still fail fast through the existing `process.is_alive()` check in `wait_for_server_ready`, so the wider budget only affects alive-but-slow startups.

## Verification

- `python -m pytest tests/fast/ray/rollout/test_router_manager.py -q`: 11 passed.
- Diagnosis evidence (complete job log, byte-cited report) collected from run 32090638792 job 95573421128.

## Review Focus

- The constant applies per server in `start_session_server`'s sequential wait loop; with children spawned before any wait, later waits already benefit from elapsed wall time, so 120s is an upper bound per port, not additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)