### PR TITLE
feat(ci): acknowledge rerun-test commands

### DIFF
--- a/.github/workflows/comment-ci-command.yml
+++ b/.github/workflows/comment-ci-command.yml
@@ -67,6 +67,8 @@ jobs:
   # Actions-capability commands: /rerun-failed-ci and /rerun-test <test-file>.
   actions-command:
     needs: handle-command
+    outputs:
+      workflow_run_url: ${{ steps.run-command.outputs.workflow_run_url }}
     if: needs.handle-command.outputs.capability == 'actions'
     concurrency:
       group: comment-ci-actions-${{ github.event.issue.number }}
@@ -95,6 +97,7 @@ jobs:
           permission-pull-requests: read
 
       - name: Authorize and run the actions command
+        id: run-command
         env:
           CI_COMMAND_API_TOKEN: ${{ steps.actions-token.outputs.token }}
           CI_COMMAND_POLICY_PATH: .github/workflows/policies/comment-command-access.json
@@ -128,4 +131,35 @@ jobs:
         env:
           CI_COMMAND_API_TOKEN: ${{ steps.reaction-token.outputs.token }}
           CI_COMMAND_ACKNOWLEDGE: "true"
+        run: python3 .github/workflows/scripts/comment_ci_command.py
+
+  reply-command:
+    needs: actions-command
+    if: >-
+      needs.actions-command.result == 'success' &&
+      needs.actions-command.outputs.workflow_run_url != ''
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check out the trusted handler
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+          sparse-checkout: .github/workflows/scripts/comment_ci_command.py
+          sparse-checkout-cone-mode: false
+
+      - name: Mint the reply-scoped App token
+        id: reply-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
+        with:
+          client-id: ${{ vars.CI_COMMAND_APP_CLIENT_ID }}
+          private-key: ${{ secrets.CI_COMMAND_APP_PRIVATE_KEY }}
+          permission-issues: write
+
+      - name: Reply with the workflow run
+        env:
+          CI_COMMAND_API_TOKEN: ${{ steps.reply-token.outputs.token }}
+          CI_COMMAND_REPLY: "true"
+          CI_COMMAND_WORKFLOW_RUN_URL: ${{ needs.actions-command.outputs.workflow_run_url }}
         run: python3 .github/workflows/scripts/comment_ci_command.py

--- a/.github/workflows/comment-ci-command.yml
+++ b/.github/workflows/comment-ci-command.yml
@@ -16,6 +16,7 @@ jobs:
       github.event.comment.user.type == 'User'
     outputs:
       capability: ${{ steps.authorize.outputs.capability }}
+      success_reaction: ${{ steps.authorize.outputs.success_reaction }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -37,11 +38,13 @@ jobs:
           CI_COMMAND_PREFLIGHT: "true"
         run: python3 .github/workflows/scripts/comment_ci_command.py
 
-      - name: Reject an unknown capability
+      - name: Reject unknown routing outputs
         if: >-
-          steps.authorize.outputs.capability != 'none' &&
-          steps.authorize.outputs.capability != 'issues' &&
-          steps.authorize.outputs.capability != 'actions'
+          (steps.authorize.outputs.capability != 'none' &&
+           steps.authorize.outputs.capability != 'issues' &&
+           steps.authorize.outputs.capability != 'actions') ||
+          (steps.authorize.outputs.success_reaction != 'none' &&
+           steps.authorize.outputs.success_reaction != '+1')
         run: exit 1
 
       - name: Mint the issues-scoped App token
@@ -95,4 +98,34 @@ jobs:
         env:
           CI_COMMAND_API_TOKEN: ${{ steps.actions-token.outputs.token }}
           CI_COMMAND_POLICY_PATH: .github/workflows/policies/comment-command-access.json
+        run: python3 .github/workflows/scripts/comment_ci_command.py
+
+  acknowledge-command:
+    needs: [handle-command, actions-command]
+    if: >-
+      needs.actions-command.result == 'success' &&
+      needs.handle-command.outputs.success_reaction == '+1'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check out the trusted handler
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+          sparse-checkout: .github/workflows/scripts/comment_ci_command.py
+          sparse-checkout-cone-mode: false
+
+      - name: Mint the reaction-scoped App token
+        id: reaction-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
+        with:
+          client-id: ${{ vars.CI_COMMAND_APP_CLIENT_ID }}
+          private-key: ${{ secrets.CI_COMMAND_APP_PRIVATE_KEY }}
+          permission-issues: write
+
+      - name: Acknowledge the successful command
+        env:
+          CI_COMMAND_API_TOKEN: ${{ steps.reaction-token.outputs.token }}
+          CI_COMMAND_ACKNOWLEDGE: "true"
         run: python3 .github/workflows/scripts/comment_ci_command.py

--- a/.github/workflows/scripts/comment_ci_command.py
+++ b/.github/workflows/scripts/comment_ci_command.py
@@ -89,6 +89,7 @@ class CommandSpec(NamedTuple):
     allows_user_ids: bool
     audit_key: str
     audit_value: object
+    success_reaction: str
 
 
 class CommandContext(NamedTuple):
@@ -286,7 +287,7 @@ class GitHubAPI:
             raise CommentCommandError("GitHub API token is missing")
         self.token = token
 
-    def _request(self, path, *, method="GET", payload=None, expected_status=None, expect_json=True):
+    def _request(self, path, *, method="GET", payload=None, expected_statuses=None, expect_json=True):
         data = None
         if payload is not None:
             data = json.dumps(payload, separators=(",", ":")).encode("utf-8")
@@ -303,10 +304,9 @@ class GitHubAPI:
         )
         try:
             with urllib.request.urlopen(request, timeout=15) as response:
-                if expected_status is not None and response.status != expected_status:
-                    raise CommentCommandError(
-                        f"GitHub API returned HTTP {response.status}; expected {expected_status}"
-                    )
+                if expected_statuses is not None and response.status not in expected_statuses:
+                    expected = " or ".join(str(status) for status in expected_statuses)
+                    raise CommentCommandError(f"GitHub API returned HTTP {response.status}; expected {expected}")
                 body = response.read()
                 if not expect_json:
                     if body.strip():
@@ -401,7 +401,7 @@ class GitHubAPI:
         self._request(
             f"/repos/{REPOSITORY}/actions/runs/{run_id}/rerun-failed-jobs",
             method="POST",
-            expected_status=201,
+            expected_statuses=(201,),
             expect_json=False,
         )
 
@@ -411,9 +411,19 @@ class GitHubAPI:
             f"/repos/{REPOSITORY}/actions/workflows/{encoded_workflow}/dispatches",
             method="POST",
             payload={"ref": ref, "inputs": inputs},
-            expected_status=204,
+            expected_statuses=(204,),
             expect_json=False,
         )
+
+    def add_comment_reaction(self, comment_id, content):
+        result = self._request(
+            f"/repos/{REPOSITORY}/issues/comments/{comment_id}/reactions",
+            method="POST",
+            payload={"content": content},
+            expected_statuses=(200, 201),
+        )
+        if not isinstance(result, dict) or result.get("content") != content:
+            raise CommentCommandError("GitHub API did not confirm the comment reaction")
 
 
 def _validate_live_pull(pull, pull_number):
