### PR TITLE
[multi-lora] add opaque rollout handoff for downstream cleanup

### DIFF
--- a/miles/ray/multi_lora/backend.py
+++ b/miles/ray/multi_lora/backend.py
@@ -293,9 +293,14 @@ class MultiLoraOperationBackend:
             tuple((operation_id, binding) for operation_id, binding in bindings_by_operation)
         )
 
-    def release_batch_lease(self, lease_metadata: dict) -> None:
-        """Completion-boundary lifecycle hook; no-op under fixed residency."""
-        self.residency.release_batch(lease_from_metadata(lease_metadata))
+    def release_batch_lease(self, lease: BatchExecutionLease[ResidentBinding] | dict) -> None:
+        """Completion-boundary lifecycle hook; no-op under fixed residency.
+
+        The typed form lets the rollout producer release an acquired lease if
+        converting it into the plain cross-actor receipt itself fails.
+        """
+        typed_lease = lease_from_metadata(lease) if isinstance(lease, dict) else lease
+        self.residency.release_batch(typed_lease)
 
     # ---------------- control-operation claims ----------------
 

--- a/miles/ray/multi_lora/controller.py
+++ b/miles/ray/multi_lora/controller.py
@@ -101,8 +101,8 @@ class MultiLoraOperationController:
     def acquire_batch_lease(self, bindings_by_operation: list):
         return self.backend.acquire_batch_lease(bindings_by_operation)
 
-    def release_batch_lease(self, lease_metadata: dict) -> None:
-        self.backend.release_batch_lease(lease_metadata)
+    def release_batch_lease(self, lease) -> None:
+        self.backend.release_batch_lease(lease)
 
     def claim_ready_control_operations(self) -> list[dict]:
         return self.backend.claim_ready_control_operations()

--- a/miles/ray/rollout/rollout_manager.py
+++ b/miles/ray/rollout/rollout_manager.py
@@ -19,18 +19,18 @@ from miles.ray.rollout.train_data_conversion import (
     ROLLOUT_DATA_VALUE_SPEC,
     convert_samples_to_train_data,
     split_train_data_by_dp,
-    tinker_dispatch_summary,
 )
 from miles.ray.utils import Lock
 from miles.rollout.base_types import (
     RolloutFnConstructorInput,
     RolloutFnEvalInput,
+    RolloutFnHandoff,
     RolloutFnTrainInput,
     RolloutPostprocessOptions,
     call_rollout_fn,
 )
 from miles.rollout.checkpoint_eval import CheckpointEvalFn, EvalSkip
-from miles.rollout.inference_rollout.compatibility import call_rollout_function, load_rollout_function
+from miles.rollout.inference_rollout.compatibility import call_rollout_function_async, load_rollout_function
 from miles.utils import object_store
 from miles.utils.audit_utils.event_analyzer import analyzer as event_analyzer
 from miles.utils.audit_utils.event_logger import checkpoint as event_logger_checkpoint
@@ -50,6 +50,16 @@ logging.getLogger("httpcore").setLevel(logging.WARNING)
 
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class TrainRolloutResult:
+    """Postprocessed samples plus an optional opaque driver handoff."""
+
+    data: list
+    metadata: dict
+    metrics: dict | None
+    handoff: RolloutFnHandoff | None = None
 
 
 @ray.remote
@@ -145,30 +155,35 @@ class RolloutManager:
         dashboard_hooks.register_engines(self.servers)
         if (get_buffer_length := getattr(self.data_source, "get_buffer_length", None)) is not None:
             dashboard_hooks.report_data_buffer(get_buffer_length())
-        with timer("rollout"):
-            data, metadata, metrics = await self._get_rollout_data(rollout_id=rollout_id)
-        save_debug_rollout_data(self.args, data, rollout_id=rollout_id, evaluation=False, metadata=metadata)
-        log_rollout_data(rollout_id, self.args, data, metrics, time.time() - start_time)
-        data = convert_samples_to_train_data(
-            self.args,
-            data,
-            metadata=metadata,
-            custom_convert_samples_to_train_data_func=self.custom_convert_samples_to_train_data_func,
-            custom_reward_post_process_func=self.custom_reward_post_process_func,
-        )
-        sample_indices = data.get("sample_indices")
-        # Driver-visible dispatch identity (computed before the DP split so it
-        # never depends on shard layout): the tinker driver's abnormal-outcome
-        # finalizer fails these operations and releases this lease without
-        # fetching the batch back from the object store.
-        dispatch = tinker_dispatch_summary(data)
-        if self.args.delay_split_train_data_by_dp:
-            data_ref = object_store.get_instance().put(value=data, value_spec=ROLLOUT_DATA_VALUE_SPEC)
-        else:
-            data_ref = split_train_data_by_dp(self.args, data, self.train_parallel_config)
+        rollout = None
+        try:
+            # The timer's exit hook is part of the protected handoff window:
+            # once ``_get_rollout_data`` returns, a failure while recording the
+            # timing must abort the same handed-off work too.
+            with timer("rollout"):
+                rollout = await self._get_rollout_data(rollout_id=rollout_id)
+            data, metadata = rollout.data, rollout.metadata
+            save_debug_rollout_data(self.args, data, rollout_id=rollout_id, evaluation=False, metadata=metadata)
+            log_rollout_data(rollout_id, self.args, data, rollout.metrics, time.time() - start_time)
+            data = convert_samples_to_train_data(
+                self.args,
+                data,
+                metadata=metadata,
+                custom_convert_samples_to_train_data_func=self.custom_convert_samples_to_train_data_func,
+                custom_reward_post_process_func=self.custom_reward_post_process_func,
+            )
+            sample_indices = data.get("sample_indices")
+            if self.args.delay_split_train_data_by_dp:
+                data_ref = object_store.get_instance().put(value=data, value_spec=ROLLOUT_DATA_VALUE_SPEC)
+            else:
+                data_ref = split_train_data_by_dp(self.args, data, self.train_parallel_config)
+        except BaseException as error:
+            if rollout is not None:
+                await self._abort_rollout_handoff(rollout.handoff, error)
+            raise
         pack = dict(sample_indices=sample_indices, data_ref=data_ref)
