### PR TITLE
Feat(rollout): fail fast on invalid rollout log probabilities

### DIFF
--- a/miles/ray/rollout/train_data_conversion.py
+++ b/miles/ray/rollout/train_data_conversion.py
@@ -3,6 +3,7 @@ from typing import Any
 
 import torch
 
+from miles.rollout.logprob_guard import guard_rollout_log_probs
 from miles.utils import object_store
 from miles.utils.dp_schedule import build_dp_schedule, has_full_schedule_config
 from miles.utils.multi_lora import is_multi_lora_enabled
@@ -97,6 +98,7 @@ def convert_samples_to_train_data(
             sample.loss_mask = [0] * sample.response_length
         loss_masks.append(sample.loss_mask)
     train_data["loss_masks"] = loss_masks
+    guard_rollout_log_probs(samples, loss_masks)
 
     train_data["rollout_mask_sums"] = _compute_rollout_mask_sums(train_data["rollout_ids"], loss_masks)
 

--- a/miles/rollout/logprob_guard.py
+++ b/miles/rollout/logprob_guard.py
@@ -3,11 +3,26 @@ import math
 from miles.utils.types import Sample
 
 
+def _invalid_log_prob_kind(log_prob: object) -> str | None:
+    """Classify non-finite values and their JSON null representation."""
+    if log_prob is None:
+        return "null"
+    if isinstance(log_prob, bool):
+        return "invalid_type"
+
+    try:
+        if math.isfinite(log_prob):
+            return None
+        return "nan" if math.isnan(log_prob) else "inf"
+    except (TypeError, ValueError, OverflowError):
+        return "invalid_type"
+
+
 def guard_rollout_log_probs(samples: list[Sample], loss_masks: list[list[int]]) -> None:
-    """Reject non-finite rollout log probabilities on trainable tokens."""
-    nan_count = 0
-    inf_count = 0
-    valid_token_count = 0
+    """Reject malformed values and non-finite trainable rollout log probabilities."""
+    invalid_counts = {"active_nan": 0, "active_inf": 0, "null": 0, "invalid_type": 0}
+    total_token_count = 0
+    active_token_count = 0
     bad_rows = []
 
     for row, (sample, loss_mask) in enumerate(zip(samples, loss_masks, strict=True)):
@@ -21,24 +36,28 @@ def guard_rollout_log_probs(samples: list[Sample], loss_masks: list[list[int]]) 
 
         row_is_bad = False
         for log_prob, is_active in zip(log_probs, loss_mask, strict=True):
-            if not is_active:
+            total_token_count += 1
+            if is_active:
+                active_token_count += 1
+            invalid_kind = _invalid_log_prob_kind(log_prob)
+            if invalid_kind is None:
                 continue
-            valid_token_count += 1
-            if math.isfinite(log_prob):
-                continue
+            if invalid_kind in ("nan", "inf"):
+                if not is_active:
+                    continue
+                invalid_kind = f"active_{invalid_kind}"
             row_is_bad = True
-            if math.isnan(log_prob):
-                nan_count += 1
-            else:
-                inf_count += 1
+            invalid_counts[invalid_kind] += 1
         if row_is_bad:
             bad_rows.append(row)
 
-    non_finite_count = nan_count + inf_count
-    if non_finite_count:
+    invalid_count = sum(invalid_counts.values())
+    if invalid_count:
         raise ValueError(
-            f"Non-finite rollout_log_probs detected: {non_finite_count} bad tokens "
-            f"(nan={nan_count}, inf={inf_count}) out of {valid_token_count} valid tokens, "
+            f"Invalid rollout_log_probs detected: {invalid_count} bad tokens "
+            f"(active_nan={invalid_counts['active_nan']}, active_inf={invalid_counts['active_inf']}, "
+            f"null={invalid_counts['null']}, invalid_type={invalid_counts['invalid_type']}) "
+            f"across {total_token_count} total tokens ({active_token_count} active), "
             f"in {len(bad_rows)}/{len(samples)} sequences "
             f"(first bad row indices: {bad_rows[:16]})"
         )

--- a/miles/rollout/logprob_guard.py
+++ b/miles/rollout/logprob_guard.py
@@ -1,0 +1,44 @@
+import math
+
+from miles.utils.types import Sample
+
+
+def guard_rollout_log_probs(samples: list[Sample], loss_masks: list[list[int]]) -> None:
+    """Reject non-finite rollout log probabilities on trainable tokens."""
+    nan_count = 0
+    inf_count = 0
+    valid_token_count = 0
+    bad_rows = []
+
+    for row, (sample, loss_mask) in enumerate(zip(samples, loss_masks, strict=True)):
+        log_probs = sample.rollout_log_probs
+        if log_probs is None:
+            continue
+        if len(log_probs) != len(loss_mask):
+            raise ValueError(
+                f"rollout_log_probs length ({len(log_probs)}) != loss_mask length ({len(loss_mask)}) " f"at row {row}"
+            )
+
+        row_is_bad = False
+        for log_prob, is_active in zip(log_probs, loss_mask, strict=True):
+            if not is_active:
+                continue
+            valid_token_count += 1
+            if math.isfinite(log_prob):
+                continue
+            row_is_bad = True
+            if math.isnan(log_prob):
+                nan_count += 1
+            else:
+                inf_count += 1
+        if row_is_bad:
+            bad_rows.append(row)
+
+    non_finite_count = nan_count + inf_count
+    if non_finite_count:
+        raise ValueError(
+            f"Non-finite rollout_log_probs detected: {non_finite_count} bad tokens "
+            f"(nan={nan_count}, inf={inf_count}) out of {valid_token_count} valid tokens, "
+            f"in {len(bad_rows)}/{len(samples)} sequences "
+            f"(first bad row indices: {bad_rows[:16]})"
+        )

--- a/tests/fast/ray/rollout/test_train_data_conversion.py
+++ b/tests/fast/ray/rollout/test_train_data_conversion.py
@@ -120,6 +120,20 @@ class TestConvertSamplesToTrainData:
         )
         assert out["rollout_log_probs"][0] == [-0.1, -0.2, -0.3, -0.4]
 
