### PR TITLE
docs: name the Slack channel #miles-rl

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@
 [![GitHub Repo](https://img.shields.io/badge/github-radixark%2Fmiles-black?logo=github)](https://github.com/radixark/miles)
 [![Docs](https://img.shields.io/badge/docs-miles.radixark.com-d55816)](https://miles.radixark.com/docs)
 [![License](https://img.shields.io/github/license/radixark/miles)](LICENSE)
-[![Slack](https://img.shields.io/badge/slack-join-brightgreen.svg)](https://slack.sglang.ai)
+[![Slack](https://img.shields.io/badge/slack-%23miles--rl-brightgreen.svg)](https://slack.sglang.ai)
 
-| [**Documentation**](https://miles.radixark.com/docs) | [**Quick Start**](https://miles.radixark.com/docs/getting-started/quick-start) | [**Supported Models**](https://miles.radixark.com/docs/models) | [**Blog**](https://www.lmsys.org/blog) | [**Slack**](https://slack.sglang.ai) |
+| [**Documentation**](https://miles.radixark.com/docs) | [**Quick Start**](https://miles.radixark.com/docs/getting-started/quick-start) | [**Supported Models**](https://miles.radixark.com/docs/models) | [**Blog**](https://www.lmsys.org/blog) | [**Slack**](https://slack.sglang.ai) (`#miles-rl`) |
 
 </div>
 

--- a/docs/ci/contributor-guide.md
+++ b/docs/ci/contributor-guide.md
@@ -96,7 +96,7 @@ When a re-run still shows an infra signal from the table above, open a **GitHub 
 - A short **log snippet** of the error (the infra signal line).
 - What you already tried (e.g. "re-ran twice, same `ENOSPC`").
 
-A maintainer maps the runner to its host and fixes the machine; you don't need runner access. For a fast sanity check before filing, you can ask in the Miles channel of the [SGLang Slack](https://slack.sglang.ai), but the **GitHub Issue is the tracked record**.
+A maintainer maps the runner to its host and fixes the machine; you don't need runner access. For a fast sanity check before filing, you can ask in the `#miles-rl` channel of the [SGLang Slack](https://slack.sglang.ai), but the **GitHub Issue is the tracked record**.
 
 ## Report a flaky test
 

--- a/docs/developer/contributor-guide.md
+++ b/docs/developer/contributor-guide.md
@@ -270,7 +270,7 @@ map it to a host.
 
 ## Where to ask
 
-* **Quick questions:** the Miles channel of the [SGLang Slack](https://slack.sglang.ai).
+* **Quick questions:** the `#miles-rl` channel of the [SGLang Slack](https://slack.sglang.ai).
 * **Design discussions:** a GitHub Discussion, or an Issue labeled `discussion`.
 * **CI internals:** [Stage](/ci/00-stage) (stages), [Labels](/ci/01-label) (label
   semantics), [Docker build](/ci/02-docker-build) (images),

--- a/docs/index.md
+++ b/docs/index.md
@@ -135,5 +135,5 @@ from hardware and cloud to model labs, agent infrastructure, and academia:
 ## Contribute
 
 - GitHub: [github.com/radixark/miles](https://github.com/radixark/miles)
-- Slack: [slack.sglang.ai](https://slack.sglang.ai), channel `#miles`
+- Slack: [slack.sglang.ai](https://slack.sglang.ai), channel `#miles-rl`
 - Contributing: [developer guide](/developer/contributor-guide)


### PR DESCRIPTION
## Motivation

The Miles channel on the [SGLang Slack](https://slack.sglang.ai) is `#miles-rl`, but the docs said `#miles` (or just "the Miles channel"), so readers searching the workspace can miss it.

## Modifications

- `docs/index.md` — `channel #miles` → `channel #miles-rl`.
- `docs/developer/contributor-guide.md`, `docs/ci/contributor-guide.md` — "the Miles channel" → the explicit `` `#miles-rl` `` channel.
- `README.md` — the Slack badge now reads `#miles-rl` instead of `join`, and the header table's Slack entry carries the channel name, so the channel is visible on the repo front page.

Docs/README only; no code or behavior change.

## Checklist

- [x] Format the code and execute related tests (docs-only change).
- [x] Update documentation as needed, including docstrings or example tutorials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)