-        if dispatch is not None:
-            pack["tinker_dispatch"] = dispatch
+        if rollout.handoff is not None:
+            pack["rollout_handoff"] = rollout.handoff.receipt
         return pack
 
     async def eval(
@@ -188,8 +203,8 @@ class RolloutManager:
 
         with timer("eval_rollout"):
             if not self.use_legacy_rollout_v1:
-                result = await asyncio.to_thread(
-                    call_rollout_function, self.eval_generate_rollout, RolloutFnEvalInput(rollout_id=rollout_id)
+                result = await call_rollout_function_async(
+                    self.eval_generate_rollout, RolloutFnEvalInput(rollout_id=rollout_id)
                 )
             else:
                 result = await asyncio.to_thread(
@@ -225,7 +240,7 @@ class RolloutManager:
                 eval_input = RolloutFnEvalInput(
                     rollout_id=rollout_id, weight_version=version, hf_dir=hf_dir, generate_state=state
                 )
-                result = await asyncio.to_thread(call_rollout_function, self.eval_generate_rollout, eval_input)
+                result = await call_rollout_function_async(self.eval_generate_rollout, eval_input)
             except EvalSkip as e:
                 return self.report_eval_skip(rollout_id, e.reason)
 
@@ -243,28 +258,28 @@ class RolloutManager:
     def report_eval_skip(self, rollout_id: int, reason: str) -> None:
         log_eval_skip(rollout_id, self.args, reason)
 
-    async def _get_rollout_data(self, rollout_id):
+    async def _get_rollout_data(self, rollout_id) -> TrainRolloutResult:
         if self.args.load_debug_rollout_data:
             data, metadata = load_debug_rollout_data(self.args, rollout_id=rollout_id)
-            metrics = None
+            return TrainRolloutResult(data=data, metadata=metadata, metrics=None)
+
+        if not self.use_legacy_rollout_v1:
+            output = await call_rollout_function_async(
+                self.generate_rollout,
+                RolloutFnTrainInput(rollout_id=rollout_id, weight_version=self.weight_version),
+            )
         else:
-            if not self.use_legacy_rollout_v1:
-                data = await asyncio.to_thread(
-                    call_rollout_function,
-                    self.generate_rollout,
-                    RolloutFnTrainInput(rollout_id=rollout_id, weight_version=self.weight_version),
-                )
-            else:
-                data = await asyncio.to_thread(
-                    call_rollout_fn, self.generate_rollout, self.args, rollout_id, self.data_source, evaluation=False
-                )
-            metrics = data.metrics
-            conversion_metadata = getattr(data, "conversion_metadata", None) or {}
-            postprocess = getattr(data, "postprocess", None) or RolloutPostprocessOptions()
-            data = data.samples
+            output = await asyncio.to_thread(
+                call_rollout_fn, self.generate_rollout, self.args, rollout_id, self.data_source, evaluation=False
+            )
+        handoff = getattr(output, "handoff", None)
+        try:
+            metrics = output.metrics
+            conversion_metadata = getattr(output, "conversion_metadata", None) or {}
+            postprocess = getattr(output, "postprocess", None) or RolloutPostprocessOptions()
             data, metadata = postprocess_rollout_data(
                 self.args,
-                data,
+                output.samples,
                 train_parallel_config=self.train_parallel_config,
                 pad_to_dp=postprocess.pad_to_dp,
             )
@@ -276,8 +291,41 @@ class RolloutManager:
                     self.args, generated=generated_data, injected=data, rollout_id=rollout_id
                 )
                 metrics = None
+        except BaseException as error:
+            await self._abort_rollout_handoff(handoff, error)
+            raise
 
-        return data, metadata, metrics
+        return TrainRolloutResult(data=data, metadata=metadata, metrics=metrics, handoff=handoff)
+
+    async def _abort_rollout_handoff(self, handoff: RolloutFnHandoff | None, error: BaseException) -> None:
+        """Best-effort cleanup without replacing the downstream failure."""
+        if handoff is None:
+            return
+        aborter = getattr(self.generate_rollout, "abort_handoff", None)
+        if aborter is None:
+            logger.error(
+                "rollout function returned a lifecycle handoff without an abort_handoff capability; "
+                f"cannot clean up after downstream error: {error!r}"
+            )
+            return
+
+        abort_task = asyncio.ensure_future(aborter(handoff, error))
+        # A caller cancellation must not detach cleanup for handed-off work.
+        # Keep shielding until the abort task reaches a terminal state, then
+        # retrieve its outcome exactly once. Any cleanup failure (including an
+        # aborter-owned CancelledError) is logged and the caller re-raises the
+        # original downstream error from the surrounding ``except`` block.
+        while not abort_task.done():
+            try:
+                await asyncio.shield(abort_task)
+            except asyncio.CancelledError:
+                continue
+            except BaseException:
+                break
+        try:
+            abort_task.result()
+        except BaseException:
+            logger.exception(f"rollout handoff abort failed after downstream error: {error!r}")
 
     # -------------------------- checkpointing -----------------------------
 

--- a/miles/ray/rollout/train_data_conversion.py
+++ b/miles/ray/rollout/train_data_conversion.py
@@ -201,21 +201,6 @@ def convert_samples_to_train_data(
     return train_data
 
 
-def tinker_dispatch_summary(train_data: dict[str, Any]) -> dict[str, Any] | None:
-    """Driver-visible dispatch identity of one converted tinker batch: the
-    claimed operation ids plus the encoded batch execution lease. The driver's
-    abnormal-outcome finalizer (``train_multi_lora_operations.train_data_batch``)
-    must fail exactly these operations and release exactly this lease without
-    fetching the batch back from the object store. ``None`` for non-tinker
-    batches."""
-    if train_data.get("batch_kind") != "tinker":
-        return None
-    return {
-        "operation_ids": [op_id for op_id in train_data.get("operation_by_lane", {}).values() if op_id],
-        "lease": train_data.get("batch_execution_lease"),
-    }
-
-
 def _adapter_slots_from_lease(metadata: dict, sample_lanes: list[int], samples: list[Sample]) -> list[int]:
     """Join lane -> operation -> lease binding to produce per-row physical
     slots. The lease and the lane maps must agree exactly (one binding per

--- a/miles/rollout/base_types.py
+++ b/miles/rollout/base_types.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from argparse import Namespace
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Protocol
 
 from miles.rollout.data_source import DataSource
 from miles.utils.types import Sample
@@ -50,6 +50,27 @@ class RolloutFnEvalInput(RolloutFnBaseInput):
 
 
 @dataclass(frozen=True)
+class RolloutFnHandoff:
+    """Opaque lifecycle handoff from a rollout function to its driver.
+
+    The generic rollout executor forwards ``receipt`` without
+    interpreting it. The mapping MUST contain only Ray-serializable plain data
+    because it crosses the manager-to-driver actor boundary. If downstream
+    batch preparation fails after the rollout function has handed work over,
+    the same object is returned to the rollout function's ``abort_handoff``
+    capability for cleanup.
+    """
+
+    receipt: dict[str, Any]
+
+
+class RolloutFnHandoffAborter(Protocol):
+    """Required cleanup capability for any rollout fn that returns a handoff."""
+
+    async def abort_handoff(self, handoff: RolloutFnHandoff, error: BaseException) -> None: ...
+
+
+@dataclass(frozen=True)
 class RolloutPostprocessOptions:
     """Postprocess policy the rollout fn declares for its own output, so the
     generic manager never has to recognize fn-specific metadata keys.
@@ -77,6 +98,10 @@ class RolloutFnTrainOutput:
     conversion_metadata: dict[str, Any] | None = None
     # How the manager postprocesses samples before conversion.
     postprocess: RolloutPostprocessOptions = field(default_factory=RolloutPostprocessOptions)
+    # Opaque driver-facing lifecycle receipt. The generic rollout executor
+    # forwards its metadata and returns the receipt to ``abort_handoff`` if a
+    # downstream postprocess/conversion/split/store step fails.
+    handoff: RolloutFnHandoff | None = None
 
 
 # TODO make it frozen

--- a/miles/rollout/inference_rollout/compatibility.py
+++ b/miles/rollout/inference_rollout/compatibility.py
@@ -1,3 +1,4 @@
+import asyncio
 import inspect
 from collections.abc import Callable
 
@@ -45,6 +46,26 @@ def call_rollout_function(fn, input: RolloutFnInput) -> RolloutFnOutput:
     if inspect.iscoroutine(output):
         output = run(output)
 
+    return output
+
+
+async def call_rollout_function_async(fn, input: RolloutFnInput) -> RolloutFnOutput:
+    """Invoke a rollout function without detaching async work from its caller.
+
+    Class-based async rollout functions run on the caller's event loop so
+    cancellation propagates into claim/selection work. Synchronous adapters
+    still run in a worker thread to avoid blocking that loop.
+    """
+    call = fn.__call__ if callable(fn) else None
+    if inspect.iscoroutinefunction(fn) or inspect.iscoroutinefunction(call):
+        output = fn(input)
+    else:
+        output = await asyncio.to_thread(fn, input)
+
+    # Support a synchronous wrapper that returns an awaitable without forcing
+    # genuinely synchronous implementations onto the actor loop.
+    if inspect.isawaitable(output):
+        output = await output
     return output
 
 

--- a/miles/rollout/multi_lora/operation_port.py
+++ b/miles/rollout/multi_lora/operation_port.py
@@ -43,6 +43,14 @@ class BatchResidencyPort(Protocol[BindingT]):
 
     async def acquire_batch(self, bindings_by_operation: list) -> object: ...
 
+    async def release_batch(self, lease: object) -> None: ...
+
+
+class BatchAbortPort(Protocol):
+    """Finalize a claimed operation batch that will not reach the trainer."""
+
+    async def abort_batch(self, operation_ids: list[str], error: str, lease_metadata: dict | None) -> None: ...
+
 
 class RayMultiLoraOperationQueue:
     """Only this class (and its residency sibling) knows the Ray controller,
@@ -78,4 +86,22 @@ class RayTrainerResidencyPort:
 
         return await asyncio.to_thread(
             ray.get, get_multi_lora_controller().acquire_batch_lease.remote(list(bindings_by_operation))
+        )
+
+    async def release_batch(self, lease: object) -> None:
+        """Release the typed lease even if plain receipt encoding failed."""
+        from miles.ray.multi_lora.controller import get_multi_lora_controller
+
+        await asyncio.to_thread(ray.get, get_multi_lora_controller().release_batch_lease.remote(lease))
+
+
+class RayMultiLoraBatchAbort:
+    """BatchAbortPort concrete over the controller's idempotent finalizer."""
+
+    async def abort_batch(self, operation_ids: list[str], error: str, lease_metadata: dict | None) -> None:
+        from miles.ray.multi_lora.controller import get_multi_lora_controller
+
+        await asyncio.to_thread(
+            ray.get,
+            get_multi_lora_controller().fail_tinker_batch.remote(list(operation_ids), error, lease_metadata),
         )

--- a/miles/rollout/multi_lora/rollout_fn.py
+++ b/miles/rollout/multi_lora/rollout_fn.py
@@ -20,13 +20,16 @@ from miles.ray.multi_lora.config import AdapterRun
 from miles.ray.multi_lora.residency import lease_to_metadata
 from miles.rollout.base_types import (
     RolloutFnConstructorInput,
+    RolloutFnHandoff,
     RolloutFnInput,
     RolloutFnTrainOutput,
     RolloutPostprocessOptions,
 )
 from miles.rollout.multi_lora.operation_port import (
+    BatchAbortPort,
     BatchResidencyPort,
     OperationQueuePort,
+    RayMultiLoraBatchAbort,
     RayMultiLoraOperationQueue,
     RayTrainerResidencyPort,
 )
@@ -36,7 +39,7 @@ from miles.utils.types import AdapterRef, Sample
 logger = logging.getLogger(__name__)
 
 
-def batch_plan_to_metadata(batch_plan: list[dict], lease) -> dict[str, Any]:
+def _batch_plan_to_metadata(batch_plan: list[dict]) -> dict[str, Any]:
     """Distill one tinker selection's BatchPlan into conversion metadata.
     Selections are homogeneous: exactly one data-operation kind — mixed
     forward/forward_backward batches are structurally impossible, which is
@@ -68,12 +71,16 @@ def batch_plan_to_metadata(batch_plan: list[dict], lease) -> dict[str, Any]:
         "registration_by_lane": {
             lane: (entry["name"], entry["registration_id"]) for lane, entry in enumerate(batch_plan)
         },
-        # The lease is mandatory: a batch without its dispatch receipt is one
-        # the trainer must reject, so the optional path may not exist here.
-        "batch_execution_lease": lease_to_metadata(lease),
     }
     if kinds == {"forward"}:
         metadata["tinker_forward_only"] = True
+    return metadata
+
+
+def batch_plan_to_metadata(batch_plan: list[dict], lease) -> dict[str, Any]:
+    """Build conversion metadata with the mandatory encoded batch lease."""
+    metadata = _batch_plan_to_metadata(batch_plan)
+    metadata["batch_execution_lease"] = lease_to_metadata(lease)
     return metadata
 
 
@@ -220,10 +227,12 @@ class MultiLoraOperationBatchFn:
         input: RolloutFnConstructorInput,
         operations: OperationQueuePort | None = None,
         residency: BatchResidencyPort | None = None,
+        abort: BatchAbortPort | None = None,
     ):
         self.args = input.args
         self.operations = operations if operations is not None else RayMultiLoraOperationQueue()
         self.residency = residency if residency is not None else RayTrainerResidencyPort()
+        self.abort = abort if abort is not None else RayMultiLoraBatchAbort()
         self.runtimes: dict[Tenant, AdapterRolloutRuntime] = {}
         self.rotation: deque[Tenant] = deque()
         self._ready = asyncio.Event()
@@ -248,6 +257,16 @@ class MultiLoraOperationBatchFn:
             await runtime.aclose()
         self.runtimes.clear()
         self.rotation.clear()
+
+    async def abort_handoff(self, handoff: RolloutFnHandoff, error: BaseException) -> None:
+        """Finalize a leased selection when downstream batch preparation fails."""
+        await self.abort.abort_batch(
+            list(handoff.receipt["operation_ids"]),
+            f"rollout batch preparation failed before trainer dispatch: {error}; the batch never "
+            "reached the trainer and its gradient window is poisoned — resubmit the batch and "
+            "optim_step again",
+            handoff.receipt["lease"],
+        )
 
     # ------------------------------ runtimes ------------------------------
 
@@ -335,41 +354,50 @@ class MultiLoraOperationBatchFn:
         collected = 0
         coalesce_deadline: float | None = None
 
-        while True:
-            runtime = self._pop_next_ready(kind_lock)
-            if runtime is not None:
-                selected.append(runtime)
-                # Leave READY immediately or the round-robin would re-select
-                # the same batch until the target is met (duplicated samples).
-                runtime.state = AdapterRolloutRuntime.SELECTED
-                kind_lock = runtime.ready_kind
-                collected += sum(len(group) for group in runtime.ready_output.samples)
-                if coalesce_deadline is None:
-                    coalesce_deadline = time.monotonic() + coalesce_wait
-                # Whole batches only: overshoot past the soft target is allowed,
-                # trimming is not.
-                if collected >= soft_target or len(selected) >= len(self.runtimes):
-                    break
-                continue
+        try:
+            while True:
+                runtime = self._pop_next_ready(kind_lock)
+                if runtime is not None:
+                    selected.append(runtime)
+                    # Leave READY immediately or the round-robin would re-select
+                    # the same batch until the target is met (duplicated samples).
+                    runtime.state = AdapterRolloutRuntime.SELECTED
+                    kind_lock = runtime.ready_kind
+                    collected += sum(len(group) for group in runtime.ready_output.samples)
+                    if coalesce_deadline is None:
+                        coalesce_deadline = time.monotonic() + coalesce_wait
+                    # Whole batches only: overshoot past the soft target is allowed,
+                    # trimming is not.
+                    if collected >= soft_target or len(selected) >= len(self.runtimes):
+                        break
+                    continue
 
-            now = time.monotonic()
-            if selected:
-                if now >= coalesce_deadline:
-                    break
-                timeout = coalesce_deadline - now
-            else:
-                if now >= empty_deadline:
-                    raise EmptyBatchTimeoutError(
-                        "no adapter produced a batch within "
-                        f"--tinker-max-empty-wait-s ({self.args.tinker_max_empty_wait_s}s)"
-                    )
-                timeout = empty_deadline - now
-            self._ready.clear()
-            try:
-                await asyncio.wait_for(self._ready.wait(), timeout=timeout)
-            except TimeoutError:
-                continue
-        return selected
+                now = time.monotonic()
+                if selected:
+                    if now >= coalesce_deadline:
+                        break
+                    timeout = coalesce_deadline - now
+                else:
+                    if now >= empty_deadline:
+                        raise EmptyBatchTimeoutError(
+                            "no adapter produced a batch within "
+                            f"--tinker-max-empty-wait-s ({self.args.tinker_max_empty_wait_s}s)"
+                        )
+                    timeout = empty_deadline - now
+                self._ready.clear()
+                try:
+                    await asyncio.wait_for(self._ready.wait(), timeout=timeout)
+                except TimeoutError:
+                    continue
+            return selected
+        except BaseException:
+            # The selection has not acquired a lease yet. Cancellation or any
+            # other coalescing failure returns this call's local picks to the
+            # READY pool with their claimed outputs intact.
+            for runtime in selected:
+                if runtime.state == AdapterRolloutRuntime.SELECTED:
+                    runtime.state = AdapterRolloutRuntime.READY
+            raise
 
     def _pop_next_ready(self, kind_lock: str | None) -> AdapterRolloutRuntime | None:
         """Persistent round-robin over READY runtimes matching the kind lock:
@@ -398,6 +426,10 @@ class MultiLoraOperationBatchFn:
         # intact (the claimed operation stays retryable at the next selection
         # instead of orphaning the only in-memory copy of an already-CLAIMED
         # output).
+        operation_ids: list[str] = []
+        lease_acquired = False
+        lease = None
+        lease_metadata = None
         try:
             for runtime in selected:
                 claim = runtime.ready_output
@@ -418,27 +450,70 @@ class MultiLoraOperationBatchFn:
                     )
                 )
                 metrics[f"{runtime.run.name}/operation_samples"] = sum(len(group) for group in claim.samples)
+            # Validate and build everything that does not depend on residency
+            # before acquiring the lease. A malformed selection therefore
+            # remains retryable without minting a dispatch receipt.
+            conversion_metadata = _batch_plan_to_metadata(batch_plan)
+            operation_ids = [entry["operation_id"] for entry in batch_plan]
             # One immutable dispatch receipt for the whole selection: the
             # controller re-validates exact slot ownership before issuing it.
             lease = await self.residency.acquire_batch(
                 [(entry["operation_id"], entry["binding"]) for entry in batch_plan]
             )
-        except BaseException:
-            for runtime in selected:
-                runtime.state = AdapterRolloutRuntime.READY
+            lease_acquired = True
+            lease_metadata = lease_to_metadata(lease)
+            conversion_metadata["batch_execution_lease"] = lease_metadata
+            output = RolloutFnTrainOutput(
+                samples=data,
+                metrics=metrics,
+                # Converted HERE, not in the manager: the generic rollout plane
+                # never recognizes tinker keys.
+                conversion_metadata=conversion_metadata,
+                # Whole client batches: zero-weight pads round the selection up
+                # to the DP grid so the dynamic-GBS branch sizes the step to the
+                # batch instead of trimming it.
+                postprocess=RolloutPostprocessOptions(pad_to_dp=True),
+                # Mint the lifecycle receipt where operation identity and the
+                # lease are authoritative. Generic rollout infrastructure
+                # forwards it opaquely and returns it to ``abort_handoff`` on
+                # downstream failure.
+                handoff=RolloutFnHandoff(
+                    receipt={
+                        "operation_ids": operation_ids,
+                        "lease": lease_metadata,
+                    }
+                ),
+            )
+        except BaseException as error:
+            if not lease_acquired:
+                for runtime in selected:
+                    runtime.state = AdapterRolloutRuntime.READY
+            else:
+                # Once a lease exists, retrying the same in-memory claim would
+                # mint a second dispatch identity. Terminalize the exact batch
+                # instead, preserving the original construction failure.
+                abort_failed = False
+                try:
+                    await self.abort.abort_batch(
+                        operation_ids,
+                        f"failed to build rollout handoff after lease acquisition: {error}",
+                        lease_metadata,
+                    )
+                except BaseException:  # cleanup must not mask the build error
+                    abort_failed = True
+                    logger.exception("failed to abort batch after rollout handoff construction error")
+                if lease_metadata is None or abort_failed:
+                    try:
+                        await self.residency.release_batch(lease)
+                    except BaseException:  # preserve the original build error
+                        logger.exception("failed to release typed lease after rollout handoff construction error")
+                for runtime in selected:
+                    runtime.ready_output = None
+                    runtime.state = AdapterRolloutRuntime.IDLE
             raise
-        # Acquisition succeeded: NOW consume the outputs.
+        # The complete handoff now exists: only now consume the selected
+        # outputs. A build failure above leaves them READY and retryable.
         for runtime in selected:
             runtime.ready_output = None
             runtime.state = AdapterRolloutRuntime.IDLE  # relaunches at the NEXT generate call
-        return RolloutFnTrainOutput(
-            samples=data,
-            metrics=metrics,
-            # Converted HERE, not in the manager: the generic rollout plane
-            # never recognizes tinker keys.
-            conversion_metadata=batch_plan_to_metadata(batch_plan, lease),
-            # Whole client batches: zero-weight pads round the selection up to
-            # the DP grid so the multi-LoRA dynamic-GBS branch sizes the step
-            # to the batch instead of trimming it.
-            postprocess=RolloutPostprocessOptions(pad_to_dp=True),
-        )
+        return output

--- a/miles/utils/tinker.py
+++ b/miles/utils/tinker.py
@@ -29,6 +29,18 @@ def validate_tinker_args(args) -> None:
     assert (
         not use_legacy_rollout_v1()
     ), "--tinker-backend needs the class-based rollout API (the default); unset MILES_USE_LEGACY_ROLLOUT_V1"
+    assert getattr(args, "custom_convert_samples_to_train_data_path", None) is None, (
+        "--custom-convert-samples-to-train-data-path is incompatible with --tinker-backend: a custom "
+        "converter bypasses the operation lane and lease conversion"
+    )
+    assert getattr(args, "load_debug_rollout_data", None) is None, (
+        "--load-debug-rollout-data is incompatible with --tinker-backend: replayed data has no live "
+        "operation claim or execution lease"
+    )
+    assert getattr(args, "ci_inject_rollout_data_path", None) is None, (
+        "--ci-inject-rollout-data-path is incompatible with --tinker-backend: injection would replace "
+        "live claimed rows while retaining the current batch handoff"
+    )
     if args.rollout_function_path is None:
         args.rollout_function_path = "miles.rollout.multi_lora.rollout_fn.MultiLoraOperationBatchFn"
     if args.data_source_path == "miles.rollout.data_source.RolloutDataSourceWithBuffer":

--- a/tests/fast/ray/multi_lora/test_backend.py
+++ b/tests/fast/ray/multi_lora/test_backend.py
@@ -400,6 +400,17 @@ class TestFailTinkerBatch:
         view = backend.operations.get("fb1")
         assert view["state"] == "SUCCEEDED" and view["result"]["logprobs"] == [[-0.1, -0.2]]
 
+    def test_duplicate_finalization_keeps_the_first_terminal_error(self):
+        backend = ready_backend()
+        lease_metadata = self._claimed_batch(backend)
+        backend.fail_tinker_batch(["fb1"], "first failure", lease_metadata)
+        backend.fail_tinker_batch(["fb1"], "late duplicate", lease_metadata)
+
+        view = backend.operations.get("fb1")
+        assert view["state"] == "FAILED"
+        assert view["error"] == "first failure"
+        assert view["error_category"] == "server"
+
     def test_lease_releases_even_when_the_ledger_walk_raises(self):
         backend = ready_backend()
         lease_metadata = self._claimed_batch(backend)

--- a/tests/fast/ray/rollout/test_multi_lora_operation_train_data.py
+++ b/tests/fast/ray/rollout/test_multi_lora_operation_train_data.py
@@ -301,36 +301,3 @@ class TestPadding:
         data, metadata = self.postprocess(n=5, pad_to_dp=False, args=args)
         assert [s.index for s in data] == [0, 1, 2, 3]  # trimmed, never padded
         assert "dynamic_global_batch_size" not in metadata
-
-
-class TestTinkerDispatchSummary:
-    """The driver-visible dispatch identity: exactly the batch's operation ids
-    plus its encoded lease, so the abnormal-outcome finalizer never has to
-    fetch the batch back from the object store."""
-
-    def test_summary_carries_operation_ids_and_lease(self):
-        from miles.ray.rollout.train_data_conversion import tinker_dispatch_summary
-
-        lease = {"dispatch_id": "d1", "bindings_by_operation": [["op-A", ["A", "r-A", 0]]]}
-        train_data = {
-            "batch_kind": "tinker",
-            "operation_by_lane": {0: "op-A", 1: "op-B"},
-            "batch_execution_lease": lease,
-        }
-        assert tinker_dispatch_summary(train_data) == {"operation_ids": ["op-A", "op-B"], "lease": lease}
-
-    def test_non_tinker_batches_have_no_summary(self):
-        from miles.ray.rollout.train_data_conversion import tinker_dispatch_summary
-
-        assert tinker_dispatch_summary({"tokens": [[1]]}) is None
-
-    def test_summary_matches_the_converted_batch(self):
-        from miles.ray.rollout.train_data_conversion import tinker_dispatch_summary
-
-        plan = [plan_entry("A", 0, op_id="op-A"), plan_entry("B", 1, op_id="op-B")]
-        metadata = plan_metadata(plan)
-        samples = [make_sample("A", 0), make_sample("B", 0)]
-        train_data = convert(samples, metadata)
-        summary = tinker_dispatch_summary(train_data)
-        assert summary["operation_ids"] == ["op-A", "op-B"]
-        assert summary["lease"] == metadata["batch_execution_lease"]

--- a/tests/fast/ray/rollout/test_rollout_manager_handoff.py
+++ b/tests/fast/ray/rollout/test_rollout_manager_handoff.py
@@ -1,0 +1,259 @@
+"""Generic rollout handoff behavior, independent of any operation backend."""
+
+import asyncio
+from contextlib import nullcontext
+from types import SimpleNamespace
+
+from tests.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=30, suite="stage-a-cpu")
+
+import pytest
+from tests.fast.ray.rollout.conftest import make_args
+
+import miles.ray.rollout.rollout_manager as rollout_manager_module
+from miles.rollout.base_types import RolloutFnHandoff, RolloutFnTrainOutput
+
+
+class RecordingRolloutFn:
+    def __init__(self, handoff: RolloutFnHandoff, abort_error: BaseException | None = None):
+        self.handoff = handoff
+        self.abort_error = abort_error
+        self.aborts: list[tuple[RolloutFnHandoff, BaseException]] = []
+
+    def __call__(self, _input):
+        return RolloutFnTrainOutput(samples=[[object()]], handoff=self.handoff)
+
+    async def abort_handoff(self, handoff, error):
+        self.aborts.append((handoff, error))
+        if self.abort_error is not None:
+            raise self.abort_error
+
+
+class BlockingAbortRolloutFn(RecordingRolloutFn):
+    def __init__(self, handoff: RolloutFnHandoff):
+        super().__init__(handoff)
+        self.abort_started = asyncio.Event()
+        self.finish_abort = asyncio.Event()
+
+    async def abort_handoff(self, handoff, error):
+        self.aborts.append((handoff, error))
+        self.abort_started.set()
+        await self.finish_abort.wait()
+
+
+class FakeObjectStore:
+    def __init__(self):
+        self.error: BaseException | None = None
+        self.values: list[dict] = []
+
+    def put(self, value, value_spec):
+        if self.error is not None:
+            raise self.error
+        self.values.append(value)
+        return ("stored", value_spec)
+
+
+def make_manager(monkeypatch, rollout_fn, *, delay_split=False):
+    args = make_args(delay_split_train_data_by_dp=delay_split)
+    manager = object.__new__(rollout_manager_module.RolloutManager.__ray_actor_class__)
+    manager.args = args
+    manager.servers = {}
+    manager.rollout_id = -1
+    manager.weight_version = None
+    manager.train_parallel_config = {"dp_size": 1}
+    manager.use_legacy_rollout_v1 = False
+    manager.generate_rollout = rollout_fn
+    manager.custom_convert_samples_to_train_data_func = None
+    manager.custom_reward_post_process_func = None
+    manager.data_source = SimpleNamespace()
+    manager._health_monitoring_resume = lambda: None
+
+    store = FakeObjectStore()
+    monkeypatch.setattr(rollout_manager_module, "timer", lambda *_a, **_k: nullcontext())
+    monkeypatch.setattr(rollout_manager_module.dashboard_hooks, "register_engines", lambda *_a, **_k: None)
+    monkeypatch.setattr(rollout_manager_module, "save_debug_rollout_data", lambda *_a, **_k: None)
+    monkeypatch.setattr(rollout_manager_module, "log_rollout_data", lambda *_a, **_k: None)
+    monkeypatch.setattr(
+        rollout_manager_module,
+        "postprocess_rollout_data",
+        lambda *_a, **_k: (["flat-row"], {"derived": "metadata"}),
+    )
+    monkeypatch.setattr(
+        rollout_manager_module,
+        "convert_samples_to_train_data",
+        lambda *_a, **_k: {
+            "sample_indices": [7],
+            "tokens": [[1]],
+            # Deliberately conflicts with the control-plane receipt. The
+            # manager must never reconstruct identity from converted tensors.
+            "operation_by_lane": {0: "WRONG"},
+        },
+    )
+    monkeypatch.setattr(
+        rollout_manager_module,
+        "split_train_data_by_dp",
+        lambda _args, data, _config: ("split", data),
+    )
+    monkeypatch.setattr(rollout_manager_module.object_store, "get_instance", lambda: store)
+    return manager, store
+
+
+@pytest.mark.parametrize(
+    ("stage", "delay_split"),
+    [
+        ("postprocess", False),
+        ("timer", False),
+        ("save", False),
+        ("log", False),
+        ("convert", False),
+        ("split", False),
+        ("store", True),
+    ],
+)
+@pytest.mark.asyncio
+async def test_every_downstream_failure_aborts_the_same_handoff(monkeypatch, stage, delay_split):
+    error = OSError(f"{stage} failed")
+    handoff = RolloutFnHandoff(receipt={"opaque_extension": {"receipt": "r1"}})
+    rollout_fn = RecordingRolloutFn(handoff)
+    manager, store = make_manager(monkeypatch, rollout_fn, delay_split=delay_split)
+
+    def fail(*_args, **_kwargs):
+        raise error
+
+    if stage == "postprocess":
+        monkeypatch.setattr(rollout_manager_module, "postprocess_rollout_data", fail)
+    elif stage == "timer":
+
+        class FailingTimer:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                raise error
+
+        monkeypatch.setattr(rollout_manager_module, "timer", lambda *_a, **_k: FailingTimer())
+    elif stage == "save":
+        monkeypatch.setattr(rollout_manager_module, "save_debug_rollout_data", fail)
+    elif stage == "log":
+        monkeypatch.setattr(rollout_manager_module, "log_rollout_data", fail)
+    elif stage == "convert":
+        monkeypatch.setattr(rollout_manager_module, "convert_samples_to_train_data", fail)
+    elif stage == "split":
+        monkeypatch.setattr(rollout_manager_module, "split_train_data_by_dp", fail)
+    else:
+        store.error = error
+
+    with pytest.raises(OSError) as caught:
+        await manager.generate(rollout_id=1)
+
+    assert caught.value is error
+    assert rollout_fn.aborts == [(handoff, error)]
+
+
+@pytest.mark.parametrize("delay_split", [False, True])
+@pytest.mark.asyncio
+async def test_success_forwards_opaque_metadata_without_interpretation(monkeypatch, delay_split):
+    receipt = {
+        "operation_ids": ["RIGHT"],
+        "lease": {"dispatch_id": "lease-right", "bindings_by_operation": []},
+    }
+    handoff = RolloutFnHandoff(receipt=receipt)
+    rollout_fn = RecordingRolloutFn(handoff)
+    manager, _store = make_manager(monkeypatch, rollout_fn, delay_split=delay_split)
+
+    pack = await manager.generate(rollout_id=2)
+
+    assert pack["rollout_handoff"] is receipt
+    assert rollout_fn.aborts == []
+    assert pack["sample_indices"] == [7]
+    assert pack["data_ref"][0] == ("stored" if delay_split else "split")
+
+
+@pytest.mark.asyncio
+async def test_abort_failure_does_not_mask_the_downstream_error(monkeypatch):
+    handoff = RolloutFnHandoff(receipt={"opaque_extension": {"receipt": "r3"}})
+    rollout_fn = RecordingRolloutFn(handoff, abort_error=RuntimeError("abort unavailable"))
+    manager, _store = make_manager(monkeypatch, rollout_fn)
+    error = OSError("conversion failed")
+
+    def fail(*_args, **_kwargs):
+        raise error
+
+    monkeypatch.setattr(rollout_manager_module, "convert_samples_to_train_data", fail)
+    with pytest.raises(OSError) as caught:
+        await manager.generate(rollout_id=3)
+
+    assert caught.value is error
+    assert rollout_fn.aborts == [(handoff, error)]
+
+
+@pytest.mark.asyncio
+async def test_aborter_cancellation_does_not_mask_the_downstream_error(monkeypatch):
+    handoff = RolloutFnHandoff(receipt={"opaque_extension": {"receipt": "r4"}})
+    rollout_fn = RecordingRolloutFn(handoff, abort_error=asyncio.CancelledError())
+    manager, _store = make_manager(monkeypatch, rollout_fn)
+    error = OSError("conversion failed")
+
+    def fail(*_args, **_kwargs):
+        raise error
+
+    monkeypatch.setattr(rollout_manager_module, "convert_samples_to_train_data", fail)
+    with pytest.raises(OSError) as caught:
+        await manager.generate(rollout_id=4)
+
+    assert caught.value is error
+    assert rollout_fn.aborts == [(handoff, error)]
+
+
+@pytest.mark.asyncio
+async def test_caller_cancellation_waits_for_cleanup_and_preserves_the_original_error(monkeypatch):
+    handoff = RolloutFnHandoff(receipt={"opaque_extension": {"receipt": "r5"}})
+    rollout_fn = BlockingAbortRolloutFn(handoff)
+    manager, _store = make_manager(monkeypatch, rollout_fn)
+    error = OSError("conversion failed")
+
+    def fail(*_args, **_kwargs):
+        raise error
+
+    monkeypatch.setattr(rollout_manager_module, "convert_samples_to_train_data", fail)
+    task = asyncio.create_task(manager.generate(rollout_id=5))
+    await rollout_fn.abort_started.wait()
+    task.cancel()
+    await asyncio.sleep(0)
+    assert not task.done()
+    rollout_fn.finish_abort.set()
+
+    with pytest.raises(OSError) as caught:
+        await task
+    assert caught.value is error
+    assert rollout_fn.aborts == [(handoff, error)]
+
+
+@pytest.mark.asyncio
+async def test_downstream_cancellation_aborts_then_propagates(monkeypatch):
+    handoff = RolloutFnHandoff(receipt={"opaque_extension": {"receipt": "r6"}})
+    rollout_fn = RecordingRolloutFn(handoff)
+    manager, _store = make_manager(monkeypatch, rollout_fn)
+
+    def cancel(*_args, **_kwargs):
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr(rollout_manager_module, "convert_samples_to_train_data", cancel)
+    with pytest.raises(asyncio.CancelledError):
+        await manager.generate(rollout_id=6)
+
+    assert len(rollout_fn.aborts) == 1
+    assert rollout_fn.aborts[0][0] is handoff
+    assert isinstance(rollout_fn.aborts[0][1], asyncio.CancelledError)
+
+
+def test_rollout_manager_owns_no_tinker_dispatch_identity():
+    import inspect
+
+    import miles.ray.rollout.train_data_conversion as train_data_conversion
+
+    source = inspect.getsource(rollout_manager_module)
+    assert "tinker_dispatch" not in source
+    assert "tinker_dispatch_summary" not in source
+    assert not hasattr(train_data_conversion, "tinker_dispatch_summary")

