### PR TITLE
docs: fix stale paths, flags, env vars and metric names

### DIFF
--- a/docs/advanced/fault-tolerance.md
+++ b/docs/advanced/fault-tolerance.md
@@ -6,8 +6,8 @@ The `--use-fault-tolerance` flag enables Miles's rollout-side
 fault-tolerance machinery. It gates two code paths:
 
 1. A `RolloutHealthMonitor` thread per server group, started in
-   `miles/ray/rollout.py`, which periodically heart-beats each SGLang
-   engine.
+   `miles/ray/rollout/rollout_manager.py`, which periodically heart-beats
+   each SGLang engine.
 2. A recovery hook in the trainer's weight-update step
    (`miles/backends/megatron_utils/actor.py`), which restarts engines
    that the health monitor has killed.
@@ -17,15 +17,16 @@ fault-tolerance machinery. It gates two code paths:
 ```
 
 The flag is `action="store_true"`, default `False`
-(`miles/utils/arguments.py`).
+(`miles/utils/arguments.py`). The rollout paths below additionally require
+`rollout` in `--ft-components`, which is what that flag selects when omitted.
 
 ## Health monitor
 
 `RolloutHealthMonitor` (`miles/utils/health_monitor.py`) runs in a daemon
 thread. Lifecycle: `start` (called once during init), `pause` and `resume`
 (called when engines offload / onload), `stop` (called during dispose).
-`pause` / `resume` are wired up in `miles/ray/rollout.py` and called
-around offload / onload events.
+`pause` / `resume` are wired up in `miles/ray/rollout/rollout_manager.py`
+and called around offload / onload events.
 
 Each loop iteration does:
 
@@ -51,12 +52,12 @@ When `--use-fault-tolerance` is on, `MegatronActor.update_weights` calls
 `rollout_manager.recover_updatable_engines` on rank 0 before each weight
 update (`miles/backends/megatron_utils/actor.py`).
 
-`recover_updatable_engines` (`miles/ray/rollout.py`):
+`recover_updatable_engines` (`miles/ray/rollout/rollout_manager.py`):
 
 1. Pauses health monitoring.
 2. Calls `srv.recover()` on the updatable server.
 
-`srv.recover()` (`miles/ray/rollout.py`):
+`srv.recover()` (`miles/ray/rollout/rollout_server.py`, which fans out to `ServerGroup.recover` in `miles/ray/rollout/server_group.py`):
 
 1. Finds engine slots set to `None` (killed by the health monitor).
 2. Calls `start_engines` for each affected group.

--- a/docs/advanced/p2p-weight-transfer.md
+++ b/docs/advanced/p2p-weight-transfer.md
@@ -39,7 +39,7 @@ Both broadcast and P2P modes share the same bucketed weight-update pipeline in `
 | Component | Description |
 |---|---|
 | **TP/EP all-gather** | Megatron TP shards are all-gathered within each PP stage; EP shards are gathered per-bucket when the accumulated expert data exceeds `buffer_size * ep_size`. Both modes perform this identically via `common.py`. |
-| **Bucketed update** | Weights are not transferred one parameter at a time. Instead, converted tensors are accumulated into a fixed-size buffer (`--update-weight-buffer-size`, default 1 GB). When the buffer is full, the entire bucket is flushed — via NCCL broadcast or RDMA write depending on the mode. This amortizes per-transfer overhead. Non-expert and expert weights use separate buckets. |
+| **Bucketed update** | Weights are not transferred one parameter at a time. Instead, converted tensors are accumulated into a fixed-size buffer (`--update-weight-buffer-size`, default 512 MB). When the buffer is full, the entire bucket is flushed — via NCCL broadcast or RDMA write depending on the mode. This amortizes per-transfer overhead. Non-expert and expert weights use separate buckets. |
 | **PP independence** | Each pipeline-parallel stage updates its own weights independently. In broadcast mode, each PP rank has its own NCCL group (`miles-pp_{pp_rank}`). In P2P mode, each PP rank has its own transfer plan. No cross-PP synchronization is needed during weight transfer, which is key to scaling. |
 | **HF format conversion** | After all-gather, Megatron-format tensors (with custom naming and sharding) are converted to HuggingFace-format names expected by the sglang rollout engine. |
 

--- a/docs/advanced/pd-disaggregation.md
+++ b/docs/advanced/pd-disaggregation.md
@@ -25,7 +25,7 @@ PD disaggregation splits them into two pools, each sized for its own workload.
 
 `--prefill-num-servers` is a Miles-native flag added by
 `add_prefill_decode_disaggregation_arguments` in `miles/utils/arguments.py`.
-When set, `miles/ray/rollout.py` calls
+When set, `miles/ray/rollout/rollout_server.py` calls
 `SglangConfig.from_prefill_num_servers(args)` to dedicate that many SGLang
 servers to prefill, with the rest used for decode.
 

--- a/docs/ci/01-label.md
+++ b/docs/ci/01-label.md
@@ -31,7 +31,7 @@ CUDA and ROCm registrations must declare at least one domain label. GPU runners 
 
 ### The canonical label list
 
-Domain labels live in `tests/ci/labels.py` (`KNOWN_LABELS`); a `labels=[...]` value outside it is a hard error. Current set: `megatron`, `model-scripts`, `sglang`, `fsdp`, `short`, `long`, `ckpt`, `lora`, `precision`, `ft-short`, `ft-long`, `weight-update`, `replay`, `qwen35`, `mooncake`.
+Domain labels live in `tests/ci/labels.py` (`KNOWN_LABELS`); a `labels=[...]` value outside it is a hard error. Current set: `megatron`, `model-scripts`, `sglang`, `fsdp`, `short`, `long`, `ckpt`, `lora`, `eval`, `precision`, `ft-short`, `ft-long`, `weight-update`, `fully-async`, `replay`, `qwen35`, `mooncake`, `miles-plugin`, `amd`.
 
 To add one: add the entry to `KNOWN_LABELS`, then create the matching `run-ci-<key>` label on the PR. No workflow edit needed.
 

--- a/docs/ci/02-docker-build.md
+++ b/docs/ci/02-docker-build.md
@@ -10,7 +10,7 @@ GPU CI runs inside `radixark/miles`. This doc maps which Dockerfiles exist, the 
 | Path                     | Builds                   | Wired into                             |
 | ------------------------ | ------------------------ | -------------------------------------- |
 | `docker/Dockerfile`      | `radixark/miles` (CUDA)  | `docker-build.yml`, `release-docker.yml` |
-| `docker/Dockerfile.rocm` | AMD ROCm (MI30x / MI35x) | `docker-build.yml` (`rocm-*` variants) |
+| `docker/Dockerfile.rocm` | AMD ROCm (MI30x / MI35x) | `docker-build.yml` (`rocm7xx-mi3xx` variants) |
 
 
 ### `docker/Dockerfile` — inputs & output
@@ -44,8 +44,9 @@ The Dockerfile is the build recipe: it provides the cu13 defaults and emits one 
 | `cu13-x86`     | `radixark/miles:dev`               | `linux/amd64`                 | x86-only build of the same image               |
 | `cu13-aarch64` | `radixark/miles:dev`               | `linux/arm64`                 | arm64-only build of the same image             |
 | `cu12-x86`     | `radixark/miles:dev-cu12`          | `linux/amd64`                 | CUDA 12.9 legacy                               |
-| `rocm-mi300`   | `rocm/sgl-dev:miles-rocm700-mi30x` | native                        | AMD MI30x — `docker/Dockerfile.rocm`           |
-| `rocm-mi350`   | `rocm/sgl-dev:miles-rocm720-mi35x` | native                        | AMD MI35x — `docker/Dockerfile.rocm`           |
+| `rocm700-mi30x` | `rocm/sgl-dev:miles-rocm700-mi30x` | native                       | AMD MI30x (`gfx942`, ROCm 7.0) — `docker/Dockerfile.rocm` |
+| `rocm700-mi35x` | `rocm/sgl-dev:miles-rocm700-mi35x` | native                       | AMD MI35x (`gfx950`, ROCm 7.0) — `docker/Dockerfile.rocm` |
+| `rocm720-mi35x` | `rocm/sgl-dev:miles-rocm720-mi35x` | native                       | AMD MI35x (`gfx950`, ROCm 7.2) — `docker/Dockerfile.rocm` |
 
 
 The cu13 variants share one multi-arch CUDA base image and differ only in platforms. `cu13` runs a single `buildx --platform linux/amd64,linux/arm64` — buildx builds both arches and pushes them as one manifest in a single shot, with the Dockerfile picking each layer's wheels by `TARGETARCH` (see Dockerfile inputs), so `docker pull` auto-selects by host arch.
@@ -80,7 +81,7 @@ This workflow owns the rolling `dev` and `latest` image families. It has two job
 ### Triggers: automatic vs manual
 
 - **Automatic** (no human) — the **schedule** (cron 00:00 / 12:00 UTC, gated by `check-upstream`) and any **push to `main` that touches `docker/Dockerfile`, `docker/install-kube-tools.sh`, `docker/verify_transformer_engine.py`, or `requirements.txt`**. Both leave `--variant` empty and build **two images**: `cu13` → `radixark/miles` (multi-arch) and `cu12-x86` → `radixark/miles:dev-cu12`.
-- **Manual** — `workflow_dispatch` (pick one variant — see Trigger a build yourself below) or running `docker/build.py` locally. Only the `rocm-*` images have **no automatic path** (`cu13-x86` / `cu13-aarch64` just rebuild the same `dev` image single-arch).
+- **Manual** — `workflow_dispatch` (pick one variant — see Trigger a build yourself below) or running `docker/build.py` locally. Only the `rocm7xx-mi3xx` images have **no automatic path** (`cu13-x86` / `cu13-aarch64` just rebuild the same `dev` image single-arch).
 
 `docker/build.py` and `docker/patch/**` participate in PR image validation but are not `main`-push triggers; [Release a Version](/ci/04-release) treats them as manual preflight cases.
 
@@ -101,7 +102,7 @@ All images push to **Docker Hub**. CUDA variants → `radixark/miles`; ROCm vari
 | --- | --- | --- |
 | `cu13` / `cu13-x86` / `cu13-aarch64` | `radixark/miles:dev` + `radixark/miles:dev-<YYYYMMDDHHMM>` | `radixark/miles:latest` |
 | `cu12-x86` | `radixark/miles:dev-cu12` (+ timestamped sibling) | `radixark/miles:latest-cu12` |
-| `rocm-mi300` / `rocm-mi350` | `rocm/sgl-dev:miles-rocm7xx-mi3xx` (+ timestamped sibling) | `rocm/sgl-dev:latest-rocm7xx-mi3xx` |
+| `rocm700-mi30x` / `rocm700-mi35x` / `rocm720-mi35x` | `rocm/sgl-dev:miles-rocm7xx-mi3xx` (+ timestamped sibling) | `rocm/sgl-dev:latest-rocm7xx-mi3xx` |
 
 What **moves a shared tag**: `--image-tag dev` overwrites `:dev` (or `:dev-cu12`) and adds a timestamped sibling; on a **scheduled** run `latest`→`dev` *and* `latest-cu12`→`dev-cu12` both advance; pruning likewise runs **only on schedule**, keeping the newest 20 of **each** series — `dev-<ts>` and `dev-cu12-<ts>` independently. Any `workflow_dispatch` — **including** `simulate_schedule` — writes its own tag(s) but never moves `latest` or prunes; only the real cron mutates published tags. See the trigger table above.
 
@@ -120,7 +121,7 @@ gh workflow run docker-build.yml -f variant=cu13-x86 -f image_tag=custom -f cust
 
 | input | required | values / default |
 | ----- | -------- | ---------------- |
-| `variant` | yes | `cu13` / `cu13-x86` / `cu13-aarch64` / `cu12-x86` / `rocm-mi300` / `rocm-mi350` |
+| `variant` | yes | `cu13` / `cu13-x86` / `cu13-aarch64` / `cu12-x86` / `rocm700-mi30x` / `rocm700-mi35x` / `rocm720-mi35x` |
 | `image_tag` | yes | `dev` / `latest` / `custom` |
 | `custom_tag` | no | tag name; required when `image_tag=custom` |
 | `dockerfile` | no | path to Dockerfile (default `docker/Dockerfile`) |

--- a/docs/developer/architecture.md
+++ b/docs/developer/architecture.md
@@ -53,6 +53,7 @@ miles/
 │   ├── sglang_rollout.py # legacy v1 rollout function
 │   ├── data_source.py    # buffer + JSONL loader
 │   ├── filter_hub/       # built-in filters
+│   ├── rm_hub/           # built-in reward types (`--rm-type` dispatch)
 │   ├── fully_async_*.py  # queue-backed producer for train_async.py
 │   └── inference_rollout/# default class-based rollout
 ├── router/               # FastAPI proxy + worker load-balancer (router.py)
@@ -102,7 +103,7 @@ from the trainer loop and uses a continuously-running worker.
 | You want to … | Edit |
 |---|---|
 | Add a new RL algorithm | `miles/backends/training_utils/loss.py` and `loss_hub/`, plus the enum in `miles/utils/arguments.py` |
