### PR TITLE
Refuse a second init in one trainer worker process

### DIFF
--- a/miles/ray/train_actor.py
+++ b/miles/ray/train_actor.py
@@ -47,6 +47,7 @@ class TrainRayActor(NodeProbeMixin):
     ):
         self.args = args
 
+        self._init_called = False
         self._heartbeat = SimpleHeartbeat()
         self._world_size = world_size
         self._rank = rank
@@ -73,6 +74,11 @@ class TrainRayActor(NodeProbeMixin):
 
     # TODO mv the args into ctor
     def init(self, args, role, with_ref=False, with_opd_teacher=False):
+        assert (
+            not self._init_called
+        ), "init already ran in this worker process, so this is a stale worker being reused as a fresh one"
+        self._init_called = True
+
         self.args = args
         self.role = role
         self.with_ref = with_ref

--- a/tests/fast/ray/test_train_actor.py
+++ b/tests/fast/ray/test_train_actor.py
@@ -66,3 +66,13 @@ class TestConfigureMasterAddrAndPort:
 
         assert os.environ["MASTER_ADDR"] == "10.0.0.2"
         assert os.environ["MASTER_PORT"] == "20002"
+
+
+class TestInitRunsExactlyOnce:
+    def test_a_second_init_is_refused(self):
+        """A worker that already initialized is a stale process; reusing it must fail loudly, not train on."""
+        actor = TrainRayActor.__new__(TrainRayActor)
+        actor._init_called = True
+
+        with pytest.raises(AssertionError, match="stale worker"):
+            actor.init(args=None, role="actor")


### PR DESCRIPTION
Part of #1837