--- a/tests/fast/rollout/inference_rollout/test_compatibility.py
+++ b/tests/fast/rollout/inference_rollout/test_compatibility.py
@@ -16,6 +16,7 @@ from miles.rollout.inference_rollout.compatibility import (
     LegacyGenerateFnAdapter,
     LegacyRolloutFnAdapter,
     call_rollout_function,
+    call_rollout_function_async,
     load_generate_function,
     load_rollout_function,
 )
@@ -132,6 +133,28 @@ class TestSupportedRolloutFormats:
             assert isinstance(fn, AsyncRolloutFn)
             expected_type = RolloutFnEvalOutput if evaluation else RolloutFnTrainOutput
             assert isinstance(result, expected_type)
+
+    @pytest.mark.asyncio
+    async def test_async_class_runs_on_the_caller_loop_and_observes_cancellation(self):
+        started = asyncio.Event()
+        cancelled = asyncio.Event()
+        caller_loop = asyncio.get_running_loop()
+
+        class AsyncRolloutFn:
+            async def __call__(self, _input):
+                assert asyncio.get_running_loop() is caller_loop
+                started.set()
+                try:
+                    await asyncio.Event().wait()
+                finally:
+                    cancelled.set()
+
+        task = asyncio.create_task(call_rollout_function_async(AsyncRolloutFn(), RolloutFnTrainInput(rollout_id=1)))
+        await started.wait()
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert cancelled.is_set()
 
 
 class TestSupportedGenerateFormats:

