### PR TITLE
fix(lora): deduplicate native adapter checkpoints

### DIFF
--- a/miles/backends/megatron_utils/lora_checkpoint.py
+++ b/miles/backends/megatron_utils/lora_checkpoint.py
@@ -1,0 +1,54 @@
+from pathlib import Path
+
+import torch.distributed as dist
+
+from miles.backends.training_utils.parallel import get_parallel_state
+from miles.utils.distributed_utils import get_gloo_group
+
+_shard_topology: tuple[bool, tuple[tuple[int, int, int], ...]] | None = None
+
+
+def raise_if_any_rank_failed(local_error: Exception | None, operation: str) -> None:
+    message = None if local_error is None else f"{type(local_error).__name__}: {local_error}"
+    if dist.is_initialized():
+        group = get_gloo_group()
+        messages: list[str | None] = [None] * dist.get_world_size(group=group)
+        dist.all_gather_object(messages, message, group=group)
+        message = next((item for item in messages if item is not None), None)
+
+    if message is not None:
+        error = RuntimeError(f"{operation} failed on at least one rank: {message}")
+        if local_error is not None:
+            raise error from local_error
+        raise error
+
+
+def megatron_shard_name(tp_rank: int, pp_rank: int, ep_rank: int, ep_size: int) -> str:
+    name = f"adapter_megatron_tp{tp_rank}_pp{pp_rank}"
+    if ep_size > 1:
+        name += f"_ep{ep_rank}"
+    return name + ".pt"
+
+
+def adapter_shard_topology() -> tuple[bool, tuple[tuple[int, int, int], ...]]:
+    global _shard_topology
+    if _shard_topology is not None:
+        return _shard_topology
+
+    parallel_state = get_parallel_state()
+    coords = (parallel_state.tp.rank, parallel_state.pp.rank, parallel_state.ep.rank)
+    if not dist.is_initialized():
+        _shard_topology = (True, (coords,))
+        return _shard_topology
+
+    current_rank = dist.get_rank()
+    group = get_gloo_group()
+    gathered: list[object] = [None] * dist.get_world_size(group=group)
+    dist.all_gather_object(gathered, (coords, current_rank), group=group)
+    is_writer = current_rank == min(rank for entry_coords, rank in gathered if entry_coords == coords)
+    _shard_topology = (is_writer, tuple(sorted({entry_coords for entry_coords, _ in gathered})))
+    return _shard_topology
+
+
+def all_megatron_checkpoints_exist(step_dir: Path, shard_names) -> bool:
+    return all((step_dir / name).exists() for name in shard_names)

--- a/miles/backends/megatron_utils/lora_checkpoint.py
+++ b/miles/backends/megatron_utils/lora_checkpoint.py
@@ -1,0 +1,88 @@
+"""Naming and topology helpers shared by the single- and multi-LoRA checkpoint paths."""
+
+from pathlib import Path
+
+import torch.distributed as dist
+
+from miles.backends.training_utils.parallel import get_parallel_state
+from miles.utils.distributed_utils import get_gloo_group
+
+# Cached by adapter_shard_topology(); the topology is fixed for the run.
+_shard_topology: tuple[bool, tuple[tuple[int, int, int, int], ...]] | None = None
+
+
+def raise_if_any_rank_failed(local_error: Exception | None, operation: str) -> None:
+    """Raise on every rank when any rank reports ``local_error``, so failures stay collective."""
+    message = None if local_error is None else f"{type(local_error).__name__}: {local_error}"
+    if dist.is_initialized():
+        group = get_gloo_group()
+        messages: list[str | None] = [None] * dist.get_world_size(group=group)
+        dist.all_gather_object(messages, message, group=group)
+        message = next((item for item in messages if item is not None), None)
+
+    if message is not None:
+        error = RuntimeError(f"{operation} failed on at least one rank: {message}")
+        if local_error is not None:
+            raise error from local_error
+        raise error
+
+
+def megatron_shard_name(
+    tp_rank: int,
+    pp_rank: int,
+    ep_rank: int = 0,
+    etp_rank: int = 0,
+    *,
+    ep_size: int = 1,
+    etp_size: int = 1,
+    tp_size: int = 1,
+) -> str:
+    """Adapter shard name for one ``(tp, pp, ep, etp)`` coordinate; EP ranks hold different
+    local experts and ETP ranks hold different slices of them. The ep suffix is omitted at
+    ``ep_size == 1``, and the etp suffix at ``etp_size <= tp_size`` where the etp rank is a
+    function of the tp rank, so checkpoints written before either existed stay loadable."""
+    name = f"adapter_megatron_tp{tp_rank}_pp{pp_rank}"
+    if ep_size > 1:
+        name += f"_ep{ep_rank}"
+    if etp_size > tp_size:
+        name += f"_etp{etp_rank}"
+    return name + ".pt"
+
+
+def local_shard_name() -> str:
+    """Shard name for this rank's model-parallel coordinate."""
+    parallel_state = get_parallel_state()
+    return megatron_shard_name(
+        parallel_state.tp.rank,
+        parallel_state.pp.rank,
+        parallel_state.ep.rank,
+        parallel_state.etp.rank,
+        ep_size=parallel_state.ep.size,
+        etp_size=parallel_state.etp.size,
+        tp_size=parallel_state.tp.size,
+    )
+
+
+def adapter_shard_topology() -> tuple[bool, tuple[tuple[int, int, int, int], ...]]:
+    """Return ``(this_rank_writes_its_shard, realized (tp, pp, ep, etp) coords)`` via one cached gloo all-gather."""
+    global _shard_topology
+    if _shard_topology is not None:
+        return _shard_topology
+
+    parallel_state = get_parallel_state()
+    coords = (parallel_state.tp.rank, parallel_state.pp.rank, parallel_state.ep.rank, parallel_state.etp.rank)
+    if not dist.is_initialized():
+        _shard_topology = (True, (coords,))
+        return _shard_topology
+
+    current_rank = dist.get_rank()
+    group = get_gloo_group()
+    gathered: list[object] = [None] * dist.get_world_size(group=group)
+    dist.all_gather_object(gathered, (coords, current_rank), group=group)
+    is_writer = current_rank == min(rank for entry_coords, rank in gathered if entry_coords == coords)
+    _shard_topology = (is_writer, tuple(sorted({entry_coords for entry_coords, _ in gathered})))
+    return _shard_topology
+
+
+def all_megatron_checkpoints_exist(step_dir: Path, shard_names) -> bool:
+    return all((step_dir / name).exists() for name in shard_names)

