### PR TITLE
fix: resume from the checkpoint step in bridge mode

### DIFF
--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -3042,7 +3042,7 @@ def miles_validate_args(args):
             or not os.path.exists(os.path.join(args.load, "latest_checkpointed_iteration.txt"))
         ):
             args.load = args.ref_load or args.hf_checkpoint
-        args.start_rollout_id = 0
+            args.start_rollout_id = 0
     else:
         if (
             args.load is None


### PR DESCRIPTION
## Summary
Bridge-mode resume restarted training from rollout 0 instead of continuing from the checkpoint step.

## Symptom & Reproduction
- **Symptom:** With `--megatron-to-hf-mode bridge`, a run relaunched with `--load` on a saved checkpoint restarts at rollout 0 even though weights and optimizer state are restored.
- **Reproduction:** Save a bridge-mode checkpoint at rollout N and relaunch with the same `--load`: expected continuation from rollout N+1, observed restart from rollout 0.

## Root Cause
1. `miles_validate_args` set `args.start_rollout_id = 0` unconditionally in the bridge branch, even with a valid checkpoint under `--load`.
2. `create_training_models` adopts the actor's `loaded_rollout_id + 1` only while `args.start_rollout_id` is `None`, so the loaded step was discarded.

## Fix
Move `args.start_rollout_id = 0` into the fresh-run fallback (no `latest_checkpointed_iteration.txt` under `--load`), mirroring the non-bridge branch. Resume now leaves it `None`, so `create_training_models` adopts the checkpoint iteration. Fresh bridge runs still get the explicit `0`, which is required because `_load_checkpoint_hf` reports iteration `0` and the actor would otherwise return `0 + 1`.

## Verification
- `python -c "import ast; ast.parse(open('miles/utils/arguments.py').read())"`: passes; the change moves one assignment into the existing fallback block.
- `tests/fast/utils/test_arguments.py`: fails to import in this environment (`ModuleNotFoundError: No module named 'sglang'`); PR CI executes this suite.

## Review Focus
- `miles/utils/arguments.py`: bridge resume intentionally skips the non-bridge fallback's `no_load_optim` / `finetune` flags — a valid checkpoint is expected to load optimizer state.