--- a/tests/fast/rollout/multi_lora/test_rollout_fn.py
+++ b/tests/fast/rollout/multi_lora/test_rollout_fn.py
@@ -69,10 +69,24 @@ class FakeResidency:
 
     def __init__(self):
         self.leases: list[tuple] = []
+        self.releases: list[BatchExecutionLease] = []
 
     async def acquire_batch(self, bindings_by_operation):
         self.leases.append(tuple(bindings_by_operation))
         return BatchExecutionLease(dispatch_id="lease-1", bindings_by_operation=tuple(bindings_by_operation))
+
+    async def release_batch(self, lease):
+        self.releases.append(lease)
+
+
+class FakeBatchAbort:
+    """Recording BatchAbortPort used by lifecycle handoff tests."""
+
+    def __init__(self):
+        self.aborts: list[tuple] = []
+
+    async def abort_batch(self, operation_ids, error, lease_metadata):
+        self.aborts.append((list(operation_ids), error, lease_metadata))
 
 
 @pytest.fixture()
@@ -178,6 +192,7 @@ def make_fn(soft_target=100) -> MultiLoraOperationBatchFn:
         RolloutFnConstructorInput(args=args, data_source=None),
         operations=FakeOperationQueue(),
         residency=FakeResidency(),
+        abort=FakeBatchAbort(),
     )
 
 