--- a/miles/backends/megatron_utils/lora_utils.py
+++ b/miles/backends/megatron_utils/lora_utils.py
@@ -10,6 +10,11 @@ from typing import Any
 import torch
 import torch.distributed as dist
 
+from miles.backends.megatron_utils.lora_checkpoint import (
+    adapter_shard_topology,
+    megatron_shard_name,
+    raise_if_any_rank_failed,
+)
 from miles.backends.training_utils.parallel import get_parallel_state
 from miles.utils.lora import is_lora_enabled, lora_rollout_enabled  # noqa: F401  (re-exported)
 
@@ -404,6 +409,40 @@ def create_lora_instance(args: Namespace):
 # ---------------------------------------------------------------------------
 
 
+def _native_adapter_shard_path(directory: Path) -> Path:
+    parallel_state = get_parallel_state()
+    return directory / megatron_shard_name(
+        parallel_state.tp.rank,
+        parallel_state.pp.rank,
+        parallel_state.ep.rank,
+        parallel_state.ep.size,
+    )
+
+
+def _save_native_adapter_checkpoint(model: Sequence[torch.nn.Module], directory: Path) -> Path | None:
+    is_writer, _ = adapter_shard_topology()
+    path = None
+    adapter_state = {}
+    save_error = None
+    if is_writer:
+        try:
+            adapter_state = {
+                name: param.data.cpu()
+                for model_chunk in model
+                for name, param in model_chunk.named_parameters()
+                if _is_adapter_param_name(name)
+            }
+            path = _native_adapter_shard_path(directory)
+            torch.save(adapter_state, path)
+        except Exception as error:
+            save_error = error
+
+    raise_if_any_rank_failed(save_error, "Native LoRA checkpoint save")
+    if path is not None:
+        logger.info(f"Saved {len(adapter_state)} adapter tensors (native) to {path}")
+    return path
+
+
 def save_lora_checkpoint(
     model: Sequence[torch.nn.Module],
     args: Namespace,
@@ -419,16 +458,15 @@ def save_lora_checkpoint(
     1. **HF PEFT format** (``adapter_model.bin`` + ``adapter_config.json``) for
        external tool compatibility. Uses Megatron-Bridge's ``export_adapter_weights``
        which correctly handles fused QKV / gate-up weight splitting and TP gathering.
-    2. **Megatron-native format** (``adapter_megatron_rank{global_rank}.pt``) for fast
-       checkpoint resume without name/weight conversion. Each TP/PP rank saves its
-       own shard with original parameter names.
+    2. **Megatron-native format** (``adapter_megatron_tp{tp}_pp{pp}[_ep{ep}].pt``)
+       for fast checkpoint resume without name/weight conversion.
 
     When ``optimizer`` is provided, training state (optimizer + LR scheduler) is
     also saved per-rank for checkpoint resume. Base model weights are frozen and
     never change, so they are not saved.
 
-    This function is collective: **all ranks must call it** because the bridge
-    export performs TP all-gather internally. Only ``dp_rank == 0`` writes files.
+    This function is collective: all ranks participate in topology discovery and
+    Bridge export, while one writer stores each model-parallel native shard.
     """
     import json
 
@@ -446,16 +484,7 @@ def save_lora_checkpoint(
     if dist.is_initialized():
         dist.barrier()
 
-    adapter_state: dict[str, torch.Tensor] = {}
-    for model_chunk in model:
-        for name, param in model_chunk.named_parameters():
-            if _is_adapter_param_name(name):
-                adapter_state[name] = param.data.cpu()
-
-    global_rank = dist.get_rank() if dist.is_initialized() else 0
-    native_path = save_path / f"adapter_megatron_rank{global_rank}.pt"
-    torch.save(adapter_state, native_path)
-    logger.info(f"Saved {len(adapter_state)} adapter tensors (native) to {native_path}")
+    _save_native_adapter_checkpoint(model, save_path)
 
     # ---- HF PEFT format (uses bridge for correct name/weight conversion) ----
     # Bridge export is collective: all TP ranks participate in the all-gather,
@@ -496,7 +525,7 @@ def save_lora_checkpoint(
             logger.info(f"Saved HF PEFT adapter to {save_path} with {len(lora_state_dict)} tensors")
     except Exception as hf_export_err:
         logger.warning(
-            f"HF PEFT adapter export skipped ({hf_export_err}); the per-rank native "
+            f"HF PEFT adapter export skipped ({hf_export_err}); the model-parallel native "
             f"shards + training state are sufficient for training resume."
         )
 
@@ -528,8 +557,8 @@ def load_lora_adapter(
 ) -> tuple[bool, int | None]:
     """Load LoRA adapter weights from a saved checkpoint into the model.
 
-    Attempts to load from Megatron-native format first (per-rank ``.pt`` files),
-    which preserves the exact TP/PP sharding and requires no name conversion.
+    Attempts to load from Megatron-native format first (per-model-parallel ``.pt``
+    files), which preserves the exact TP/PP/EP sharding and requires no name conversion.
     Falls back to HF PEFT ``adapter_model.bin`` if native files are not found
     (not yet implemented for HF PEFT format).
 
@@ -552,17 +581,24 @@ def load_lora_adapter(
         logger.warning(f"LoRA adapter path does not exist: {adapter_dir}")
         return False, None
 
-    tp_rank = get_parallel_state().tp.rank
-    pp_rank = get_parallel_state().pp.rank
+    parallel_state = get_parallel_state()
+    tp_rank = parallel_state.tp.rank
+    pp_rank = parallel_state.pp.rank
+    ep_size = parallel_state.ep.size
 
     # ---- Try Megatron-native format first (fast, no conversion needed) ----
-    global_rank = dist.get_rank() if dist.is_initialized() else 0
-    native_path = adapter_dir / f"adapter_megatron_rank{global_rank}.pt"
+    native_path = _native_adapter_shard_path(adapter_dir)
     if not native_path.exists():
-        legacy = adapter_dir / f"adapter_megatron_tp{tp_rank}_pp{pp_rank}.pt"
-        if legacy.exists():
-            logger.warning(f"Using legacy tp/pp-named adapter shard {legacy}; only valid when EP<=TP")
-            native_path = legacy
+        global_rank = dist.get_rank() if dist.is_initialized() else 0
+        legacy_rank = adapter_dir / f"adapter_megatron_rank{global_rank}.pt"
+        if legacy_rank.exists():
+            logger.warning(f"Using legacy global-rank adapter shard {legacy_rank}")
+            native_path = legacy_rank
+        elif ep_size > 1:
+            legacy_tp_pp = adapter_dir / megatron_shard_name(tp_rank, pp_rank, 0, 1)
+            if legacy_tp_pp.exists():
+                logger.warning(f"Using legacy tp/pp-named adapter shard {legacy_tp_pp}; only valid when EP<=TP")
+                native_path = legacy_tp_pp
     if native_path.exists():
         state_dict = torch.load(native_path, map_location="cpu", weights_only=True)
         loaded = 0

--- a/miles/backends/megatron_utils/lora_utils.py
+++ b/miles/backends/megatron_utils/lora_utils.py
@@ -10,6 +10,12 @@ from typing import Any
 import torch
 import torch.distributed as dist
 
+from miles.backends.megatron_utils.lora_checkpoint import (
+    adapter_shard_topology,
+    local_shard_name,
+    megatron_shard_name,
+    raise_if_any_rank_failed,
+)
 from miles.backends.training_utils.parallel import get_parallel_state
 from miles.utils.lora import is_lora_enabled, lora_rollout_enabled  # noqa: F401  (re-exported)
 
@@ -406,6 +412,30 @@ def create_lora_instance(args: Namespace):
 # ---------------------------------------------------------------------------
 
 
+def _save_native_adapter_checkpoint(model: Sequence[torch.nn.Module], directory: Path) -> Path | None:
+    is_writer, _ = adapter_shard_topology()
+    path = None
+    adapter_state = {}
+    save_error = None
+    if is_writer:
+        try:
+            adapter_state = {
+                name: param.data.cpu()
+                for model_chunk in model
+                for name, param in model_chunk.named_parameters()
+                if _is_adapter_param_name(name)
+            }
+            path = directory / local_shard_name()
+            torch.save(adapter_state, path)
+        except Exception as error:
+            save_error = error
+
+    raise_if_any_rank_failed(save_error, "Native LoRA checkpoint save")
+    if path is not None:
+        logger.info(f"Saved {len(adapter_state)} adapter tensors (native) to {path}")
+    return path
+
+
 def save_lora_checkpoint(
     model: Sequence[torch.nn.Module],
     args: Namespace,
@@ -421,16 +451,15 @@ def save_lora_checkpoint(
     1. **HF PEFT format** (``adapter_model.bin`` + ``adapter_config.json``) for
        external tool compatibility. Uses Megatron-Bridge's ``export_adapter_weights``
        which correctly handles fused QKV / gate-up weight splitting and TP gathering.
-    2. **Megatron-native format** (``adapter_megatron_rank{global_rank}.pt``) for fast
-       checkpoint resume without name/weight conversion. Each TP/PP rank saves its
-       own shard with original parameter names.
+    2. **Megatron-native format** (``adapter_megatron_tp{tp}_pp{pp}[_ep{ep}][_etp{etp}].pt``)
+       for fast checkpoint resume without name/weight conversion.
 
     When ``optimizer`` is provided, training state (optimizer + LR scheduler) is
     also saved per-rank for checkpoint resume. Base model weights are frozen and
     never change, so they are not saved.
 
-    This function is collective: **all ranks must call it** because the bridge
-    export performs TP all-gather internally. Only ``dp_rank == 0`` writes files.
+    This function is collective: all ranks participate in topology discovery and
+    Bridge export, while one writer stores each model-parallel native shard.
     """
     import json
 
@@ -448,16 +477,7 @@ def save_lora_checkpoint(
     if dist.is_initialized():
         dist.barrier()
 
-    adapter_state: dict[str, torch.Tensor] = {}
-    for model_chunk in model:
-        for name, param in model_chunk.named_parameters():
-            if _is_adapter_param_name(name):
-                adapter_state[name] = param.data.cpu()
-
-    global_rank = dist.get_rank() if dist.is_initialized() else 0
-    native_path = save_path / f"adapter_megatron_rank{global_rank}.pt"
-    torch.save(adapter_state, native_path)
-    logger.info(f"Saved {len(adapter_state)} adapter tensors (native) to {native_path}")
+    _save_native_adapter_checkpoint(model, save_path)
 
     # ---- HF PEFT format (uses bridge for correct name/weight conversion) ----
     # Bridge export is collective: all TP ranks participate in the all-gather,
@@ -498,7 +518,7 @@ def save_lora_checkpoint(
             logger.info(f"Saved HF PEFT adapter to {save_path} with {len(lora_state_dict)} tensors")
     except Exception as hf_export_err:
         logger.warning(
-            f"HF PEFT adapter export skipped ({hf_export_err}); the per-rank native "
+            f"HF PEFT adapter export skipped ({hf_export_err}); the model-parallel native "
             f"shards + training state are sufficient for training resume."
         )
 
@@ -530,8 +550,8 @@ def load_lora_adapter(
 ) -> tuple[bool, int | None]:
     """Load LoRA adapter weights from a saved checkpoint into the model.
 
-    Attempts to load from Megatron-native format first (per-rank ``.pt`` files),
-    which preserves the exact TP/PP sharding and requires no name conversion.
+    Attempts to load from Megatron-native format first (per-model-parallel ``.pt``
+    files), which preserves the exact TP/PP/EP sharding and requires no name conversion.
     Falls back to HF PEFT ``adapter_model.bin`` if native files are not found
     (not yet implemented for HF PEFT format).
 
@@ -554,17 +574,24 @@ def load_lora_adapter(
         logger.warning(f"LoRA adapter path does not exist: {adapter_dir}")
         return False, None
 
-    tp_rank = get_parallel_state().tp.rank
-    pp_rank = get_parallel_state().pp.rank
+    parallel_state = get_parallel_state()
+    tp_rank = parallel_state.tp.rank
+    pp_rank = parallel_state.pp.rank
+    ep_size = parallel_state.ep.size
 
     # ---- Try Megatron-native format first (fast, no conversion needed) ----
-    global_rank = dist.get_rank() if dist.is_initialized() else 0
-    native_path = adapter_dir / f"adapter_megatron_rank{global_rank}.pt"
+    native_path = adapter_dir / local_shard_name()
     if not native_path.exists():
-        legacy = adapter_dir / f"adapter_megatron_tp{tp_rank}_pp{pp_rank}.pt"
-        if legacy.exists():
-            logger.warning(f"Using legacy tp/pp-named adapter shard {legacy}; only valid when EP<=TP")
-            native_path = legacy
+        global_rank = dist.get_rank() if dist.is_initialized() else 0
+        legacy_rank = adapter_dir / f"adapter_megatron_rank{global_rank}.pt"
+        if legacy_rank.exists():
+            logger.warning(f"Using legacy global-rank adapter shard {legacy_rank}")
+            native_path = legacy_rank
+        elif ep_size > 1:
+            legacy_tp_pp = adapter_dir / megatron_shard_name(tp_rank, pp_rank)
+            if legacy_tp_pp.exists():
+                logger.warning(f"Using legacy tp/pp-named adapter shard {legacy_tp_pp}; only valid when EP<=TP")
+                native_path = legacy_tp_pp
     if native_path.exists():
         state_dict = torch.load(native_path, map_location="cpu", weights_only=True)
         loaded = 0

--- a/miles/backends/megatron_utils/multi_lora_utils.py
+++ b/miles/backends/megatron_utils/multi_lora_utils.py
@@ -9,15 +9,17 @@ import ray
 import torch
 import torch.distributed as dist
 
+from miles.backends.megatron_utils.lora_checkpoint import (
+    adapter_shard_topology,
+    all_megatron_checkpoints_exist,
+    megatron_shard_name,
+)
 from miles.backends.training_utils.parallel import get_parallel_state
 from miles.ray.multi_lora.controller import get_multi_lora_controller
 from miles.utils.adapter_config import AdapterRun
 from miles.utils.distributed_utils import get_gloo_group
 
 logger = logging.getLogger(__name__)
-
-# Cached by adapter_shard_topology(); the topology is fixed for the run.
-_shard_topology: tuple[bool, tuple[tuple[int, int, int], ...]] | None = None
 
 
 def create_multi_lora_instance(args: Namespace):
@@ -46,39 +48,6 @@ def create_multi_lora_instance(args: Namespace):
         lora_A_init_method=getattr(args, "lora_A_init_method", "xavier"),
         lora_B_init_method=getattr(args, "lora_B_init_method", "zero"),
     )
-
-
-def megatron_shard_name(tp_rank: int, pp_rank: int, ep_rank: int, ep_size: int) -> str:
-    """Adapter shard name for one (tp, pp, ep) coordinate; EP ranks hold different local
-    experts. The ep suffix is omitted at ep_size == 1 so legacy checkpoints stay loadable."""
-    name = f"adapter_megatron_tp{tp_rank}_pp{pp_rank}"
-    if ep_size > 1:
-        name += f"_ep{ep_rank}"
-    return name + ".pt"
-
-
-def adapter_shard_topology() -> tuple[bool, tuple[tuple[int, int, int], ...]]:
-    """Return ``(this_rank_writes_its_shard, realized (tp, pp, ep) coords)`` via one cached gloo all-gather."""
-    global _shard_topology
-    if _shard_topology is not None:
-        return _shard_topology
-    parallel_state = get_parallel_state()
-    coords = (parallel_state.tp.rank, parallel_state.pp.rank, parallel_state.ep.rank)
-    if not dist.is_initialized():
-        _shard_topology = (True, (coords,))
-        return _shard_topology
-
-    current_rank = dist.get_rank()
-    group = get_gloo_group()
-    gathered: list[object] = [None] * dist.get_world_size(group=group)
-    dist.all_gather_object(gathered, (coords, current_rank), group=group)
-    is_writer = current_rank == min(rank for entry_coords, rank in gathered if entry_coords == coords)
-    _shard_topology = (is_writer, tuple(sorted({entry_coords for entry_coords, _ in gathered})))
-    return _shard_topology
-
-
-def all_megatron_checkpoints_exist(step_dir: Path, shard_names) -> bool:
-    return all((step_dir / name).exists() for name in shard_names)
 
 
 def find_latest_checkpoint(ckpt_dir: Path) -> tuple[Path | None, int]:
@@ -365,7 +334,6 @@ def _deregister_adapter(adapter: AdapterRun, args, model, optimizer) -> None:
 def load_adapters(args, model, optimizer, adapters) -> int:
     """Load adapters into Megatron slots; resumes step counts from checkpoints."""
     from miles.backends.megatron_utils.initialize import is_first_replica_megatron_main_rank
-    from miles.utils.distributed_utils import get_gloo_group
 
     if dist.is_initialized():
         dist.barrier(group=get_gloo_group())
@@ -391,7 +359,6 @@ def load_adapters(args, model, optimizer, adapters) -> int:
 def cleanup_adapters(args, model, optimizer, adapters) -> int:
     """Save final ckpt + clear Megatron slot, then free_slot on the controller."""
     from miles.backends.megatron_utils.initialize import is_first_replica_megatron_main_rank
-    from miles.utils.distributed_utils import get_gloo_group
 
     if dist.is_initialized():
         dist.barrier(group=get_gloo_group())
@@ -450,7 +417,6 @@ def save_due_adapter_checkpoints(args, model) -> bool:
     without a checkpoint on disk. Rank 0 picks and broadcasts, so the
     collective export lines up. Returns False when nothing is due."""
     from miles.backends.megatron_utils.initialize import is_first_replica_megatron_main_rank
-    from miles.utils.distributed_utils import get_gloo_group
 
     due_buffer = [None]
     if is_first_replica_megatron_main_rank() and args.save_interval is not None:

--- a/miles/backends/megatron_utils/multi_lora_utils.py
+++ b/miles/backends/megatron_utils/multi_lora_utils.py
@@ -9,15 +9,18 @@ import ray
 import torch
 import torch.distributed as dist
 
+from miles.backends.megatron_utils.lora_checkpoint import (
+    adapter_shard_topology,
+    all_megatron_checkpoints_exist,
+    local_shard_name,
+    megatron_shard_name,
+)
 from miles.backends.training_utils.parallel import get_parallel_state
 from miles.ray.multi_lora.controller import get_multi_lora_controller
 from miles.utils.adapter_config import AdapterRun
 from miles.utils.distributed_utils import get_gloo_group
 
 logger = logging.getLogger(__name__)
-
-# Cached by adapter_shard_topology(); the topology is fixed for the run.
-_shard_topology: tuple[bool, tuple[tuple[int, int, int], ...]] | None = None
 
 
 def create_multi_lora_instance(args: Namespace):
@@ -48,39 +51,6 @@ def create_multi_lora_instance(args: Namespace):
     )
 
 
-def megatron_shard_name(tp_rank: int, pp_rank: int, ep_rank: int, ep_size: int) -> str:
-    """Adapter shard name for one (tp, pp, ep) coordinate; EP ranks hold different local
-    experts. The ep suffix is omitted at ep_size == 1 so legacy checkpoints stay loadable."""
-    name = f"adapter_megatron_tp{tp_rank}_pp{pp_rank}"
-    if ep_size > 1:
-        name += f"_ep{ep_rank}"
-    return name + ".pt"
-
-
-def adapter_shard_topology() -> tuple[bool, tuple[tuple[int, int, int], ...]]:
-    """Return ``(this_rank_writes_its_shard, realized (tp, pp, ep) coords)`` via one cached gloo all-gather."""
-    global _shard_topology
-    if _shard_topology is not None:
-        return _shard_topology
-    parallel_state = get_parallel_state()
-    coords = (parallel_state.tp.rank, parallel_state.pp.rank, parallel_state.ep.rank)
-    if not dist.is_initialized():
-        _shard_topology = (True, (coords,))
-        return _shard_topology
-
-    current_rank = dist.get_rank()
-    group = get_gloo_group()
-    gathered: list[object] = [None] * dist.get_world_size(group=group)
-    dist.all_gather_object(gathered, (coords, current_rank), group=group)
-    is_writer = current_rank == min(rank for entry_coords, rank in gathered if entry_coords == coords)
-    _shard_topology = (is_writer, tuple(sorted({entry_coords for entry_coords, _ in gathered})))
-    return _shard_topology
-
-
-def all_megatron_checkpoints_exist(step_dir: Path, shard_names) -> bool:
-    return all((step_dir / name).exists() for name in shard_names)
-
-
 def find_latest_checkpoint(ckpt_dir: Path) -> tuple[Path | None, int]:
     _, coords = adapter_shard_topology()
     if not ckpt_dir.exists():
@@ -88,13 +58,13 @@ def find_latest_checkpoint(ckpt_dir: Path) -> tuple[Path | None, int]:
 
     parallel_state = get_parallel_state()
     ep_size = parallel_state.ep.size
-    my_coords = (parallel_state.tp.rank, parallel_state.pp.rank, parallel_state.ep.rank)
+    sizes = dict(ep_size=ep_size, etp_size=parallel_state.etp.size, tp_size=parallel_state.tp.size)
 
-    expected = {megatron_shard_name(*coord, ep_size) for coord in coords}
-    my_shard = megatron_shard_name(*my_coords, ep_size)
+    expected = {megatron_shard_name(*coord, **sizes) for coord in coords}
+    my_shard = local_shard_name()
     # Legacy pre-expert-adapter layout: no ep suffix; safe for all EP ranks to read (EP-replicated).
-    legacy = {megatron_shard_name(tp, pp, 0, 1) for tp, pp, _ in coords}
-    my_legacy = megatron_shard_name(my_coords[0], my_coords[1], 0, 1)
+    legacy = {megatron_shard_name(tp, pp) for tp, pp, _, _ in coords}
+    my_legacy = megatron_shard_name(parallel_state.tp.rank, parallel_state.pp.rank)
 
     def get_step(d):
         return int(d.name.split("_")[1])
@@ -192,7 +162,7 @@ def save_multi_lora_checkpoints(
     Layout (per adapter)::
 
         {adapter.save}/checkpoints/step_{iteration}/
-        ├── adapter_megatron_tp{tp}_pp{pp}[_ep{ep}].pt  ← per-rank shard, fast resume
+        ├── adapter_megatron_tp{tp}_pp{pp}[_ep{ep}][_etp{etp}].pt  ← per-rank shard, fast resume
         ├── adapter_model.safetensors           ← gathered HF, inference / external
         └── adapter_config.json                 ← HF PEFT metadata (r, alpha, ...)
     """
@@ -207,10 +177,11 @@ def save_multi_lora_checkpoints(
     tp_rank = parallel_state.tp.rank
     pp_rank = parallel_state.pp.rank
     ep_rank = parallel_state.ep.rank
-    ep_size = parallel_state.ep.size
-    # Exactly one writer per (tp, pp, ep) shard; see adapter_shard_topology.
+    # Exactly one writer per (tp, pp, ep, etp) shard; see adapter_shard_topology.
     is_shard_writer, _ = adapter_shard_topology()
-    is_global_writer = is_shard_writer and tp_rank == 0 and pp_rank == 0 and ep_rank == 0
+    # All four coordinates: at etp_size > tp_size several etp ranks share (tp, pp, ep), and two
+    # global writers would race to promote the same directory.
+    is_global_writer = is_shard_writer and (tp_rank, pp_rank, ep_rank, parallel_state.etp.rank) == (0, 0, 0, 0)
 
     target_modules_hf = (
         convert_target_modules_to_hf(list(args.target_modules))
@@ -245,7 +216,7 @@ def save_multi_lora_checkpoints(
                     for name, param in batch.named_parameters()
                     if ".adapter." in name
                 }
-                native_path = tmp_dir / megatron_shard_name(tp_rank, pp_rank, ep_rank, ep_size)
+                native_path = tmp_dir / local_shard_name()
                 torch.save(shard, native_path)
                 logger.info(f"{log_prefix} saved Megatron shard " f"({len(shard)} tensors) to {native_path}")
 
@@ -365,7 +336,6 @@ def _deregister_adapter(adapter: AdapterRun, args, model, optimizer) -> None:
 def load_adapters(args, model, optimizer, adapters) -> int:
     """Load adapters into Megatron slots; resumes step counts from checkpoints."""
     from miles.backends.megatron_utils.initialize import is_first_replica_megatron_main_rank
-    from miles.utils.distributed_utils import get_gloo_group
 
     if dist.is_initialized():
         dist.barrier(group=get_gloo_group())
@@ -391,7 +361,6 @@ def load_adapters(args, model, optimizer, adapters) -> int:
 def cleanup_adapters(args, model, optimizer, adapters) -> int:
     """Save final ckpt + clear Megatron slot, then free_slot on the controller."""
     from miles.backends.megatron_utils.initialize import is_first_replica_megatron_main_rank
-    from miles.utils.distributed_utils import get_gloo_group
 
     if dist.is_initialized():
         dist.barrier(group=get_gloo_group())
@@ -450,7 +419,6 @@ def save_due_adapter_checkpoints(args, model) -> bool:
     without a checkpoint on disk. Rank 0 picks and broadcasts, so the
     collective export lines up. Returns False when nothing is due."""
     from miles.backends.megatron_utils.initialize import is_first_replica_megatron_main_rank
-    from miles.utils.distributed_utils import get_gloo_group
 
     due_buffer = [None]
     if is_first_replica_megatron_main_rank() and args.save_interval is not None:

--- a/tests/fast/backends/megatron_utils/test_lora_utils.py
+++ b/tests/fast/backends/megatron_utils/test_lora_utils.py
@@ -5,10 +5,14 @@ exclude-module parsing, and LoRA sync config building — all without GPU.
 """
 
 from argparse import Namespace
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
+import torch
 
+import miles.backends.megatron_utils.lora_checkpoint as lora_checkpoint
+import miles.backends.megatron_utils.lora_utils as lora_utils
 from miles.backends.megatron_utils.lora_utils import (
     _get_lora_class_name,
     _is_adapter_param_name,
@@ -346,6 +350,87 @@ class TestBuildLoraSyncConfig:
         config = build_lora_sync_config(args)
         assert config["target_modules"] == ["q_proj", "k_proj"]
         assert config["r"] == 8
+
+
+# ---------------------------------------------------------------------------
+# Native adapter checkpoints
+# ---------------------------------------------------------------------------
+
+
+def _parallel_state(tp=0, pp=0, ep=0, ep_size=1):
+    return SimpleNamespace(
+        tp=SimpleNamespace(rank=tp),
+        pp=SimpleNamespace(rank=pp),
+        ep=SimpleNamespace(rank=ep, size=ep_size),
+    )
+
+
+def _adapter_model(name="module.lora_A.weight"):
+    model = MagicMock()
+    model.named_parameters.return_value = [(name, torch.nn.Parameter(torch.ones(2, 2)))]
+    return model
+
+
+class TestNativeAdapterCheckpoint:
+    def test_writer_saves_model_parallel_shard(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(lora_utils, "get_parallel_state", lambda: _parallel_state(tp=1, pp=2, ep=3, ep_size=4))
+        monkeypatch.setattr(lora_utils, "adapter_shard_topology", lambda: (True, ((1, 2, 3),)))
+
+        path = lora_utils._save_native_adapter_checkpoint([_adapter_model()], tmp_path)
+
+        assert path == tmp_path / "adapter_megatron_tp1_pp2_ep3.pt"
+        assert path.exists()
+        assert not list(tmp_path.glob("adapter_megatron_rank*.pt"))
+
+    def test_replica_does_not_write_duplicate_shard(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(lora_utils, "adapter_shard_topology", lambda: (False, ((0, 0, 0),)))
+
+        assert lora_utils._save_native_adapter_checkpoint([_adapter_model()], tmp_path) is None
+        assert not list(tmp_path.iterdir())
+
+    def test_writer_failure_is_reported_before_later_collectives(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(lora_utils, "adapter_shard_topology", lambda: (True, ((0, 0, 0),)))
+        monkeypatch.setattr(lora_utils, "get_parallel_state", lambda: _parallel_state())
+        monkeypatch.setattr(lora_utils.torch, "save", MagicMock(side_effect=OSError("disk full")))
+
+        with pytest.raises(RuntimeError, match="Native LoRA checkpoint save.*disk full"):
+            lora_utils._save_native_adapter_checkpoint([_adapter_model()], tmp_path)
+
+    def test_replica_observes_peer_writer_failure(self, monkeypatch):
+        monkeypatch.setattr(lora_checkpoint.dist, "is_initialized", lambda: True)
+        monkeypatch.setattr(lora_checkpoint.dist, "get_world_size", lambda group: 2)
+        monkeypatch.setattr(lora_checkpoint, "get_gloo_group", MagicMock(return_value=object()))
+
+        def gather(messages, _local_message, group):
+            messages[:] = ["OSError: disk full", None]
+
+        monkeypatch.setattr(lora_checkpoint.dist, "all_gather_object", gather)
+
+        with pytest.raises(RuntimeError, match="Native LoRA checkpoint save.*disk full"):
+            lora_checkpoint.raise_if_any_rank_failed(None, "Native LoRA checkpoint save")
+
+    def test_loads_model_parallel_shard(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(lora_utils, "get_parallel_state", lambda: _parallel_state())
+        expected = torch.full((2, 2), 3.0)
+        torch.save({"module.lora_A.weight": expected}, tmp_path / "adapter_megatron_tp0_pp0.pt")
+        model = _adapter_model()
+
+        loaded, iteration = lora_utils.load_lora_adapter([model], str(tmp_path))
+
+        assert loaded
+        assert iteration is None
+        assert torch.equal(model.named_parameters.return_value[0][1], expected)
+
+    def test_loads_legacy_global_rank_shard(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(lora_utils, "get_parallel_state", lambda: _parallel_state())
+        expected = torch.full((2, 2), 4.0)
+        torch.save({"module.lora_A.weight": expected}, tmp_path / "adapter_megatron_rank0.pt")
+        model = _adapter_model()
+
+        loaded, _ = lora_utils.load_lora_adapter([model], str(tmp_path))
+
+        assert loaded
+        assert torch.equal(model.named_parameters.return_value[0][1], expected)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/fast/backends/megatron_utils/test_lora_utils.py
+++ b/tests/fast/backends/megatron_utils/test_lora_utils.py
@@ -5,10 +5,14 @@ exclude-module parsing, and LoRA sync config building — all without GPU.
 """
 
 from argparse import Namespace
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
+import torch
 
+import miles.backends.megatron_utils.lora_checkpoint as lora_checkpoint
+import miles.backends.megatron_utils.lora_utils as lora_utils
 from miles.backends.megatron_utils.lora_utils import (
     _get_lora_class_name,
     _is_adapter_param_name,
@@ -346,6 +350,100 @@ class TestBuildLoraSyncConfig:
         config = build_lora_sync_config(args)
         assert config["target_modules"] == ["q_proj", "k_proj"]
         assert config["r"] == 8
+
+
+# ---------------------------------------------------------------------------
+# Native adapter checkpoints
+# ---------------------------------------------------------------------------
+
+
+def _use_parallel_state(monkeypatch, *, tp=0, pp=0, ep=0, ep_size=1, etp=0, etp_size=1, tp_size=1):
+    state = SimpleNamespace(
+        tp=SimpleNamespace(rank=tp, size=tp_size),
+        pp=SimpleNamespace(rank=pp),
+        ep=SimpleNamespace(rank=ep, size=ep_size),
+        etp=SimpleNamespace(rank=etp, size=etp_size),
+    )
+    monkeypatch.setattr(lora_utils, "get_parallel_state", lambda: state)
+    monkeypatch.setattr(lora_checkpoint, "get_parallel_state", lambda: state)
+
+
+def _adapter_model(name="module.lora_A.weight"):
+    model = MagicMock()
+    model.named_parameters.return_value = [(name, torch.nn.Parameter(torch.ones(2, 2)))]
+    return model
+
+
+class TestNativeAdapterCheckpoint:
+    def test_writer_saves_model_parallel_shard(self, tmp_path, monkeypatch):
+        _use_parallel_state(monkeypatch, tp=1, pp=2, ep=3, ep_size=4)
+        monkeypatch.setattr(lora_utils, "adapter_shard_topology", lambda: (True, ((1, 2, 3, 0),)))
+
+        path = lora_utils._save_native_adapter_checkpoint([_adapter_model()], tmp_path)
+
+        assert path == tmp_path / "adapter_megatron_tp1_pp2_ep3.pt"
+        assert path.exists()
+        assert not list(tmp_path.glob("adapter_megatron_rank*.pt"))
+
+    def test_writer_shard_separates_expert_tensor_parallel_ranks(self, tmp_path, monkeypatch):
+        # ETP > TP: ranks share a tp rank but hold different expert slices, so the
+        # shard name must stay distinct or one rank silently overwrites the other.
+        _use_parallel_state(monkeypatch, ep_size=2, etp=1, etp_size=2, tp_size=1)
+        monkeypatch.setattr(lora_utils, "adapter_shard_topology", lambda: (True, ((0, 0, 0, 1),)))
+
+        path = lora_utils._save_native_adapter_checkpoint([_adapter_model()], tmp_path)
+
+        assert path == tmp_path / "adapter_megatron_tp0_pp0_ep0_etp1.pt"
+
+    def test_replica_does_not_write_duplicate_shard(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(lora_utils, "adapter_shard_topology", lambda: (False, ((0, 0, 0, 0),)))
+
+        assert lora_utils._save_native_adapter_checkpoint([_adapter_model()], tmp_path) is None
+        assert not list(tmp_path.iterdir())
+
+    def test_writer_failure_is_reported_before_later_collectives(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(lora_utils, "adapter_shard_topology", lambda: (True, ((0, 0, 0, 0),)))
+        _use_parallel_state(monkeypatch)
+        monkeypatch.setattr(lora_utils.torch, "save", MagicMock(side_effect=OSError("disk full")))
+
+        with pytest.raises(RuntimeError, match="Native LoRA checkpoint save.*disk full"):
+            lora_utils._save_native_adapter_checkpoint([_adapter_model()], tmp_path)
+
+    def test_replica_observes_peer_writer_failure(self, monkeypatch):
+        monkeypatch.setattr(lora_checkpoint.dist, "is_initialized", lambda: True)
+        monkeypatch.setattr(lora_checkpoint.dist, "get_world_size", lambda group: 2)
+        monkeypatch.setattr(lora_checkpoint, "get_gloo_group", MagicMock(return_value=object()))
+
+        def gather(messages, _local_message, group):
+            messages[:] = ["OSError: disk full", None]
+
+        monkeypatch.setattr(lora_checkpoint.dist, "all_gather_object", gather)
+
+        with pytest.raises(RuntimeError, match="Native LoRA checkpoint save.*disk full"):
+            lora_checkpoint.raise_if_any_rank_failed(None, "Native LoRA checkpoint save")
+
+    def test_loads_model_parallel_shard(self, tmp_path, monkeypatch):
+        _use_parallel_state(monkeypatch)
+        expected = torch.full((2, 2), 3.0)
+        torch.save({"module.lora_A.weight": expected}, tmp_path / "adapter_megatron_tp0_pp0.pt")
+        model = _adapter_model()
+
+        loaded, iteration = lora_utils.load_lora_adapter([model], str(tmp_path))
+
+        assert loaded
+        assert iteration is None
+        assert torch.equal(model.named_parameters.return_value[0][1], expected)
+
+    def test_loads_legacy_global_rank_shard(self, tmp_path, monkeypatch):
+        _use_parallel_state(monkeypatch)
+        expected = torch.full((2, 2), 4.0)
+        torch.save({"module.lora_A.weight": expected}, tmp_path / "adapter_megatron_rank0.pt")
+        model = _adapter_model()
+
+        loaded, _ = lora_utils.load_lora_adapter([model], str(tmp_path))
+
+        assert loaded
+        assert torch.equal(model.named_parameters.return_value[0][1], expected)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/fast/backends/megatron_utils/test_multi_lora_checkpoint_naming.py
+++ b/tests/fast/backends/megatron_utils/test_multi_lora_checkpoint_naming.py
@@ -1,7 +1,7 @@
 """Adapter shards are keyed by (tp, pp, ep): EP ranks hold different local experts, and
 the realized coordinates are not the tp x pp x ep cross product when ETP < TP."""
 
-from miles.backends.megatron_utils.multi_lora_utils import all_megatron_checkpoints_exist, megatron_shard_name
+from miles.backends.megatron_utils.lora_checkpoint import all_megatron_checkpoints_exist, megatron_shard_name
 
 
 def _names(coords, ep_size):

--- a/tests/fast/backends/megatron_utils/test_multi_lora_checkpoint_naming.py
+++ b/tests/fast/backends/megatron_utils/test_multi_lora_checkpoint_naming.py
@@ -1,46 +1,58 @@
-"""Adapter shards are keyed by (tp, pp, ep): EP ranks hold different local experts, and
-the realized coordinates are not the tp x pp x ep cross product when ETP < TP."""
+"""Adapter shards are keyed by (tp, pp, ep, etp): EP ranks hold different local experts,
+ETP ranks hold different slices of them, and the realized coordinates are not the
+tp x pp x ep cross product when ETP < TP."""
 
-from miles.backends.megatron_utils.multi_lora_utils import all_megatron_checkpoints_exist, megatron_shard_name
+from miles.backends.megatron_utils.lora_checkpoint import all_megatron_checkpoints_exist, megatron_shard_name
 
 
 def _names(coords, ep_size):
-    return {megatron_shard_name(*coord, ep_size) for coord in coords}
+    return {megatron_shard_name(*coord, ep_size=ep_size) for coord in coords}
 
 
 def test_shard_name_omits_ep_suffix_without_expert_parallelism():
     # Checkpoints written before expert adapters existed must stay loadable.
-    assert megatron_shard_name(0, 0, 0, ep_size=1) == "adapter_megatron_tp0_pp0.pt"
-    assert megatron_shard_name(1, 2, 0, ep_size=1) == "adapter_megatron_tp1_pp2.pt"
+    assert megatron_shard_name(0, 0, 0, 0, ep_size=1) == "adapter_megatron_tp0_pp0.pt"
+    assert megatron_shard_name(1, 2, 0, 0, ep_size=1) == "adapter_megatron_tp1_pp2.pt"
 
 
 def test_shard_name_is_unique_per_expert_parallel_rank():
-    names = {megatron_shard_name(0, 0, ep, ep_size=4) for ep in range(4)}
+    names = {megatron_shard_name(0, 0, ep, 0, ep_size=4) for ep in range(4)}
     assert len(names) == 4
-    assert megatron_shard_name(0, 0, 2, ep_size=4) == "adapter_megatron_tp0_pp0_ep2.pt"
+    assert megatron_shard_name(0, 0, 2, 0, ep_size=4) == "adapter_megatron_tp0_pp0_ep2.pt"
+
+
+def test_shard_name_omits_etp_suffix_when_etp_does_not_exceed_tp():
+    # ETP <= TP: the etp rank is a function of the tp rank, so names stay unchanged.
+    assert megatron_shard_name(1, 0, 0, 0, ep_size=1, etp_size=1, tp_size=2) == "adapter_megatron_tp1_pp0.pt"
+
+
+def test_shard_name_is_unique_per_expert_tensor_parallel_rank():
+    # ETP > TP: two ranks share a tp rank but hold different expert slices.
+    names = {megatron_shard_name(0, 0, 0, etp, ep_size=2, etp_size=2, tp_size=1) for etp in range(2)}
+    assert names == {"adapter_megatron_tp0_pp0_ep0_etp0.pt", "adapter_megatron_tp0_pp0_ep0_etp1.pt"}
 
 
 def test_completeness_check_requires_every_realized_shard(tmp_path):
-    coords = [(0, 0, 0), (0, 0, 1), (0, 0, 2)]
+    coords = [(0, 0, 0, 0), (0, 0, 1, 0), (0, 0, 2, 0)]
     for coord in coords[:2]:
-        (tmp_path / megatron_shard_name(*coord, 3)).touch()
+        (tmp_path / megatron_shard_name(*coord, ep_size=3)).touch()
 
     assert not all_megatron_checkpoints_exist(tmp_path, _names(coords, 3))
 
-    (tmp_path / megatron_shard_name(*coords[2], 3)).touch()
+    (tmp_path / megatron_shard_name(*coords[2], ep_size=3)).touch()
     assert all_megatron_checkpoints_exist(tmp_path, _names(coords, 3))
 
 
 def test_completeness_ignores_unrealized_coordinates(tmp_path):
     # TP=2, EP=2, ETP=1: only (0,0,0) and (1,0,1) exist; a cross-product check
     # would demand four shards and never resume.
-    coords = [(0, 0, 0), (1, 0, 1)]
+    coords = [(0, 0, 0, 0), (1, 0, 1, 0)]
     for coord in coords:
-        (tmp_path / megatron_shard_name(*coord, 2)).touch()
+        (tmp_path / megatron_shard_name(*coord, ep_size=2)).touch()
 
     assert all_megatron_checkpoints_exist(tmp_path, _names(coords, 2))
 
 
 def test_completeness_check_with_single_shard(tmp_path):
     (tmp_path / "adapter_megatron_tp0_pp0.pt").touch()
-    assert all_megatron_checkpoints_exist(tmp_path, _names([(0, 0, 0)], 1))
+    assert all_megatron_checkpoints_exist(tmp_path, _names([(0, 0, 0, 0)], 1))


### PR DESCRIPTION
Part of #2705.

## Problem

Single-LoRA checkpoints write one native adapter shard per global rank, so DP and CP replicas duplicate identical data. A writer-side save failure can also leave peer ranks entering later Bridge collectives.

## Reproduction on `main`

Both halves run on CPU with the gloo backend, so no GPU or vendor runtime is on the path.

4 gloo ranks at TP=PP=EP=ETP=1, DP=4 call `save_lora_checkpoint`:

```
4 native shard files, byte-identical adapter tensors, 75% of the bytes redundant
```

An 8-GPU run of `examples/lora/run-qwen3-4b-megatron-lora-result.sh` (no TP/PP, `--save-interval 50`) is DP=8, so it writes eight copies of one shard.

Saving at 4 ranks and resuming the same checkpoint at 8:

```
rank 0-3   load_lora_adapter -> True    adapter restored
rank 4-7   load_lora_adapter -> False   fresh random init
```

The shard name is keyed on the global rank, so half the DP replicas silently start from a different adapter. No crash, no error.

## Change

Write one native shard for each realized `(TP, PP, EP, ETP)` coordinate, retaining distinct EP shards and legacy load compatibility. Share native-save failures across ranks before PEFT export begins.

ETP is part of the shard identity because when `ETP > TP` two ranks share a TP rank while holding different expert slices. The `_etp` filename suffix is emitted only in that case: for `ETP <= TP` the ETP rank is a function of the TP rank, so every filename in use today is byte-identical.

## Validation

- 76 fast tests in `test_lora_utils.py` and `test_multi_lora_checkpoint_naming.py`, including shard naming and completeness under EP and ETP. Full `tests/fast/backends/megatron_utils` green apart from the two `TestUpdateWeightsZeroChunks` failures that reproduce on `main`.
- 4x MI350X: one `adapter_megatron_tp0_pp0.pt` shard with finite tensors
- EP4 full-model runs: four expert-distinct shards with replicated attention tensors

Fixes #2668

## Notes for reviewers

Land this first among the checkpoint PRs: it adds `lora_checkpoint.py`, and #2516 and #2580 each carry their own copy of the collective-failure helper it puts there. See #2705 for the ordering rationale.