-| Add a new built-in reward type | `miles/rollout/sglang_rollout.py` (rm dispatch) |
+| Add a new built-in reward type | `miles/rollout/rm_hub/` (the `rm_type` dispatch lives in its `__init__.py`) |
 | Add a new built-in filter | `miles/rollout/filter_hub/` |
 | Support a new architecture on Megatron | `miles_plugins/models/<model>.py` + a bridge in `miles_plugins/mbridge/` |
 | Support a new architecture on FSDP | `miles/backends/fsdp_utils/adaptations/specs/<arch>.py` |

--- a/docs/developer/contributor-guide.md
+++ b/docs/developer/contributor-guide.md
@@ -29,7 +29,7 @@ miles/
 │   ├── mbridge/              # per-architecture weight bridges
 │   ├── megatron_bridge/      # megatron.bridge shims
 │   └── optimizers/           # optimizer plugins (NVMe streaming store)
-├── scripts/                  # launchers, one per recipe; scripts/models/ holds MODEL_ARGS
+├── scripts/                  # launchers, one per recipe; scripts/models/ holds the architecture flags
 ├── tools/                    # checkpoint converters, quantizers, profilers
 ├── tests/                    # fast / fast-gpu / e2e / ci / manual (see Running CI)
 ├── docker/                   # Dockerfile, Dockerfile.rocm, build.py, patches

--- a/docs/developer/versions.md
+++ b/docs/developer/versions.md
@@ -92,7 +92,7 @@ fleet's image is.
 | `cu13` | `radixark/miles:dev` | `linux/amd64` + `linux/arm64`, one manifest. This is the daily image |
 | `cu13-x86` / `cu13-aarch64` | `radixark/miles:dev` | Single-arch rebuilds of the same image |
 | `cu12-x86` | `radixark/miles:dev-cu12` | `linux/amd64`, CUDA 12.9 legacy |
-| `rocm-mi300` / `rocm-mi350` | `rocm/sgl-dev:miles-rocm7xx-mi3xx` | Native |
+| `rocm700-mi30x` / `rocm700-mi35x` / `rocm720-mi35x` | `rocm/sgl-dev:miles-rocm7xx-mi3xx` | Native |
 
 `--image-tag dev` also publishes a timestamped sibling. Scheduled retention and manual tag behavior are documented in [Docker build](/ci/02-docker-build).
 

--- a/docs/examples/geo3k-vlm.md
+++ b/docs/examples/geo3k-vlm.md
@@ -100,7 +100,7 @@ All three performed similarly, so we use the default math RM for simplicity.
 
 Our initial geo3k-specific verifier produced "format scores" (**0 and 0.9**) instead of clean binary rewards. Under **fp32**, fractional values like 0.9 can't be exactly represented, so when all samples in a group have the same reward, `reward - mean` doesn't equal zero—creating spurious gradient signal.
 
-We fixed this by switching to the default math RM with clean **binary 0/1 rewards**. If you encounter similar precision issues with non-binary rewards, you can change the reward tensor dtype from `torch.float` to `torch.float16` in `miles/ray/rollout.py` (`_post_process_rewards` method) to truncate precision artifacts.
+We fixed this by switching to the default math RM with clean **binary 0/1 rewards**. If you encounter similar precision issues with non-binary rewards, you can change the reward tensor dtype from `torch.float` to `torch.float16` in `miles/ray/rollout/train_data_conversion.py` (`_post_process_rewards`) to truncate precision artifacts.
 
 ## B200
 Blackwell currently does not support fa3, we need to use  `--sglang-mm-attention-backend sdpa` and `--attn-implementation flash_attention_2`

--- a/docs/examples/infra-features/train-infer-mismatch-helper.md
+++ b/docs/examples/infra-features/train-infer-mismatch-helper.md
@@ -184,27 +184,36 @@ Reject entire sequence if $\exists t \in T$ such that $\rho_t < C_{\text{veto}}$
 
 ## Mismatch Metrics
 
-When rollout log probabilities are available, MILES automatically tracks comprehensive metrics to monitor training-inference mismatch and importance sampling weights. These metrics help diagnose policy divergence and guide hyperparameter tuning.
+These metrics help diagnose policy divergence and guide hyperparameter tuning. Which
+ones you get depends on the correction function in use. The built-in one
+(`vanilla_tis_function`, used when `--custom-tis-function-path` is unset) reports only
+`tis`, `tis_clipfrac` and `tis_abs`. Everything below comes from `mis.py`, so it needs
+the `--custom-tis-function-path` wiring shown above.
+
+All names below are logged under the `train/` namespace, and every key `mis.py` produces
+carries a `mis_` prefix that its wrapper adds on the way out — so `training_log_ppl`
+reaches wandb as `train/mis_training_log_ppl`. The two exceptions, marked in the tables,
+come from miles itself and are not prefixed.
 
 ### Mismatch Monitoring Metrics
 
-These metrics quantify the difference between training and rollout policies. They are computed automatically when `rollout_log_probs` are provided, regardless of whether TIS/MIS correction is enabled.
-
-All names below are logged under the `train/` namespace.
+These metrics quantify the difference between training and rollout policies. `mis.py`
+computes them whenever `rollout_log_probs` are available, whether or not IS/RS correction
+is actually applied.
 
 | Metric Name | Description |
 |------------|-------------|
-| `training_log_ppl` | Negative mean log probability under training policy: $-\mathbb{E}[\log \pi_{\text{train}}]$ |
-| `training_ppl` | Perplexity of training policy: $\exp(-\mathbb{E}[\log \pi_{\text{train}}])$ |
-| `rollout_log_ppl` | Negative mean log probability under rollout policy: $-\mathbb{E}[\log \pi_{\text{rollout}}]$ |
-| `rollout_ppl` | Perplexity of rollout policy: $\exp(-\mathbb{E}[\log \pi_{\text{rollout}}])$ |
-| `kl` | Forward KL divergence estimator: $\mathbb{E}[\log \pi_{\text{rollout}} - \log \pi_{\text{train}}]$ |
-| `k3_kl` | K3 KL estimator: $\mathbb{E}[\exp(r) - r - 1]$ where $r = \log \pi_{\text{train}} - \log \pi_{\text{rollout}}$ |
-| `log_ppl_diff` | Log perplexity difference|
-| `log_ppl_abs_diff` | Absolute log perplexity difference |
-| `ppl_ratio` | Perplexity ratio |
-| `chi2_token`, `chi2_seq` | Token- and sequence-level $\chi^2$ divergence between the two policies |
-| `train_rollout_logprob_abs_diff` | Token-level absolute log probability difference (emitted by miles, not `mis.py`) |
+| `mis_training_log_ppl` | Negative mean log probability under training policy: $-\mathbb{E}[\log \pi_{\text{train}}]$ |
+| `mis_training_ppl` | Perplexity of training policy: $\exp(-\mathbb{E}[\log \pi_{\text{train}}])$ |
+| `mis_rollout_log_ppl` | Negative mean log probability under rollout policy: $-\mathbb{E}[\log \pi_{\text{rollout}}]$ |
+| `mis_rollout_ppl` | Perplexity of rollout policy: $\exp(-\mathbb{E}[\log \pi_{\text{rollout}}])$ |
+| `mis_kl` | Forward KL divergence estimator: $\mathbb{E}[\log \pi_{\text{rollout}} - \log \pi_{\text{train}}]$ |
+| `mis_k3_kl` | K3 KL estimator: $\mathbb{E}[\exp(r) - r - 1]$ where $r = \log \pi_{\text{train}} - \log \pi_{\text{rollout}}$ |
+| `mis_log_ppl_diff` | Log perplexity difference|
+| `mis_log_ppl_abs_diff` | Absolute log perplexity difference |
+| `mis_ppl_ratio` | Perplexity ratio |
+| `mis_chi2_token`, `mis_chi2_seq` | Token- and sequence-level $\chi^2$ divergence between the two policies |
+| `train_rollout_logprob_abs_diff` (miles, unprefixed) | Token-level absolute log probability difference |
 
 **Usage**: These metrics help you monitor policy drift. Large values indicate a significant mismatch between the training and rollout engines.
 
@@ -212,22 +221,22 @@ All names below are logged under the `train/` namespace.
 
 These metrics track importance sampling weights and corrections. They are only computed when `--use-tis` is enabled.
 
-When using `--custom-tis-function-path` pointing to MIS implementation (e.g., `mis.py`), additional fine-grained metrics become available. The `tis_` and `rs_` prefixes say which stage produced the number.
+When using `--custom-tis-function-path` pointing to MIS implementation (e.g., `mis.py`), additional fine-grained metrics become available. Under the shared `mis_` prefix, the `tis_` and `rs_` parts say which stage produced the number.
 
 | Metric Name | Description | Emitted when |
 |------------|-------------|--------------|
-| `ois` | On-policy importance sampling ratio: $\exp(\log \pi_{\text{train}} - \log \pi_{\text{old}})$ | `--use-tis` (Algorithm 2 only) |
-| `tis_weight_before_bound` | Raw IS weights before any bounding: $\exp(\text{log-ratio})$ | `use_tis` |
-| `tis_weight_after_bound` | IS weights after the `tis_mode` bounding | `use_tis` |
-| `tis_truncate_fraction` | Fraction of weights truncated | `tis_mode: truncate` |
-| `tis_clip_fraction_low` / `tis_clip_fraction_high` | Fraction of weights clipped below / above the bound | `tis_mode: clip` |
-| `tis_mask_fraction_low` / `tis_mask_fraction_high` | Fraction of tokens rejected below / above the bound | `tis_mode: mask` |
-| `rs_mask_fraction_low` / `rs_mask_fraction_high` | Fraction of tokens rejected by rejection sampling | `use_rs` |
-| `rs_catastrophic_token_fraction` | Fraction of catastrophic tokens (below the veto threshold) | `rs_veto_threshold` set |
-| `rs_catastrophic_seq_fraction` | Fraction of sequences holding a catastrophic token | `rs_veto_threshold` set |
-| `is_ratio_mean_after_tis_rs` | Mean IS weight after both TIS and RS | `use_tis` |
-| `batch_norm_factor` | Batch normalization factor applied to weights (1.0 when off) | `use_tis` |
-| `is_ratio_mean_final` / `is_ratio_min_final` / `is_ratio_max_final` | Final IS weight statistics actually multiplied into the loss | `use_tis` |
+| `ois` (miles, unprefixed) | On-policy importance sampling ratio: $\exp(\log \pi_{\text{train}} - \log \pi_{\text{old}})$ | `--use-tis` (Algorithm 2 only) |
+| `mis_tis_weight_before_bound` | Raw IS weights before any bounding: $\exp(\text{log-ratio})$ | `use_tis` |
+| `mis_tis_weight_after_bound` | IS weights after the `tis_mode` bounding | `use_tis` |
+| `mis_tis_truncate_fraction` | Fraction of weights truncated | `tis_mode: truncate` |
+| `mis_tis_clip_fraction_low` / `mis_tis_clip_fraction_high` | Fraction of weights clipped below / above the bound | `tis_mode: clip` |
+| `mis_tis_mask_fraction_low` / `mis_tis_mask_fraction_high` | Fraction of tokens rejected below / above the bound | `tis_mode: mask` |
+| `mis_rs_mask_fraction_low` / `mis_rs_mask_fraction_high` | Fraction of tokens rejected by rejection sampling | `use_rs` |
+| `mis_rs_catastrophic_token_fraction` | Fraction of catastrophic tokens (below the veto threshold) | `rs_veto_threshold` set |
+| `mis_rs_catastrophic_seq_fraction` | Fraction of sequences holding a catastrophic token | `rs_veto_threshold` set |
+| `mis_is_ratio_mean_after_tis_rs` | Mean IS weight after both TIS and RS | `use_tis` |
+| `mis_batch_norm_factor` | Batch normalization factor applied to weights (1.0 when off) | `use_tis` |
+| `mis_is_ratio_mean_final` / `mis_is_ratio_min_final` / `mis_is_ratio_max_final` | Final IS weight statistics actually multiplied into the loss | `use_tis` |
 
 ## Reference
 

--- a/docs/examples/infra-features/train-infer-mismatch-helper.md
+++ b/docs/examples/infra-features/train-infer-mismatch-helper.md
@@ -92,13 +92,15 @@ Advantages:
 
 ## APIs of Algorithms
 
-You may choose from above algorithms by specifying arguments below:
+You may choose from above algorithms with the two command-line flags below. They are the
+only CLI flags this feature adds; everything in **Configs and Recommended Settings** is a
+key in the YAML file you pass to `--custom-config-path`.
 
 `--use-rollout-logprobs`: True if only use `rollout_log_probs` to compute the loss, bypassing old_log_probs calculated by training engine;
 
-`--use-rollout-correction`: True if apply importance sampling/rejection sampling to loss.
+`--use-tis`: True if apply importance sampling/rejection sampling to loss.
 