@@ -212,6 +227,24 @@ class TestSelectionKindLock:
         with pytest.raises(EmptyBatchTimeoutError):
             asyncio.run(fn._select())
 
+    @pytest.mark.asyncio
+    async def test_cancelled_coalescing_restores_local_selection_to_ready(self):
+        fn = make_fn()
+        fn.args.tinker_max_coalesce_wait_s = 60
+        selected_runtime = ready_runtime(fn, "A", 0, "forward_backward")
+        other_kind = ready_runtime(fn, "B", 1, "forward")
+
+        task = asyncio.create_task(fn._select())
+        while selected_runtime.state != AdapterRolloutRuntime.SELECTED:
+            await asyncio.sleep(0)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        assert selected_runtime.state == AdapterRolloutRuntime.READY
+        assert selected_runtime.ready_output is not None
+        assert other_kind.state == AdapterRolloutRuntime.READY
+
     def test_merge_ships_the_converted_plan_and_pad_policy(self):
         """Correlation is batch-local (§3.3): the selected operation gets lane
         0, the loss/result maps key by lane, and the exact registration rides
@@ -234,6 +267,10 @@ class TestSelectionKindLock:
             },
         }
         assert output.postprocess.pad_to_dp is True
+        assert output.handoff.receipt == {
+            "operation_ids": ["op-A"],
+            "lease": output.conversion_metadata["batch_execution_lease"],
+        }
         assert first.state == AdapterRolloutRuntime.IDLE and first.ready_output is None
 
     def test_failed_lease_acquisition_keeps_claimed_output_retryable(self):
@@ -269,6 +306,48 @@ class TestSelectionKindLock:
         assert output.conversion_metadata["operation_by_lane"] == {0: "op-A"}
         assert runtime.state == AdapterRolloutRuntime.IDLE and runtime.ready_output is None
 
+    def test_post_lease_handoff_build_failure_aborts_the_claimed_batch(self, monkeypatch):
+        import miles.rollout.multi_lora.rollout_fn as rollout_module
+
+        fn = make_fn()
+        runtime = ready_runtime(fn, "A", 0, "forward_backward")
+        selected = asyncio.run(fn._select())
+
+        def fail_output_build(**_kwargs):
+            raise RuntimeError("handoff construction failed")
+
+        monkeypatch.setattr(rollout_module, "RolloutFnTrainOutput", fail_output_build)
+        with pytest.raises(RuntimeError, match="handoff construction failed"):
+            merge(fn, selected)
+
+        [(operation_ids, error, lease_metadata)] = fn.abort.aborts
+        assert operation_ids == ["op-A"]
+        assert "handoff construction failed" in error
+        assert lease_metadata["dispatch_id"] == "lease-1"
+        assert runtime.state == AdapterRolloutRuntime.IDLE and runtime.ready_output is None
+
+    def test_lease_encoding_failure_releases_the_exact_typed_lease(self, monkeypatch):
+        import miles.rollout.multi_lora.rollout_fn as rollout_module
+
+        fn = make_fn()
+        runtime = ready_runtime(fn, "A", 0, "forward_backward")
+        selected = asyncio.run(fn._select())
+
+        def fail_encoding(_lease):
+            raise RuntimeError("lease encoding failed")
+
+        monkeypatch.setattr(rollout_module, "lease_to_metadata", fail_encoding)
+        with pytest.raises(RuntimeError, match="lease encoding failed"):
+            merge(fn, selected)
+
+        [(operation_ids, error, lease_metadata)] = fn.abort.aborts
+        assert operation_ids == ["op-A"]
+        assert "lease encoding failed" in error
+        assert lease_metadata is None
+        [released] = fn.residency.releases
+        assert released.dispatch_id == "lease-1"
+        assert runtime.state == AdapterRolloutRuntime.IDLE and runtime.ready_output is None
+
     def test_merge_of_a_forward_selection_marks_forward_only(self):
         """Forward kind: the same composition with ``tinker_forward_only``
         set — the flag that keeps forward operations gradient-free must
