### PR TITLE
Fail a mismatched rpc result in the process that produced it

### DIFF
--- a/miles/utils/workers/rpc/common/serialization.py
+++ b/miles/utils/workers/rpc/common/serialization.py
@@ -35,7 +35,7 @@ class RpcSerializer:
         return dict(self.query_model(**_NonFiniteFloatCodec.decode(query)))
 
     def encode_result(self, result: Any) -> Any:
-        return _NonFiniteFloatCodec.encode(self.result_adapter.dump_python(result, mode="json"))
+        return _NonFiniteFloatCodec.encode(self.result_adapter.dump_python(result, mode="json", warnings="error"))
 
     def decode_result(self, payload: Any) -> Any:
         return self.result_adapter.validate_python(_NonFiniteFloatCodec.decode(payload))

--- a/tests/fast/utils/workers/e2e/test_worker_errors.py
+++ b/tests/fast/utils/workers/e2e/test_worker_errors.py
@@ -1,7 +1,6 @@
 import asyncio
 
 import pytest
-from pydantic import ValidationError
 
 from miles.utils.workers.rpc.client.misc import RpcWorkerCallError
 from miles.utils.workers.worker_handle import WorkerUnreachableError
@@ -69,14 +68,14 @@ class TestResultContract:
         with pytest.raises(RpcWorkerCallError):
             await handle.demo_unserializable_result()
 
-    async def test_result_type_mismatch_is_caught_client_side(self, handle):
-        """A result that does not match the annotation fails validation on the client."""
-        with pytest.raises(ValidationError):
+    async def test_result_type_mismatch_fails_on_the_server(self, handle):
+        """A result that does not match the annotation fails in the process that produced it."""
+        with pytest.raises(RpcWorkerCallError, match="demo_wrong_result_type"):
             await handle.demo_wrong_result_type()
 
     async def test_server_survives_a_mismatched_result(self, handle):
-        """A validation failure on the client leaves the server usable."""
-        with pytest.raises(ValidationError):
+        """A failed result serialization leaves the server usable."""
+        with pytest.raises(RpcWorkerCallError):
             await handle.demo_wrong_result_type()
         assert await handle.demo_sync(a=2, b=2) == 4
 

--- a/tests/fast/utils/workers/rpc/common/test_serialization.py
+++ b/tests/fast/utils/workers/rpc/common/test_serialization.py
@@ -506,6 +506,12 @@ class TestRejectedPayloads:
         with pytest.raises((TypeError, PydanticSerializationError)):
             json.dumps(serializer.encode_result(object()))
 
+    def test_wrong_result_type_is_rejected_at_encode(self):
+        """The worker that produced the bad result is where the failure lands, not the caller."""
+        serializer = _serializer(int)
+        with pytest.raises(PydanticSerializationError):
+            serializer.encode_result("not-an-int")
+
     def test_wrong_result_type_is_rejected(self):
         """A result payload that does not match the annotation fails validation."""
         serializer = _serializer(int)


### PR DESCRIPTION
Part of #1837