### PR TITLE
docs: fix LoRA E2E GPU requirement

### DIFF
--- a/tests/e2e/lora/test_lora_qwen2.5_0.5B.py
+++ b/tests/e2e/lora/test_lora_qwen2.5_0.5B.py
@@ -7,7 +7,7 @@ with LoRA enabled (rank=32, all-linear) to validate:
   - LoRA checkpoint save (native + HF PEFT format)
   - Training completes without errors
 
-Requires: 8 GPUs, Qwen2.5-0.5B-Instruct model, GSM8K dataset.
+Requires: 4 GPUs, Qwen2.5-0.5B-Instruct model, GSM8K dataset.
 Triggered by label: run-ci-lora
 """
 


### PR DESCRIPTION
## Problem

The Qwen2.5 LoRA E2E test docstring identifies 8 GPUs as a requirement, but the intended requirement is 4 GPUs.

## Change

Change the documented GPU requirement from 8 to 4.