@@ -297,3 +376,29 @@ class TestSelectionKindLock:
         assert output.conversion_metadata["registration_by_lane"] == {0: ("A", "r-A"), 1: ("B", "r-B")}
         lease = output.conversion_metadata["batch_execution_lease"]
         assert lease["bindings_by_operation"] == [["op-A", ["A", "r-A", 7]], ["op-B", ["B", "r-B", 2]]]
+
+
+class TestDriverHandoff:
+    def test_merge_mints_exact_operation_ids_and_the_conversion_lease(self):
+        import ray.cloudpickle
+
+        fn = make_fn()
+        ready_runtime(fn, "A", 7, "forward_backward")
+        ready_runtime(fn, "B", 2, "forward_backward")
+        output = merge(fn, asyncio.run(fn._select()))
+
+        assert output.handoff.receipt["operation_ids"] == ["op-A", "op-B"]
+        assert output.handoff.receipt["lease"] is output.conversion_metadata["batch_execution_lease"]
+        assert ray.cloudpickle.loads(ray.cloudpickle.dumps(output.handoff.receipt)) == output.handoff.receipt
+
+    def test_abort_handoff_finalizes_the_exact_batch(self):
+        fn = make_fn()
+        ready_runtime(fn, "A", 0, "forward_backward")
+        output = merge(fn, asyncio.run(fn._select()))
+
+        asyncio.run(fn.abort_handoff(output.handoff, OSError("object-store placement failed")))
+
+        [(operation_ids, error, lease_metadata)] = fn.abort.aborts
+        assert operation_ids == ["op-A"]
+        assert lease_metadata is output.handoff.receipt["lease"]
+        assert "placement failed" in error and "poisoned" in error and "resubmit" in error