-| `use_rollout_logprobs` | `use_rollout_correction` | Algorithm | Policies |Compute old_log_probs | Batch Invariant | Recommended TIS Mode |
+| `use_rollout_logprobs` | `use_tis` | Algorithm | Policies |Compute old_log_probs | Batch Invariant | Recommended TIS Mode |
 |-----------------|-------------|-----------|--------------|---------------|-----------------|----------------------|
 | False | False | Standard PPO (Algorithm 0) | 2 ($\pi_\theta$, $\pi_{\textcolor{blue}{\text{old}}}$)|Yes | No | N/A |
 | True | False | Bypassing PPO (Algorithm 3) | 2 ($\pi_\theta$, $\pi_{\textcolor{red}{\text{SGLang}}}$) |🚀 Skipped | No | N/A |
@@ -106,22 +108,33 @@ You may choose from above algorithms by specifying arguments below:
 
 ## Configs and Recommended Settings
 
-When choosing to use importance sampling or rejection sampling for mismatch correction (`use-rollout-correction` enabled, Algorithm 2 & 3), you may specify the IS modes and applied levels. 
+When choosing to use importance sampling or rejection sampling for mismatch correction
+(`--use-tis` enabled, Algorithm 2 & 3), you may specify the IS modes and applied levels.
 
-### Arguments
+### Config keys
 
