### PR TITLE
docs: improve Miles Diffusion discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![License](https://img.shields.io/github/license/radixark/miles)](LICENSE)
 [![Slack](https://img.shields.io/badge/slack-%23miles--rl-brightgreen.svg)](https://slack.sglang.ai)
 
-| [**Documentation**](https://miles.radixark.com/docs) | [**Quick Start**](https://miles.radixark.com/docs/getting-started/quick-start) | [**Supported Models**](https://miles.radixark.com/docs/models) | [**Blog**](https://www.lmsys.org/blog) | [**Slack**](https://slack.sglang.ai) (`#miles-rl`) |
+| [**Documentation**](https://miles.radixark.com/docs) | [**Quick Start**](https://miles.radixark.com/docs/getting-started/quick-start) | [**Supported Models**](https://miles.radixark.com/docs/models) | [**Miles Diffusion**](https://github.com/radixark/miles_diffusion) | [**Blog**](https://www.lmsys.org/blog) | [**Slack**](https://slack.sglang.ai) (`#miles-rl`) |
 
 </div>
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -86,6 +86,7 @@ of the box, including older generations of the families below.
 | **Wan** | [Wan2.2-T2V-A14B](/diffusion/models/wan/wan2-2) |
 | **LTX** | [LTX-2.3](/diffusion/models/ltx/ltx2) |
 | **Cosmos** | [Cosmos3-Nano](/diffusion/models/cosmos/cosmos3) |
+| **MiniMax** | [MiniMax H3](/diffusion/models/h3/h3) |
 
 See [Models](/models/index) for LLM family guides and [Diffusion](/diffusion) for
 diffusion recipes and validation details.

--- a/docs/models/index.md
+++ b/docs/models/index.md
@@ -3,11 +3,9 @@ title: Supported Models
 sidebarTitle: Overview
 description: Per-family recipes covering weight conversion, launch flags, and parallelism choices.
 ---
-Miles ships ready-to-run recipes for every model family listed below. Each page covers
-weight conversion, parallelism, and the launch script in the order you'd actually run
-them.
+Miles ships ready-to-run recipes for the language and diffusion model families below.
 
-## By family
+## Language Models
 
 Each model name links to its recipe page.
 
@@ -23,9 +21,20 @@ Each model name links to its recipe page.
 | **JoyAI** | [JoyAI-LLM-Flash](https://github.com/radixark/miles/blob/main/scripts/run_joy_ai_llm_flash.py) |
 | **GPT-OSS** | [gpt-oss-20b](/models/gpt-oss/gpt-oss) |
 
-## How a recipe is structured
+## Diffusion
 
-Every recipe page follows the same six sections:
+| Family | Models |
+|---|---|
+| **Stable Diffusion** | [SD3.5](/diffusion/models/sd3/sd3) |
+| **Qwen-Image** | [Qwen-Image](/diffusion/models/qwen-image/qwen-image) |
+| **Wan** | [Wan2.2-T2V-A14B](/diffusion/models/wan/wan2-2) |
+| **LTX** | [LTX-2.3](/diffusion/models/ltx/ltx2) |
+| **Cosmos** | [Cosmos3-Nano](/diffusion/models/cosmos/cosmos3) |
+| **MiniMax** | [MiniMax H3](/diffusion/models/h3/h3) |
+
+## How a language-model recipe is structured
+
+Every language-model recipe page follows the same six sections:
 
 1. **Model Introduction** — what the model is and why miles supports it.
 2. **Supported Variants** — model sizes + HF links.
@@ -34,7 +43,7 @@ Every recipe page follows the same six sections:
 5. **Recipe Configuration** — parallelism, algorithm, rollout/SGLang, optimizer.
 6. **Pairs Well With** — links to the advanced features that complement this recipe.
 
-## Adding a new model
+## Adding a new language model
 
 Miles's plugin architecture lets you wrap a HuggingFace implementation as a Megatron
 module without patching Megatron core. See

--- a/docs/models/index.md
+++ b/docs/models/index.md
@@ -3,7 +3,9 @@ title: Supported Models
 sidebarTitle: Overview
 description: Per-family recipes covering weight conversion, launch flags, and parallelism choices.
 ---
-Miles ships ready-to-run recipes for the language and diffusion model families below.
+Miles ships ready-to-run recipes for every model family listed below. Each page covers
+weight conversion, parallelism, and the launch script in the order you'd actually run
+them.
 
 ## Language Models
 
@@ -32,9 +34,9 @@ Each model name links to its recipe page.
 | **Cosmos** | [Cosmos3-Nano](/diffusion/models/cosmos/cosmos3) |
 | **MiniMax** | [MiniMax H3](/diffusion/models/h3/h3) |
 
-## How a language-model recipe is structured
+## How a recipe is structured
 
-Every language-model recipe page follows the same six sections:
+Every recipe page follows the same six sections:
 
 1. **Model Introduction** — what the model is and why miles supports it.
 2. **Supported Variants** — model sizes + HF links.
@@ -43,7 +45,7 @@ Every language-model recipe page follows the same six sections:
 5. **Recipe Configuration** — parallelism, algorithm, rollout/SGLang, optimizer.
 6. **Pairs Well With** — links to the advanced features that complement this recipe.
 
-## Adding a new language model
+## Adding a new model
 
 Miles's plugin architecture lets you wrap a HuggingFace implementation as a Megatron
 module without patching Megatron core. See


### PR DESCRIPTION
## Summary

- Rename the existing model table to `Language Models`.
- Add a separate `Diffusion` table with links to each recipe guide.
- Add MiniMax H3 to the landing-page and diffusion model lists.
- Add a `Miles Diffusion` repository link to the README navigation.

## Why

Make diffusion models and their source repository easier to discover.

## Test plan

- [x] `git diff --check upstream/main...HEAD`
- [x] Documentation diagnostics report no errors

## Checklist

- [ ] `pre-commit run --all-files` passes — not run
- [ ] Added/updated tests for new behaviour — docs-only change
- [ ] `pytest -x` is green — not run for docs-only change
- [x] If launch flags changed, `python3 train.py --help` still parses — not applicable
- [x] If a public flag was added, it appears in the CLI reference docs — not applicable
- [x] If an example was added, it has a real walkthrough — not applicable