--- a/tests/fast/rollout/test_checkpoint_eval.py
+++ b/tests/fast/rollout/test_checkpoint_eval.py
@@ -136,7 +136,10 @@ async def test_eval_checkpoint_runs_the_eval_fn_on_the_fleet(controller_env, mon
             return "fleet-state"
 
     fleet = FakeFleet()
-    monkeypatch.setattr(rollout_manager_mod, "call_rollout_function", lambda fn, input: fn(input))
+    async def call(fn, input):
+        return fn(input)
+
+    monkeypatch.setattr(rollout_manager_mod, "call_rollout_function_async", call)
     args = make_args(hf_checkpoint="/base", eval_hf_dir=str(tmp_path))
     mgr = make_manager(args, eval_fn=eval_generate_rollout, fleet=fleet)
 
@@ -187,7 +190,10 @@ async def test_eval_shared_path_shape_unchanged(controller_env, monkeypatch):
         seen_inputs.append(input)
         return RolloutFnEvalOutput(data={})
 
-    monkeypatch.setattr(rollout_manager_mod, "call_rollout_function", lambda fn, input: fn(input))
+    async def call(fn, input):
+        return fn(input)
+
+    monkeypatch.setattr(rollout_manager_mod, "call_rollout_function_async", call)
     args = make_args(hf_checkpoint="/base", eval_num_gpus=0)
     mgr = make_manager(args, eval_fn=eval_generate_rollout)
 

--- a/tests/fast/test_multi_lora_operation_driver.py
+++ b/tests/fast/test_multi_lora_operation_driver.py
@@ -9,6 +9,8 @@ register_cpu_ci(est_time=60, suite="stage-a-cpu")
 import asyncio
 from types import SimpleNamespace
 
+import pytest
+
 from train_multi_lora_operations import ActorGroupWeightPublisher, run_control_phase
 
 
@@ -143,6 +145,33 @@ def test_validate_tinker_args_defaults_the_rollout_plane():
     validate_tinker_args(off)  # no-op without the flag
 
 
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        (
+            "custom_convert_samples_to_train_data_path",
+            "my.module.custom_converter",
+            "custom-convert-samples-to-train-data-path",
+        ),
+        ("load_debug_rollout_data", "/data/rollout_{rollout_id}.pt", "load-debug-rollout-data"),
+        ("ci_inject_rollout_data_path", "/data/inject_{rollout_id}.pt", "ci-inject-rollout-data-path"),
+    ],
+)
+def test_validate_tinker_args_rejects_live_dispatch_bypasses(field, value, message):
+    from miles.utils.tinker import validate_tinker_args
+
+    args = SimpleNamespace(
+        tinker_backend=True,
+        multi_lora_n_adapters=4,
+        rollout_function_path=None,
+        data_source_path="miles.rollout.data_source.RolloutDataSourceWithBuffer",
+        use_dynamic_global_batch_size=False,
+        **{field: value},
+    )
+    with pytest.raises(AssertionError, match=message):
+        validate_tinker_args(args)
+
+
 class TestDataBatchFinalizer:
     """train_data_batch: a NORMAL train commits rank-side; every other exit
     (abnormal TrainStepOutcome, raised train error) must fail the batch's
@@ -154,7 +183,7 @@ class TestDataBatchFinalizer:
             "dispatch_id": "lease-9",
             "bindings_by_operation": [["fb1", ["A", "r-A", 0]], ["fb2", ["B", "r-B", 1]]],
         }
-        pack = {"data_ref": None, "tinker_dispatch": {"operation_ids": ["fb1", "fb2"], "lease": lease}}
+        pack = {"data_ref": None, "rollout_handoff": {"operation_ids": ["fb1", "fb2"], "lease": lease}}
         return pack, lease
 
     def test_normal_outcome_never_calls_the_finalizer(self):
@@ -209,8 +238,8 @@ class TestDataBatchFinalizer:
         assert name == "fail" and operation_ids == ["fb1", "fb2"] and lease_arg == lease
         assert "trainer rank died" in error and "poisoned" in error
 
-    def test_missing_dispatch_summary_still_finalizes_with_empty_ids(self):
-        # A pack without the summary (defensive: custom conversion path) must
+    def test_missing_handoff_metadata_still_finalizes_with_empty_ids(self):
+        # A pack without the handoff metadata (defensive) must
         # not crash the driver; the finalizer degrades to a lease-less no-op
         # call rather than an AttributeError.
         from train_multi_lora_operations import train_data_batch

--- a/train_multi_lora_operations.py
+++ b/train_multi_lora_operations.py
@@ -69,7 +69,10 @@ async def train_data_batch(actor_model, controller, rollout_id: int, rollout_dat
     operations."""
     from miles.backends.megatron_utils.ft.types import TrainStepOutcome
 