-`use-tis`: Enable importance sampling. The IS weight will be multiplied by the policy gradient loss. 
+These are **not command-line flags**. They live in the YAML file the run points at with
+`--custom-config-path`, and `mis.py` reads them off the parsed config. The reference file
+is [`mis.yaml`](https://github.com/radixark/miles/blob/main/examples/infra_features/train_infer_mismatch_helper/mis.yaml), wired up like this:
 
-- `--tis-mode`: Mode for IS. Allowed mode: **truncate**, **clip**.
-- `--tis-lower-bound`, `--tis-upper-bound`: Bounds for IS weights.
-- `--tis-level`: Allowed levels: **token**, **sequence**, **geometric**. See explanations below.
-- `--tis-batch-normalize`: Normalize IS weights to mean=1.0 across batch
+```bash
+--use-tis
+--custom-config-path examples/infra_features/train_infer_mismatch_helper/mis.yaml
+--custom-tis-function-path examples.infra_features.train_infer_mismatch_helper.mis.compute_mis_weights_with_cp
+```
 
-`use-rs`: Enable rejection sampling. When choosing to use rejection sampling, the tokens/sequences with an IS weight out of threshold will be directly masked. Those rejected tokens/sequences will not be considered for loss averaging.
+`use_tis`: Enable importance sampling. The IS weight will be multiplied by the policy gradient loss.
 
-- `--rs-lower-bound`, `--rs-upper-bound`: Bounds for RS
-- `--rs-level`: Allowed levels: **token**, **sequence**, **geometric**. See explanations below.
-- `--rs-veto-threshold`: Sequence-level rejection threshold for catastrophic mismatches
+- `tis_mode`: Mode for IS. Allowed mode: **truncate**, **clip**, **mask**.
+- `tis_lower_bound`, `tis_upper_bound`: Bounds for IS weights.
+- `tis_level`: Allowed levels: **token**, **sequence**, **geometric**. See explanations below.
+- `tis_batch_normalize`: Normalize IS weights to mean=1.0 across batch
+
+`use_rs`: Enable rejection sampling. When choosing to use rejection sampling, the tokens/sequences with an IS weight out of threshold will be directly masked. Those rejected tokens/sequences will not be considered for loss averaging.
+
+- `rs_lower_bound`, `rs_upper_bound`: Bounds for RS. Unset falls back to the `tis_` bounds.
+- `rs_level`: Allowed levels: **token**, **sequence**, **geometric**. See explanations below.
+- `rs_veto_threshold`: Sequence-level rejection threshold for catastrophic mismatches
 
 ### Importance Sampling
 
@@ -177,18 +190,21 @@ When rollout log probabilities are available, MILES automatically tracks compreh
 
 These metrics quantify the difference between training and rollout policies. They are computed automatically when `rollout_log_probs` are provided, regardless of whether TIS/MIS correction is enabled.
 
+All names below are logged under the `train/` namespace.
+
 | Metric Name | Description |
 |------------|-------------|
-| `mismatch_training_log_ppl` | Negative mean log probability under training policy: $-\mathbb{E}[\log \pi_{\text{train}}]$ |
-| `mismatch_training_ppl` | Perplexity of training policy: $\exp(-\mathbb{E}[\log \pi_{\text{train}}])$ |
-| `mismatch_rollout_log_ppl` | Negative mean log probability under rollout policy: $-\mathbb{E}[\log \pi_{\text{rollout}}]$ |
-| `mismatch_rollout_ppl` | Perplexity of rollout policy: $\exp(-\mathbb{E}[\log \pi_{\text{rollout}}])$ |
-| `mismatch_kl` | Forward KL divergence estimator: $\mathbb{E}[\log \pi_{\text{rollout}} - \log \pi_{\text{train}}]$ |
-| `mismatch_k3_kl` | K3 KL estimator: $\mathbb{E}[\exp(r) - r - 1]$ where $r = \log \pi_{\text{train}} - \log \pi_{\text{rollout}}$ |
-| `mismatch_log_ppl_diff` | Log perplexity difference|
-| `mismatch_log_ppl_abs_diff` | Absolute log perplexity difference |
-| `mismatch_ppl_ratio` | Perplexity ratio |
-| `train_rollout_logprob_abs_diff` | Token-level absolute log probability difference |
+| `training_log_ppl` | Negative mean log probability under training policy: $-\mathbb{E}[\log \pi_{\text{train}}]$ |
+| `training_ppl` | Perplexity of training policy: $\exp(-\mathbb{E}[\log \pi_{\text{train}}])$ |
+| `rollout_log_ppl` | Negative mean log probability under rollout policy: $-\mathbb{E}[\log \pi_{\text{rollout}}]$ |
+| `rollout_ppl` | Perplexity of rollout policy: $\exp(-\mathbb{E}[\log \pi_{\text{rollout}}])$ |
+| `kl` | Forward KL divergence estimator: $\mathbb{E}[\log \pi_{\text{rollout}} - \log \pi_{\text{train}}]$ |
+| `k3_kl` | K3 KL estimator: $\mathbb{E}[\exp(r) - r - 1]$ where $r = \log \pi_{\text{train}} - \log \pi_{\text{rollout}}$ |
+| `log_ppl_diff` | Log perplexity difference|
+| `log_ppl_abs_diff` | Absolute log perplexity difference |
+| `ppl_ratio` | Perplexity ratio |
+| `chi2_token`, `chi2_seq` | Token- and sequence-level $\chi^2$ divergence between the two policies |
+| `train_rollout_logprob_abs_diff` | Token-level absolute log probability difference (emitted by miles, not `mis.py`) |
 
 **Usage**: These metrics help you monitor policy drift. Large values indicate a significant mismatch between the training and rollout engines.
 
@@ -196,21 +212,22 @@ These metrics quantify the difference between training and rollout policies. The
 
 These metrics track importance sampling weights and corrections. They are only computed when `--use-tis` is enabled.
 
-When using `--custom-tis-function-path` pointing to MIS implementation (e.g., `mis.py`), additional fine-grained metrics become available:
+When using `--custom-tis-function-path` pointing to MIS implementation (e.g., `mis.py`), additional fine-grained metrics become available. The `tis_` and `rs_` prefixes say which stage produced the number.
 
-| Metric Name | Description | Required Args | Optional Control Args |
-|------------|-------------|---------------|----------------------|
-| `ois` | On-policy importance sampling ratio: $\exp(\log \pi_{\text{train}} - \log \pi_{\text{old}})$ | `--use-tis` | Only for Algorithm 2 (Decoupled PPO) |
-| `mis_mean_is_weight_before_clip` | Raw IS weights before any correction: $\exp(\text{log-ratio})$ | `--use-tis` | `--mis-level` (token/sequence/geometric) |
-| `mis_ratio_mean_after_mis` | IS weights after correction (bounded or masked) | `--use-tis` | `--mis-mode`, bounds |
-| `mis_truncate_fraction` | Fraction of weights truncated (mode-specific) | `--use-tis`, `--mis-mode=truncate` | `--mis-upper-bound` |
-| `mis_clip_fraction_low` | Fraction of weights clipped below lower bound | `--use-tis`, `--mis-mode=clip` | `--mis-lower-bound`, `--mis-upper-bound` |
-| `mis_clip_fraction_high` | Fraction of weights clipped above upper bound | `--use-tis`, `--mis-mode=clip` | `--mis-lower-bound`, `--mis-upper-bound` |
-| `mis_mask_fraction_low` | Fraction of tokens rejected (below lower bound) | `--use-tis`, `--mis-mode=mask` | `--mis-lower-bound`, `--mis-upper-bound` |
-| `mis_mask_fraction_high` | Fraction of tokens rejected (above upper bound) | `--use-tis`, `--mis-mode=mask` | `--mis-lower-bound`, `--mis-upper-bound` |
-| `mis_catastrophic_token_fraction` | Fraction of catastrophic tokens (veto-specific) | `--use-tis`, `--mis-veto-threshold` set | Sequence-level rejection |
-| `mis_catastrophic_seq_fraction` | Fraction of sequences with catastrophic tokens | `--use-tis`, `--mis-veto-threshold` set | Sequence-level rejection |
-| `mis_batch_norm_factor` | Batch normalization factor applied to weights | `--use-tis`, `--mis-batch-normalize` | Normalizes mean to 1.0 |
+| Metric Name | Description | Emitted when |
+|------------|-------------|--------------|
+| `ois` | On-policy importance sampling ratio: $\exp(\log \pi_{\text{train}} - \log \pi_{\text{old}})$ | `--use-tis` (Algorithm 2 only) |
+| `tis_weight_before_bound` | Raw IS weights before any bounding: $\exp(\text{log-ratio})$ | `use_tis` |
+| `tis_weight_after_bound` | IS weights after the `tis_mode` bounding | `use_tis` |
+| `tis_truncate_fraction` | Fraction of weights truncated | `tis_mode: truncate` |
+| `tis_clip_fraction_low` / `tis_clip_fraction_high` | Fraction of weights clipped below / above the bound | `tis_mode: clip` |
+| `tis_mask_fraction_low` / `tis_mask_fraction_high` | Fraction of tokens rejected below / above the bound | `tis_mode: mask` |
+| `rs_mask_fraction_low` / `rs_mask_fraction_high` | Fraction of tokens rejected by rejection sampling | `use_rs` |
+| `rs_catastrophic_token_fraction` | Fraction of catastrophic tokens (below the veto threshold) | `rs_veto_threshold` set |
+| `rs_catastrophic_seq_fraction` | Fraction of sequences holding a catastrophic token | `rs_veto_threshold` set |
+| `is_ratio_mean_after_tis_rs` | Mean IS weight after both TIS and RS | `use_tis` |
+| `batch_norm_factor` | Batch normalization factor applied to weights (1.0 when off) | `use_tis` |
+| `is_ratio_mean_final` / `is_ratio_min_final` / `is_ratio_max_final` | Final IS weight statistics actually multiplied into the loss | `use_tis` |
 
 ## Reference
 

--- a/docs/models/deepseek/deepseek-v4-flash.md
+++ b/docs/models/deepseek/deepseek-v4-flash.md
@@ -121,7 +121,7 @@ Alternatively, you can set `MILES_SCRIPT_EXTERNAL_RAY=1` and `RAY_ADDRESS=…` t
 
 ### 4.4 Notable quirks
 
-- **Custom `transformers` patch.** miles ships `with_transformers_patch()` (`miles/utils/transformers_patch.py`) so HF's `AutoConfig.from_pretrained` recognizes `model_type=deepseek_v4` / `deepseek_ref` until support lands upstream.
+- **`model_type` rewrite for pruned checkpoints.** The older layer-pruning flow wrote `"model_type": "deepseek_ref"` into the local `config.json`. The launcher rewrites it back to `deepseek_v4` in place (`scripts/run_deepseek_v4.py`), so HF's `AutoConfig.from_pretrained` resolves the checkpoint without a patched `transformers`.
 
 ## 5. Example Recipe Configuration
 
@@ -170,7 +170,7 @@ SGLANG_ARGS=(
 )
 ```
 
-The launcher sets the required env vars for you: `SGLANG_SKIP_CHECKPOINT_LOAD_CHECK=1`, `SGLANG_DSV4_FP4_EXPERTS=0`, `MILES_HACK_TRAIN_TORCH_DETERMINISTIC=1`, and `NCCL_ALGO=Ring`.
+The launcher sets the required env vars for you: `SGLANG_SKIP_CHECKPOINT_LOAD_CHECK=1`, `SGLANG_DSV4_FP4_EXPERTS=0`, `SGLANG_HEALTH_CHECK_TIMEOUT=120`, `SGLANG_DG_CACHE_DIR_PER_PROCESS=1`, and `SGLANG_OPT_FP8_WO_A_GEMM=0`. Passing `--train-deterministic` adds `NCCL_ALGO=Ring`, `NVTE_ALLOW_NONDETERMINISTIC_ALGO=0`, and `CUBLAS_WORKSPACE_CONFIG=:4096:8` on top of those.
 
 On the Megatron side, V4 needs `--qkv-format bshd` with CP-aware data slicing. The DSA indexer additionally supports replay via `--use-rollout-indexer-replay` (off by default).
 

--- a/docs/models/deepseek/deepseek-v4-flash.md
+++ b/docs/models/deepseek/deepseek-v4-flash.md
@@ -170,7 +170,7 @@ SGLANG_ARGS=(
 )
 ```
 
-The launcher sets the required env vars for you: `SGLANG_SKIP_CHECKPOINT_LOAD_CHECK=1`, `SGLANG_DSV4_FP4_EXPERTS=0`, `SGLANG_HEALTH_CHECK_TIMEOUT=120`, `SGLANG_DG_CACHE_DIR_PER_PROCESS=1`, and `SGLANG_OPT_FP8_WO_A_GEMM=0`. Passing `--train-deterministic` adds `NCCL_ALGO=Ring`, `NVTE_ALLOW_NONDETERMINISTIC_ALGO=0`, and `CUBLAS_WORKSPACE_CONFIG=:4096:8` on top of those.
+The launcher sets the required env vars for you: `SGLANG_SKIP_CHECKPOINT_LOAD_CHECK=1`, `SGLANG_DSV4_FP4_EXPERTS=0`, `SGLANG_HEALTH_CHECK_TIMEOUT=120`, `SGLANG_DG_CACHE_DIR_PER_PROCESS=1`, and `SGLANG_OPT_FP8_WO_A_GEMM=0`. Because `--train-deterministic` defaults to on, a stock run also gets `--deterministic-mode` plus `NCCL_ALGO=Ring`, `NVTE_ALLOW_NONDETERMINISTIC_ALGO=0` and `CUBLAS_WORKSPACE_CONFIG=:4096:8`; pass `--no-train-deterministic` to drop those four.
 
 On the Megatron side, V4 needs `--qkv-format bshd` with CP-aware data slicing. The DSA indexer additionally supports replay via `--use-rollout-indexer-replay` (off by default).
 

--- a/docs/models/deepseek/deepseek-v4-pro.md
+++ b/docs/models/deepseek/deepseek-v4-pro.md
@@ -90,7 +90,7 @@ SGLANG_ARGS=(
 )
 ```
 
-Required env vars (the launcher sets these for you): `SGLANG_SKIP_CHECKPOINT_LOAD_CHECK=1`, `SGLANG_DSV4_FP4_EXPERTS=0`, `SGLANG_HEALTH_CHECK_TIMEOUT=120`, `SGLANG_DG_CACHE_DIR_PER_PROCESS=1`, `SGLANG_OPT_FP8_WO_A_GEMM=0`, and the Pro-only pair `SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK=256`, `SGLANG_JIT_DEEPGEMM_PRECOMPILE=0`.
+Required env vars (the launcher sets these for you): `SGLANG_SKIP_CHECKPOINT_LOAD_CHECK=1`, `SGLANG_DSV4_FP4_EXPERTS=0`, `SGLANG_HEALTH_CHECK_TIMEOUT=120`, `SGLANG_DG_CACHE_DIR_PER_PROCESS=1`, `SGLANG_OPT_FP8_WO_A_GEMM=0`, and the Pro-only pair `SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK=256`, `SGLANG_JIT_DEEPGEMM_PRECOMPILE=0`. Pro shares the V4 launcher, so `--train-deterministic` is on by default here too and brings the same `NCCL_ALGO` / `NVTE_ALLOW_NONDETERMINISTIC_ALGO` / `CUBLAS_WORKSPACE_CONFIG` trio.
 
 Megatron side: `--qkv-format bshd` (V4 needs `bshd` with CP-aware data slicing). The DSA indexer additionally supports replay via `--use-rollout-indexer-replay` (off by default).
 

--- a/docs/models/deepseek/deepseek-v4-pro.md
+++ b/docs/models/deepseek/deepseek-v4-pro.md
@@ -90,7 +90,7 @@ SGLANG_ARGS=(
 )
 ```
 
-Required env vars (the launcher sets these for you): `SGLANG_SKIP_CHECKPOINT_LOAD_CHECK=1`, `SGLANG_DSV4_FP4_EXPERTS=0`, and the Pro-only pair `SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK=256`, `SGLANG_JIT_DEEPGEMM_PRECOMPILE=0`.
+Required env vars (the launcher sets these for you): `SGLANG_SKIP_CHECKPOINT_LOAD_CHECK=1`, `SGLANG_DSV4_FP4_EXPERTS=0`, `SGLANG_HEALTH_CHECK_TIMEOUT=120`, `SGLANG_DG_CACHE_DIR_PER_PROCESS=1`, `SGLANG_OPT_FP8_WO_A_GEMM=0`, and the Pro-only pair `SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK=256`, `SGLANG_JIT_DEEPGEMM_PRECOMPILE=0`.
 
 Megatron side: `--qkv-format bshd` (V4 needs `bshd` with CP-aware data slicing). The DSA indexer additionally supports replay via `--use-rollout-indexer-replay` (off by default).
 

--- a/docs/models/glm/glm4-5.md
+++ b/docs/models/glm/glm4-5.md
@@ -48,7 +48,7 @@ The 8-node launcher does **not** convert for you — produce `/root/models/GLM-4
 
 ```bash
 cd /root/miles
-MODEL_ARGS_LINE="$(python3 scripts/model_args.py glm4.5-355B-A32B)" || exit 1
+MODEL_ARGS_LINE="$(python3 miles/utils/external_utils/model_args_utils.py glm4.5-355B-A32B)" || exit 1
 read -ra MODEL_ARGS <<< "${MODEL_ARGS_LINE}"
 PYTHONPATH=/root/Megatron-LM torchrun --nproc-per-node 8 \
    tools/convert_hf_to_torch_dist.py \

--- a/docs/models/glm/glm4-7-flash.md
+++ b/docs/models/glm/glm4-7-flash.md
@@ -35,7 +35,7 @@ The launcher does all three downloads itself into `--model-dir` (default `/root/
 
 ```bash
 cd /root/miles
-MODEL_ARGS_LINE="$(python3 scripts/model_args.py glm4.7-flash)" || exit 1
+MODEL_ARGS_LINE="$(python3 miles/utils/external_utils/model_args_utils.py glm4.7-flash)" || exit 1
 read -ra MODEL_ARGS <<< "${MODEL_ARGS_LINE}"
 PYTHONPATH=/root/Megatron-LM torchrun --nproc-per-node 8 \
    tools/convert_hf_to_torch_dist.py \

--- a/docs/models/kimi/kimi-k2.5.md
+++ b/docs/models/kimi/kimi-k2.5.md
@@ -85,11 +85,11 @@ The launcher builds the flags it passes to `train.py` as one f-string group per 
 
 That definition sets the MLA latent ranks (`q_lora_rank=1536`, `kv_lora_rank=512`, `qk_head_dim=128`, `qk_pos_emb_head_dim=64`, `v_head_dim=128`), the MoE routing (384 experts, top-8, sigmoid pre-softmax scoring, FP32 router, `--moe-router-topk-scaling-factor 2.827`), and YaRN RoPE (`--rope-type yarn`, `--rotary-base 50000`, `--rotary-scaling-factor 64.0`, `--original-max-position-embeddings 4096`, `--beta-fast 32`, `--beta-slow 1`). The K2.5 recipe then layers the following on top:
 
-- **`CKPT_ARGS`** wires up the dual checkpoint (INT4 actor via `--hf-checkpoint`, BF16 reference via `--ref-load`) together with `--megatron-to-hf-mode bridge` and `--model-name kimi_k25`.
-- **`ROLLOUT_ARGS`** and **`EVAL_ARGS`** configure GRPO sampling and periodic AIME evaluation (covered in §5.2).
-- **`PERF_ARGS`** sets the parallelism layout and recomputation (§5.1).
-- **`GRPO_ARGS`** and **`OPTIMIZER_ARGS`** set the algorithm and CPU-offloaded Adam (§5.2, §5.4).
-- **`SGLANG_ARGS`** configures the colocated rollout engine (§5.3).
+- **`ckpt_args`** wires up the dual checkpoint (INT4 actor via `--hf-checkpoint`, BF16 reference via `--ref-load`) together with `--megatron-to-hf-mode bridge` and `--model-name kimi_k25`.
+- **`rollout_args`** and **`eval_args`** configure GRPO sampling and periodic AIME evaluation (covered in §5.2).
+- **`perf_args`** sets the parallelism layout and recomputation (§5.1).
+- **`grpo_args`** and **`optimizer_args`** set the algorithm and CPU-offloaded Adam (§5.2, §5.4).
+- **`sglang_args`** configures the colocated rollout engine (§5.3).
 
 The job runs colocated (`--colocate`) across 32 nodes (`--actor-num-nodes 32 --actor-num-gpus-per-node 8`) with `--update-weight-buffer-size $((4*512*1024*1024))`.
 

--- a/docs/models/kimi/kimi-k2.md
+++ b/docs/models/kimi/kimi-k2.md
@@ -140,7 +140,7 @@ Identical for both:
 --sglang-server-concurrency 1024
 ```
 
-SGLang DeepEP (`--sglang-enable-deepep-moe`, `--sglang-deepep-mode`) is not enabled for either variant. Megatron-side `--moe-enable-deepep` and `--moe-token-dispatcher-type flex` are **on** for `Kimi-K2-Instruct` and **off** for `Kimi-K2-Thinking`.
+SGLang DeepEP (`--sglang-moe-a2a-backend deepep`, `--sglang-deepep-mode`) is not enabled for either variant. Megatron-side `--moe-enable-deepep` and `--moe-token-dispatcher-type flex` are **on** for `Kimi-K2-Instruct` and **off** for `Kimi-K2-Thinking`.
 
 ### 5.4 Optimizer
 

--- a/docs/models/thinkingmachines/inkling.md
+++ b/docs/models/thinkingmachines/inkling.md
@@ -166,15 +166,18 @@ Weight updates stream Megatron shards into SGLang's tensor layout in bounded buc
 ```bash
 --optimizer adam
 --lr 1e-6 --lr-decay-style constant
---accumulate-allreduce-grads-in-fp32
 --attention-softmax-in-fp32
 
+# gradient reduction: bf16 under --fully-async, fp32 otherwise
+--grad-reduce-in-bf16  # --fully-async
+--accumulate-allreduce-grads-in-fp32  # colocated
+
 # full-parameter only, set by the launcher
---optimizer-state-nvme-dir /tmp/opt_offload
---optimizer-state-nvme-chunk-mb 256
---offload-train-target disk
---offload-train-disk-dir /tmp/train_offload
 --micro-batch-size 1
+--offload-train-disk-dir /tmp/train_offload
+--offload-train-target disk  # colocated: back the paused actor with node-local NVMe
+--stream-optimizer-state-to-disk  # --fully-async: stream the optimizer state instead
+--offload-train-disk-chunk-mb 256  # --fully-async
 ```
 
 Within a single GB300 rack the 975 B policy, gradients, and FP32 optimizer state exceed GPU memory, so Miles streams Megatron `DistributedOptimizer` state between a bounded GPU working set and node-local NVMe. The offload changes storage placement, not the update math. The paused training actor's weights are additionally disk-backed through `torch_memory_saver`. LoRA training skips both offloads and uses dynamic batching (`--use-dynamic-batch-size --max-tokens-per-gpu 4096`) instead of the fixed micro-batch.

--- a/docs/user-guide/argument-groups.md
+++ b/docs/user-guide/argument-groups.md
@@ -2,28 +2,36 @@
 title: Argument Groups
 description: The launch-script argument groups used by Miles recipes, with links to the flags that belong in each group.
 ---
-Miles launch scripts are bash arrays. The grouping is deliberately boring: each array
-owns one operational concern, then the script expands all arrays into `train.py` or
-`train_async.py`.
+Miles launch scripts are Python (`scripts/run_*.py`). The grouping is deliberately
+boring: each script builds one string per operational concern, concatenates them into
+`train_args`, and hands that to `execute_train`, which submits `train.py` or
+`train_async.py` as a Ray job.
 
 Use this page to decide where a flag belongs. Use the [CLI Reference](/user-guide/cli-reference)
-when you need the full default and type for an individual flag.
+when you need the full default and type for an individual flag. For how a script is laid
+out and how to override one, see [Launch Script](/user-guide/launch-script).
 
-| Group | Owns | Typical source |
+| Group | Owns | Where it comes from |
 |---|---|---|
-| [`MODEL_ARGS`](#model-args) | Architecture constants and plugin specs | `scripts/models/<family>.py` |
-| [`CKPT_ARGS`](#ckpt-args) | Actor, reference, HF tokenizer/config, save paths | Launch script |
-| [`ROLLOUT_ARGS`](#rollout-args) | Prompt data, sampling, reward, train/eval batch flow | Launch script |
-| [`EVAL_ARGS`](#eval-args) | Evaluation datasets and eval-only sampling overrides | Launch script |
-| [`PERF_ARGS`](#perf-args) | Parallelism, recomputation, dynamic batching | Recipe defaults |
-| [`GRPO_ARGS`](#grpo-args) | RL objective, KL, clipping, entropy, advantage estimator | Recipe defaults |
-| [`OPTIMIZER_ARGS`](#optimizer-args) | Learning rate, schedule, weight decay, Adam betas | Recipe defaults |
-| [`SGLANG_ARGS`](#sglang-args) | Rollout engine topology and `--sglang-*` passthrough | Deployment shape |
+| [model args](#model-args) | Architecture constants and plugin specs | `scripts/models/<megatron_model_type>.py`, spliced in by `execute_train` |
+| [`ckpt_args`](#ckpt-args) | Actor, reference, HF tokenizer/config, save paths | Launch script |
+| [`rollout_args`](#rollout-args) | Prompt data, sampling, reward, train/eval batch flow | Launch script |
+| [`eval_args`](#eval-args) | Evaluation datasets and eval-only sampling overrides | Launch script |
+| [`perf_args`](#perf-args) | Parallelism, recomputation, dynamic batching | Recipe defaults |
+| [`grpo_args`](#grpo-args) | RL objective, KL, clipping, entropy, advantage estimator | Recipe defaults |
+| [`optimizer_args`](#optimizer-args) | Learning rate, schedule, weight decay, Adam betas | Recipe defaults |
+| [`sglang_args`](#sglang-args) | Rollout engine topology and `--sglang-*` passthrough | Deployment shape |
+| [`misc_args`](#misc-args) | GPU layout, colocation, dropout, dashboard | Launch script |
+
+The names above are the local variables every launcher uses; a script that needs no eval
+simply leaves `eval_args` empty. Model args are the one group a launcher does not build:
+it passes `megatron_model_type` to `execute_train`, which resolves the matching file
+under `scripts/models/` and prepends those flags to the command line.
 
 <a id="model-args"></a>
-## MODEL_ARGS - architecture constants
+## Model args - architecture constants
 
-`MODEL_ARGS` tells Megatron what model it is instantiating. Megatron cannot infer all
+Model args tell Megatron what model it is instantiating. Megatron cannot infer all
 architecture details from a HuggingFace checkpoint, so each recipe loads a matching
 file from `scripts/models/`.
 
@@ -42,9 +50,9 @@ family changes rotary base, vocab padding, or normalization epsilon, override th
 sourced defaults in the launch script.
 
 <a id="ckpt-args"></a>
-## CKPT_ARGS - checkpoint paths
+## `ckpt_args` - checkpoint paths
 
-`CKPT_ARGS` wires the three model roles in a run:
+`ckpt_args` wires the three model roles in a run:
 
 | Role | Flag |
 |---|---|
@@ -57,9 +65,9 @@ sourced defaults in the launch script.
 `latest_checkpointed_iteration.txt`, Miles warm-starts the actor from `--ref-load`.
 
 <a id="rollout-args"></a>
-## ROLLOUT_ARGS - sampling and reward
+## `rollout_args` - sampling and reward
 
-`ROLLOUT_ARGS` controls data entering the loop and how many samples each rollout
+`rollout_args` controls data entering the loop and how many samples each rollout
 produces.
 
 | Concern | Flags |
@@ -75,7 +83,7 @@ The rollout volume and training consumption must satisfy the
 [four-knob invariant](/user-guide/concepts#the-four-knob-invariant).
 
 <a id="eval-args"></a>
-## EVAL_ARGS - evaluation overrides
+## `eval_args` - evaluation overrides
 
 Evaluation reuses the rollout stack but usually runs with a different dataset and more
 deterministic sampling.
@@ -89,12 +97,12 @@ Common entries:
 | Eval group size | `--n-samples-per-eval-prompt` |
 | Eval-only generation | `--eval-max-response-len`, `--eval-top-p`, `--eval-temperature` |
 
-Flags not set in `EVAL_ARGS` inherit from `ROLLOUT_ARGS`.
+Flags not set in `eval_args` inherit from `rollout_args`.
 
 <a id="perf-args"></a>
-## PERF_ARGS - parallelism and memory
+## `perf_args` - parallelism and memory
 
-`PERF_ARGS` controls how training is sharded and how activation memory is managed.
+`perf_args` controls how training is sharded and how activation memory is managed.
 
 | Concern | Flags |
 |---|---|
@@ -111,9 +119,9 @@ see [parallelism compatibility](/user-guide/training-backend#parallelism-compati
 more than one dimension.
 
 <a id="grpo-args"></a>
-## GRPO_ARGS - RL objective
+## `grpo_args` - RL objective
 
-`GRPO_ARGS` controls the policy-gradient objective and the stability terms around it.
+`grpo_args` controls the policy-gradient objective and the stability terms around it.
 
 | Concern | Flags |
 |---|---|
@@ -128,9 +136,9 @@ Zero-weight KL is recipe-specific. `--use-kl-loss --kl-loss-coef 0.00` still loa
 reference and logs KL; it does not remove the reference model.
 
 <a id="optimizer-args"></a>
-## OPTIMIZER_ARGS - optimizer schedule
+## `optimizer_args` - optimizer schedule
 
-`OPTIMIZER_ARGS` carries the optimizer choice and scalar schedule.
+`optimizer_args` carries the optimizer choice and scalar schedule.
 
 Common entries:
 
@@ -145,9 +153,9 @@ Post-training is sensitive to large updates. Most recipes start near `1e-6` and 
 constant schedule unless the model page says otherwise.
 
 <a id="sglang-args"></a>
-## SGLANG_ARGS - rollout engine passthrough
+## `sglang_args` - rollout engine passthrough
 
-`SGLANG_ARGS` configures the inference side. Miles owns
+`sglang_args` configures the inference side. Miles owns
 `--rollout-num-gpus-per-engine`; everything prefixed with `--sglang-` is forwarded to
 `python -m sglang.launch_server` after removing the prefix.
 
@@ -158,9 +166,30 @@ Common entries:
 | Engine tensor parallelism | `--rollout-num-gpus-per-engine` |
 | Engine memory | `--sglang-mem-fraction-static` |
 | Context length | `--sglang-context-length` |
-| MoE serving | `--sglang-enable-ep-moe`, `--sglang-enable-dp-attention` |
+| MoE serving | `--sglang-ep-size`, `--sglang-moe-a2a-backend`, `--sglang-enable-dp-attention` |
 | Debugging | `--sglang-log-level` |
 
 SGLang parallelism is separate from trainer parallelism. For example,
 `--rollout-num-gpus-per-engine` maps to the SGLang server's TP size, not Megatron's
 `--tensor-model-parallel-size`.
+
+<a id="misc-args"></a>
+## `misc_args` - GPU layout and everything else
+
+`misc_args` carries what the other groups do not: how many GPUs the actor gets, whether
+it shares them with the rollout engines, the Megatron knobs a recipe pins once and never
+tunes, and the optional dashboard.
+
+Common entries:
+
+| Concern | Flags |
+|---|---|
+| GPU layout | `--actor-num-nodes`, `--actor-num-gpus-per-node`, `--num-gpus-per-node` |
+| Colocation | `--colocate` |
+| Numerics pinned by the recipe | `--attention-dropout 0.0`, `--hidden-dropout 0.0`, `--attention-softmax-in-fp32`, `--accumulate-allreduce-grads-in-fp32` |
+| Attention kernel | `--attention-backend` |
+| Observability | `--use-miles-dashboard`, `--dump-details` |
+
+Under `--colocate` the actor and the engines share the same GPUs and take turns, so
+`--rollout-num-gpus` is ignored; see
+[Training Backends](/user-guide/training-backend#3-choosing-the-gpu-layout).

--- a/docs/user-guide/cli-reference.md
+++ b/docs/user-guide/cli-reference.md
@@ -64,7 +64,7 @@ then push up until you OOM.
 
 | Flag | Default | What |
 |---|---|---|
-| `--advantage-estimator` | `grpo` | `grpo`, `gspo`, `ppo`, `reinforce_plus_plus`, `reinforce_plus_plus_baseline`, `on_policy_distillation` |
+| `--advantage-estimator` | `grpo` | `grpo`, `gspo`, `ppo`, `reinforce_plus_plus`, `reinforce_plus_plus_baseline`. On-policy distillation is not an estimator — enable it with `--use-opd` on top of any of these. |
 | `--use-kl-loss` | off | Compute KL against the reference model. |
 | `--kl-loss-coef` | `0.0` | Weight of KL in the loss (0 means monitor only). |
 | `--kl-loss-type` | `k1` | `k1`, `k2`, `k3`, `low_var_kl`. |
@@ -112,8 +112,8 @@ Any flag accepted by `python -m sglang.launch_server` is accepted by Miles with 
 ```bash
 --sglang-log-level INFO
 --sglang-mem-fraction-static 0.8
---sglang-enable-overlap-schedule
---sglang-enable-ep-moe
+--sglang-ep-size 8
+--sglang-moe-a2a-backend deepep
 --sglang-enable-dp-attention
 ```
 
@@ -234,7 +234,7 @@ Sections mirror the launch-script argument groups.
 
 | Flag | Type | Default | Notes |
 |---|---|---|---|
-| `--advantage-estimator` | enum | `grpo` | `grpo`, `gspo`, `ppo`, `reinforce_plus_plus`, `reinforce_plus_plus_baseline`, `on_policy_distillation` |
+| `--advantage-estimator` | enum | `grpo` | `grpo`, `gspo`, `ppo`, `reinforce_plus_plus`, `reinforce_plus_plus_baseline`. |
 | `--use-kl-loss` | flag | off | Compute KL vs. reference. |
 | `--kl-loss-coef` | float | `0.0` | KL weight in loss (0 means monitor). |
 | `--kl-loss-type` | enum | `k1` | `k1`, `k2`, `k3`, `low_var_kl`. |
@@ -270,7 +270,7 @@ Sections mirror the launch-script argument groups.
 
 | Flag | Type | Default | Notes |
 |---|---|---|---|
-| `--rm-type` | enum | – | Built-in reward: `math`, `dapo`, `deepscaler`, `f1`, `gpqa`, `ifbench`, `remote_rm`, `random`. |
+| `--rm-type` | str | – | Built-in reward: `math`, `dapo`, `deepscaler`, `gemma_math`, `f1`, `gpqa`, `ifbench`, `remote_rm`, `random`, `deterministic_random`. A `boxed_` prefix (e.g. `boxed_math`) extracts `\boxed{}` from the response before grading. |
 | `--rm-url` | str | – | Endpoint when `--rm-type remote_rm`. |
 | `--group-rm` | flag | off | Batched reward computation. |
 | `--custom-rm-path` | str | – | Custom reward function (see [Customization](/user-guide/customization)). |
@@ -294,11 +294,12 @@ Common `--sglang-*` flags:
 --sglang-mem-fraction-static 0.8
 --sglang-context-length 32768
 --sglang-log-level INFO
---sglang-enable-ep-moe
+--sglang-ep-size 8
 --sglang-enable-dp-attention
---sglang-enable-deepep
---sglang-enable-overlap-schedule
---sglang-cuda-graph-backend-prefill       # prefill graphs default to disabled in colocate mode
+--sglang-moe-a2a-backend deepep
+--sglang-moe-runner-backend triton
+--sglang-deepep-mode auto
+--sglang-cuda-graph-backend-prefill  # prefill graphs default to disabled in colocate mode
 ```
 
 ### Agentic sessions

--- a/docs/user-guide/concepts.md
+++ b/docs/user-guide/concepts.md
@@ -73,14 +73,15 @@ Use this map when reading any launch script:
 
 | Argument group | Concerns |
 |---|---|
-| [`MODEL_ARGS`](/user-guide/argument-groups#model-args) | Architecture constants (layers, hidden size, rotary base, ...) |
-| [`CKPT_ARGS`](/user-guide/argument-groups#ckpt-args) | Filesystem paths for the actor / reference / save directory |
-| [`ROLLOUT_ARGS`](/user-guide/argument-groups#rollout-args) | Prompt dataset, batch knobs, sampling parameters, reward type |
-| [`EVAL_ARGS`](/user-guide/argument-groups#eval-args) | Eval dataset, cadence, sampling overrides for evaluation |
-| [`PERF_ARGS`](/user-guide/argument-groups#perf-args) | Parallelism (TP/PP/CP/EP/ETP), recomputation, dynamic batching |
-| [`GRPO_ARGS`](/user-guide/argument-groups#grpo-args) | RL algorithm, KL, clipping, entropy bonus, advantage estimator |
-| [`OPTIMIZER_ARGS`](/user-guide/argument-groups#optimizer-args) | Learning rate, schedule, weight decay, Adam betas |
-| [`SGLANG_ARGS`](/user-guide/argument-groups#sglang-args) | Engine TP, memory fraction, log level, `--sglang-*` passthrough |
+| [model args](/user-guide/argument-groups#model-args) | Architecture constants (layers, hidden size, rotary base, ...) |
+| [`ckpt_args`](/user-guide/argument-groups#ckpt-args) | Filesystem paths for the actor / reference / save directory |
+| [`rollout_args`](/user-guide/argument-groups#rollout-args) | Prompt dataset, batch knobs, sampling parameters, reward type |
+| [`eval_args`](/user-guide/argument-groups#eval-args) | Eval dataset, cadence, sampling overrides for evaluation |
+| [`perf_args`](/user-guide/argument-groups#perf-args) | Parallelism (TP/PP/CP/EP/ETP), recomputation, dynamic batching |
+| [`grpo_args`](/user-guide/argument-groups#grpo-args) | RL algorithm, KL, clipping, entropy bonus, advantage estimator |
+| [`optimizer_args`](/user-guide/argument-groups#optimizer-args) | Learning rate, schedule, weight decay, Adam betas |
+| [`sglang_args`](/user-guide/argument-groups#sglang-args) | Engine TP, memory fraction, log level, `--sglang-*` passthrough |
+| [`misc_args`](/user-guide/argument-groups#misc-args) | GPU layout, colocation, pinned Megatron numerics, dashboard |
 
 ## Next
 

--- a/docs/user-guide/customization.md
+++ b/docs/user-guide/customization.md
@@ -140,8 +140,10 @@ async def batched_custom_rm(args, samples: list[Sample]) -> list[float]:
     ...
 ```
 
-**Built-in `--rm-type` options:** `math`, `dapo`, `deepscaler`, `f1`, `gpqa`,
-`ifbench`, `remote_rm` (with `--rm-url`), `random`.
+**Built-in `--rm-type` options:** `math`, `dapo`, `deepscaler`, `gemma_math`, `f1`,
+`gpqa`, `ifbench`, `remote_rm` (with `--rm-url`), `random`, `deterministic_random`.
+Prefixing any of them with `boxed_` (for example `boxed_math`) extracts `\boxed{}`
+from the response before grading.
 
 ### `--custom-reward-post-process-path`
 

--- a/docs/user-guide/fully-async.md
+++ b/docs/user-guide/fully-async.md
@@ -326,9 +326,8 @@ Every skipped point is logged at the step it would have landed on, with the reas
 | `eval/skipped_busy` | At `--eval-max-in-flight` under `--eval-overflow-policy skip` |
 | `eval/skipped_export_failed` | The snapshot export raised |
 | `eval/skipped_ckpt_missing` | No `.complete` marker in the snapshot directory |
-| `eval/skipped_unhealthy` | The fleet or its router was unreachable |
-| `eval/skipped_pin_violation` | The engines did not all report the expected weight version |
 | `eval/skipped_crashed` | Anything else the eval raised |
+| `eval/skipped_<reason>` | A `CheckpointEvalFn` raised `EvalSkip(reason)` |
 
 For a point that did run, `eval/{dataset}/weight_version/mean == eval/step` and
 `eval/{dataset}/weight_version/mixed_version_ratio == 0` together confirm it measured

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -7,7 +7,7 @@ description: Concepts, launch scripts, customization hooks, and a complete CLI r
 |---|---|
 | [Core Concepts](/user-guide/concepts) | The four objects in the training loop and the four-knob invariant. |
 | [Launch Script](/user-guide/launch-script) | What `python scripts/run_*.py` does, how a launch script is structured, and how to override a recipe. |
-| [Argument Groups](/user-guide/argument-groups) | Where `MODEL_ARGS`, `PERF_ARGS`, `GRPO_ARGS`, and the other launch-script arrays belong. |
+| [Argument Groups](/user-guide/argument-groups) | Where model args, `perf_args`, `grpo_args`, and the other launch-script flag groups belong. |
 | [Fully Async RL](/user-guide/fully-async) | Continuous generation decoupled from training: the schedule, the data buffer, async eval, and the metrics to watch. |
 | [Training Backends](/user-guide/training-backend) | Megatron-LM and FSDP: what each one owns, how to choose, parallelism, checkpoints, and hooks. |
 | [Monitoring & Logging](/user-guide/monitoring) | wandb, structured logs, per-source breakdowns, profiling, router metrics. |

--- a/docs/user-guide/launch-script.md
+++ b/docs/user-guide/launch-script.md
@@ -141,11 +141,11 @@ documents the flags themselves:
 | `grpo_args` | [RL objective](/user-guide/argument-groups#grpo-args) |
 | `optimizer_args` | [Optimizer](/user-guide/argument-groups#optimizer-args) |
 | `sglang_args` | [Rollout engine](/user-guide/argument-groups#sglang-args) |
+| `misc_args` | [GPU layout and everything else](/user-guide/argument-groups#misc-args) |
 
-Two blocks have no Argument Groups section: `misc_args` carries the cluster shape
-(`--colocate`, `--actor-num-nodes`, `--actor-num-gpus-per-node`), and the wandb flags
-come from `U.get_default_wandb_args`, which returns them only when `WANDB_API_KEY` is
-set — so wandb logging turns on by exporting the key, with no script change.
+One block has no Argument Groups section: the wandb flags come from
+`U.get_default_wandb_args`, which returns them only when `WANDB_API_KEY` is set — so
+wandb logging turns on by exporting the key, with no script change.
 
 ## Three ways to override a recipe
 

--- a/docs/user-guide/monitoring.md
+++ b/docs/user-guide/monitoring.md
@@ -20,7 +20,7 @@ fields depend on backend and config):
 ```
 
 When `--use-wandb` is set, metrics also go to wandb under the `train/`, `rollout/`,
-and `perf/` namespaces (see `miles/utils/wandb_utils.py`).
+and `perf/` namespaces (see `miles/utils/tracking_utils/wandb_utils.py`).
 
 ## Enabling wandb
 

--- a/docs/user-guide/training-backend.md
+++ b/docs/user-guide/training-backend.md
@@ -49,7 +49,7 @@ The rest follows from that split:
 |---|---|---|
 | Model splitting | TP × PP × CP × EP × ETP, plus DP | `dp_replicate` × `dp_shard` |
 | Model input | `torch_dist` checkpoint (offline conversion step) | HF directory, loaded as-is |
-| Architecture definition | `MODEL_ARGS` plus a Megatron spec for anything non-standard | HF `config.json`, plus an optional adaptation spec |
+| Architecture definition | `scripts/models/<megatron_model_type>.py` plus a Megatron spec for anything non-standard | HF `config.json`, plus an optional adaptation spec |
 | Checkpoints written | Megatron `torch_dist` | PyTorch Distributed Checkpoint |
 | Activation recompute | `--recompute-granularity / method / num-layers` | `--gradient-checkpointing` |
 | Optimizer on CPU | `--optimizer-cpu-offload` | `--fsdp-cpu-offload` |
@@ -85,8 +85,8 @@ That import is also why you export the Megatron source before launching:
 export PYTHONPATH=/root/Megatron-LM
 ```
 
-In a launch script the architecture flags live in `MODEL_ARGS`, generated from
-`scripts/models/<family>.py`. Most models need nothing beyond the stock
+In a launch script the architecture flags come from `scripts/models/<family>.py`,
+selected by the `megatron_model_type` the script hands to `execute_train`. Most models need nothing beyond the stock
 `--num-layers / --hidden-size / ...`. For the ones that do, see
 [bringing in a new architecture](#going-deeper-bringing-in-a-new-architecture) below.
 
@@ -110,7 +110,7 @@ tested combination, then change one dimension at a time.**
 Do not assume TP, CP, EP and ETP can all be raised independently for a new model. The exact
 set of supported combinations depends on the Megatron Core kernels and model spec in use.
 [Argument Groups](/user-guide/argument-groups#perf-args) lists the flags that belong in
-`PERF_ARGS`.
+`perf_args`.
 
 ### 3. Choosing the GPU layout
 
@@ -309,7 +309,7 @@ HuggingFace `config.json`, weights load through `AutoModelForCausalLM.from_pretr
 and sharding, the distributed optimizer and mixed precision all come from PyTorch FSDP2
 rather than from Miles.
 
-So there is no conversion step, no `MODEL_ARGS`, and no spec to write for a model that
+So there is no conversion step, no architecture flag block, and no spec to write for a model that
 `transformers` already implements. The bill comes due on parallelism, which is why large
 models and complex layouts belong on [Megatron-LM](#megatron-lm).
 
@@ -322,7 +322,7 @@ models and complex layouts belong on [Megatron-LM](#megatron-lm).
 
 `--hf-checkpoint` is the whole model input: tokenizer, config and weights. Layer count is
 read from the HF config, so Megatron's architecture flags (`--num-layers`, `--hidden-size`,
-`--spec`, `MODEL_ARGS`) simply do not apply here.
+`--spec`, and the rest of `scripts/models/`) simply do not apply here.
 
 ### 2. Sharding it
 
@@ -462,7 +462,7 @@ fit.
 Any flag `python -m sglang.launch_server` accepts, Miles accepts with a `--sglang-` prefix:
 
 ```bash
---sglang-enable-ep-moe
+--sglang-ep-size 8
 --sglang-enable-dp-attention
 --sglang-dp-size 8
 --sglang-mem-fraction-static 0.7

--- a/examples/geo3k_vlm/README.md
+++ b/examples/geo3k_vlm/README.md
@@ -99,7 +99,7 @@ All three performed similarly, so we use the default math RM for simplicity.
 
 Our initial geo3k-specific verifier produced "format scores" (**0 and 0.9**) instead of clean binary rewards. Under **fp32**, fractional values like 0.9 can't be exactly represented, so when all samples in a group have the same reward, `reward - mean` doesn't equal zero—creating spurious gradient signal.
 
-We fixed this by switching to the default math RM with clean **binary 0/1 rewards**. If you encounter similar precision issues with non-binary rewards, you can change the reward tensor dtype from `torch.float` to `torch.float16` in `miles/ray/rollout.py` (`_post_process_rewards` method) to truncate precision artifacts.
+We fixed this by switching to the default math RM with clean **binary 0/1 rewards**. If you encounter similar precision issues with non-binary rewards, you can change the reward tensor dtype from `torch.float` to `torch.float16` in `miles/ray/rollout/train_data_conversion.py` (`_post_process_rewards`) to truncate precision artifacts.
 
 ## B200
 Blackwell currently does not support fa3, we need to use  `--sglang-mm-attention-backend sdpa` and `--attn-implementation flash_attention_2`

--- a/examples/infra_features/train_infer_mismatch_helper/README.md
+++ b/examples/infra_features/train_infer_mismatch_helper/README.md
@@ -92,13 +92,15 @@ Advantages:
 
 ## APIs of Algorithms
 
-You may choose from above algorithms by specifying arguments below:
+You may choose from above algorithms with the two command-line flags below. They are the
+only CLI flags this feature adds; everything in **Configs and Recommended Settings** is a
+key in the YAML file you pass to `--custom-config-path`.
 
 `--use-rollout-logprobs`: True if only use `rollout_log_probs` to compute the loss, bypassing old_log_probs calculated by training engine;
 
-`--use-rollout-correction`: True if apply importance sampling/rejection sampling to loss.
+`--use-tis`: True if apply importance sampling/rejection sampling to loss.
 
-| `use_rollout_logprobs` | `use_rollout_correction` | Algorithm | Policies |Compute old_log_probs | Batch Invariant | Recommended TIS Mode |
+| `use_rollout_logprobs` | `use_tis` | Algorithm | Policies |Compute old_log_probs | Batch Invariant | Recommended TIS Mode |
 |-----------------|-------------|-----------|--------------|---------------|-----------------|----------------------|
 | False | False | Standard PPO (Algorithm 0) | 2 ($\pi_\theta$, $\pi_{\textcolor{blue}{\text{old}}}$)|Yes | No | N/A |
 | True | False | Bypassing PPO (Algorithm 3) | 2 ($\pi_\theta$, $\pi_{\textcolor{red}{\text{SGLang}}}$) |🚀 Skipped | No | N/A |
@@ -106,23 +108,34 @@ You may choose from above algorithms by specifying arguments below:
 
 ## Configs and Recommended Settings
 
-When choosing to use importance sampling or rejection sampling for mismatch correction (`use-rollout-correction` enabled, Algorithm 2 & 3), you may specify the IS modes and applied levels. 
+When choosing to use importance sampling or rejection sampling for mismatch correction
+(`--use-tis` enabled, Algorithm 2 & 3), you may specify the IS modes and applied levels.
 
-### Arguments
+### Config keys
 
-`use-tis`: Enable importance sampling. The IS weight will be multiplied by the policy gradient loss. 
+These are **not command-line flags**. They live in the YAML file the run points at with
+`--custom-config-path`, and `mis.py` reads them off the parsed config. The reference file
+is [`mis.yaml`](mis.yaml), wired up like this:
 
-- `--tis-mode`: Mode for IS. Allowed mode: **truncate**, **clip**.
-- `--tis-lower-bound`, `--tis-upper-bound`: Bounds for IS weights.
-- `--tis-level`: Allowed levels: **token**, **sequence**, **geometric**. See explanations below.
-- `--tis-batch-normalize`: Normalize IS weights to mean=1.0 across batch
+```bash
+--use-tis
+--custom-config-path examples/infra_features/train_infer_mismatch_helper/mis.yaml
+--custom-tis-function-path examples.infra_features.train_infer_mismatch_helper.mis.compute_mis_weights_with_cp
+```
+
+`use_tis`: Enable importance sampling. The IS weight will be multiplied by the policy gradient loss.
+
+- `tis_mode`: Mode for IS. Allowed mode: **truncate**, **clip**, **mask**.
+- `tis_lower_bound`, `tis_upper_bound`: Bounds for IS weights.
+- `tis_level`: Allowed levels: **token**, **sequence**, **geometric**. See explanations below.
+- `tis_batch_normalize`: Normalize IS weights to mean=1.0 across batch
 
 
-`use-rs`: Enable rejection sampling. When choosing to use rejection sampling, the tokens/sequences with an IS weight out of threshold will be directly masked. Those rejected tokens/sequences will not be considered for loss averaging.
+`use_rs`: Enable rejection sampling. When choosing to use rejection sampling, the tokens/sequences with an IS weight out of threshold will be directly masked. Those rejected tokens/sequences will not be considered for loss averaging.
 
-- `--rs-lower-bound`, `--rs-upper-bound`: Bounds for RS
-- `--rs-level`: Allowed levels: **token**, **sequence**, **geometric**. See explanations below.
-- `--rs-veto-threshold`: Sequence-level rejection threshold for catastrophic mismatches
+- `rs_lower_bound`, `rs_upper_bound`: Bounds for RS. Unset falls back to the `tis_` bounds.
+- `rs_level`: Allowed levels: **token**, **sequence**, **geometric**. See explanations below.
+- `rs_veto_threshold`: Sequence-level rejection threshold for catastrophic mismatches
 
 ### Importance Sampling
 
@@ -178,18 +191,21 @@ When rollout log probabilities are available, MILES automatically tracks compreh
 
 These metrics quantify the difference between training and rollout policies. They are computed automatically when `rollout_log_probs` are provided, regardless of whether TIS/MIS correction is enabled.
 
+All names below are logged under the `train/` namespace.
+
 | Metric Name | Description |
 |------------|-------------|
-| `mismatch_training_log_ppl` | Negative mean log probability under training policy: $-\mathbb{E}[\log \pi_{\text{train}}]$ |
-| `mismatch_training_ppl` | Perplexity of training policy: $\exp(-\mathbb{E}[\log \pi_{\text{train}}])$ |
-| `mismatch_rollout_log_ppl` | Negative mean log probability under rollout policy: $-\mathbb{E}[\log \pi_{\text{rollout}}]$ |
-| `mismatch_rollout_ppl` | Perplexity of rollout policy: $\exp(-\mathbb{E}[\log \pi_{\text{rollout}}])$ |
-| `mismatch_kl` | Forward KL divergence estimator: $\mathbb{E}[\log \pi_{\text{rollout}} - \log \pi_{\text{train}}]$ |
-| `mismatch_k3_kl` | K3 KL estimator: $\mathbb{E}[\exp(r) - r - 1]$ where $r = \log \pi_{\text{train}} - \log \pi_{\text{rollout}}$ |
-| `mismatch_log_ppl_diff` | Log perplexity difference|
-| `mismatch_log_ppl_abs_diff` | Absolute log perplexity difference |
-| `mismatch_ppl_ratio` | Perplexity ratio |
-| `train_rollout_logprob_abs_diff` | Token-level absolute log probability difference |
+| `training_log_ppl` | Negative mean log probability under training policy: $-\mathbb{E}[\log \pi_{\text{train}}]$ |
+| `training_ppl` | Perplexity of training policy: $\exp(-\mathbb{E}[\log \pi_{\text{train}}])$ |
+| `rollout_log_ppl` | Negative mean log probability under rollout policy: $-\mathbb{E}[\log \pi_{\text{rollout}}]$ |
+| `rollout_ppl` | Perplexity of rollout policy: $\exp(-\mathbb{E}[\log \pi_{\text{rollout}}])$ |
+| `kl` | Forward KL divergence estimator: $\mathbb{E}[\log \pi_{\text{rollout}} - \log \pi_{\text{train}}]$ |
+| `k3_kl` | K3 KL estimator: $\mathbb{E}[\exp(r) - r - 1]$ where $r = \log \pi_{\text{train}} - \log \pi_{\text{rollout}}$ |
+| `log_ppl_diff` | Log perplexity difference|
+| `log_ppl_abs_diff` | Absolute log perplexity difference |
+| `ppl_ratio` | Perplexity ratio |
+| `chi2_token`, `chi2_seq` | Token- and sequence-level $\chi^2$ divergence between the two policies |
+| `train_rollout_logprob_abs_diff` | Token-level absolute log probability difference (emitted by miles, not `mis.py`) |
 
 **Usage**: These metrics help you monitor policy drift. Large values indicate a significant mismatch between the training and rollout engines.
 
@@ -197,21 +213,22 @@ These metrics quantify the difference between training and rollout policies. The
 
 These metrics track importance sampling weights and corrections. They are only computed when `--use-tis` is enabled.
 
-When using `--custom-tis-function-path` pointing to MIS implementation (e.g., `mis.py`), additional fine-grained metrics become available:
+When using `--custom-tis-function-path` pointing to MIS implementation (e.g., `mis.py`), additional fine-grained metrics become available. The `tis_` and `rs_` prefixes say which stage produced the number.
 
-| Metric Name | Description | Required Args | Optional Control Args |
-|------------|-------------|---------------|----------------------|
-| `ois` | On-policy importance sampling ratio: $\exp(\log \pi_{\text{train}} - \log \pi_{\text{old}})$ | `--use-tis` | Only for Algorithm 2 (Decoupled PPO) |
-| `mis_mean_is_weight_before_clip` | Raw IS weights before any correction: $\exp(\text{log-ratio})$ | `--use-tis` | `--mis-level` (token/sequence/geometric) |
-| `mis_ratio_mean_after_mis` | IS weights after correction (bounded or masked) | `--use-tis` | `--mis-mode`, bounds |
-| `mis_truncate_fraction` | Fraction of weights truncated (mode-specific) | `--use-tis`, `--mis-mode=truncate` | `--mis-upper-bound` |
-| `mis_clip_fraction_low` | Fraction of weights clipped below lower bound | `--use-tis`, `--mis-mode=clip` | `--mis-lower-bound`, `--mis-upper-bound` |
-| `mis_clip_fraction_high` | Fraction of weights clipped above upper bound | `--use-tis`, `--mis-mode=clip` | `--mis-lower-bound`, `--mis-upper-bound` |
-| `mis_mask_fraction_low` | Fraction of tokens rejected (below lower bound) | `--use-tis`, `--mis-mode=mask` | `--mis-lower-bound`, `--mis-upper-bound` |
-| `mis_mask_fraction_high` | Fraction of tokens rejected (above upper bound) | `--use-tis`, `--mis-mode=mask` | `--mis-lower-bound`, `--mis-upper-bound` |
-| `mis_catastrophic_token_fraction` | Fraction of catastrophic tokens (veto-specific) | `--use-tis`, `--mis-veto-threshold` set | Sequence-level rejection |
-| `mis_catastrophic_seq_fraction` | Fraction of sequences with catastrophic tokens | `--use-tis`, `--mis-veto-threshold` set | Sequence-level rejection |
-| `mis_batch_norm_factor` | Batch normalization factor applied to weights | `--use-tis`, `--mis-batch-normalize` | Normalizes mean to 1.0 |
+| Metric Name | Description | Emitted when |
+|------------|-------------|--------------|
+| `ois` | On-policy importance sampling ratio: $\exp(\log \pi_{\text{train}} - \log \pi_{\text{old}})$ | `--use-tis` (Algorithm 2 only) |
+| `tis_weight_before_bound` | Raw IS weights before any bounding: $\exp(\text{log-ratio})$ | `use_tis` |
+| `tis_weight_after_bound` | IS weights after the `tis_mode` bounding | `use_tis` |
+| `tis_truncate_fraction` | Fraction of weights truncated | `tis_mode: truncate` |
+| `tis_clip_fraction_low` / `tis_clip_fraction_high` | Fraction of weights clipped below / above the bound | `tis_mode: clip` |
+| `tis_mask_fraction_low` / `tis_mask_fraction_high` | Fraction of tokens rejected below / above the bound | `tis_mode: mask` |
+| `rs_mask_fraction_low` / `rs_mask_fraction_high` | Fraction of tokens rejected by rejection sampling | `use_rs` |
+| `rs_catastrophic_token_fraction` | Fraction of catastrophic tokens (below the veto threshold) | `rs_veto_threshold` set |
+| `rs_catastrophic_seq_fraction` | Fraction of sequences holding a catastrophic token | `rs_veto_threshold` set |
+| `is_ratio_mean_after_tis_rs` | Mean IS weight after both TIS and RS | `use_tis` |
+| `batch_norm_factor` | Batch normalization factor applied to weights (1.0 when off) | `use_tis` |
+| `is_ratio_mean_final` / `is_ratio_min_final` / `is_ratio_max_final` | Final IS weight statistics actually multiplied into the loss | `use_tis` |
 
 ## Reference
 

--- a/examples/infra_features/train_infer_mismatch_helper/README.md
+++ b/examples/infra_features/train_infer_mismatch_helper/README.md
@@ -185,27 +185,36 @@ Reject entire sequence if $\exists t \in T$ such that $\rho_t < C_{\text{veto}}$
 
 ## Mismatch Metrics
 
-When rollout log probabilities are available, MILES automatically tracks comprehensive metrics to monitor training-inference mismatch and importance sampling weights. These metrics help diagnose policy divergence and guide hyperparameter tuning.
+These metrics help diagnose policy divergence and guide hyperparameter tuning. Which
+ones you get depends on the correction function in use. The built-in one
+(`vanilla_tis_function`, used when `--custom-tis-function-path` is unset) reports only
+`tis`, `tis_clipfrac` and `tis_abs`. Everything below comes from `mis.py`, so it needs
+the `--custom-tis-function-path` wiring shown above.
+
+All names below are logged under the `train/` namespace, and every key `mis.py` produces
+carries a `mis_` prefix that its wrapper adds on the way out — so `training_log_ppl`
+reaches wandb as `train/mis_training_log_ppl`. The two exceptions, marked in the tables,
+come from miles itself and are not prefixed.
 
 ### Mismatch Monitoring Metrics
 
-These metrics quantify the difference between training and rollout policies. They are computed automatically when `rollout_log_probs` are provided, regardless of whether TIS/MIS correction is enabled.
-
-All names below are logged under the `train/` namespace.
+These metrics quantify the difference between training and rollout policies. `mis.py`
+computes them whenever `rollout_log_probs` are available, whether or not IS/RS correction
+is actually applied.
 
 | Metric Name | Description |
 |------------|-------------|
-| `training_log_ppl` | Negative mean log probability under training policy: $-\mathbb{E}[\log \pi_{\text{train}}]$ |
-| `training_ppl` | Perplexity of training policy: $\exp(-\mathbb{E}[\log \pi_{\text{train}}])$ |
-| `rollout_log_ppl` | Negative mean log probability under rollout policy: $-\mathbb{E}[\log \pi_{\text{rollout}}]$ |
-| `rollout_ppl` | Perplexity of rollout policy: $\exp(-\mathbb{E}[\log \pi_{\text{rollout}}])$ |
-| `kl` | Forward KL divergence estimator: $\mathbb{E}[\log \pi_{\text{rollout}} - \log \pi_{\text{train}}]$ |
-| `k3_kl` | K3 KL estimator: $\mathbb{E}[\exp(r) - r - 1]$ where $r = \log \pi_{\text{train}} - \log \pi_{\text{rollout}}$ |
-| `log_ppl_diff` | Log perplexity difference|
-| `log_ppl_abs_diff` | Absolute log perplexity difference |
-| `ppl_ratio` | Perplexity ratio |
-| `chi2_token`, `chi2_seq` | Token- and sequence-level $\chi^2$ divergence between the two policies |
-| `train_rollout_logprob_abs_diff` | Token-level absolute log probability difference (emitted by miles, not `mis.py`) |
+| `mis_training_log_ppl` | Negative mean log probability under training policy: $-\mathbb{E}[\log \pi_{\text{train}}]$ |
+| `mis_training_ppl` | Perplexity of training policy: $\exp(-\mathbb{E}[\log \pi_{\text{train}}])$ |
+| `mis_rollout_log_ppl` | Negative mean log probability under rollout policy: $-\mathbb{E}[\log \pi_{\text{rollout}}]$ |
+| `mis_rollout_ppl` | Perplexity of rollout policy: $\exp(-\mathbb{E}[\log \pi_{\text{rollout}}])$ |
+| `mis_kl` | Forward KL divergence estimator: $\mathbb{E}[\log \pi_{\text{rollout}} - \log \pi_{\text{train}}]$ |
+| `mis_k3_kl` | K3 KL estimator: $\mathbb{E}[\exp(r) - r - 1]$ where $r = \log \pi_{\text{train}} - \log \pi_{\text{rollout}}$ |
+| `mis_log_ppl_diff` | Log perplexity difference|
+| `mis_log_ppl_abs_diff` | Absolute log perplexity difference |
+| `mis_ppl_ratio` | Perplexity ratio |
+| `mis_chi2_token`, `mis_chi2_seq` | Token- and sequence-level $\chi^2$ divergence between the two policies |
+| `train_rollout_logprob_abs_diff` (miles, unprefixed) | Token-level absolute log probability difference |
 
 **Usage**: These metrics help you monitor policy drift. Large values indicate a significant mismatch between the training and rollout engines.
 
@@ -213,22 +222,22 @@ All names below are logged under the `train/` namespace.
 
 These metrics track importance sampling weights and corrections. They are only computed when `--use-tis` is enabled.
 
-When using `--custom-tis-function-path` pointing to MIS implementation (e.g., `mis.py`), additional fine-grained metrics become available. The `tis_` and `rs_` prefixes say which stage produced the number.
+When using `--custom-tis-function-path` pointing to MIS implementation (e.g., `mis.py`), additional fine-grained metrics become available. Under the shared `mis_` prefix, the `tis_` and `rs_` parts say which stage produced the number.
 
 | Metric Name | Description | Emitted when |
 |------------|-------------|--------------|
-| `ois` | On-policy importance sampling ratio: $\exp(\log \pi_{\text{train}} - \log \pi_{\text{old}})$ | `--use-tis` (Algorithm 2 only) |
-| `tis_weight_before_bound` | Raw IS weights before any bounding: $\exp(\text{log-ratio})$ | `use_tis` |
-| `tis_weight_after_bound` | IS weights after the `tis_mode` bounding | `use_tis` |
-| `tis_truncate_fraction` | Fraction of weights truncated | `tis_mode: truncate` |
-| `tis_clip_fraction_low` / `tis_clip_fraction_high` | Fraction of weights clipped below / above the bound | `tis_mode: clip` |
-| `tis_mask_fraction_low` / `tis_mask_fraction_high` | Fraction of tokens rejected below / above the bound | `tis_mode: mask` |
-| `rs_mask_fraction_low` / `rs_mask_fraction_high` | Fraction of tokens rejected by rejection sampling | `use_rs` |
-| `rs_catastrophic_token_fraction` | Fraction of catastrophic tokens (below the veto threshold) | `rs_veto_threshold` set |
-| `rs_catastrophic_seq_fraction` | Fraction of sequences holding a catastrophic token | `rs_veto_threshold` set |
-| `is_ratio_mean_after_tis_rs` | Mean IS weight after both TIS and RS | `use_tis` |
-| `batch_norm_factor` | Batch normalization factor applied to weights (1.0 when off) | `use_tis` |
-| `is_ratio_mean_final` / `is_ratio_min_final` / `is_ratio_max_final` | Final IS weight statistics actually multiplied into the loss | `use_tis` |
+| `ois` (miles, unprefixed) | On-policy importance sampling ratio: $\exp(\log \pi_{\text{train}} - \log \pi_{\text{old}})$ | `--use-tis` (Algorithm 2 only) |
+| `mis_tis_weight_before_bound` | Raw IS weights before any bounding: $\exp(\text{log-ratio})$ | `use_tis` |
+| `mis_tis_weight_after_bound` | IS weights after the `tis_mode` bounding | `use_tis` |
+| `mis_tis_truncate_fraction` | Fraction of weights truncated | `tis_mode: truncate` |
+| `mis_tis_clip_fraction_low` / `mis_tis_clip_fraction_high` | Fraction of weights clipped below / above the bound | `tis_mode: clip` |
+| `mis_tis_mask_fraction_low` / `mis_tis_mask_fraction_high` | Fraction of tokens rejected below / above the bound | `tis_mode: mask` |
+| `mis_rs_mask_fraction_low` / `mis_rs_mask_fraction_high` | Fraction of tokens rejected by rejection sampling | `use_rs` |
+| `mis_rs_catastrophic_token_fraction` | Fraction of catastrophic tokens (below the veto threshold) | `rs_veto_threshold` set |
+| `mis_rs_catastrophic_seq_fraction` | Fraction of sequences holding a catastrophic token | `rs_veto_threshold` set |
+| `mis_is_ratio_mean_after_tis_rs` | Mean IS weight after both TIS and RS | `use_tis` |
+| `mis_batch_norm_factor` | Batch normalization factor applied to weights (1.0 when off) | `use_tis` |
+| `mis_is_ratio_mean_final` / `mis_is_ratio_min_final` / `mis_is_ratio_max_final` | Final IS weight statistics actually multiplied into the loss | `use_tis` |
 
 ## Reference
 


### PR DESCRIPTION
Audit of `docs/` against `main`. This PR only fixes claims that are **wrong** — commands that fail as written, symbols that no longer exist, and values that disagree with the code. Coverage gaps (flags that exist but are undocumented) are deliberately left out; see the follow-ups at the bottom.

## Commands that fail as written

| Page | Was | Now |
|---|---|---|
| `models/glm/glm4-5`, `models/glm/glm4-7-flash` | `python3 scripts/model_args.py <type>` | `python3 miles/utils/external_utils/model_args_utils.py <type>` — `scripts/model_args.py` does not exist; the other 17 conversion snippets already use the right path |
| `user-guide/cli-reference` | `on_policy_distillation` listed as an `--advantage-estimator` value | removed. `arguments.py:1422` has no such choice, and its own help says OPD is enabled *on top of any estimator* via `--use-opd` |
| `ci/02-docker-build`, `developer/versions` | `--variant rocm-mi300` / `rocm-mi350` | `rocm700-mi30x` / `rocm700-mi35x` / `rocm720-mi35x` — the real keys in `docker/build.py` and the `variant` choice list in `docker-build.yml`. `rocm700-mi35x` was missing from both tables |
| `models/thinkingmachines/inkling` §5.5 | `--optimizer-state-nvme-dir`, `--optimizer-state-nvme-chunk-mb` | neither flag exists. `scripts/run_inkling.py` passes `--offload-train-target disk --offload-train-disk-dir` when colocated and `--stream-optimizer-state-to-disk --offload-train-disk-dir --offload-train-disk-chunk-mb 256` under `--fully-async`. Also split the grad-reduce line, which is `--grad-reduce-in-bf16` vs `--accumulate-allreduce-grads-in-fp32` on the same condition |
| `cli-reference`, `training-backend`, `argument-groups`, `models/kimi/kimi-k2` | `--sglang-enable-ep-moe`, `--sglang-enable-deepep`, `--sglang-enable-deepep-moe`, `--sglang-enable-overlap-schedule` | all four are gone from the pinned sglang `ServerArgs`. Replaced with what the recipes actually pass: `--sglang-ep-size` (75 uses), `--sglang-moe-a2a-backend` (15), `--sglang-moe-runner-backend` (40), `--sglang-deepep-mode` (13) |
| `examples/infra_features/train_infer_mismatch_helper/README.md` | `--tis-mode` / `--tis-level` / `--tis-*-bound` / `--tis-batch-normalize` / `--rs-*` documented as CLI flags, plus a `--use-rollout-correction` flag | none of those are CLI flags. They are keys in `mis.yaml`, reached through `--custom-config-path` + `--custom-tis-function-path`; the only CLI toggles are `--use-tis` and `--use-rollout-logprobs`. `--use-rollout-correction` does not exist anywhere in the repo and was the header of an algorithm table |

## Symbols and paths that do not exist

- **`miles/ray/rollout.py`** is a package now. `advanced/fault-tolerance` (4×), `advanced/pd-disaggregation` and `examples/geo3k_vlm/README.md` now point at `rollout_manager.py`, `rollout_server.py`, `server_group.py` and `train_data_conversion.py` respectively. While there, `fault-tolerance` now also mentions that the rollout paths need `rollout` in `--ft-components`, not just `--use-fault-tolerance`.
- **`MILES_HACK_TRAIN_TORCH_DETERMINISTIC`** (`models/deepseek/deepseek-v4-flash`) does not exist. `scripts/run_deepseek_v4.py` sets five env vars unconditionally (`SGLANG_SKIP_CHECKPOINT_LOAD_CHECK`, `SGLANG_DSV4_FP4_EXPERTS`, `SGLANG_HEALTH_CHECK_TIMEOUT`, `SGLANG_DG_CACHE_DIR_PER_PROCESS`, `SGLANG_OPT_FP8_WO_A_GEMM`) and three more only under `--train-deterministic` (`NCCL_ALGO`, `NVTE_ALLOW_NONDETERMINISTIC_ALGO`, `CUBLAS_WORKSPACE_CONFIG`). The V4-Pro page got the same five.
- **`with_transformers_patch()` / `miles/utils/transformers_patch.py`** are both gone; the `deepseek_ref` → `deepseek_v4` handling is an in-place `config.json` rewrite in the launcher.
- **`eval/skipped_unhealthy`, `eval/skipped_pin_violation`** have no emitter. The built-in reasons are `busy`, `export_failed`, `ckpt_missing`, `crashed`, plus whatever a `CheckpointEvalFn` passes to `EvalSkip(reason)`.
- **The `mis_*` / `mismatch_*` metric names** in the rollout-correction example match nothing in `mis.py`. Replaced with the names actually emitted: `tis_weight_before_bound`, `tis_truncate_fraction`, `tis_clip_fraction_low|high`, `tis_mask_fraction_low|high`, `rs_mask_fraction_low|high`, `rs_catastrophic_token_fraction`, `rs_catastrophic_seq_fraction`, `is_ratio_mean_after_tis_rs`, `batch_norm_factor`, `is_ratio_{mean,min,max}_final`, and the unprefixed `training_log_ppl` / `rollout_log_ppl` / `kl` / `k3_kl` / `log_ppl_diff` / `ppl_ratio` / `chi2_token` / `chi2_seq`.
- **`miles/utils/wandb_utils.py`** → `miles/utils/tracking_utils/wandb_utils.py`.

## Wrong values and premises

- **`--update-weight-buffer-size` defaults to 512 MB**, not 1 GB (`arguments.py:773` is `512 * 1024**2`).
- **`user-guide/argument-groups` opened with "Miles launch scripts are bash arrays."** `scripts/` holds 34 Python launchers and zero `.sh` files, and the page contradicted `user-guide/launch-script`, which already describes the Python layout correctly. Rewritten around the `<group>_args` locals the launchers actually build, with the previously-missing `misc_args` group (35 launchers use it) documented and the architecture flags explained as coming from `scripts/models/<megatron_model_type>.py` via `execute_train`. The `<a id>` anchors are unchanged, so incoming links still resolve; `concepts`, `training-backend`, `user-guide/index`, `developer/contributor-guide` and `models/kimi/kimi-k2.5` were updated to the same names.
- **`developer/architecture`** sent new reward types to `miles/rollout/sglang_rollout.py`; the `rm_type` dispatch lives in `miles/rollout/rm_hub/__init__.py`, and `rm_hub/` was missing from the package tree.
- **`--rm-type` enumerations** (`cli-reference`, `customization`) omitted `gemma_math` — which `scripts/run_gemma_4_*.py` and `models/gemma/gemma-4` both use, so readers would take it for an invalid value — plus `deterministic_random` and the `boxed_` prefix modifier. `--rm-type` is also a free `str`, not an enum.
- **The canonical CI label list** (`ci/01-label`) listed 15 of the 19 entries in `KNOWN_LABELS`, omitting `eval`, `fully-async`, `miles-plugin` and `amd`. `ci/00-stage` already tells readers how `run-ci-amd` behaves.

## Verification

- `pre-commit run --all-files` clean (includes the examples→docs mirror check).
- `python scripts/tools/sync_example_docs.py --check` clean; the two generated pages were regenerated from their READMEs rather than edited directly.
- Re-ran the audit passes on the result: 0 broken internal links, 0 missing images, 0 nonexistent repo paths outside the pages that deliberately document unmerged PRs (`kimi-k3` → #1825, `qwen3-8` → #2488), 0 `--sglang-*` flags absent from the pinned `ServerArgs`.

## Deliberately not in this PR

Coverage and consistency work, worth separate PRs:

- `cli-reference` says it lists *every* Miles flag; it covers 91 of 344, and 133 registered flags appear nowhere in the docs — including all of MLflow (`--use-mlflow` + 4), TensorBoard (`--use-tensorboard` + 2) and Prometheus (`--prometheus-port` + 1). `user-guide/monitoring` documents only wandb as a result.
- `customization` says it lists *every* hook; six `load_function` hooks are missing (`--custom-async-data-buffer-path`, `--custom-update-weight-post-write-path`, `--generate-{execute-tool-function,tool-specs}-path`, `--session-sample-{picker,postprocessor}-path`).
- Ascend NPU has `docker/npu_patch/`, `scripts/run_qwen3_4b_npu.py` and `execute_train_npu()`, but no page mentions it; `index` and `installation` list only NVIDIA and AMD, and disagree on `MI350` vs `MI350X`.
- 24 links across 17 pages still point at the removed `/advanced/architecture-support` and survive only on the `docs.json` redirect, with link text that no longer names the destination.
- Several model and advanced pages still illustrate flags with uppercase `SGLANG_ARGS=(...)` shell blocks, a leftover of the same bash-array framing this PR removed from `argument-groups`.
- `low-precision` writes `GroupLinear` / `GroupGEMM` where `int4-qat` writes TE `GroupedLinear`; a stray empty `## TODO` section in `examples/infra_features/low_precision/README.md`; an unrendered `{/* FIGURE PLACEHOLDER */}` in `launch-script`; and five British spellings.
