### PR TITLE
fix: convert base weights with the bridge on the disaggregated path

### DIFF
--- a/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/mixin.py
+++ b/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/mixin.py
@@ -95,6 +95,75 @@ class DistBucketedWeightUpdateMixin:
                 is_lora=True,
             )
 
+    @property
+    def _convert_base_via_bridge(self) -> bool:
+        """Whether base weights must be converted by the bridge rather than megatron_to_hf/.
+
+        In bridge mode the model is built by AutoBridge, so its parameter names
+        are the bridge's and not the ones ``--spec`` would have produced --
+        ``args.spec`` is ignored on that path. The hand-written converters only
+        know the ``--spec`` names, so they raise "Unknown parameter name" on
+        architectures where the two disagree (Qwen3.5/3.6/3.8 GDN, Qwen3-VL).
+
+        A property rather than state set in __init__, so it holds for all three
+        transports; p2p does not call _init_lora.
+        """
+        return self.args.megatron_to_hf_mode == "bridge"
+
+    def _base_hf_weight_iterator(self) -> HfWeightIteratorBase:
+        """The base-weight bridge iterator, created on first use.
+
+        Built lazily for the same reason: the transports construct themselves
+        differently, and LoRA runs already build their own adapter iterator in
+        _init_lora, which this must not replace.
+        """
+        iterator = getattr(self, "_hf_weight_iterator", None)
+        if iterator is None:
+            iterator = HfWeightIteratorBase.create(
+                args=self.args,
+                model=self.model,
+                model_name=self.model_name,
+                quantization_config=self.quantization_config,
+                is_lora=False,
+            )
+            self._hf_weight_iterator = iterator
+        return iterator
+
+    def _update_base_weights_via_bridge(
+        self,
+        update_bucket_weight_func: Callable[[list[tuple[str, torch.Tensor]], tqdm | None], None],
+        pbar: tqdm | None = None,
+    ) -> None:
+        """Convert and push base weights using megatron.bridge's mapping table.
+
+        Used whenever the model was built by the bridge, because only the bridge
+        knows that model's parameter names. It also owns conversions that are
+        more than a rename -- Qwen3.5 alone needs a fused ``in_proj`` split four
+        ways, a zero-centered RMSNorm offset, and a TP-aware conv1d shard
+        interleave -- so reimplementing them in megatron_to_hf/ would be
+        duplicating logic that already exists here.
+
+        This replaces both the non-expert and expert passes: the bridge exports
+        routed experts as part of the same walk, and applies its own TP/EP
+        sharding rather than consuming pre-gathered tensors.
+
+        Rank handling follows _update_lora_weights: every rank has to iterate
+        the bridge because it runs collectives internally, but only the source
+        rank transmits.
+        """
+        produced_any = False
+        for hf_named_tensors in self._base_hf_weight_iterator().get_hf_weight_chunks({}, weight_type="base"):
+            produced_any = True
+            if self._is_source:
+                update_bucket_weight_func(hf_named_tensors, pbar)
+
+        if not produced_any:
+            raise RuntimeError(
+                "Base weight sync produced zero chunks from the bridge, so no weights "
+                "reached the rollout engines. This usually means the Megatron-Bridge "
+                "version does not support this architecture."
+            )
+
     def _gather_and_update_non_expert_weights(
         self,
         update_bucket_weight_func: Callable[[list[tuple[str, torch.Tensor]], tqdm | None], None],
@@ -371,10 +440,15 @@ class DistBucketedWeightUpdateMixin:
             if not is_lora:
                 pbar = tqdm(desc=f"[{self._group_name}] Update weights", total=0) if self._is_source else None
 
-                self._gather_and_update_non_expert_weights(self._update_weight_implementation, pbar)
-                dist.barrier(group=get_gloo_group())
-                self._gather_and_update_expert_weights(self._update_weight_implementation, pbar)
-                dist.barrier(group=get_gloo_group())
+                if self._convert_base_via_bridge:
+                    # One pass: the bridge exports non-expert and expert params together.
+                    self._update_base_weights_via_bridge(self._update_weight_implementation, pbar)
+                    dist.barrier(group=get_gloo_group())
+                else:
+                    self._gather_and_update_non_expert_weights(self._update_weight_implementation, pbar)
+                    dist.barrier(group=get_gloo_group())
+                    self._gather_and_update_expert_weights(self._update_weight_implementation, pbar)
+                    dist.barrier(group=get_gloo_group())
 
             # Adapter weights: every iteration.
             if is_lora:

--- a/tests/fast/backends/megatron_utils/test_update_weight_bridge_base_sync.py
+++ b/tests/fast/backends/megatron_utils/test_update_weight_bridge_base_sync.py
@@ -1,0 +1,139 @@
+"""Base weight sync on the disaggregated path must follow --megatron-to-hf-mode.
+
+In bridge mode the model is built by AutoBridge, so its parameter names are the
+bridge's; the hand-written converters in megatron_to_hf/ only know the names
+``--spec`` would have produced. Converting bridge-built weights with them raises
+"Unknown parameter name" on architectures where the two disagree (Qwen3.5 GDN,
+Qwen3-VL), so bridge mode has to convert base weights with the bridge too.
+"""
+
+from argparse import Namespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+
+from miles.backends.megatron_utils.update_weight.update_weight_from_distributed.mixin import (
+    DistBucketedWeightUpdateMixin,
+)
+
+_MIXIN_MODULE = "miles.backends.megatron_utils.update_weight.update_weight_from_distributed.mixin"
+
+
+class _Harness(DistBucketedWeightUpdateMixin):
+    """Minimal stand-in for the transports, which build themselves differently."""
+
+    def __init__(self, megatron_to_hf_mode, *, is_source=True, chunks=None):
+        self.args = Namespace(
+            megatron_to_hf_mode=megatron_to_hf_mode,
+            update_weight_buffer_size=1 << 30,
+            pipeline_model_parallel_size=1,
+        )
+        self.model = [MagicMock()]
+        self.model_name = "qwen3_5"
+        self.quantization_config = None
+        self.weight_version = 0
+        self.is_lora = False
+        self.multi_lora_adapters = None
+        self._group_name = "test"
+        self.__is_source = is_source
+        self.transmitted: list[list[tuple[str, torch.Tensor]]] = []
+
+        if chunks is not None:
+            iterator = MagicMock()
+            iterator.get_hf_weight_chunks.return_value = iter(chunks)
+            self._hf_weight_iterator = iterator
+
+    @property
+    def _is_source(self):
+        return self.__is_source
+
+    def _update_weight_implementation(self, named_tensors, pbar=None):
+        self.transmitted.append(named_tensors)
+
+
+_CHUNKS = [
+    [("model.layers.0.linear_attn.in_proj_qkv.weight", torch.zeros(2, 2))],
+    [("model.layers.0.linear_attn.out_proj.weight", torch.zeros(2, 2))],
+]
+
+
+class TestConversionRouting:
+    def test_bridge_mode_converts_base_via_bridge(self):
+        assert _Harness("bridge")._convert_base_via_bridge is True
+
+    def test_raw_mode_keeps_hand_written_converters(self):
+        assert _Harness("raw")._convert_base_via_bridge is False
+
+    def test_bridge_mode_skips_the_raw_gather_paths(self):
+        """The bug: bridge-built weights were fed to the megatron_to_hf/ converters."""
+        harness = _Harness("bridge", chunks=list(_CHUNKS))
+
+        with (
+            patch.object(harness, "_gather_and_update_non_expert_weights") as gather_non_expert,
+            patch.object(harness, "_gather_and_update_expert_weights") as gather_expert,
+            patch.object(harness, "_pause_and_prepare_engines"),
+            patch.object(harness, "_finalize_and_resume_engines"),
+            patch(f"{_MIXIN_MODULE}.dist.barrier"),
+            patch(f"{_MIXIN_MODULE}.get_gloo_group"),
+        ):
+            harness.update_weights()
+
+        gather_non_expert.assert_not_called()
+        gather_expert.assert_not_called()
+        assert harness.transmitted == _CHUNKS
+
+    def test_raw_mode_still_uses_the_gather_paths(self):
+        harness = _Harness("raw")
+
+        with (
+            patch.object(harness, "_gather_and_update_non_expert_weights") as gather_non_expert,
+            patch.object(harness, "_gather_and_update_expert_weights") as gather_expert,
+            patch.object(harness, "_update_base_weights_via_bridge") as via_bridge,
+            patch.object(harness, "_pause_and_prepare_engines"),
+            patch.object(harness, "_finalize_and_resume_engines"),
+            patch(f"{_MIXIN_MODULE}.dist.barrier"),
+            patch(f"{_MIXIN_MODULE}.get_gloo_group"),
+        ):
+            harness.update_weights()
+
+        via_bridge.assert_not_called()
+        gather_non_expert.assert_called_once()
+        gather_expert.assert_called_once()
+
+
+class TestBridgeBaseSync:
+    def test_non_source_ranks_iterate_but_do_not_transmit(self):
+        """The bridge runs collectives internally, so every rank has to iterate it."""
+        harness = _Harness("bridge", is_source=False, chunks=list(_CHUNKS))
+
+        harness._update_base_weights_via_bridge(harness._update_weight_implementation)
+
+        harness._hf_weight_iterator.get_hf_weight_chunks.assert_called_once_with({}, weight_type="base")
+        assert harness.transmitted == []
+
+    def test_empty_export_is_an_error_not_a_silent_no_op(self):
+        harness = _Harness("bridge", chunks=[])
+
+        with pytest.raises(RuntimeError, match="zero chunks"):
+            harness._update_base_weights_via_bridge(harness._update_weight_implementation)
+
+    def test_base_iterator_is_created_once_and_reused(self):
+        harness = _Harness("bridge")
+        sentinel = object()
+
+        with patch(f"{_MIXIN_MODULE}.HfWeightIteratorBase.create", return_value=sentinel) as create:
+            assert harness._base_hf_weight_iterator() is sentinel
+            assert harness._base_hf_weight_iterator() is sentinel
+
+        create.assert_called_once()
+        assert create.call_args.kwargs["is_lora"] is False
+
+    def test_an_existing_lora_iterator_is_not_replaced(self):
+        harness = _Harness("bridge", chunks=list(_CHUNKS))
+        existing = harness._hf_weight_iterator
+
+        with patch(f"{_MIXIN_MODULE}.HfWeightIteratorBase.create") as create:
+            assert harness._base_hf_weight_iterator() is existing
+
+        create.assert_not_called()


### PR DESCRIPTION
Fixes #2679. Also fixes #634, which has the same root cause.

## The problem

In bridge mode the model is built by `AutoBridge`, so its parameter names are the bridge's and not the ones `--spec` would have produced: `model_provider` only reads `args.spec` on the non-bridge branch, so the plugin is silently ignored.

`update_weight_from_distributed` nevertheless converted base weights with the hand-written converters in `megatron_to_hf/`, which only know the `--spec` names. Weight sync therefore dies with `ValueError: Unknown parameter name` on every architecture where the two disagree — Qwen3.5/3.6/3.8 (gated delta net) and Qwen3-VL — on the first sync, after the model has loaded and rollouts have been generated.

Renaming inside the converters would not have been enough. Some of these conversions are more than a rename, and the bridge already implements them: Qwen3.5 alone needs the fused `in_proj` split four ways, a zero-centered RMSNorm offset, and a TP-aware conv1d shard interleave.

## The change

Base weights now go through `HfWeightIteratorBase.create()`, which is what the colocated path in `update_weight_from_tensor` has always done. The two paths now agree on who owns the conversion, and bridge-built models are converted by the bridge that built them.

Because the bridge exports routed experts in the same walk and applies its own TP/EP sharding, it replaces the non-expert and expert gather passes rather than feeding them. Every rank iterates the bridge, since it runs collectives internally, and only the source rank transmits — the same rank handling `_update_lora_weights` already uses.

Scope: only runs passing `--megatron-to-hf-mode bridge` change behavior; `raw` stays on the existing converters. Since `raw` cannot build a model from an HF checkpoint at all (it asserts `--load`), bridge mode is what HF-checkpoint users are already on.

## Verification

2 nodes x 8 MI355X, Qwen3.8-27B, fully-async with TITO. Weight sync used to raise immediately; it now completes in 26.5s cold and ~2s in steady state, and the run trains through to completion.

The synced weights are correct, not merely accepted — the trainer's recomputed logprobs agree with the rollout engine's:

| metric | value |
| --- | --- |
| `train_rollout_logprob_abs_diff` | 0.0077 |
| `train_rollout_kl` | 0.00029 |
| `ess_ratio` | 1.000 |
| `ppo_kl` | 7.6e-09 |

No regression on a standard architecture. Qwen3-4B in bridge mode, new path vs. four runs of the previous behavior:

| | previous | this PR |
| --- | --- | --- |
| `logprob_abs_diff` (step 0) | 0.01113 - 0.01136 | 0.01139 |
| `rollout_kl` (step 0) | 0.000799 - 0.000848 | 0.000821 |
| `ess_ratio` | 1.000 | 1.000 |

Added `tests/fast/backends/megatron_utils/test_update_weight_bridge_base_sync.py` (8 tests) covering the routing decision in both modes, that bridge mode no longer reaches the raw gather paths, non-source ranks iterating without transmitting, and iterator reuse.

`tests/fast/backends/megatron_utils/` is 267 passed / 2 failed; both failures (`TestUpdateWeightsZeroChunks`) reproduce on unmodified `main` when the directory runs as a whole and pass when the file runs alone, so they are a pre-existing isolation issue in that suite and unrelated to this change.

## Note for reviewers

Two things surfaced next to this that are outside the scope of this PR, in case they are worth their own issues:

1. `args.spec` being accepted and silently ignored in bridge mode is what makes this class of bug quiet. Warning or erroring when both are passed would surface it at startup rather than at the first weight sync.
2. Megatron's GDN raises `NotImplementedError: GDN does not support packed sequence for now.`, so linear-attention models need `--qkv-format bshd` and cannot use `--use-dynamic-batch-size` — the same trade-off gpt-oss documents for sink attention. Worth documenting on the Qwen3.5/3.8 pages.

Made with [Cursor](https://cursor.com)