### PR TITLE
docs: link the Miles website from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,13 @@
 
 ### **Enterprise-Grade Reinforcement Learning for Large-Scale Model Post-Training**
 
+[![Website](https://img.shields.io/badge/website-miles.radixark.com-d55816)](https://miles.radixark.com/)
 [![GitHub Repo](https://img.shields.io/badge/github-radixark%2Fmiles-black?logo=github)](https://github.com/radixark/miles)
-[![Docs](https://img.shields.io/badge/docs-miles.radixark.com-d55816)](https://miles.radixark.com/docs)
+[![Docs](https://img.shields.io/badge/docs-miles.radixark.com%2Fdocs-d55816)](https://miles.radixark.com/docs)
 [![License](https://img.shields.io/github/license/radixark/miles)](LICENSE)
 [![Slack](https://img.shields.io/badge/slack-%23miles--rl-brightgreen.svg)](https://slack.sglang.ai)
 
-| [**Documentation**](https://miles.radixark.com/docs) | [**Quick Start**](https://miles.radixark.com/docs/getting-started/quick-start) | [**Supported Models**](https://miles.radixark.com/docs/models) | [**Miles Diffusion**](https://github.com/radixark/miles_diffusion) | [**Blog**](https://www.lmsys.org/blog?filter=miles) | [**Slack**](https://slack.sglang.ai) (`#miles-rl`) |
+| [**Website**](https://miles.radixark.com/) | [**Documentation**](https://miles.radixark.com/docs) | [**Quick Start**](https://miles.radixark.com/docs/getting-started/quick-start) | [**Supported Models**](https://miles.radixark.com/docs/models) | [**Miles Diffusion**](https://github.com/radixark/miles_diffusion) | [**Blog**](https://www.lmsys.org/blog?filter=miles) | [**Slack**](https://slack.sglang.ai) (`#miles-rl`) |
 
 </div>
 


### PR DESCRIPTION
## What

The README header linked `/docs`, `/docs/getting-started/quick-start`, `/docs/models` and the Diffusion repo, but never the site root. Added [miles.radixark.com](https://miles.radixark.com/) to both places a reader looks first:

- the badge row, as the leading badge
- the nav table, as the leading cell

Also relabelled the docs badge from `docs-miles.radixark.com` to `docs-miles.radixark.com/docs`. With a website badge beside it, two badges both reading `miles.radixark.com` would not tell you which one goes where.

## Checked

`https://miles.radixark.com/` returns 200 and is a page in its own right, not a redirect to `/docs`. Both shields.io badge URLs render.
