### PR TITLE
fix(docker): update torch_memory_saver for CUDA VMM granularity

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -163,7 +163,7 @@ RUN pip install "git+https://github.com/NVIDIA-NeMo/Emerging-Optimizers.git@v0.1
 
 # torch_memory_saver's source build needs TMS_CUDA_MAJOR; take it from torch.
 RUN TMS_CUDA_MAJOR=$(python3 -c "import torch; print(torch.version.cuda.split('.')[0])") \
-    pip install git+https://github.com/fzyzcjy/torch_memory_saver.git@74d68c5e4bedf2b6774f2c92ed0f81b7c8d91ed0 --no-cache-dir --force-reinstall
+    pip install git+https://github.com/fzyzcjy/torch_memory_saver.git@f05a8754daf68238d54e4cf31cb3ba866684bbaf --no-cache-dir --force-reinstall
 RUN pip install "nvidia-modelopt[torch]>=0.37.0" --no-build-isolation
 # radixark/Megatron-Bridge#24 (TE 2.17 grouped-linear contract), merged to @bridge.
 # Pinned by SHA, not branch: buildkit caches this layer on the instruction text, so a

--- a/docker/Dockerfile.rocm
+++ b/docker/Dockerfile.rocm
@@ -135,7 +135,7 @@ RUN cd /sgl-workspace/sglang && \
 
 RUN python -c "import sglang; import sgl_kernel; print('SGLang + sgl_kernel: OK')"
 
-RUN pip install git+https://github.com/fzyzcjy/torch_memory_saver.git@74d68c5e4bedf2b6774f2c92ed0f81b7c8d91ed0 --no-cache-dir --force-reinstall
+RUN pip install git+https://github.com/fzyzcjy/torch_memory_saver.git@f05a8754daf68238d54e4cf31cb3ba866684bbaf --no-cache-dir --force-reinstall
 
 # Fix the ROCm 7.2 ROCr VMM-pause leak.
 RUN if [ "$APPLY_ROCR_VMMFIX" = "1" ]; then \


### PR DESCRIPTION
## Summary

- update the `torch_memory_saver` pin in the CUDA and ROCm images to the merge commit of [fzyzcjy/torch_memory_saver#82](https://github.com/fzyzcjy/torch_memory_saver/pull/82)
- pick up the CUDA VMM allocation-granularity fix used by the GB200 OPD workflow
- this unblocks [radixark/miles#1726](https://github.com/radixark/miles/pull/1726)

## Testing

- `git diff --check`
- validated the upstream fix in the two-node GB200 OPD workflow
