### PR TITLE
feat(openenv): report episode end reason

### DIFF
--- a/examples/experimental/openenv/openenv_agent_function.py
+++ b/examples/experimental/openenv/openenv_agent_function.py
@@ -259,13 +259,15 @@ async def multi_turn(
     ends when the policy stops emitting a command, says TASK_COMPLETE, or hits
     OPENENV_MAX_TURNS. Scoring is the standard ``evaluate`` action: the server
     runs the task's tests/test.sh and reports the verdict (see the module
-    docstring for the required server contract).
+    docstring for the required server contract). The returned agent metrics
+    label the stop as ``task_complete``, ``no_command``, ``max_turns``, or
+    ``length``.
     """
     action_cls = classes["action"]
     task_id = metadata.get("task_id") or metadata.get("task_name")
     max_turns = int(os.getenv("OPENENV_MAX_TURNS", "30"))
 
-    async def body(env: Any) -> tuple[float | None, int, list[float], list[float], float, float]:
+    async def body(env: Any) -> tuple[float | None, int, str, list[float], list[float], float, float]:
         # Per-turn wall-clock timings. gen_times[i] is turn i's policy generation
         # latency; tool_times[i] is turn i's env.step(exec) latency. reset_time and
         # eval_time bracket the one-off reset() and the final evaluate() env steps.
@@ -281,6 +283,7 @@ async def multi_turn(
             convo.append({"role": "user", "content": instruction})
 
         turns = 0
+        end_reason = "max_turns"
         while turns < max_turns:
             turns += 1
             t0 = time.monotonic()
@@ -302,10 +305,15 @@ async def multi_turn(
             convo.append(message.model_dump(exclude_none=True))
 
             if choice.finish_reason == "length":
+                end_reason = "length"
                 break
 
             command = _strip_fence(reply) if "```" in reply else reply.strip()
-            if not command or command.upper().startswith("TASK_COMPLETE"):
+            if not command:
+                end_reason = "no_command"
+                break
+            if command.upper().startswith("TASK_COMPLETE"):
+                end_reason = "task_complete"
                 break
 
             t0 = time.monotonic()
@@ -353,10 +361,10 @@ async def multi_turn(
         if post_episode is not None:
             await post_episode(env, action_cls)
 
-        return reward, turns, gen_times, tool_times, reset_time, eval_time
+        return reward, turns, end_reason, gen_times, tool_times, reset_time, eval_time
 
     result = await run_body(classes["env"], metadata, body)
-    reward, turns, gen_times, tool_times, reset_time, eval_time = result
+    reward, turns, end_reason, gen_times, tool_times, reset_time, eval_time = result
     total_gen_time = sum(gen_times)
     # non_generation_time = everything the rollout spent outside policy generation:
     # per-turn exec latency plus the one-off reset() and evaluate() env steps. Feeds
@@ -364,6 +372,7 @@ async def multi_turn(
     total_tool_time = sum(tool_times) + reset_time + eval_time
     return reward, {
         "turns": turns,
+        "end_reason": end_reason,
         "tool_calls": len(tool_times),
         "gen_times": gen_times,
         "tool_times": tool_times,

--- a/tests/fast/examples/experimental/openenv/test_openenv_agent_function.py
+++ b/tests/fast/examples/experimental/openenv/test_openenv_agent_function.py
@@ -67,6 +67,13 @@ class _FakeAction:
         self.command = command
 
 
+def _fake_completion(text, finish_reason="stop"):
+    msg = types.SimpleNamespace(
+        content=text, model_dump=lambda exclude_none=True: {"role": "assistant", "content": text}
+    )
+    return types.SimpleNamespace(choices=[types.SimpleNamespace(message=msg, finish_reason=finish_reason)])
+
+
 class _FakePolicy:
     """Turn 1: emit a bash command. Turn 2: TASK_COMPLETE."""
 
@@ -77,10 +84,15 @@ class _FakePolicy:
     async def _create(self, **kw):
         self.n += 1
         text = "```bash\necho hi\n```" if self.n == 1 else "TASK_COMPLETE"
-        msg = types.SimpleNamespace(
-            content=text, model_dump=lambda exclude_none=True: {"role": "assistant", "content": text}
-        )
-        return types.SimpleNamespace(choices=[types.SimpleNamespace(message=msg, finish_reason="stop")])
+        return _fake_completion(text)
+
+
+class _NoCommandPolicy(_FakePolicy):
+    """Emits only whitespace, so there is no command to execute."""
+
+    async def _create(self, **kw):
+        self.n += 1
+        return _fake_completion(" \n")
 
 
 _CLASSES = {"env": _FakeEnv, "action": _FakeAction}
@@ -111,7 +123,9 @@ def test_shared_leg_dispatch(monkeypatch):
     assert execs[0].command == "echo hi"
     assert any("/tmp/tbench2_env_runs" in (a.command or "") for a in execs), "trial-dir purge missing"
     assert any(a.action_type == "evaluate" for a in actions)
-    assert metrics["turns"] == 2 and metrics["tool_calls"] == 1
+    assert metrics["turns"] == 2
+    assert metrics["end_reason"] == "task_complete"
+    assert metrics["tool_calls"] == 1
 
 
 class _TruncatingPolicy(_FakePolicy):
@@ -138,9 +152,45 @@ def test_length_capped_turn_ends_the_episode(monkeypatch):
     )
 
     assert metrics["turns"] == 1
+    assert metrics["end_reason"] == "length"
     assert metrics["tool_calls"] == 0
     execs = [a for a in _FakeEnv.last_actions if a.action_type == "exec"]
     assert not [a for a in execs if "echo hi" in (a.command or "")], "ran a command the model never finished"
+
+
+def test_no_command_reports_end_reason(monkeypatch):
+    monkeypatch.setattr(oaf, "load_tbench2", lambda: _CLASSES)
+
+    async def spying_with_env(env_cls, env_url, body):
+        return await body(env_cls())
+
+    monkeypatch.setattr(oaf, "_with_env", spying_with_env)
+
+    _, metrics = run_async(
+        oaf.run_episode(_NoCommandPolicy(), "m", [{"role": "system", "content": "s"}], {}, {"task_id": "t1"})
+    )
+
+    assert metrics["turns"] == 1
+    assert metrics["end_reason"] == "no_command"
+    assert metrics["tool_calls"] == 0
+
+
+def test_max_turns_reports_end_reason(monkeypatch):
+    monkeypatch.setenv("OPENENV_MAX_TURNS", "1")
+    monkeypatch.setattr(oaf, "load_tbench2", lambda: _CLASSES)
+
+    async def spying_with_env(env_cls, env_url, body):
+        return await body(env_cls())
+
+    monkeypatch.setattr(oaf, "_with_env", spying_with_env)
+
+    policy = _FakePolicy()
+    _, metrics = run_async(oaf.run_episode(policy, "m", [{"role": "system", "content": "s"}], {}, {"task_id": "t1"}))
+
+    assert policy.n == 1
+    assert metrics["turns"] == 1
+    assert metrics["end_reason"] == "max_turns"
+    assert metrics["tool_calls"] == 1
 
 
 def test_old_server_reward_is_not_trusted(monkeypatch):
@@ -208,3 +258,4 @@ def test_truncated_turn_ends_the_episode(monkeypatch):
     assert all("/tmp/tbench2_env_runs" in (a.command or "") for a in execs), execs
     assert any(a.action_type == "evaluate" for a in actions), "scoring still runs"
     assert reward == 1.0 and metrics["turns"] == 1
+    assert metrics["end_reason"] == "length"


### PR DESCRIPTION
## Summary

  - report why each OpenEnv agent episode ended
  - distinguish `task_complete`, `no_command`, `max_turns`, and `length`
  - add offline test coverage for all four termination paths

  ## Testing

  - `python -m pytest --confcutdir=tests/fast/examples/experimental/openenv tests/fast/examples/experimental/openenv -q`
    - 106 passed, 3 skipped
  - Ruff, Black, isort, and autoflake checks passed

  Closes #2592

cc @nblintao @yueming-yuan 