-    dispatch = rollout_data.get("tinker_dispatch") or {}
+    # Generic rollout infrastructure forwards the rollout function's opaque
+    # lifecycle receipt. This Tinker-compatible driver is the layer that
+    # interprets it as operation identity plus an execution lease.
+    dispatch = rollout_data.get("rollout_handoff") or {}
     operation_ids = list(dispatch.get("operation_ids") or [])
     lease = dispatch.get("lease")
 


### PR DESCRIPTION
## Stack

This is a follow-up stacked on #2273. Its base is
`tinker-compatible-backend`, so this PR intentionally shows only the
additional delta proposed for #2273.

Merge this PR into `tinker-compatible-backend` only after review; doing so
updates the head of #2273.

## Problem

The generic rollout manager reconstructed Tinker dispatch identity from
converted training tensors. It therefore understood operation-specific
metadata, while failures after lease acquisition but before `generate()`
returned could lose the only driver-visible finalization receipt and leave
claimed operations or their lease stranded.

Async class-based rollout functions also ran on a detached background loop,
so caller cancellation could leave claim/selection work running after the
manager stopped waiting for its result.

## Changes

- Add an opaque `RolloutFnHandoff` contract between rollout functions,
  generic rollout infrastructure, and the driver.
- Mint operation IDs and lease metadata in the Multi-LoRA rollout function,
  where both are authoritative.
- Forward the receipt without interpretation in the generic manager, and
  return it to the rollout function for cleanup when postprocessing, timing,
  logging, conversion, DP splitting, or object-store placement fails.
- Direct-await async rollout functions so caller cancellation reaches their
  claim/selection work; synchronous adapters still run in a worker thread.
- Restore locally selected claims on cancellation, and release the exact
  typed lease if plain receipt encoding fails.
- Move operation-specific interpretation to the Multi-LoRA driver and delete
  manager-side dispatch reconstruction.
- Reject live-data replacement paths that cannot preserve claim/handoff
  identity.
- Add focused lifecycle, cancellation, serialization, idempotency, and
  generic-manager regression tests.

## Validation

- 137 focused CPU tests passed locally.
- Ruff checks, Python bytecode compilation, and `git diff --check` passed.
- The local CPU run used an existing SGLang source checkout plus a macOS-only
  import shim that disables `torch.compile`; the shim is not part of this PR.

## Non-goals

- Full-parameter training executor support.
- The complete RolloutExecutor / InferenceController split.
- Controller-side reconciliation after actor/process death, a successful
  return that is not delivered to the driver, or an ambiguous remote RPC.
- GPU or distributed end-to-end validation.