@@ -847,6 +857,7 @@ COMMAND_REGISTRY = {
         True,
         "label",
         _add_label_resource,
+        "none",
     ),
     ClearLabels: CommandSpec(
         "clear_labels",
@@ -858,6 +869,7 @@ COMMAND_REGISTRY = {
         False,
         "command",
         _clear_command_value,
+        "none",
     ),
     RerunFailedCI: CommandSpec(
         "rerun_failed_ci",
@@ -869,6 +881,7 @@ COMMAND_REGISTRY = {
         False,
         "command",
         _rerun_command_value,
+        "none",
     ),
     RunTestFile: CommandSpec(
         "run_test_file",
@@ -880,6 +893,7 @@ COMMAND_REGISTRY = {
         False,
         "test_file",
         _run_file_value,
+        "+1",
     ),
 }
 
@@ -933,15 +947,33 @@ def authorize_policy(event, policy, api):
     return pull_number, actor_id, request, spec
 
 
-def _write_capability(capability):
+def acknowledge_event(event, api):
+    pull_number, actor_id, _, request = parse_event(event)
+    spec = _command_spec(request)
+    if spec.success_reaction == "none":
+        raise CommentCommandError("command does not define a success reaction")
+    comment_id = _positive_int(event["comment"].get("id"), "comment ID")
+    api.add_comment_reaction(comment_id, spec.success_reaction)
+    return {
+        "actor_id": actor_id,
+        "decision": "ALLOW_SUCCESS_REACTION_CONFIRMED",
+        "pull_number": pull_number,
+        "reaction": spec.success_reaction,
+    }
+
+
+def _write_routing(capability, success_reaction):
     if capability not in {"none", "issues", "actions"}:
         raise CommentCommandError("command registry selected an unknown capability")
+    if success_reaction not in {"none", "+1"}:
+        raise CommentCommandError("command registry selected an unknown success reaction")
     output_path = os.environ.get("GITHUB_OUTPUT")
     if not output_path:
         return
     try:
         with Path(output_path).open("a", encoding="utf-8") as output:
             output.write(f"capability={capability}\n")
+            output.write(f"success_reaction={success_reaction}\n")
     except OSError as error:
         raise CommentCommandError(f"cannot write GITHUB_OUTPUT: {error}") from error
 
@@ -949,10 +981,13 @@ def _write_capability(capability):
 def main():
     try:
         event = load_json(os.environ["GITHUB_EVENT_PATH"])
-        if os.environ.get("CI_COMMAND_PREFLIGHT") == "true":
+        if os.environ.get("CI_COMMAND_ACKNOWLEDGE") == "true":
+            api = GitHubAPI(os.environ["CI_COMMAND_API_TOKEN"])
+            result = acknowledge_event(event, api)
+        elif os.environ.get("CI_COMMAND_PREFLIGHT") == "true":
             pull_number, actor_id, _, request = parse_event(event)
             if request is None:
-                _write_capability("none")
+                _write_routing("none", "none")
                 print(
                     json.dumps(
                         {
@@ -965,14 +1000,12 @@ def main():
                     )
                 )
                 return 0
-
-        policy = load_policy(os.environ["CI_COMMAND_POLICY_PATH"])
-        api = GitHubAPI(os.environ["CI_COMMAND_API_TOKEN"])
-        if os.environ.get("CI_COMMAND_PREFLIGHT") == "true":
+            policy = load_policy(os.environ["CI_COMMAND_POLICY_PATH"])
+            api = GitHubAPI(os.environ["CI_COMMAND_API_TOKEN"])
             pull_number, actor_id, request, spec = authorize_policy(event, policy, api)
             authorization = {"actor_id": actor_id, "pull_number": pull_number}
             authorization[spec.audit_key] = spec.audit_value(request)
-            _write_capability(spec.capability)
+            _write_routing(spec.capability, spec.success_reaction)
             print(
                 json.dumps(
                     authorization,
@@ -981,7 +1014,10 @@ def main():
                 )
             )
             return 0
-        result = process_event(event, policy, api)
+        else:
+            policy = load_policy(os.environ["CI_COMMAND_POLICY_PATH"])
+            api = GitHubAPI(os.environ["CI_COMMAND_API_TOKEN"])
+            result = process_event(event, policy, api)
     except CommentCommandError as error:
         print(f"::error::{error}")
         return 1

--- a/.github/workflows/scripts/comment_ci_command.py
+++ b/.github/workflows/scripts/comment_ci_command.py
@@ -55,6 +55,7 @@ PR_BODY_PINS = (
 )
 LABEL_PATTERN = re.compile(r"(?:run-ci-[A-Za-z0-9][A-Za-z0-9_.-]*|bypass-fastfail)")
 SHA_PATTERN = re.compile(r"[0-9a-f]{40}")
+WORKFLOW_RUN_URL_PATTERN = re.compile(rf"https://github\.com/{re.escape(REPOSITORY)}/actions/runs/[1-9][0-9]*")
 POLICY_PERMISSIONS = frozenset({"write", "admin"})
 POLICY_GROUPS = frozenset({"add_label_access", "repo_write_access"})
 
@@ -249,6 +250,12 @@ def _positive_int(value, name):
     return value
 
 
+def _validate_workflow_run_url(value):
+    if not isinstance(value, str) or WORKFLOW_RUN_URL_PATTERN.fullmatch(value) is None:
+        raise CommentCommandError("workflow run URL is invalid")
+    return value
+
+
 def parse_event(event):
     if not isinstance(event, dict) or event.get("action") != "created":
         raise CommentCommandError("event must be issue_comment.created")
@@ -407,13 +414,22 @@ class GitHubAPI:
 
     def create_workflow_dispatch(self, workflow_file, ref, inputs):
         encoded_workflow = urllib.parse.quote(workflow_file, safe="")
-        self._request(
+        result = self._request(
             f"/repos/{REPOSITORY}/actions/workflows/{encoded_workflow}/dispatches",
             method="POST",
-            payload={"ref": ref, "inputs": inputs},
-            expected_statuses=(204,),
-            expect_json=False,
+            payload={"ref": ref, "inputs": inputs, "return_run_details": True},
+            expected_statuses=(200,),
         )
+        if not isinstance(result, dict):
+            raise CommentCommandError("GitHub API returned invalid workflow dispatch details")
+        run_id = _positive_int(result.get("workflow_run_id"), "workflow run ID")
+        html_url = _validate_workflow_run_url(result.get("html_url"))
+        if (
+            result.get("run_url") != f"{API_ROOT}/repos/{REPOSITORY}/actions/runs/{run_id}"
+            or html_url != f"https://github.com/{REPOSITORY}/actions/runs/{run_id}"
+        ):
+            raise CommentCommandError("GitHub API returned mismatched workflow dispatch details")
+        return html_url
 
     def add_comment_reaction(self, comment_id, content):
         result = self._request(
@@ -424,6 +440,16 @@ class GitHubAPI:
         )
         if not isinstance(result, dict) or result.get("content") != content:
             raise CommentCommandError("GitHub API did not confirm the comment reaction")
+
+    def create_issue_comment(self, pull_number, body):
+        result = self._request(
+            f"/repos/{REPOSITORY}/issues/{pull_number}/comments",
+            method="POST",
+            payload={"body": body},
+            expected_statuses=(201,),
+        )
+        if not isinstance(result, dict) or result.get("body") != body:
+            raise CommentCommandError("GitHub API did not confirm the workflow reply")
 
 
 def _validate_live_pull(pull, pull_number):
@@ -812,13 +838,18 @@ def _handle_run_test_file(context, request):
         "test_file": request.test_file,
     }
     inputs.update(_pr_body_pins(context.body))
-    context.api.create_workflow_dispatch(RUN_FILE_WORKFLOW, RUN_FILE_WORKFLOW_REF, inputs)
+    workflow_run_url = context.api.create_workflow_dispatch(
+        RUN_FILE_WORKFLOW,
+        RUN_FILE_WORKFLOW_REF,
+        inputs,
+    )
     return {
         "actor_id": context.actor_id,
         "decision": "ALLOW_FILE_RUN_DISPATCHED",
         "head_sha": context.head_sha,
         "pull_number": context.pull_number,
         "test_file": request.test_file,
+        "workflow_run_url": workflow_run_url,
     }
 
 
@@ -962,6 +993,21 @@ def acknowledge_event(event, api):
     }
 
 
+def reply_event(event, api, workflow_run_url):
+    pull_number, actor_id, _, request = parse_event(event)
+    if type(request) is not RunTestFile:
+        raise CommentCommandError("command does not define a workflow reply")
+    workflow_run_url = _validate_workflow_run_url(workflow_run_url)
+    body = f"Started `/{RUN_FILE_COMMAND} {request.test_file}`.\n\n" f"[View workflow run]({workflow_run_url})"
+    api.create_issue_comment(pull_number, body)
+    return {
+        "actor_id": actor_id,
+        "decision": "ALLOW_WORKFLOW_REPLY_CONFIRMED",
+        "pull_number": pull_number,
+        "workflow_run_url": workflow_run_url,
+    }
+
+
 def _write_routing(capability, success_reaction):
     if capability not in {"none", "issues", "actions"}:
         raise CommentCommandError("command registry selected an unknown capability")
@@ -978,12 +1024,30 @@ def _write_routing(capability, success_reaction):
         raise CommentCommandError(f"cannot write GITHUB_OUTPUT: {error}") from error
 
 
+def _write_workflow_run_url(result):
+    workflow_run_url = result.get("workflow_run_url")
+    if workflow_run_url is None:
+        return
+    workflow_run_url = _validate_workflow_run_url(workflow_run_url)
+    output_path = os.environ.get("GITHUB_OUTPUT")
+    if not output_path:
+        return
+    try:
+        with Path(output_path).open("a", encoding="utf-8") as output:
+            output.write(f"workflow_run_url={workflow_run_url}\n")
+    except OSError as error:
+        raise CommentCommandError(f"cannot write GITHUB_OUTPUT: {error}") from error
+
+
 def main():
     try:
         event = load_json(os.environ["GITHUB_EVENT_PATH"])
         if os.environ.get("CI_COMMAND_ACKNOWLEDGE") == "true":
             api = GitHubAPI(os.environ["CI_COMMAND_API_TOKEN"])
             result = acknowledge_event(event, api)
+        elif os.environ.get("CI_COMMAND_REPLY") == "true":
+            api = GitHubAPI(os.environ["CI_COMMAND_API_TOKEN"])
+            result = reply_event(event, api, os.environ.get("CI_COMMAND_WORKFLOW_RUN_URL"))
         elif os.environ.get("CI_COMMAND_PREFLIGHT") == "true":
             pull_number, actor_id, _, request = parse_event(event)
             if request is None:
@@ -1018,6 +1082,7 @@ def main():
             policy = load_policy(os.environ["CI_COMMAND_POLICY_PATH"])
             api = GitHubAPI(os.environ["CI_COMMAND_API_TOKEN"])
             result = process_event(event, policy, api)
+            _write_workflow_run_url(result)
     except CommentCommandError as error:
         print(f"::error::{error}")
         return 1

--- a/docs/ci/01-label.md
+++ b/docs/ci/01-label.md
@@ -25,7 +25,7 @@ A test declares its labels: `register_cuda_ci(..., labels=["megatron"])`. The PR
 | `labels=["sglang"]` | PR has `run-ci-sglang` |
 | `labels=["fsdp", "lora"]` | PR has `run-ci-fsdp` or `run-ci-lora` |
 
-PR labels without the `run-ci-` prefix are ignored.
+Bare domain labels without the `run-ci-` prefix do not select domains. The workflow-only `nightly` and `bypass-fastfail` labels are handled separately as cadence and behavior inputs.
 
 CUDA and ROCm registrations must declare at least one domain label. GPU runners are scarce and expensive, so an always-on GPU test would defeat the purpose of selecting only the GPU coverage a PR requests.
 
@@ -33,11 +33,11 @@ CUDA and ROCm registrations must declare at least one domain label. GPU runners 
 
 Domain labels live in `tests/ci/labels.py` (`KNOWN_LABELS`); a `labels=[...]` value outside it is a hard error. Current set: `megatron`, `model-scripts`, `sglang`, `fsdp`, `short`, `long`, `ckpt`, `lora`, `eval`, `precision`, `ft-short`, `ft-long`, `weight-update`, `fully-async`, `replay`, `qwen35`, `mooncake`, `miles-plugin`, `amd`.
 
-To add one: add the entry to `KNOWN_LABELS`, then create the matching `run-ci-<key>` label on the PR. No workflow edit needed.
+To add one: add the entry to `KNOWN_LABELS`, then create the matching `run-ci-<key>` repository label in GitHub. No workflow edit is needed. To expose it through PR comments, also add that exact label to `commands.add_label.allowed_labels` in `.github/workflows/policies/comment-command-access.json`.
 
 ## Manage CI from PR comments
 
-The PR-comment entrypoint is a command gateway rather than a label handler. Each recognized comment becomes a typed request, and a code-defined static registry selects its fixed handler, policy key, and token capability. The JSON policy controls only access groups and per-command resource allowlists. The registry implements add-label, clear-labels, rerun-failed-ci, and run-test-file requests.
+The PR-comment entrypoint is a command gateway rather than a label handler. Each recognized comment becomes a typed request, and a code-defined static registry selects its fixed handler, policy key, and token capability. The JSON policy controls only access groups and per-command resource allowlists. The registry implements exact-label additions plus `/clear-labels`, `/rerun-failed-ci`, and `/rerun-test`.
 
 After the comment gateway is enabled, post `/<label>` as the entire comment on an open PR to append that exact label. The label must be a supported `run-ci-*` label or `bypass-fastfail` and must be listed in `.github/workflows/policies/comment-command-access.json`; for example, `/run-ci-short` appends only `run-ci-short`, while `/bypass-fastfail` appends only `bypass-fastfail`.
 
@@ -47,7 +47,7 @@ A label command permits leading and trailing whitespace only; it cannot include 
 
 The `add_label_access` group controls every command that adds a label. A caller belongs to this group when either their live legacy permission on `radixark/miles` appears in `repository_permissions` or their stable numeric GitHub user ID appears in `user_ids`.
 
-The initial policy accepts `write` and `admin` and starts with no explicit user IDs. Workflow owners can grant a contributor label-command access by adding only that numeric ID to the JSON policy, without granting repository write access. GitHub reports the `maintain` role as legacy `write`; custom roles follow their base repository access.
+The checked-in policy accepts `write` and `admin` and has no explicit user IDs. Workflow owners can grant a contributor label-command access by adding only that numeric ID to the JSON policy, without granting repository write access. GitHub reports the `maintain` role as legacy `write`; custom roles follow their base repository access.
 
 The `repo_write_access` group restricts `/clear-labels`, `/rerun-failed-ci`, and `/rerun-test <test-file>` to live `write` or `admin` permission. Only `add_label_access` can contain explicit `user_ids`; those IDs do not grant any non-label operation.
 
@@ -73,17 +73,17 @@ Started `/rerun-test tests/e2e/precision/test_hf_attention_cp_relayout.py`.
 [View workflow run](https://github.com/radixark/miles/actions/runs/<run-id>)
 ```
 
-The reaction acknowledges that the request was accepted, while the reply identifies the dispatched run. The final pass or failure remains in that `Rerun Test` Actions run; v1 does not update the reply with later status changes.
+The reaction acknowledges that the request was accepted, while the reply identifies the dispatched run. The reply is not updated as the run status changes; the final pass or failure remains in that `Rerun Test` Actions run.
 
 An explicit file request is the selection: domain labels and the nightly cadence gate do not apply, while a symlinked or `disabled` test, an unregistered path, a ROCm-only registration, or a file with more than one CPU/CUDA registration fails the resolve job instead of silently running nothing.
 
-The dispatched workflow and its reusable workflows come from the reviewed default-branch commit. A trusted resolver reads the separately checked-out PR snapshot without importing it and maps the requested registration to a fixed CPU/CUDA suite, runner, image, and timeout. The execution job then checks out that same exact SHA and uses the requested path as its command entrypoint: bounded `pytest` for CPU or bounded `python3` for CUDA. It does not depend on a runner implementation in the PR snapshot, so the command also works for PRs created before this command exists.
+The dispatched workflow and its reusable workflows come from the reviewed default-branch commit. A trusted resolver reads the separately checked-out PR snapshot without importing it and maps the requested registration to a fixed CPU/CUDA suite, runner, image, and timeout. The execution job then checks out that same exact SHA and uses the requested path as its command entrypoint: bounded `pytest` for CPU or bounded `python3` for CUDA. It does not depend on workflow or runner code from the PR snapshot.
 
-The trust boundary ends after the resolver produces that fixed plan. The execution job intentionally installs and runs PR-controlled dependencies, configuration, imports, and test code; it is not a sandbox for hostile PR code. The command supports only same-repository PRs and becomes available after `run-ci-file.yml` exists on the default branch. A later push does not change the already dispatched snapshot.
+The trust boundary ends after the resolver produces that fixed plan. The execution job intentionally installs and runs PR-controlled dependencies, configuration, imports, and test code; it is not a sandbox for hostile PR code. The command supports only same-repository PRs and requires the fixed `run-ci-file.yml` workflow on the default branch. A later push does not change the already dispatched snapshot.
 
 A file run honors the PR body's `ci-megatron-pr` and `ci-sglang-pr` pins; CUDA file runs also honor `ci-image-tag`, while CPU file runs use the hosted bare environment. The gateway validates and forwards these inputs, and a pin whose value fails validation rejects the command. Without a `ci-image-tag` pin a CUDA run uses the released `dev` image even when the PR built a `pr-<N>` image, so docker-changing PRs should pin the tag explicitly. The run writes no perf baseline (regular cadence), and its result is informational: it does not appear among the PR's required checks.
 
-The workflow is disabled by default. Workflow owners may set the repository variable `CI_COMMAND_APP_ENABLED=true` only after completing these steps:
+The command gateway remains off until workflow owners complete the following steps and set the repository variable `CI_COMMAND_APP_ENABLED=true`:
 
 1. Create a GitHub App, install it only on `radixark/miles`, and grant `Pull requests: read`, `Issues: write`, and `Actions: write`; do not grant `Contents: write`. Mutation tokens remain capability-specific: label commands request `Issues: write`, while rerun and file-run commands request `Actions: write`. After a successful `/rerun-test` dispatch, independent feedback jobs each request only `Issues: write` to add the 👍 reaction and workflow-link reply.
 2. Store the App client ID in the repository variable `CI_COMMAND_APP_CLIENT_ID` and its private key in the repository secret `CI_COMMAND_APP_PRIVATE_KEY`.
@@ -91,9 +91,9 @@ The workflow is disabled by default. Workflow owners may set the repository vari
 4. In the target repository, compare manually adding a test label with adding the same label through the App. Confirm that both trigger the expected CUDA, ROCm, and held-run approval consumers.
    Then run `/clear-labels`; confirm that it removes only the CI control labels and does not start another CUDA, ROCm, or held-run approval workflow.
    Then create a disposable failed run on the current PR head and confirm that `/rerun-failed-ci` reruns only its failed jobs and dependent jobs.
-   Finally, after `run-ci-file.yml` exists on the default branch, post `/rerun-test` with one registered CUDA test file and confirm the dispatched run uses that file as the command entrypoint from the recorded PR head SHA on its registered suite's runner, the original command receives a 👍 reaction only after dispatch succeeds, and a separate reply links that exact workflow run.
+   Finally, post `/rerun-test` with one registered CUDA test file and confirm the dispatched run uses that file as the command entrypoint from the recorded PR head SHA on its registered suite's runner, the original command receives a 👍 reaction only after dispatch succeeds, and a separate reply links that exact workflow run.
 
-The handler evaluates the caller against the checked-in access policy before minting the App token and again before label mutation begins. An explicit `add_label_access.user_ids` match uses the numeric comment-author identity bound to the event; otherwise the handler checks the caller's live repository permission.
+The handler evaluates the caller against the checked-in access policy before minting the App token and again in the capability-specific job before the command mutates GitHub state. An explicit `add_label_access.user_ids` match uses the numeric comment-author identity bound to the event; otherwise the handler checks the caller's live repository permission.
 Actions command comments for one PR are serialized in GitHub's queued concurrency mode. Up to GitHub's 100-pending limit, commands wait instead of replacing an older pending comment.
 Before each rerun request, the handler rechecks the permission, PR head, and latest run of that workflow. Each lookup is a point-in-time result, so a small race remains between the final check and the mutation request.
 
@@ -151,13 +151,15 @@ Each `test_*.py` under `tests/fast/` is auto-registered as a CPU test (backend C
 
 By default CI fails fast on two levels:
 
-- Cross-stage: GPU stages run only when `stage-a-cpu` succeeds — the `if` requires `needs.stage-a-cpu.result == 'success'`.
+- Cross-stage: CUDA GPU stages run only when `stage-a-cpu` succeeds — the `if` requires `needs.stage-a-cpu.result == 'success'`.
 - Within-stage: each suite stops at the first failure (`pytest -x` for CPU; `run_unittest_files` breaks on the first failing file for CUDA).
 
 The `bypass-fastfail` PR label turns both off so one run surfaces every failure:
 
-- Cross-stage: each GPU stage consumes the shared `bypass_fastfail` policy output, so GPU stages run even after `stage-a-cpu` fails.
+- Cross-stage: each CUDA GPU stage consumes the shared `bypass_fastfail` policy output, so CUDA GPU stages run even after `stage-a-cpu` fails.
 - Within-stage: `run_suite.py` derives continue-on-error from the same resolved policy (drops `pytest -x`; sets `continue_on_error=True` for CUDA). The stage still ends red — it changes coverage, not the verdict.
+
+The ROCm workflow has no CPU cross-stage gate, so `bypass-fastfail` changes only its within-stage behavior.
 
 A resolved nightly, weekly, or release cadence bypasses fast-fail on both levels so a broad run surfaces every failure rather than stopping at the first. For nightly this applies equally whether the cadence came from the PR `nightly` label or the explicitly mapped nightly cron; release comes from the called workflow's explicit override. Local `--nightly` applies the same nightly selection and within-stage behavior; cross-stage gating does not exist in a local invocation.
 
@@ -165,4 +167,4 @@ Like the scope labels, `bypass-fastfail` is a workflow-only input and is not in 
 
 ## Labels double as fork-PR CI approval
 
-GitHub holds a first-time contributor's fork-PR CI at "Approve and run" after every push. Any maintainer-applied or comment-gateway-authorized `run-ci*` label is already that human decision, so the `Approve Trusted CI` workflow (on `pull_request_target`) auto-approves the held runs while such a label is present. Removing the labels restores manual approval; the friction ends permanently once the contributor's first PR merges.
+GitHub holds a first-time contributor's fork-PR CI at "Approve and run" after every push. Any maintainer-applied or comment-gateway-authorized `run-ci*` label is already that human decision, so the `Approve Trusted CI` workflow (on `pull_request_target`) auto-approves those held runs while such a label is present. Removing the labels restores manual approval. This automation covers the first-time-contributor hold only; GitHub may separately hold a workflow it identifies as potentially malicious, and that hold requires approval through an authenticated web session.

--- a/docs/ci/01-label.md
+++ b/docs/ci/01-label.md
@@ -65,7 +65,15 @@ GitHub can omit `pull_requests` from fork workflow-run payloads. For a fork, the
 
 Post `/rerun-test <test-file>` as the entire comment to run one registered test file on the PR's current head, e.g. `/rerun-test tests/e2e/precision/test_hf_attention_cp_relayout.py`. Despite the name, this dispatches a fresh workflow and does not require the test to have run previously. The handler accepts only a repo-relative path under the registry scan roots (`tests/e2e`, `tests/fast`, `tests/fast-gpu`, `tests/ci`), then dispatches the fixed default-branch `.github/workflows/run-ci-file.yml` with the PR number, exact head SHA, and file path as inputs.
 
-After GitHub confirms the workflow dispatch, the App reacts to the original command with 👍. The reaction acknowledges that the request was accepted; the final pass or failure remains in the `Rerun Test` Actions run and is not posted back as a PR comment.
+After GitHub confirms the workflow dispatch, the App reacts to the original command with 👍 and posts a separate PR comment containing the exact Actions run link:
+
+```text
+Started `/rerun-test tests/e2e/precision/test_hf_attention_cp_relayout.py`.
+
+[View workflow run](https://github.com/radixark/miles/actions/runs/<run-id>)
+```
+
+The reaction acknowledges that the request was accepted, while the reply identifies the dispatched run. The final pass or failure remains in that `Rerun Test` Actions run; v1 does not update the reply with later status changes.
 
 An explicit file request is the selection: domain labels and the nightly cadence gate do not apply, while a symlinked or `disabled` test, an unregistered path, a ROCm-only registration, or a file with more than one CPU/CUDA registration fails the resolve job instead of silently running nothing.
 
@@ -77,13 +85,13 @@ A file run honors the PR body's `ci-megatron-pr` and `ci-sglang-pr` pins; CUDA f
 
 The workflow is disabled by default. Workflow owners may set the repository variable `CI_COMMAND_APP_ENABLED=true` only after completing these steps:
 
-1. Create a GitHub App, install it only on `radixark/miles`, and grant `Pull requests: read`, `Issues: write`, and `Actions: write`; do not grant `Contents: write`. Mutation tokens remain capability-specific: label commands request `Issues: write`, while rerun and file-run commands request `Actions: write`. After a successful `/rerun-test` dispatch, a separate token requests only `Issues: write` to add the 👍 reaction.
+1. Create a GitHub App, install it only on `radixark/miles`, and grant `Pull requests: read`, `Issues: write`, and `Actions: write`; do not grant `Contents: write`. Mutation tokens remain capability-specific: label commands request `Issues: write`, while rerun and file-run commands request `Actions: write`. After a successful `/rerun-test` dispatch, independent feedback jobs each request only `Issues: write` to add the 👍 reaction and workflow-link reply.
 2. Store the App client ID in the repository variable `CI_COMMAND_APP_CLIENT_ID` and its private key in the repository secret `CI_COMMAND_APP_PRIVATE_KEY`.
 3. Protect the final bytes under `.github/workflows/` that implement the command gateway—its workflows, handler, and policy: require code-owner review, enable stale-review dismissal or last-push approval, and explicitly accept administrators who can still bypass the rule as external trust roots.
 4. In the target repository, compare manually adding a test label with adding the same label through the App. Confirm that both trigger the expected CUDA, ROCm, and held-run approval consumers.
    Then run `/clear-labels`; confirm that it removes only the CI control labels and does not start another CUDA, ROCm, or held-run approval workflow.
    Then create a disposable failed run on the current PR head and confirm that `/rerun-failed-ci` reruns only its failed jobs and dependent jobs.
-   Finally, after `run-ci-file.yml` exists on the default branch, post `/rerun-test` with one registered CUDA test file and confirm the dispatched run uses that file as the command entrypoint from the recorded PR head SHA on its registered suite's runner and the original command receives a 👍 reaction only after dispatch succeeds.
+   Finally, after `run-ci-file.yml` exists on the default branch, post `/rerun-test` with one registered CUDA test file and confirm the dispatched run uses that file as the command entrypoint from the recorded PR head SHA on its registered suite's runner, the original command receives a 👍 reaction only after dispatch succeeds, and a separate reply links that exact workflow run.
 
 The handler evaluates the caller against the checked-in access policy before minting the App token and again before label mutation begins. An explicit `add_label_access.user_ids` match uses the numeric comment-author identity bound to the event; otherwise the handler checks the caller's live repository permission.
 Actions command comments for one PR are serialized in GitHub's queued concurrency mode. Up to GitHub's 100-pending limit, commands wait instead of replacing an older pending comment.
@@ -93,7 +101,9 @@ The comment handler runs only fixed, reviewed code from the default branch and n
 
 Initial authorization, PR, policy, or run-state errors fail before any mutation. A recheck error before a later rerun request stops that request, while any earlier accepted reruns remain applied.
 
-If the additive label `POST`, a label `DELETE`, a failed-job rerun `POST`, a workflow-dispatch `POST`, or the later reaction `POST` was sent but its response timed out, was malformed, or could not be confirmed, GitHub may already have applied the change. A reaction failure after dispatch does not cancel the file run. `/clear-labels` and `/rerun-failed-ci` can issue multiple requests and are not atomic: if a later request fails, earlier changes remain applied. The handler does not retry or roll back automatically; inspect the PR's current labels or Actions runs before deciding whether to retry.
+If the additive label `POST`, a label `DELETE`, a failed-job rerun `POST`, a workflow-dispatch `POST`, the later reaction `POST`, or the workflow-reply `POST` was sent but its response timed out, was malformed, or could not be confirmed, GitHub may already have applied the change. A feedback failure after dispatch does not cancel the file run.
+
+`/clear-labels` and `/rerun-failed-ci` can issue multiple requests and are not atomic: if a later request fails, earlier changes remain applied. The handler does not retry or roll back automatically; inspect the PR's current labels, comments, or Actions runs before deciding whether to retry. Manually rerunning a reply job after an ambiguous response can create a duplicate link comment.
 
 GitHub reruns failed jobs and their dependent jobs with the original run's `GITHUB_SHA`, `GITHUB_REF`, event payload, and triggering actor privileges. A rerun therefore does not inherit the commenter's or App token's privileges; consumers of the original event payload do not see labels changed afterward. GitHub permits reruns for up to 30 days after the original run and limits a workflow run to 50 attempts.
 

--- a/docs/ci/01-label.md
+++ b/docs/ci/01-label.md
@@ -65,6 +65,8 @@ GitHub can omit `pull_requests` from fork workflow-run payloads. For a fork, the
 
 Post `/rerun-test <test-file>` as the entire comment to run one registered test file on the PR's current head, e.g. `/rerun-test tests/e2e/precision/test_hf_attention_cp_relayout.py`. Despite the name, this dispatches a fresh workflow and does not require the test to have run previously. The handler accepts only a repo-relative path under the registry scan roots (`tests/e2e`, `tests/fast`, `tests/fast-gpu`, `tests/ci`), then dispatches the fixed default-branch `.github/workflows/run-ci-file.yml` with the PR number, exact head SHA, and file path as inputs.
 
+After GitHub confirms the workflow dispatch, the App reacts to the original command with 👍. The reaction acknowledges that the request was accepted; the final pass or failure remains in the `Rerun Test` Actions run and is not posted back as a PR comment.
+
 An explicit file request is the selection: domain labels and the nightly cadence gate do not apply, while a symlinked or `disabled` test, an unregistered path, a ROCm-only registration, or a file with more than one CPU/CUDA registration fails the resolve job instead of silently running nothing.
 
 The dispatched workflow and its reusable workflows come from the reviewed default-branch commit. A trusted resolver reads the separately checked-out PR snapshot without importing it and maps the requested registration to a fixed CPU/CUDA suite, runner, image, and timeout. The execution job then checks out that same exact SHA and uses the requested path as its command entrypoint: bounded `pytest` for CPU or bounded `python3` for CUDA. It does not depend on a runner implementation in the PR snapshot, so the command also works for PRs created before this command exists.
@@ -75,13 +77,13 @@ A file run honors the PR body's `ci-megatron-pr` and `ci-sglang-pr` pins; CUDA f
 
 The workflow is disabled by default. Workflow owners may set the repository variable `CI_COMMAND_APP_ENABLED=true` only after completing these steps:
 
-1. Create a GitHub App, install it only on `radixark/miles`, and grant `Pull requests: read`, `Issues: write`, and `Actions: write`; do not grant `Contents: write`. Each request mints only one capability-specific token: label commands request `Issues: write`, while rerun and file-run commands request `Actions: write`.
+1. Create a GitHub App, install it only on `radixark/miles`, and grant `Pull requests: read`, `Issues: write`, and `Actions: write`; do not grant `Contents: write`. Mutation tokens remain capability-specific: label commands request `Issues: write`, while rerun and file-run commands request `Actions: write`. After a successful `/rerun-test` dispatch, a separate token requests only `Issues: write` to add the 👍 reaction.
 2. Store the App client ID in the repository variable `CI_COMMAND_APP_CLIENT_ID` and its private key in the repository secret `CI_COMMAND_APP_PRIVATE_KEY`.
 3. Protect the final bytes under `.github/workflows/` that implement the command gateway—its workflows, handler, and policy: require code-owner review, enable stale-review dismissal or last-push approval, and explicitly accept administrators who can still bypass the rule as external trust roots.
 4. In the target repository, compare manually adding a test label with adding the same label through the App. Confirm that both trigger the expected CUDA, ROCm, and held-run approval consumers.
    Then run `/clear-labels`; confirm that it removes only the CI control labels and does not start another CUDA, ROCm, or held-run approval workflow.
    Then create a disposable failed run on the current PR head and confirm that `/rerun-failed-ci` reruns only its failed jobs and dependent jobs.
-   Finally, after `run-ci-file.yml` exists on the default branch, post `/rerun-test` with one registered CUDA test file and confirm the dispatched run uses that file as the command entrypoint from the recorded PR head SHA on its registered suite's runner.
+   Finally, after `run-ci-file.yml` exists on the default branch, post `/rerun-test` with one registered CUDA test file and confirm the dispatched run uses that file as the command entrypoint from the recorded PR head SHA on its registered suite's runner and the original command receives a 👍 reaction only after dispatch succeeds.
 
 The handler evaluates the caller against the checked-in access policy before minting the App token and again before label mutation begins. An explicit `add_label_access.user_ids` match uses the numeric comment-author identity bound to the event; otherwise the handler checks the caller's live repository permission.
 Actions command comments for one PR are serialized in GitHub's queued concurrency mode. Up to GitHub's 100-pending limit, commands wait instead of replacing an older pending comment.
@@ -91,7 +93,7 @@ The comment handler runs only fixed, reviewed code from the default branch and n
 
 Initial authorization, PR, policy, or run-state errors fail before any mutation. A recheck error before a later rerun request stops that request, while any earlier accepted reruns remain applied.
 
-If the additive label `POST`, a label `DELETE`, a failed-job rerun `POST`, or a workflow-dispatch `POST` was sent but its response timed out, was malformed, or could not be confirmed, GitHub may already have applied the change. `/clear-labels` and `/rerun-failed-ci` can issue multiple requests and are not atomic: if a later request fails, earlier changes remain applied. The handler does not retry or roll back automatically; inspect the PR's current labels or Actions runs before deciding whether to retry.
+If the additive label `POST`, a label `DELETE`, a failed-job rerun `POST`, a workflow-dispatch `POST`, or the later reaction `POST` was sent but its response timed out, was malformed, or could not be confirmed, GitHub may already have applied the change. A reaction failure after dispatch does not cancel the file run. `/clear-labels` and `/rerun-failed-ci` can issue multiple requests and are not atomic: if a later request fails, earlier changes remain applied. The handler does not retry or roll back automatically; inspect the PR's current labels or Actions runs before deciding whether to retry.
 
 GitHub reruns failed jobs and their dependent jobs with the original run's `GITHUB_SHA`, `GITHUB_REF`, event payload, and triggering actor privileges. A rerun therefore does not inherit the commenter's or App token's privileges; consumers of the original event payload do not see labels changed afterward. GitHub permits reruns for up to 30 days after the original run and limits a workflow run to 50 attempts.
 

--- a/tests/ci/test/test_comment_ci_command.py
+++ b/tests/ci/test/test_comment_ci_command.py
@@ -30,6 +30,10 @@ HEAD_REF = "feature/test"
 WRITE_PERMISSIONS = frozenset({"write", "admin"})
 RUN_FILE_BODY = "/rerun-test tests/e2e/precision/test_hf_attention_cp_relayout.py"
 RUN_FILE_PATH = "tests/e2e/precision/test_hf_attention_cp_relayout.py"
+WORKFLOW_RUN_ID = 987654321
+WORKFLOW_RUN_API_URL = f"https://api.github.com/repos/radixark/miles/actions/runs/{WORKFLOW_RUN_ID}"
+WORKFLOW_RUN_URL = f"https://github.com/radixark/miles/actions/runs/{WORKFLOW_RUN_ID}"
+WORKFLOW_REPLY = f"Started `{RUN_FILE_BODY}`.\n\n[View workflow run]({WORKFLOW_RUN_URL})"
 
 
 class FakeAPI:
@@ -50,6 +54,7 @@ class FakeAPI:
         self.list_pull_calls = []
         self.dispatch_calls = []
         self.reaction_calls = []
+        self.comment_calls = []
         self.head_pulls = [pull]
 
     def get_pull(self, pull_number):
@@ -90,10 +95,15 @@ class FakeAPI:
     def create_workflow_dispatch(self, workflow_file, ref, inputs):
         self.calls.append(("create_workflow_dispatch", workflow_file, ref, inputs))
         self.dispatch_calls.append((workflow_file, ref, inputs))
+        return WORKFLOW_RUN_URL
 
     def add_comment_reaction(self, comment_id, content):
         self.calls.append(("add_comment_reaction", comment_id, content))
         self.reaction_calls.append((comment_id, content))
+
+    def create_issue_comment(self, pull_number, body):
+        self.calls.append(("create_issue_comment", pull_number, body))
+        self.comment_calls.append((pull_number, body))
 
 
 def event(*, body="/run-ci-short", actor_id=ACTOR_ID):
@@ -1472,7 +1482,24 @@ def test_repository_writer_dispatches_a_file_run(permission):
         "head_sha": HEAD_SHA,
         "pull_number": 123,
         "test_file": RUN_FILE_PATH,
+        "workflow_run_url": WORKFLOW_RUN_URL,
     }
+
+
+def test_file_run_main_writes_the_confirmed_workflow_url(monkeypatch, tmp_path, capsys):
+    api = FakeAPI(pull())
+    output_path = tmp_path / "github-output"
+    monkeypatch.setattr(HANDLER, "load_json", lambda _path: event(body=RUN_FILE_BODY))
+    monkeypatch.setattr(HANDLER, "load_policy", lambda _path: policy())
+    monkeypatch.setattr(HANDLER, "GitHubAPI", lambda _token: api)
+    monkeypatch.setenv("GITHUB_EVENT_PATH", "event.json")
+    monkeypatch.setenv("CI_COMMAND_POLICY_PATH", "policy.json")
+    monkeypatch.setenv("CI_COMMAND_API_TOKEN", "actions-token")
+    monkeypatch.setenv("GITHUB_OUTPUT", str(output_path))
+
+    assert HANDLER.main() == 0
+    assert output_path.read_text() == f"workflow_run_url={WORKFLOW_RUN_URL}\n"
+    assert json.loads(capsys.readouterr().out)["workflow_run_url"] == WORKFLOW_RUN_URL
 
 
 def test_file_run_forwards_validated_pr_body_pins():
@@ -1533,11 +1560,11 @@ def test_add_label_access_user_id_cannot_dispatch_a_file_run():
     assert api.dispatch_calls == []
 
 
-def test_create_workflow_dispatch_uses_exact_endpoint_and_accepts_empty_204(monkeypatch):
+def test_create_workflow_dispatch_requests_and_returns_exact_run_details(monkeypatch):
     requests = []
 
     class Response:
-        status = 204
+        status = 200
 
         def __enter__(self):
             return self
@@ -1546,14 +1573,20 @@ def test_create_workflow_dispatch_uses_exact_endpoint_and_accepts_empty_204(monk
             return False
 
         def read(self):
-            return b""
+            return json.dumps(
+                {
+                    "workflow_run_id": WORKFLOW_RUN_ID,
+                    "run_url": WORKFLOW_RUN_API_URL,
+                    "html_url": WORKFLOW_RUN_URL,
+                }
+            ).encode("utf-8")
 
     def urlopen(request, *, timeout):
         requests.append((request, timeout))
         return Response()
 
     monkeypatch.setattr(HANDLER.urllib.request, "urlopen", urlopen)
-    HANDLER.GitHubAPI("secret-token").create_workflow_dispatch(
+    result = HANDLER.GitHubAPI("secret-token").create_workflow_dispatch(
         "run-ci-file.yml", "feature/test", {"test_file": "tests/e2e/test_a.py"}
     )
 
@@ -1565,13 +1598,15 @@ def test_create_workflow_dispatch_uses_exact_endpoint_and_accepts_empty_204(monk
     assert json.loads(request.data.decode("utf-8")) == {
         "ref": "feature/test",
         "inputs": {"test_file": "tests/e2e/test_a.py"},
+        "return_run_details": True,
     }
     assert timeout == 15
+    assert result == WORKFLOW_RUN_URL
 
 
 @pytest.mark.parametrize(
     ("status", "body", "message"),
-    [(200, b"", "expected 204"), (204, b"{}", "unexpected response body")],
+    [(204, b"", "expected 200"), (200, b"", "invalid JSON")],
 )
 def test_create_workflow_dispatch_rejects_unconfirmed_response(monkeypatch, status, body, message):
     attempts = 0
@@ -1598,6 +1633,115 @@ def test_create_workflow_dispatch_rejects_unconfirmed_response(monkeypatch, stat
     monkeypatch.setattr(HANDLER.urllib.request, "urlopen", urlopen)
     with pytest.raises(HANDLER.CommentCommandError, match=message):
         HANDLER.GitHubAPI("secret-token").create_workflow_dispatch("run-ci-file.yml", "feature/test", {})
+    assert attempts == 1
+
+
+@pytest.mark.parametrize(
+    ("details", "message"),
+    [
+        ({}, "workflow run ID must be a positive integer"),
+        (
+            {
+                "workflow_run_id": WORKFLOW_RUN_ID,
+                "run_url": "https://api.github.com/repos/radixark/miles/actions/runs/1",
+                "html_url": WORKFLOW_RUN_URL,
+            },
+            "mismatched workflow dispatch details",
+        ),
+        (
+            {
+                "workflow_run_id": WORKFLOW_RUN_ID,
+                "run_url": WORKFLOW_RUN_API_URL,
+                "html_url": "https://example.invalid/actions/runs/987654321",
+            },
+            "workflow run URL is invalid",
+        ),
+    ],
+)
+def test_create_workflow_dispatch_rejects_invalid_run_details(monkeypatch, details, message):
+    class Response:
+        status = 200
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def read(self):
+            return json.dumps(details).encode("utf-8")
+
+    monkeypatch.setattr(HANDLER.urllib.request, "urlopen", lambda _request, timeout: Response())
+    with pytest.raises(HANDLER.CommentCommandError, match=message):
+        HANDLER.GitHubAPI("secret-token").create_workflow_dispatch("run-ci-file.yml", "main", {})
+
+
+def test_create_issue_comment_uses_exact_endpoint_and_confirms_body(monkeypatch):
+    requests = []
+
+    class Response:
+        status = 201
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def read(self):
+            return json.dumps({"body": WORKFLOW_REPLY}).encode("utf-8")
+
+    def urlopen(request, *, timeout):
+        requests.append((request, timeout))
+        return Response()
+
+    monkeypatch.setattr(HANDLER.urllib.request, "urlopen", urlopen)
+    HANDLER.GitHubAPI("secret-token").create_issue_comment(123, WORKFLOW_REPLY)
+
+    request, timeout = requests[0]
+    assert request.full_url == "https://api.github.com/repos/radixark/miles/issues/123/comments"
+    assert request.method == "POST"
+    assert json.loads(request.data.decode("utf-8")) == {"body": WORKFLOW_REPLY}
+    assert timeout == 15
+
+
+@pytest.mark.parametrize(
+    ("status", "body", "message"),
+    [
+        (200, {"body": WORKFLOW_REPLY}, "expected 201"),
+        (201, {"body": "wrong"}, "did not confirm"),
+    ],
+)
+def test_create_issue_comment_rejects_unconfirmed_response_without_retry(
+    monkeypatch,
+    status,
+    body,
+    message,
+):
+    attempts = 0
+
+    class Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def read(self):
+            return json.dumps(body).encode("utf-8")
+
+    response = Response()
+    response.status = status
+
+    def urlopen(_request, *, timeout):
+        nonlocal attempts
+        attempts += 1
+        assert timeout == 15
+        return response
+
+    monkeypatch.setattr(HANDLER.urllib.request, "urlopen", urlopen)
+    with pytest.raises(HANDLER.CommentCommandError, match=message):
+        HANDLER.GitHubAPI("secret-token").create_issue_comment(123, WORKFLOW_REPLY)
     assert attempts == 1
 
 
@@ -1754,6 +1898,50 @@ def test_acknowledge_mode_rejects_a_command_without_a_success_reaction(monkeypat
     assert api.calls == []
 
 
+def test_reply_event_posts_the_exact_workflow_link_only_for_run_test_file():
+    api = FakeAPI(pull())
+
+    result = HANDLER.reply_event(event(body=RUN_FILE_BODY), api, WORKFLOW_RUN_URL)
+
+    assert api.comment_calls == [(123, WORKFLOW_REPLY)]
+    assert result == {
+        "actor_id": ACTOR_ID,
+        "decision": "ALLOW_WORKFLOW_REPLY_CONFIRMED",
+        "pull_number": 123,
+        "workflow_run_url": WORKFLOW_RUN_URL,
+    }
+
+
+@pytest.mark.parametrize(
+    ("body", "workflow_run_url", "message"),
+    [
+        ("/rerun-failed-ci", WORKFLOW_RUN_URL, "does not define a workflow reply"),
+        (RUN_FILE_BODY, "https://example.invalid/actions/runs/1", "workflow run URL is invalid"),
+    ],
+)
+def test_reply_event_fails_closed_before_posting(body, workflow_run_url, message):
+    api = FakeAPI(pull())
+
+    with pytest.raises(HANDLER.CommentCommandError, match=message):
+        HANDLER.reply_event(event(body=body), api, workflow_run_url)
+    assert api.comment_calls == []
+
+
+def test_reply_mode_posts_without_loading_policy(monkeypatch, capsys):
+    api = FakeAPI(pull())
+    monkeypatch.setattr(HANDLER, "load_json", lambda _path: event(body=RUN_FILE_BODY))
+    monkeypatch.setattr(HANDLER, "load_policy", lambda _path: pytest.fail("policy must not be loaded"))
+    monkeypatch.setattr(HANDLER, "GitHubAPI", lambda _token: api)
+    monkeypatch.setenv("GITHUB_EVENT_PATH", "event.json")
+    monkeypatch.setenv("CI_COMMAND_API_TOKEN", "reply-token")
+    monkeypatch.setenv("CI_COMMAND_REPLY", "true")
+    monkeypatch.setenv("CI_COMMAND_WORKFLOW_RUN_URL", WORKFLOW_RUN_URL)
+
+    assert HANDLER.main() == 0
+    assert api.calls == [("create_issue_comment", 123, WORKFLOW_REPLY)]
+    assert json.loads(capsys.readouterr().out)["workflow_run_url"] == WORKFLOW_RUN_URL
+
+
 def test_workflow_runs_only_trusted_code_with_minimal_permissions():
     workflow = WORKFLOW_PATH.read_text()
     assert "issue_comment:\n    types: [created]" in workflow
@@ -1763,7 +1951,7 @@ def test_workflow_runs_only_trusted_code_with_minimal_permissions():
     assert "ref: ${{ github.sha }}" in workflow
     assert "persist-credentials: false" in workflow
     assert "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683" in workflow
-    assert workflow.count("actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1") == 3
+    assert workflow.count("actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1") == 4
     assert "client-id: ${{ vars.CI_COMMAND_APP_CLIENT_ID }}" in workflow
     assert "private-key: ${{ secrets.CI_COMMAND_APP_PRIVATE_KEY }}" in workflow
     assert "permission-issues: write" in workflow
@@ -1773,6 +1961,7 @@ def test_workflow_runs_only_trusted_code_with_minimal_permissions():
     assert "CI_COMMAND_API_TOKEN: ${{ steps.issues-token.outputs.token }}" in workflow
     assert "CI_COMMAND_API_TOKEN: ${{ steps.actions-token.outputs.token }}" in workflow
     assert "CI_COMMAND_API_TOKEN: ${{ steps.reaction-token.outputs.token }}" in workflow
+    assert "CI_COMMAND_API_TOKEN: ${{ steps.reply-token.outputs.token }}" in workflow
     assert "CI_COMMAND_APP_TOKEN" not in workflow
     assert workflow.index("CI_COMMAND_PREFLIGHT") < workflow.index("actions/create-github-app-token@")
     assert "steps.authorize.outputs.capability != 'none'" in workflow
@@ -1786,7 +1975,8 @@ def test_workflow_runs_only_trusted_code_with_minimal_permissions():
     assert "cancel-in-progress: false" in workflow
     assert "queue: max" in workflow
     actions_job = workflow.split("  actions-command:", 1)[1].split("  acknowledge-command:", 1)[0]
-    acknowledge_job = workflow.split("  acknowledge-command:", 1)[1]
+    acknowledge_job = workflow.split("  acknowledge-command:", 1)[1].split("  reply-command:", 1)[0]
+    reply_job = workflow.split("  reply-command:", 1)[1]
     issues_token = workflow.split("- name: Mint the issues-scoped App token", 1)[1].split(
         "- name: Authorize and run the issues command", 1
     )[0]
@@ -1796,6 +1986,9 @@ def test_workflow_runs_only_trusted_code_with_minimal_permissions():
     reaction_token = workflow.split("- name: Mint the reaction-scoped App token", 1)[1].split(
         "- name: Acknowledge the successful command", 1
     )[0]
+    reply_token = workflow.split("- name: Mint the reply-scoped App token", 1)[1].split(
+        "- name: Reply with the workflow run", 1
+    )[0]
     assert "permission-issues: write" in issues_token
     assert "permission-actions: write" not in issues_token
     assert "permission-actions: write" in actions_token
@@ -1803,6 +1996,9 @@ def test_workflow_runs_only_trusted_code_with_minimal_permissions():
     assert "permission-issues: write" in reaction_token
     assert "permission-actions: write" not in reaction_token
     assert "permission-pull-requests: read" not in reaction_token
+    assert "permission-issues: write" in reply_token
+    assert "permission-actions: write" not in reply_token
+    assert "permission-pull-requests: read" not in reply_token
     assert workflow.index("Authorize and run the actions command") < workflow.index(
         "Acknowledge the successful command"
     )
@@ -1818,6 +2014,18 @@ def test_workflow_runs_only_trusted_code_with_minimal_permissions():
     assert "always()" not in acknowledge_job
     assert "permission-issues: write" in acknowledge_job
     assert 'CI_COMMAND_ACKNOWLEDGE: "true"' in acknowledge_job
+    assert "workflow_run_url: ${{ steps.run-command.outputs.workflow_run_url }}" in actions_job
+    assert "id: run-command" in actions_job
+    assert "CI_COMMAND_REPLY" not in actions_job
+    assert "needs: actions-command" in reply_job
+    assert (
+        "if: >-\n"
+        "      needs.actions-command.result == 'success' &&\n"
+        "      needs.actions-command.outputs.workflow_run_url != ''"
+    ) in reply_job
+    assert "always()" not in reply_job
+    assert 'CI_COMMAND_REPLY: "true"' in reply_job
+    assert "CI_COMMAND_WORKFLOW_RUN_URL: ${{ needs.actions-command.outputs.workflow_run_url }}" in reply_job
     assert "pull_request_target" not in workflow
     assert "github.event.pull_request.head" not in workflow
     assert "pip install" not in workflow

--- a/tests/ci/test/test_comment_ci_command.py
+++ b/tests/ci/test/test_comment_ci_command.py
@@ -49,6 +49,7 @@ class FakeAPI:
         self.rerun_calls = []
         self.list_pull_calls = []
         self.dispatch_calls = []
+        self.reaction_calls = []
         self.head_pulls = [pull]
 
     def get_pull(self, pull_number):
@@ -90,6 +91,10 @@ class FakeAPI:
         self.calls.append(("create_workflow_dispatch", workflow_file, ref, inputs))
         self.dispatch_calls.append((workflow_file, ref, inputs))
 
+    def add_comment_reaction(self, comment_id, content):
+        self.calls.append(("add_comment_reaction", comment_id, content))
+        self.reaction_calls.append((comment_id, content))
+
 
 def event(*, body="/run-ci-short", actor_id=ACTOR_ID):
     return {
@@ -97,6 +102,7 @@ def event(*, body="/run-ci-short", actor_id=ACTOR_ID):
         "repository": {"id": HANDLER.REPOSITORY_ID, "full_name": HANDLER.REPOSITORY},
         "issue": {"number": 123, "pull_request": {"url": "https://example.invalid/pulls/123"}},
         "comment": {
+            "id": 5678,
             "body": body,
             "user": {"id": actor_id, "login": "actor", "type": "User"},
         },
@@ -258,15 +264,20 @@ def test_command_parser_ignores_unrelated_comments(body):
 
 def test_static_registry_owns_policy_capability_and_handler_routing():
     expected = {
-        HANDLER.AddLabel: ("add_label", "issues", HANDLER._handle_add_label),
-        HANDLER.ClearLabels: ("clear_labels", "issues", HANDLER._handle_clear_labels),
-        HANDLER.RerunFailedCI: ("rerun_failed_ci", "actions", HANDLER._handle_rerun_failed_ci),
-        HANDLER.RunTestFile: ("run_test_file", "actions", HANDLER._handle_run_test_file),
+        HANDLER.AddLabel: ("add_label", "issues", HANDLER._handle_add_label, "none"),
+        HANDLER.ClearLabels: ("clear_labels", "issues", HANDLER._handle_clear_labels, "none"),
+        HANDLER.RerunFailedCI: ("rerun_failed_ci", "actions", HANDLER._handle_rerun_failed_ci, "none"),
+        HANDLER.RunTestFile: ("run_test_file", "actions", HANDLER._handle_run_test_file, "+1"),
     }
     assert set(HANDLER.COMMAND_REGISTRY) == set(expected)
-    for request_type, (policy_key, capability, handler) in expected.items():
+    for request_type, (policy_key, capability, handler, success_reaction) in expected.items():
         spec = HANDLER.COMMAND_REGISTRY[request_type]
-        assert (spec.policy_key, spec.capability, spec.handler) == (policy_key, capability, handler)
+        assert (spec.policy_key, spec.capability, spec.handler, spec.success_reaction) == (
+            policy_key,
+            capability,
+            handler,
+            success_reaction,
+        )
 
 
 def test_unknown_request_type_fails_closed():
@@ -1363,16 +1374,16 @@ def test_clear_rejects_a_final_response_with_a_new_ci_control_label():
 
 
 @pytest.mark.parametrize(
-    ("body", "capability"),
+    ("body", "capability", "success_reaction"),
     [
-        ("/run-ci-short", "issues"),
-        ("/bypass-fastfail", "issues"),
-        ("/clear-labels", "issues"),
-        ("/rerun-failed-ci", "actions"),
-        (RUN_FILE_BODY, "actions"),
+        ("/run-ci-short", "issues", "none"),
+        ("/bypass-fastfail", "issues", "none"),
+        ("/clear-labels", "issues", "none"),
+        ("/rerun-failed-ci", "actions", "none"),
+        (RUN_FILE_BODY, "actions", "+1"),
     ],
 )
-def test_preflight_writes_only_a_fixed_capability(monkeypatch, tmp_path, body, capability):
+def test_preflight_writes_only_fixed_routing(monkeypatch, tmp_path, body, capability, success_reaction):
     api = FakeAPI(pull())
     output_path = tmp_path / "github-output"
     monkeypatch.setattr(HANDLER, "load_json", lambda _path: event(body=body))
@@ -1385,7 +1396,7 @@ def test_preflight_writes_only_a_fixed_capability(monkeypatch, tmp_path, body, c
     monkeypatch.setenv("GITHUB_OUTPUT", str(output_path))
 
     assert HANDLER.main() == 0
-    assert output_path.read_text() == f"capability={capability}\n"
+    assert output_path.read_text() == (f"capability={capability}\nsuccess_reaction={success_reaction}\n")
     assert api.calls == [("get_permission", "actor")]
 
 
@@ -1395,6 +1406,28 @@ def test_preflight_rejects_an_unknown_registry_capability(monkeypatch, tmp_path)
     spec = HANDLER.COMMAND_REGISTRY[HANDLER.AddLabel]
     monkeypatch.setitem(HANDLER.COMMAND_REGISTRY, HANDLER.AddLabel, spec._replace(capability="unknown"))
     monkeypatch.setattr(HANDLER, "load_json", lambda _path: event())
+    monkeypatch.setattr(HANDLER, "load_policy", lambda _path: policy())
+    monkeypatch.setattr(HANDLER, "GitHubAPI", lambda _token: api)
+    monkeypatch.setenv("GITHUB_EVENT_PATH", "event.json")
+    monkeypatch.setenv("CI_COMMAND_POLICY_PATH", "policy.json")
+    monkeypatch.setenv("CI_COMMAND_API_TOKEN", "token")
+    monkeypatch.setenv("CI_COMMAND_PREFLIGHT", "true")
+    monkeypatch.setenv("GITHUB_OUTPUT", str(output_path))
+
+    assert HANDLER.main() == 1
+    assert not output_path.exists()
+
+
+def test_preflight_rejects_an_unknown_registry_success_reaction(monkeypatch, tmp_path):
+    api = FakeAPI(pull())
+    output_path = tmp_path / "github-output"
+    spec = HANDLER.COMMAND_REGISTRY[HANDLER.RunTestFile]
+    monkeypatch.setitem(
+        HANDLER.COMMAND_REGISTRY,
+        HANDLER.RunTestFile,
+        spec._replace(success_reaction="heart"),
+    )
+    monkeypatch.setattr(HANDLER, "load_json", lambda _path: event(body=RUN_FILE_BODY))
     monkeypatch.setattr(HANDLER, "load_policy", lambda _path: policy())
     monkeypatch.setattr(HANDLER, "GitHubAPI", lambda _token: api)
     monkeypatch.setenv("GITHUB_EVENT_PATH", "event.json")
@@ -1417,7 +1450,7 @@ def test_unrelated_comment_preflight_uses_no_policy_or_api(monkeypatch, tmp_path
     monkeypatch.setenv("GITHUB_OUTPUT", str(output_path))
 
     assert HANDLER.main() == 0
-    assert output_path.read_text() == "capability=none\n"
+    assert output_path.read_text() == "capability=none\nsuccess_reaction=none\n"
 
 
 @pytest.mark.parametrize("permission", ["write", "admin"])
@@ -1568,6 +1601,159 @@ def test_create_workflow_dispatch_rejects_unconfirmed_response(monkeypatch, stat
     assert attempts == 1
 
 
+@pytest.mark.parametrize("status", [200, 201])
+def test_add_comment_reaction_accepts_created_or_existing_reaction(monkeypatch, status):
+    requests = []
+
+    class Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def read(self):
+            return b'{"content":"+1"}'
+
+    response = Response()
+    response.status = status
+
+    def urlopen(request, *, timeout):
+        requests.append((request, timeout))
+        return response
+
+    monkeypatch.setattr(HANDLER.urllib.request, "urlopen", urlopen)
+    HANDLER.GitHubAPI("secret-token").add_comment_reaction(5678, "+1")
+
+    request, timeout = requests[0]
+    assert request.full_url == ("https://api.github.com/repos/radixark/miles/issues/comments/5678/reactions")
+    assert request.method == "POST"
+    assert json.loads(request.data.decode("utf-8")) == {"content": "+1"}
+    assert timeout == 15
+
+
+@pytest.mark.parametrize(
+    ("status", "body", "message"),
+    [
+        (202, b'{"content":"+1"}', "expected 200 or 201"),
+        (204, b"", "expected 200 or 201"),
+        (201, b'{"content":"heart"}', "did not confirm"),
+        (201, b"not-json", "invalid JSON"),
+    ],
+)
+def test_add_comment_reaction_rejects_unconfirmed_response_without_retry(monkeypatch, status, body, message):
+    attempts = 0
+
+    class Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def read(self):
+            return body
+
+    response = Response()
+    response.status = status
+
+    def urlopen(_request, *, timeout):
+        nonlocal attempts
+        attempts += 1
+        assert timeout == 15
+        return response
+
+    monkeypatch.setattr(HANDLER.urllib.request, "urlopen", urlopen)
+    with pytest.raises(HANDLER.CommentCommandError, match=message):
+        HANDLER.GitHubAPI("secret-token").add_comment_reaction(5678, "+1")
+    assert attempts == 1
+
+
+@pytest.mark.parametrize(
+    ("exception", "message"),
+    [
+        (urllib.error.HTTPError("url", 403, "forbidden", {}, None), "HTTP 403"),
+        (TimeoutError(), "timed out"),
+    ],
+)
+def test_comment_reaction_api_failure_is_not_retried(monkeypatch, exception, message):
+    attempts = []
+
+    def urlopen(_request, *, timeout):
+        attempts.append(timeout)
+        raise exception
+
+    monkeypatch.setattr(HANDLER.urllib.request, "urlopen", urlopen)
+    with pytest.raises(HANDLER.CommentCommandError, match=message):
+        HANDLER.GitHubAPI("secret-token").add_comment_reaction(5678, "+1")
+    assert attempts == [15]
+
+
+def test_acknowledge_event_reacts_only_for_run_test_file():
+    api = FakeAPI(pull())
+
+    result = HANDLER.acknowledge_event(event(body=RUN_FILE_BODY), api)
+
+    assert api.reaction_calls == [(5678, "+1")]
+    assert result == {
+        "actor_id": ACTOR_ID,
+        "decision": "ALLOW_SUCCESS_REACTION_CONFIRMED",
+        "pull_number": 123,
+        "reaction": "+1",
+    }
+
+
+def test_acknowledge_event_rejects_commands_without_a_success_reaction():
+    api = FakeAPI(pull())
+
+    with pytest.raises(HANDLER.CommentCommandError, match="does not define"):
+        HANDLER.acknowledge_event(event(body="/rerun-failed-ci"), api)
+    assert api.reaction_calls == []
+
+
+@pytest.mark.parametrize("comment_id", [None, 0, "5678"])
+def test_acknowledge_event_rejects_an_invalid_comment_id(comment_id):
+    api = FakeAPI(pull())
+    command_event = event(body=RUN_FILE_BODY)
+    command_event["comment"]["id"] = comment_id
+
+    with pytest.raises(HANDLER.CommentCommandError, match="comment ID must be a positive integer"):
+        HANDLER.acknowledge_event(command_event, api)
+    assert api.reaction_calls == []
+
+
+def test_acknowledge_mode_reacts_without_loading_policy(monkeypatch, capsys):
+    api = FakeAPI(pull())
+    monkeypatch.setattr(HANDLER, "load_json", lambda _path: event(body=RUN_FILE_BODY))
+    monkeypatch.setattr(HANDLER, "load_policy", lambda _path: pytest.fail("policy must not be loaded"))
+    monkeypatch.setattr(HANDLER, "GitHubAPI", lambda _token: api)
+    monkeypatch.setenv("GITHUB_EVENT_PATH", "event.json")
+    monkeypatch.setenv("CI_COMMAND_API_TOKEN", "reaction-token")
+    monkeypatch.setenv("CI_COMMAND_ACKNOWLEDGE", "true")
+
+    assert HANDLER.main() == 0
+    assert api.calls == [("add_comment_reaction", 5678, "+1")]
+    assert json.loads(capsys.readouterr().out) == {
+        "actor_id": ACTOR_ID,
+        "decision": "ALLOW_SUCCESS_REACTION_CONFIRMED",
+        "pull_number": 123,
+        "reaction": "+1",
+    }
+
+
+def test_acknowledge_mode_rejects_a_command_without_a_success_reaction(monkeypatch):
+    api = FakeAPI(pull())
+    monkeypatch.setattr(HANDLER, "load_json", lambda _path: event(body="/rerun-failed-ci"))
+    monkeypatch.setattr(HANDLER, "load_policy", lambda _path: pytest.fail("policy must not be loaded"))
+    monkeypatch.setattr(HANDLER, "GitHubAPI", lambda _token: api)
+    monkeypatch.setenv("GITHUB_EVENT_PATH", "event.json")
+    monkeypatch.setenv("CI_COMMAND_API_TOKEN", "reaction-token")
+    monkeypatch.setenv("CI_COMMAND_ACKNOWLEDGE", "true")
+
+    assert HANDLER.main() == 1
+    assert api.calls == []
+
+
 def test_workflow_runs_only_trusted_code_with_minimal_permissions():
     workflow = WORKFLOW_PATH.read_text()
     assert "issue_comment:\n    types: [created]" in workflow
@@ -1577,7 +1763,7 @@ def test_workflow_runs_only_trusted_code_with_minimal_permissions():
     assert "ref: ${{ github.sha }}" in workflow
     assert "persist-credentials: false" in workflow
     assert "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683" in workflow
-    assert workflow.count("actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1") == 2
+    assert workflow.count("actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1") == 3
     assert "client-id: ${{ vars.CI_COMMAND_APP_CLIENT_ID }}" in workflow
     assert "private-key: ${{ secrets.CI_COMMAND_APP_PRIVATE_KEY }}" in workflow
     assert "permission-issues: write" in workflow
@@ -1586,27 +1772,52 @@ def test_workflow_runs_only_trusted_code_with_minimal_permissions():
     assert "CI_COMMAND_API_TOKEN: ${{ github.token }}" in workflow
     assert "CI_COMMAND_API_TOKEN: ${{ steps.issues-token.outputs.token }}" in workflow
     assert "CI_COMMAND_API_TOKEN: ${{ steps.actions-token.outputs.token }}" in workflow
+    assert "CI_COMMAND_API_TOKEN: ${{ steps.reaction-token.outputs.token }}" in workflow
     assert "CI_COMMAND_APP_TOKEN" not in workflow
     assert workflow.index("CI_COMMAND_PREFLIGHT") < workflow.index("actions/create-github-app-token@")
     assert "steps.authorize.outputs.capability != 'none'" in workflow
     assert "steps.authorize.outputs.capability != 'issues'" in workflow
     assert "steps.authorize.outputs.capability != 'actions'" in workflow
     assert "capability: ${{ steps.authorize.outputs.capability }}" in workflow
+    assert "success_reaction: ${{ steps.authorize.outputs.success_reaction }}" in workflow
     assert "needs: handle-command" in workflow
     assert "if: needs.handle-command.outputs.capability == 'actions'" in workflow
     assert "group: comment-ci-actions-${{ github.event.issue.number }}" in workflow
     assert "cancel-in-progress: false" in workflow
     assert "queue: max" in workflow
+    actions_job = workflow.split("  actions-command:", 1)[1].split("  acknowledge-command:", 1)[0]
+    acknowledge_job = workflow.split("  acknowledge-command:", 1)[1]
     issues_token = workflow.split("- name: Mint the issues-scoped App token", 1)[1].split(
         "- name: Authorize and run the issues command", 1
     )[0]
     actions_token = workflow.split("- name: Mint the actions-scoped App token", 1)[1].split(
         "- name: Authorize and run the actions command", 1
     )[0]
+    reaction_token = workflow.split("- name: Mint the reaction-scoped App token", 1)[1].split(
+        "- name: Acknowledge the successful command", 1
+    )[0]
     assert "permission-issues: write" in issues_token
     assert "permission-actions: write" not in issues_token
     assert "permission-actions: write" in actions_token
     assert "permission-issues: write" not in actions_token
+    assert "permission-issues: write" in reaction_token
+    assert "permission-actions: write" not in reaction_token
+    assert "permission-pull-requests: read" not in reaction_token
+    assert workflow.index("Authorize and run the actions command") < workflow.index(
+        "Acknowledge the successful command"
+    )
+    assert "Mint the reaction-scoped App token" not in actions_job
+    assert "permission-issues: write" not in actions_job
+    assert "CI_COMMAND_ACKNOWLEDGE" not in actions_job
+    assert "needs: [handle-command, actions-command]" in acknowledge_job
+    assert (
+        "if: >-\n"
+        "      needs.actions-command.result == 'success' &&\n"
+        "      needs.handle-command.outputs.success_reaction == '+1'"
+    ) in acknowledge_job
+    assert "always()" not in acknowledge_job
+    assert "permission-issues: write" in acknowledge_job
+    assert 'CI_COMMAND_ACKNOWLEDGE: "true"' in acknowledge_job
     assert "pull_request_target" not in workflow
     assert "github.event.pull_request.head" not in workflow
     assert "pip install" not in workflow


### PR DESCRIPTION
## Summary

Acknowledge accepted `/rerun-test` commands and reply with the exact dispatched workflow run link.

## Motivation

Accepted targeted-test requests need a direct path from the PR conversation to their Actions run. The PR feedback must confirm acceptance and identify the exact run without requiring a search through the Actions list.

## Usage

Post `/rerun-test tests/e2e/precision/test_hf_attention_cp_relayout.py`. The original comment receives a `+1` reaction, and the App posts a separate `[View workflow run](https://github.com/radixark/miles/actions/runs/<run-id>)` reply. The reply is not updated with later status changes; the final result remains in that `Rerun Test` run.

## Design Notes

- **Mental model:** The trusted command registry marks only `RunTestFile` for feedback; the Actions-scoped job reauthorizes the caller, dispatches the fixed default-branch workflow with `return_run_details: true`, validates the returned same-repository run ID plus URLs, then exports only that exact `html_url`; independent Issues-only jobs preserve the existing `+1` acknowledgement plus post the link reply; label commands plus `/rerun-failed-ci` retain their existing routes.
- [SGLang at `f1b9a1f4`](https://github.com/sgl-project/sglang/blob/f1b9a1f42abfd26c36a8f740f383ec6da3752461/scripts/ci/utils/slash_command_handler.py#L1175-L1247) establishes the reaction plus workflow-link reply model. Miles adopts those two signals but deliberately omits SGLang's later running/pass/fail comment edits.
- GitHub's [workflow dispatch API](https://docs.github.com/en/rest/actions/workflows?apiVersion=2022-11-28#create-a-workflow-dispatch-event) returns the run ID and URLs when `return_run_details` is true. The reply job never polls or executes PR code.
- Feedback failures do not cancel or redispatch the accepted test run. An ambiguous reply response is not retried automatically; manually rerunning that job can create a duplicate link comment.

## Verification

- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest -p no:cacheprovider tests/ci/test/test_comment_ci_command.py tests/ci/test/test_file_run.py -q`: 227 passed, covering dispatch details, URL validation/output propagation, reply posting, preserved acknowledgement, and token/job isolation.
- `pre-commit run --files .github/workflows/comment-ci-command.yml .github/workflows/scripts/comment_ci_command.py docs/ci/01-label.md tests/ci/test/test_comment_ci_command.py`: all affected-file checks passed.
- Three independent read-only reviews found no P0, P1, or P2 issue.

## Review Focus

- `GitHubAPI.create_workflow_dispatch`: verify exact run-detail validation and no polling fallback.
- `acknowledge-command` / `reply-command`: verify both feedback paths depend on successful dispatch and hold only `Issues: write` App tokens.