+    def test_non_finite_rollout_log_probs_rejected(self):
+        args = make_args(rewards_normalization=False)
+        sample = make_sample()
+        sample.rollout_log_probs = [-0.1, float("nan"), -0.3, -0.4]
+
+        with pytest.raises(ValueError, match="Non-finite rollout_log_probs"):
+            convert_samples_to_train_data(
+                args,
+                [sample],
+                metadata={},
+                custom_convert_samples_to_train_data_func=None,
+                custom_reward_post_process_func=None,
+            )
+
     def test_optional_field_round_number_from_metadata(self):
         args = make_args(rewards_normalization=False)
         s = make_sample()

--- a/tests/fast/ray/rollout/test_train_data_conversion.py
+++ b/tests/fast/ray/rollout/test_train_data_conversion.py
@@ -125,7 +125,21 @@ class TestConvertSamplesToTrainData:
         sample = make_sample()
         sample.rollout_log_probs = [-0.1, float("nan"), -0.3, -0.4]
 
-        with pytest.raises(ValueError, match="Non-finite rollout_log_probs"):
+        with pytest.raises(ValueError, match="Invalid rollout_log_probs"):
+            convert_samples_to_train_data(
+                args,
+                [sample],
+                metadata={},
+                custom_convert_samples_to_train_data_func=None,
+                custom_reward_post_process_func=None,
+            )
+
+    def test_wire_null_rollout_log_probs_rejected(self):
+        args = make_args(rewards_normalization=False)
+        sample = make_sample()
+        sample.rollout_log_probs = [-0.1, None, -0.3, -0.4]
+
+        with pytest.raises(ValueError, match=r"Invalid rollout_log_probs.*null=1"):
             convert_samples_to_train_data(
                 args,
                 [sample],

--- a/tests/fast/rollout/test_logprob_guard.py
+++ b/tests/fast/rollout/test_logprob_guard.py
@@ -1,0 +1,44 @@
+import pytest
+
+from miles.rollout.logprob_guard import guard_rollout_log_probs
+from miles.utils.types import Sample
+
+
+def _sample(log_probs: list[float] | None) -> Sample:
+    response_length = len(log_probs) if log_probs is not None else 2
+    return Sample(
+        tokens=list(range(response_length)),
+        response_length=response_length,
+        rollout_log_probs=log_probs,
+    )
+
+
+def test_guard_accepts_finite_and_missing_log_probs():
+    samples = [_sample([-0.1, -0.2]), _sample(None)]
+
+    guard_rollout_log_probs(samples, [[1, 1], [1, 1]])
+
+
+def test_guard_ignores_non_finite_masked_tokens():
+    sample = _sample([float("nan"), float("inf"), -0.1])
+
+    guard_rollout_log_probs([sample], [[0, 0, 1]])
+
+
+def test_guard_reports_non_finite_active_tokens():
+    samples = [
+        _sample([-0.1, float("nan")]),
+        _sample([float("inf"), float("-inf")]),
+        _sample([float("nan"), -0.2]),
+    ]
+
+    with pytest.raises(
+        ValueError,
+        match=r"3 bad tokens \(nan=1, inf=2\) out of 5 valid tokens.*row indices: \[0, 1\]",
+    ):
+        guard_rollout_log_probs(samples, [[1, 1], [1, 1], [0, 1]])
+
+
+def test_guard_rejects_length_mismatch():
+    with pytest.raises(ValueError, match=r"rollout_log_probs length \(1\) != loss_mask length \(2\) at row 0"):
+        guard_rollout_log_probs([_sample([-0.1])], [[1, 1]])

--- a/tests/fast/rollout/test_logprob_guard.py
+++ b/tests/fast/rollout/test_logprob_guard.py
@@ -1,10 +1,12 @@
+from typing import Any
+
 import pytest
 
 from miles.rollout.logprob_guard import guard_rollout_log_probs
 from miles.utils.types import Sample
 
 
-def _sample(log_probs: list[float] | None) -> Sample:
+def _sample(log_probs: list[Any] | None) -> Sample:
     response_length = len(log_probs) if log_probs is not None else 2
     return Sample(
         tokens=list(range(response_length)),
@@ -34,9 +36,32 @@ def test_guard_reports_non_finite_active_tokens():
 
     with pytest.raises(
         ValueError,
-        match=r"3 bad tokens \(nan=1, inf=2\) out of 5 valid tokens.*row indices: \[0, 1\]",
+        match=(
+            r"3 bad tokens \(active_nan=1, active_inf=2, null=0, invalid_type=0\) "
+            r"across 6 total tokens \(5 active\).*row indices: \[0, 1\]"
+        ),
     ):
         guard_rollout_log_probs(samples, [[1, 1], [1, 1], [0, 1]])
+
+
+def test_guard_reports_wire_null_and_invalid_type():
+    samples = [_sample([None, -0.1]), _sample(["invalid", -0.2])]
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            r"2 bad tokens \(active_nan=0, active_inf=0, null=1, invalid_type=1\) "
+            r"across 4 total tokens \(4 active\).*row indices: \[0, 1\]"
+        ),
+    ):
+        guard_rollout_log_probs(samples, [[1, 1], [1, 1]])
+
+
+def test_guard_rejects_structurally_invalid_masked_tokens():
+    samples = [_sample([None, -0.1]), _sample(["invalid", -0.2])]
+
+    with pytest.raises(ValueError, match=r"null=1, invalid_type=1.*4 total tokens \(2 active\)"):
+        guard_rollout_log_probs(samples, [[0, 1], [0, 1]])
 
 
 def test_guard_rejects_length_mismatch():


