### PR TITLE
docs: fix diffusion docs

### DIFF
--- a/docs/diffusion/index.md
+++ b/docs/diffusion/index.md
@@ -11,7 +11,7 @@ pipeline, or from a native package when a family brings its own modeling. Shippe
 ## Core features
 
 - **Verified Recipes for Latest Diffusion Models.** Launchers for Wan2.2-T2V-A14B, Qwen-Image,
-  LTX-2.3, the Cosmos3 MoT omni family, and SD3.5. `TrainPipelineConfig` allows for easy model support.
+  LTX-2.3, Cosmos3-Nano, and SD3.5. `TrainPipelineConfig` allows for easy model support.
 - **Quality control on three fronts.** Deterministic mode supports bit-for-bit comparisons for recipes covered by
   committed E2E standards; sglang-side monkey patches reduce train/rollout mismatches; and an FSDP2 param-dtype patch
   provides per-parameter fp32 control under the mixed-precision policy. See [Deterministic
@@ -33,8 +33,9 @@ pipeline, or from a native package when a family brings its own modeling. Shippe
 
 ## Supported models
 
-Each model name links to its recipe page. Every documented recipe is labeled with a
-[recipe verification level](/diffusion/user-guide/recipe-verification).
+Each model links to its recipe page; see
+[verification levels](/diffusion/user-guide/recipe-verification). Validated models also
+appear in the [Miles model list](/#supported-models).
 
 
 | Model                                                   | Task      | Canonical recipes                         |

--- a/docs/diffusion/models/cosmos/cosmos3.md
+++ b/docs/diffusion/models/cosmos/cosmos3.md
@@ -1,14 +1,14 @@
 ---
 title: Cosmos3
-description: The Cosmos3 MoT omni family (UND + GEN towers) — token-level conditioning, packed single-sample forward, Flow-GRPO + PickScore recipe.
+description: Cosmos3-Nano Flow-GRPO and PickScore recipe with token-level conditioning and packed single-sample forwards.
 ---
 
 ## 1. Model introduction
 
 [Cosmos3](https://huggingface.co/collections/nvidia/cosmos3) is NVIDIA's Mixture-of-Transformers (MoT) omni family: an
 **UND** (understanding) tower and a **GEN** (generation) tower over a joint text+vision packed sequence, with the Wan2.2
-VAE (4× temporal compression). All sizes share this architecture and differ only in layer count and hidden dim, so
-everything below applies family-wide; the canonical recipes are validated on **Cosmos3-Nano**.
+VAE (4× temporal compression). This guide covers **Cosmos3-Nano**, the variant validated by the canonical recipe and
+training curve.
 
 **Key highlights for RL training:**
 
@@ -26,14 +26,9 @@ everything below applies family-wide; the canonical recipes are validated on **C
 
 ## 2. Supported variants
 
-All sizes resolve to the same family config — detection matches any checkpoint name containing `cosmos3` / `cosmos-3`.
-
-
-| Size  | Composition              | HF checkpoints                                                                                                                                                                                                                         | Status                              |
-| ----- | ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
-| Nano  | 16 B (8 B UND + 8 B GEN) | [Cosmos3-Nano](https://huggingface.co/nvidia/Cosmos3-Nano), [Cosmos3-Nano-Policy-DROID](https://huggingface.co/nvidia/Cosmos3-Nano-Policy-DROID)                                                                                       | **Validated** — canonical recipes   |
-| Edge  | 4 B (2 B + 2 B)          | [Cosmos3-Edge](https://huggingface.co/nvidia/Cosmos3-Edge), [Cosmos3-Edge-Policy-DROID](https://huggingface.co/nvidia/Cosmos3-Edge-Policy-DROID)                                                                                       | Untested                            |
-| Super | 64 B (32 B + 32 B)       | [Cosmos3-Super](https://huggingface.co/nvidia/Cosmos3-Super), [Cosmos3-Super-Text2Image](https://huggingface.co/nvidia/Cosmos3-Super-Text2Image), [Cosmos3-Super-Image2Video](https://huggingface.co/nvidia/Cosmos3-Super-Image2Video) | Untested; needs a larger GPU layout |
+| Size  | Composition              | HF checkpoints                                                                                                                                                                                                   | Status                            |
+| ----- | ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------- |
+| Nano  | 16 B (8 B UND + 8 B GEN) | [Cosmos3-Nano](https://huggingface.co/nvidia/Cosmos3-Nano), [Cosmos3-Nano-Policy-DROID](https://huggingface.co/nvidia/Cosmos3-Nano-Policy-DROID)                                                                 | **Validated** — canonical recipes |
 
 
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -84,6 +84,11 @@ of the box, including older generations of the families below.
 | **Nemotron** | [Nemotron-3-Ultra-550B-A55B](/models/nemotron/nemotron-3-ultra)<br/>[Nemotron-3-Super-120B-A12B-FP8](/models/nemotron/nemotron-3-super)<br/>[Nemotron-3-Nano MoE](/models/nemotron/nemotron-3-nano-moe)<br/>[Nemotron-3-Nano](/models/nemotron/nemotron-3-nano) |
 | **Gemma** | [Gemma-4 26B-A4B](/models/gemma/gemma-4)<br/>[Gemma-4 31B](/models/gemma/gemma-4) |
 | **JoyAI** | [JoyAI-LLM-Flash](https://github.com/radixark/miles/blob/main/scripts/run_joy_ai_llm_flash.py) |
+| **Stable Diffusion** | [SD3.5](/diffusion/models/sd3/sd3) |
+| **Qwen-Image** | [Qwen-Image](/diffusion/models/qwen-image/qwen-image) |
+| **Wan** | [Wan2.2-T2V-A14B](/diffusion/models/wan/wan2-2) |
+| **LTX** | [LTX-2.3](/diffusion/models/ltx/ltx2) |
+| **Cosmos** | [Cosmos3-Nano](/diffusion/models/cosmos/cosmos3) |
 
 See [Models](/models/index) for the full family lists, exact conversion commands, launch
 scripts, and parallelism settings.

--- a/docs/index.md
+++ b/docs/index.md
@@ -90,8 +90,8 @@ of the box, including older generations of the families below.
 | **LTX** | [LTX-2.3](/diffusion/models/ltx/ltx2) |
 | **Cosmos** | [Cosmos3-Nano](/diffusion/models/cosmos/cosmos3) |
 
-See [Models](/models/index) for the full family lists, exact conversion commands, launch
-scripts, and parallelism settings.
+See [Models](/models/index) for LLM family guides and [Diffusion](/diffusion) for
+diffusion recipes and validation details.
 
 ## Supported hardware
 


### PR DESCRIPTION
## Summary

- Add validated diffusion families to the top-level supported-model table.
- Limit the embedded Cosmos3 documentation to Nano, the variant backed by a canonical recipe and training curve.
- Link the embedded diffusion model table back to the top-level list.

## Test plan

- [x] `git diff --check`
- [x] Documentation diagnostics report no errors

## Checklist

- [ ] `pre-commit run --all-files` passes — not run
- [ ] Added/updated tests for new behaviour — docs-only change
- [ ] `pytest -x` is green — not run for docs-only change
- [x] If launch flags changed, `python3 train.py --help` still parses — not applicable
- [x] If a public flag was added, it appears in the CLI reference docs — not applicable
- [x] If an example was added, it has a real walkthrough — not applicable
