### PR TITLE
docs: filter the blog link to Miles posts

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![License](https://img.shields.io/github/license/radixark/miles)](LICENSE)
 [![Slack](https://img.shields.io/badge/slack-%23miles--rl-brightgreen.svg)](https://slack.sglang.ai)
 
-| [**Documentation**](https://miles.radixark.com/docs) | [**Quick Start**](https://miles.radixark.com/docs/getting-started/quick-start) | [**Supported Models**](https://miles.radixark.com/docs/models) | [**Miles Diffusion**](https://github.com/radixark/miles_diffusion) | [**Blog**](https://www.lmsys.org/blog) | [**Slack**](https://slack.sglang.ai) (`#miles-rl`) |
+| [**Documentation**](https://miles.radixark.com/docs) | [**Quick Start**](https://miles.radixark.com/docs/getting-started/quick-start) | [**Supported Models**](https://miles.radixark.com/docs/models) | [**Miles Diffusion**](https://github.com/radixark/miles_diffusion) | [**Blog**](https://www.lmsys.org/blog?filter=miles) | [**Slack**](https://slack.sglang.ai) (`#miles-rl`) |
 
 </div>
 


### PR DESCRIPTION
## Motivation

The **Blog** link in the README header row pointed at the full LMSYS blog index (`https://www.lmsys.org/blog`), so readers had to scan unrelated posts to find Miles content.

## Modifications

Point the header **Blog** link at the Miles-filtered view: `https://www.lmsys.org/blog?filter=miles`. The dated per-post links in the News section are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)