### PR DESCRIPTION
## Summary

  Fail fast on invalid `rollout_log_probs` before rollout data reaches the object-store and training paths. The guard covers both numeric `NaN`/Inf values and the JSON `null` representation that Miles can receive from SGLang over HTTP.

  ## Problem

  Invalid rollout log probabilities can corrupt importance-sampling weights and policy-loss calculations. If they are only
  discovered later, the resulting tensor-conversion or training failure no longer clearly identifies the rollout engine as
  the source. Miles consumes SGLang generation results through HTTP JSON rather than a direct in-process RPC. SGLang uses ORJSON for responses, and ORJSON serializes `NaN`, `+Inf`, and `-Inf` as JSON `null`. These values therefore arrive in Miles as Python `None`, so a guard that only calls `math.isfinite()` does not cover the actual wire format.

  SGLang-side NaN detection and sanitization are optional and do not cover other Miles inputs such as external rollouts or
  restored debug data. Replacing invalid values locally would fabricate rollout probabilities and hide the upstream
  failure, so this PR intentionally fails fast.

  Related upstream reports:

  - https://github.com/sgl-project/sglang/issues/32968

  ## Fix

  Add a centralized `guard_rollout_log_probs()` call in `convert_samples_to_train_data()`, after final loss masks are
  constructed and before data is packaged for training.

  The guard:

  - Validates that each log-probability list matches its loss mask.
  - Rejects `NaN` and positive/negative infinity on active training tokens.
  - Classifies JSON `null`, booleans, and other non-numeric values as structurally invalid.
  - Rejects structurally invalid values even on masked positions because they cannot be encoded into the typed `float32`
  rollout-data path.
  - Reports counts for `active_nan`, `active_inf`, `null`, and `invalid_type`, plus the first affected row indices.
  - Remains a no-op when rollout log probabilities are not provided.

  Masked numeric `NaN`/Inf values retain the existing loss-mask-aware behavior.