### PR TITLE
[CI] Report the replay mismatch fraction as a ci metric

### DIFF
--- a/miles/backends/fsdp_utils/actor.py
+++ b/miles/backends/fsdp_utils/actor.py
@@ -541,6 +541,11 @@ class FSDPTrainRayActor(TrainRayActor):
                 self.optimizer.step()
                 self.lr_scheduler.step()
 
+                r3_mismatch_fraction = None
+                if (stats := routing_replay.pop_and_reduce_check_stats(get_gloo_group())) is not None:
+                    mismatched, checked = stats
+                    r3_mismatch_fraction = mismatched / checked if checked else 0.0
+
                 if self.args.ci_test:
                     check_grad_norm(
                         args=self.args,
@@ -566,6 +571,7 @@ class FSDPTrainRayActor(TrainRayActor):
                     num_steps_per_rollout=num_steps_per_rollout,
                     role="actor",
                     extra_metrics=extra_metrics,
+                    r3_mismatch_fraction=r3_mismatch_fraction,
                 )
 
         routing_replay.reset()

--- a/miles/backends/fsdp_utils/adaptations/routing_replay.py
+++ b/miles/backends/fsdp_utils/adaptations/routing_replay.py
@@ -17,10 +17,11 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 from typing import Any
 
+import torch.distributed as dist
 import torch.nn as nn
 
 from miles.backends.training_utils.replay_data import fill_replay_data, register_replay_list_sequential
-from miles.utils.replay_base import routing_replay_manager
+from miles.utils.replay_base import reduce_check_stats, routing_replay_manager
 
 logger = logging.getLogger(__name__)
 
@@ -183,6 +184,13 @@ def stage(name: str):
 def rewind() -> None:
     """Return the forward cursors to the head of their queues."""
     routing_replay_manager.clear_all_forward()
+
+
+def pop_and_reduce_check_stats(group: dist.ProcessGroup) -> tuple[int, int] | None:
+    """Reset local checker counters and sum them across the participating ranks."""
+    if not routing_replay_manager.enable_check_replay_result:
+        return None
+    return reduce_check_stats(routing_replay_manager.pop_check_stats(), group)
 
 
 def reset() -> None:

--- a/miles/backends/megatron_utils/model.py
+++ b/miles/backends/megatron_utils/model.py
@@ -30,9 +30,11 @@ from miles.backends.megatron_utils.ft.types import TrainStepOutcome
 from miles.backends.megatron_utils.local_weight_checksum import dump_local_weight_checksums
 from miles.utils.audit_utils.witness.allocator import WitnessInfo
 from miles.utils.audit_utils.witness.module import witness_dump_and_clear_stale
+from miles.utils.distributed_utils import get_gloo_group
 from miles.utils.dumper_utils import DumperMegatronUtil, DumperPhase
 from miles.utils.memory_utils import clear_memory
 from miles.utils.multi_lora import is_multi_lora_enabled
+from miles.utils.replay_base import reduce_check_stats, routing_replay_manager
 from miles.utils.test_utils.ft_test_actions import FTTestActionActorExecutor
 from miles.utils.tracking_utils.structured_log import log_structured
 
@@ -791,6 +793,14 @@ def train(
             ft_test_action_executor=ft_test_action_executor,
         )
 
+        r3_mismatch_fraction = None
+        if routing_replay_manager.enable_check_replay_result:
+            local_stats = routing_replay_manager.pop_check_stats()
+            if train_step_outcome == TrainStepOutcome.NORMAL:
+                # Independent-DP cells can discard different attempts, so reduce within this cell only.
+                mismatched, checked = reduce_check_stats(local_stats, get_gloo_group())
+                r3_mismatch_fraction = mismatched / checked if checked else 0.0
+
         if step_id == 0:
             # Enable forward pre-hook after training step has successfully run. All subsequent
             # forward passes will use the forward pre-hook / `param_sync_func` in
@@ -845,6 +855,7 @@ def train(
                 num_steps_per_rollout=num_steps_per_rollout,
                 role=role,
                 extra_metrics=extra_metrics,
+                r3_mismatch_fraction=r3_mismatch_fraction,
                 should_log=True,
             )
 

--- a/miles/backends/training_utils/log_utils.py
+++ b/miles/backends/training_utils/log_utils.py
@@ -11,7 +11,6 @@ from miles.utils import train_metric_utils
 from miles.utils.flops_utils import fwd_tflops_per_gpu
 from miles.utils.ft_utils.process_group_utils import MultiPGUtil
 from miles.utils.metric_utils import compute_rollout_step
-from miles.utils.replay_base import routing_replay_manager
 from miles.utils.tracking_utils.structured_log import log_structured
 from miles.utils.types import RolloutBatch
 
@@ -501,6 +500,7 @@ def log_train_step(
     role: str = "actor",
     extra_metrics: dict[str, float] | None = None,
     should_log: bool | None = None,
+    r3_mismatch_fraction: float | None = None,
 ) -> dict[str, float]:
     """Log training metrics for one step.
 
@@ -516,6 +516,7 @@ def log_train_step(
         role: Role name (e.g., "actor", "critic").
         extra_metrics: Optional extra metrics to log (e.g., learning rates, MTP loss).
         should_log: Optional override for logging condition. If None, uses rank == 0.
+        r3_mismatch_fraction: Optional pre-aggregated routing-replay mismatch fraction.
 
     Returns:
         The formatted log_dict (for CI tests or other uses).
@@ -533,11 +534,8 @@ def log_train_step(
         for key, val in extra_metrics.items():
             log_dict_out[f"train/{role_tag}{key}"] = val
 
-    if routing_replay_manager.enable_check_replay_result:
-        # log_train_step runs on one rank only, so no collective here: the counts are
-        # this rank's, and every rank runs the same layers.
-        mismatched, checked = routing_replay_manager.pop_check_stats()
-        log_dict_out[f"ci/{role_tag}r3_mismatch_fraction"] = mismatched / checked if checked else 0.0
+    if r3_mismatch_fraction is not None:
+        log_dict_out[f"ci/{role_tag}r3_mismatch_fraction"] = r3_mismatch_fraction
 
     log_dict_out["train/step"] = accumulated_step_id
 

--- a/miles/backends/training_utils/log_utils.py
+++ b/miles/backends/training_utils/log_utils.py
@@ -11,6 +11,7 @@ from miles.utils import train_metric_utils
 from miles.utils.flops_utils import fwd_tflops_per_gpu
 from miles.utils.ft_utils.process_group_utils import MultiPGUtil
 from miles.utils.metric_utils import compute_rollout_step
+from miles.utils.replay_base import routing_replay_manager
 from miles.utils.tracking_utils.structured_log import log_structured
 from miles.utils.types import RolloutBatch
 
@@ -531,6 +532,12 @@ def log_train_step(
     if extra_metrics:
         for key, val in extra_metrics.items():
             log_dict_out[f"train/{role_tag}{key}"] = val
+
+    if routing_replay_manager.enable_check_replay_result:
+        # log_train_step runs on one rank only, so no collective here: the counts are
+        # this rank's, and every rank runs the same layers.
+        mismatched, checked = routing_replay_manager.pop_check_stats()
+        log_dict_out[f"ci/{role_tag}r3_mismatch_fraction"] = mismatched / checked if checked else 0.0
 
     log_dict_out["train/step"] = accumulated_step_id
 

--- a/miles/utils/replay_base.py
+++ b/miles/utils/replay_base.py
@@ -4,11 +4,21 @@ import os
 import torch
 import torch.distributed as dist
 
+from miles.utils.ft_utils.process_group_utils import GeneralPGUtil
+
 logger = logging.getLogger(__name__)
 
 
 def _get_rank():
     return dist.get_rank() if dist.is_initialized() else 0
+
+
+def reduce_check_stats(stats: tuple[int, int], group: dist.ProcessGroup) -> tuple[int, int]:
+    """Sum replay-check counters across a rank-symmetric Gloo group."""
+    values = torch.tensor(stats, dtype=torch.long)
+    GeneralPGUtil.create(group).all_reduce(values, group, op=dist.ReduceOp.SUM)
+    mismatched, checked = values.tolist()
+    return int(mismatched), int(checked)
 
 
 class Replay:
@@ -68,7 +78,7 @@ class BaseReplayManager:
         self.mismatched_tokens = 0
 
     def pop_check_stats(self) -> tuple[int, int]:
-        """Mismatched and checked token counts since the last call, then reset."""
+        """Mismatched and total checker-row counts since the last call, then reset."""
         stats = (self.mismatched_tokens, self.checked_tokens)
         self.mismatched_tokens = 0
         self.checked_tokens = 0
@@ -200,13 +210,14 @@ class BaseReplayManager:
         is_mismatch = (overlap < required) & ~is_padding
 
         mismatch_count = is_mismatch.sum().item()
-        self.checked_tokens += int((~is_padding).sum().item())
+        checked_count = orig_flat.shape[0]
+        self.checked_tokens += checked_count
         self.mismatched_tokens += mismatch_count
         if mismatch_count == 0:
             return
 
         threshold = float(os.environ.get("MILES_TEST_R3_THRESHOLD", self.replay_check_max_mismatch_fraction))
-        mismatch_threshold = threshold * orig_flat.shape[0]
+        mismatch_threshold = threshold * checked_count
         mismatch_indices = is_mismatch.nonzero(as_tuple=False).squeeze(1)
         for idx in mismatch_indices[:10]:
             i = idx.item()

--- a/miles/utils/replay_base.py
+++ b/miles/utils/replay_base.py
@@ -64,6 +64,15 @@ class BaseReplayManager:
         self.enabled = False
         self.stage = "fallthrough"
         self.register_replay_list_func = None
+        self.checked_tokens = 0
+        self.mismatched_tokens = 0
+
+    def pop_check_stats(self) -> tuple[int, int]:
+        """Mismatched and checked token counts since the last call, then reset."""
+        stats = (self.mismatched_tokens, self.checked_tokens)
+        self.mismatched_tokens = 0
+        self.checked_tokens = 0
+        return stats
 
     def create_replay(self, stream_idx: int | None = None) -> Replay:
         replay = Replay(stream_idx=stream_idx)
@@ -191,6 +200,8 @@ class BaseReplayManager:
         is_mismatch = (overlap < required) & ~is_padding
 
         mismatch_count = is_mismatch.sum().item()
+        self.checked_tokens += int((~is_padding).sum().item())
+        self.mismatched_tokens += mismatch_count
         if mismatch_count == 0:
             return
 

--- a/miles/utils/tracking_utils/ci_history.py
+++ b/miles/utils/tracking_utils/ci_history.py
@@ -53,6 +53,7 @@ TARGET_METRIC_KEYS: tuple[str, ...] = (
     "rollout/raw_reward",
     "rollout/tito_session_mismatch_rate/v1/assistant_text",
     "rollout/tito_session_mismatch_rate/v2/assistant_text",
+    "ci/r3_mismatch_fraction",
 )
 
 # Env var naming the directory the harness assigns for this run's records.

--- a/tests/ci/metric_history/register.py
+++ b/tests/ci/metric_history/register.py
@@ -108,6 +108,10 @@ GATE_DEFAULTS: dict[str, dict] = {
         "steps": "all",
         "constraint": {"rel_up": 0.5, "abs_floor_up": 0.05, "rel_down": 0.2, "abs_floor_down": 0.05},
     },
+    "ci/r3_mismatch_fraction": {
+        "steps": "all",
+        "constraint": {"rel_up": 1.0, "abs_floor_up": 0.01, "rel_down": 1.0},
+    },
     "rollout/tito_session_mismatch_rate/v1/assistant_text": {
         "steps": "last",
         "constraint": {"rel_up": 1.0, "abs_floor_up": 0.1, "rel_down": 1.0},

--- a/tests/ci/test/test_ci_history.py
+++ b/tests/ci/test/test_ci_history.py
@@ -42,7 +42,15 @@ def test_record_has_target_keys_and_is_parseable(tmp_path, monkeypatch):
     backend = CiHistoryBackend()
     backend.init(object(), primary=False)
 
-    backend.log({"train/grad_norm": 1.5, "train/ppo_kl": 0.0, "train/step": 0}, step=0)
+    backend.log(
+        {
+            "train/grad_norm": 1.5,
+            "train/ppo_kl": 0.0,
+            "ci/r3_mismatch_fraction": 0.005,
+            "train/step": 0,
+        },
+        step=0,
+    )
     backend.log({"train/grad_norm": 2.5, "train/ppo_kl": 0.1, "train/step": 1}, step=1)
     backend.log(
         {
@@ -63,12 +71,14 @@ def test_record_has_target_keys_and_is_parseable(tmp_path, monkeypatch):
     assert set(by_metric) == {
         "train/grad_norm",
         "train/ppo_kl",
+        "ci/r3_mismatch_fraction",
         "rollout/raw_reward",
         "rollout/tito_session_mismatch_rate/v2/assistant_text",
     }
     # Raw series are preserved unreduced: both grad_norm points are present.
     assert by_metric["train/grad_norm"] == [[0, 1.5], [1, 2.5]]
     assert by_metric["train/ppo_kl"] == [[0, 0.0], [1, 0.1]]
+    assert by_metric["ci/r3_mismatch_fraction"] == [[0, 0.005]]
     assert by_metric["rollout/raw_reward"] == [[0, 0.3]]
     assert by_metric["rollout/tito_session_mismatch_rate/v2/assistant_text"] == [[0, 0.125]]
 

--- a/tests/ci/test/test_gate_integration.py
+++ b/tests/ci/test/test_gate_integration.py
@@ -350,6 +350,35 @@ class TestBaselineWrite:
             ('"all"', 3, 0.80),
         ]
 
+    def test_nightly_r3_one_liner_writes_metric_values(self, tmp_path, store):
+        test_file = _write_test_file(
+            tmp_path,
+            'register_ci_gate(metric_key="ci/r3_mismatch_fraction")',
+        )
+        registry = _registry(test_file)
+        record = _write_record(
+            tmp_path,
+            {"ci/r3_mismatch_fraction": [[0, 0.0], [1, 0.005]]},
+            name="m.jsonl",
+        )
+
+        run_gate_hook(
+            test_file,
+            record,
+            store=store,
+            registry=registry,
+            write_baseline=True,
+            provenance=PROVENANCE,
+        )
+
+        rows = store._conn.execute(
+            "SELECT metric_key, steps_key, step, value FROM metric_values ORDER BY step"
+        ).fetchall()
+        assert rows == [
+            ("ci/r3_mismatch_fraction", '"all"', 0, 0.0),
+            ("ci/r3_mismatch_fraction", '"all"', 1, 0.005),
+        ]
+
     def test_nightly_no_spec_file_writes_nothing(self, tmp_path, store, monkeypatch):
         # A file with no register_ci_gate call has nothing a baseline can use:
         # the hook must skip the write entirely, not leave an empty runs row.

--- a/tests/ci/test/test_metric_selection.py
+++ b/tests/ci/test/test_metric_selection.py
@@ -401,6 +401,59 @@ def test_standard_rl_gate_defaults_capture_all_steps(metric_key):
     assert GATE_DEFAULTS[metric_key]["steps"] == "all"
 
 
+def test_r3_mismatch_fraction_gate_default():
+    assert GATE_DEFAULTS["ci/r3_mismatch_fraction"] == {
+        "steps": "all",
+        "constraint": {"rel_up": 1.0, "abs_floor_up": 0.01, "rel_down": 1.0},
+    }
+
+
+def test_routing_replay_e2e_declares_r3_history_gate():
+    case_files = (
+        "e2e/fsdp/r3/test_glm47_flash_r3.py",
+        "e2e/fsdp/r3/test_qwen3_30b_a3b_r3.py",
+        "e2e/fsdp/r3/test_qwen3_5_35b_a3b_r3.py",
+        "e2e/megatron/model_scripts/test_deepseek_v32_5layer_fp8.py",
+        "e2e/megatron/model_scripts/test_deepseek_v32_5layer_mxfp8.py",
+        "e2e/megatron/test_glm47_flash/test_amd_r3_mtp.py",
+        "e2e/megatron/test_glm47_flash/test_r3_mtp.py",
+        "e2e/megatron/test_glm47_flash/test_r3_mtp_deepep.py",
+        "e2e/megatron/test_glm5_2_744b_a40b_5layer_nvfp4.py",
+        "e2e/megatron/test_qwen3_30B_A3B/test_amd_moriep_fp8_bridge.py",
+        "e2e/megatron/test_qwen3_30B_A3B/test_baseline.py",
+        "e2e/megatron/test_qwen3_30B_A3B/test_deepep_fp8.py",
+        "e2e/megatron/test_qwen3_30B_A3B/test_deepep_fp8_bridge.py",
+        "e2e/megatron/test_qwen3_30B_A3B/test_disagg_broadcast.py",
+        "e2e/megatron/test_qwen3_30B_A3B/test_dp_attention.py",
+        "e2e/megatron/test_qwen3_30B_A3B/test_fully_async.py",
+        "e2e/megatron/test_qwen3_30B_A3B/test_int4_rollout.py",
+        "e2e/megatron/test_qwen3_30B_A3B/test_r3_baseline.py",
+        "e2e/megatron/test_qwen3_30B_A3B/test_r3_deepep_fp8.py",
+        "e2e/megatron/test_qwen3_5_35B_A3B_mtp/test_amd_mtp1_spec_v2_r3.py",
+        "e2e/megatron/test_qwen3_5_35B_A3B_mtp/test_mtp1_spec_v2_r3.py",
+    )
+    loose_glm47_files = {
+        "e2e/megatron/test_glm47_flash/test_amd_r3_mtp.py",
+        "e2e/megatron/test_glm47_flash/test_r3_mtp.py",
+        "e2e/megatron/test_glm47_flash/test_r3_mtp_deepep.py",
+    }
+    assert len(case_files) == 21
+
+    tests_root = Path(__file__).parents[2]
+    for relative_path in case_files:
+        specs = parse_ci_gate_specs(str(tests_root / relative_path))
+        r3_specs = [spec for spec in specs if spec.metric_key == "ci/r3_mismatch_fraction"]
+        assert len(r3_specs) == 1, relative_path
+        expected_floor = 0.05 if relative_path in loose_glm47_files else 0.01
+        assert r3_specs[0].steps == "all", relative_path
+        assert r3_specs[0].constraint == {
+            "rel_up": 1.0,
+            "abs_floor_up": expected_floor,
+            "rel_down": 1.0,
+            "abs_floor_down": 0.0,
+        }, relative_path
+
+
 @pytest.mark.parametrize("version", ["v1", "v2"])
 def test_session_tito_gate_default_is_loose(version):
     metric_key = f"rollout/tito_session_mismatch_rate/{version}/assistant_text"

--- a/tests/e2e/fsdp/r3/test_glm47_flash_r3.py
+++ b/tests/e2e/fsdp/r3/test_glm47_flash_r3.py
@@ -14,6 +14,7 @@ register_cuda_ci(est_time=1800, suite="stage-c-8-gpu-h200", labels=["fsdp", "rep
 register_ci_gate(metric_key="train/grad_norm")
 register_ci_gate(metric_key="train/ppo_kl")
 register_ci_gate(metric_key="rollout/raw_reward")
+register_ci_gate(metric_key="ci/r3_mismatch_fraction")
 
 CASE = CaseConfig(
     model_name="GLM-4.7-Flash",

--- a/tests/e2e/fsdp/r3/test_qwen3_30b_a3b_r3.py
+++ b/tests/e2e/fsdp/r3/test_qwen3_30b_a3b_r3.py
@@ -9,6 +9,7 @@ register_cuda_ci(est_time=1800, suite="stage-c-8-gpu-h200", labels=["fsdp", "rep
 register_ci_gate(metric_key="train/grad_norm")
 register_ci_gate(metric_key="train/ppo_kl")
 register_ci_gate(metric_key="rollout/raw_reward")
+register_ci_gate(metric_key="ci/r3_mismatch_fraction")
 
 CASE = CaseConfig(
     model_name="Qwen3-30B-A3B",

--- a/tests/e2e/fsdp/r3/test_qwen3_5_35b_a3b_r3.py
+++ b/tests/e2e/fsdp/r3/test_qwen3_5_35b_a3b_r3.py
@@ -9,6 +9,7 @@ register_cuda_ci(est_time=1800, suite="stage-c-8-gpu-h200", labels=["fsdp", "rep
 register_ci_gate(metric_key="train/grad_norm")
 register_ci_gate(metric_key="train/ppo_kl")
 register_ci_gate(metric_key="rollout/raw_reward")
+register_ci_gate(metric_key="ci/r3_mismatch_fraction")
 
 CASE = CaseConfig(
     model_name="Qwen3.5-35B-A3B",

--- a/tests/e2e/megatron/model_scripts/test_deepseek_v32_5layer_fp8.py
+++ b/tests/e2e/megatron/model_scripts/test_deepseek_v32_5layer_fp8.py
@@ -23,6 +23,7 @@ register_ci_gate(metric_key="train/ppo_kl")
 register_ci_gate(metric_key="train/train_rollout_logprob_abs_diff")
 register_ci_gate(metric_key="train/train_rollout_kl")
 register_ci_gate(metric_key="rollout/raw_reward")
+register_ci_gate(metric_key="ci/r3_mismatch_fraction")
 
 
 def _args() -> ScriptArgs:

--- a/tests/e2e/megatron/model_scripts/test_deepseek_v32_5layer_mxfp8.py
+++ b/tests/e2e/megatron/model_scripts/test_deepseek_v32_5layer_mxfp8.py
@@ -1,6 +1,7 @@
 import os
 
 from tests.ci.ci_register import register_cuda_ci
+from tests.ci.metric_history import register_ci_gate
 
 import miles.utils.external_utils.command_utils as U
 
@@ -10,6 +11,8 @@ register_cuda_ci(
     labels=["megatron", "model-scripts"],
     disabled="Temporarily disabled; superseded by test_deepseek_v32_5layer_ci on H100.",
 )
+
+register_ci_gate(metric_key="ci/r3_mismatch_fraction")
 
 MODEL_ORG = "Pinaster"
 MODEL_NAME = "DeepSeek-V3.2-5layer"

--- a/tests/e2e/megatron/test_glm47_flash/test_amd_r3_mtp.py
+++ b/tests/e2e/megatron/test_glm47_flash/test_amd_r3_mtp.py
@@ -33,6 +33,10 @@ register_ci_gate(metric_key="train/ppo_kl")
 register_ci_gate(metric_key="train/train_rollout_logprob_abs_diff")
 register_ci_gate(metric_key="train/train_rollout_kl")
 register_ci_gate(metric_key="rollout/raw_reward")
+register_ci_gate(
+    metric_key="ci/r3_mismatch_fraction",
+    constraint={"rel_up": 1.0, "abs_floor_up": 0.05, "rel_down": 1.0},
+)
 
 CASE = CaseConfig(
     use_deepep=False,

--- a/tests/e2e/megatron/test_glm47_flash/test_r3_mtp.py
+++ b/tests/e2e/megatron/test_glm47_flash/test_r3_mtp.py
@@ -11,6 +11,10 @@ register_ci_gate(metric_key="train/ppo_kl")
 register_ci_gate(metric_key="train/train_rollout_logprob_abs_diff")
 register_ci_gate(metric_key="train/train_rollout_kl")
 register_ci_gate(metric_key="rollout/raw_reward")
+register_ci_gate(
+    metric_key="ci/r3_mismatch_fraction",
+    constraint={"rel_up": 1.0, "abs_floor_up": 0.05, "rel_down": 1.0},
+)
 
 CASE = CaseConfig(
     use_deepep=False,

--- a/tests/e2e/megatron/test_glm47_flash/test_r3_mtp_deepep.py
+++ b/tests/e2e/megatron/test_glm47_flash/test_r3_mtp_deepep.py
@@ -1,6 +1,7 @@
 import os
 
 from tests.ci.ci_register import register_cuda_ci
+from tests.ci.metric_history import register_ci_gate
 from tests.e2e.megatron.test_glm47_flash._common import CaseConfig, execute, prepare
 
 # FIXME: sglang deepep code path bug.
@@ -9,6 +10,11 @@ register_cuda_ci(
     suite="stage-c-8-gpu-h100",
     labels=["megatron"],
     disabled="Disabled due to sglang deepep code path bug.",
+)
+
+register_ci_gate(
+    metric_key="ci/r3_mismatch_fraction",
+    constraint={"rel_up": 1.0, "abs_floor_up": 0.05, "rel_down": 1.0},
 )
 
 CASE = CaseConfig(

--- a/tests/e2e/megatron/test_glm5_2_744b_a40b_5layer_nvfp4.py
+++ b/tests/e2e/megatron/test_glm5_2_744b_a40b_5layer_nvfp4.py
@@ -3,6 +3,7 @@ import os
 from pathlib import Path
 
 from tests.ci.ci_register import register_cuda_ci
+from tests.ci.metric_history import register_ci_gate
 
 import miles.utils.external_utils.command_utils as U
 
@@ -12,6 +13,8 @@ register_cuda_ci(
     labels=["model-scripts"],
     disabled="Requires Blackwell/B200 CI runner for NVFP4.",
 )
+
+register_ci_gate(metric_key="ci/r3_mismatch_fraction")
 
 MODEL_ORG = "Pinaster"
 MODEL_NAME = "GLM-5.2_5layer"

--- a/tests/e2e/megatron/test_qwen3_30B_A3B/test_amd_moriep_fp8_bridge.py
+++ b/tests/e2e/megatron/test_qwen3_30B_A3B/test_amd_moriep_fp8_bridge.py
@@ -34,6 +34,7 @@ register_ci_gate(metric_key="train/ppo_kl")
 register_ci_gate(metric_key="train/train_rollout_logprob_abs_diff")
 register_ci_gate(metric_key="train/train_rollout_kl")
 register_ci_gate(metric_key="rollout/raw_reward")
+register_ci_gate(metric_key="ci/r3_mismatch_fraction")
 
 CASE = CaseConfig(
     use_deepep=False,

--- a/tests/e2e/megatron/test_qwen3_30B_A3B/test_baseline.py
+++ b/tests/e2e/megatron/test_qwen3_30B_A3B/test_baseline.py
@@ -11,6 +11,7 @@ register_ci_gate(metric_key="train/ppo_kl")
 register_ci_gate(metric_key="train/train_rollout_logprob_abs_diff")
 register_ci_gate(metric_key="train/train_rollout_kl")
 register_ci_gate(metric_key="rollout/raw_reward")
+register_ci_gate(metric_key="ci/r3_mismatch_fraction")
 
 register_rocm_ci(
     est_time=900, suite="nightly-stage-c-4-gpu-mi350", labels=["megatron", "weight-update", "short", "mooncake"]

--- a/tests/e2e/megatron/test_qwen3_30B_A3B/test_deepep_fp8.py
+++ b/tests/e2e/megatron/test_qwen3_30B_A3B/test_deepep_fp8.py
@@ -11,6 +11,7 @@ register_ci_gate(metric_key="train/ppo_kl")
 register_ci_gate(metric_key="train/train_rollout_logprob_abs_diff")
 register_ci_gate(metric_key="train/train_rollout_kl")
 register_ci_gate(metric_key="rollout/raw_reward")
+register_ci_gate(metric_key="ci/r3_mismatch_fraction")
 
 CASE = CaseConfig(
     use_deepep=True,

--- a/tests/e2e/megatron/test_qwen3_30B_A3B/test_deepep_fp8_bridge.py
+++ b/tests/e2e/megatron/test_qwen3_30B_A3B/test_deepep_fp8_bridge.py
@@ -12,6 +12,7 @@ register_ci_gate(metric_key="train/ppo_kl")
 register_ci_gate(metric_key="train/train_rollout_logprob_abs_diff")
 register_ci_gate(metric_key="train/train_rollout_kl")
 register_ci_gate(metric_key="rollout/raw_reward")
+register_ci_gate(metric_key="ci/r3_mismatch_fraction")
 
 CASE = CaseConfig(
     use_deepep=True,

--- a/tests/e2e/megatron/test_qwen3_30B_A3B/test_disagg_broadcast.py
+++ b/tests/e2e/megatron/test_qwen3_30B_A3B/test_disagg_broadcast.py
@@ -12,6 +12,7 @@ register_ci_gate(metric_key="train/ppo_kl")
 register_ci_gate(metric_key="train/train_rollout_logprob_abs_diff")
 register_ci_gate(metric_key="train/train_rollout_kl")
 register_ci_gate(metric_key="rollout/raw_reward")
+register_ci_gate(metric_key="ci/r3_mismatch_fraction")
 
 CASE = CaseConfig(
     use_deepep=False,

--- a/tests/e2e/megatron/test_qwen3_30B_A3B/test_dp_attention.py
+++ b/tests/e2e/megatron/test_qwen3_30B_A3B/test_dp_attention.py
@@ -18,6 +18,7 @@ register_ci_gate(metric_key="train/ppo_kl")
 register_ci_gate(metric_key="train/train_rollout_logprob_abs_diff")
 register_ci_gate(metric_key="train/train_rollout_kl")
 register_ci_gate(metric_key="rollout/raw_reward")
+register_ci_gate(metric_key="ci/r3_mismatch_fraction")
 
 CASE = CaseConfig(
     num_gpus_per_node=4,

--- a/tests/e2e/megatron/test_qwen3_30B_A3B/test_fully_async.py
+++ b/tests/e2e/megatron/test_qwen3_30B_A3B/test_fully_async.py
@@ -14,6 +14,7 @@ register_ci_gate(metric_key="train/ppo_kl")
 register_ci_gate(metric_key="train/train_rollout_logprob_abs_diff")
 register_ci_gate(metric_key="train/train_rollout_kl")
 register_ci_gate(metric_key="rollout/raw_reward")
+register_ci_gate(metric_key="ci/r3_mismatch_fraction")
 
 # Fully-async rollout on the disaggregated topology (it cannot colocate). Three
 # rollouts exercise the states that only exist with a persistent worker: a cold

--- a/tests/e2e/megatron/test_qwen3_30B_A3B/test_int4_rollout.py
+++ b/tests/e2e/megatron/test_qwen3_30B_A3B/test_int4_rollout.py
@@ -11,6 +11,7 @@ register_ci_gate(metric_key="train/ppo_kl")
 register_ci_gate(metric_key="train/train_rollout_logprob_abs_diff")
 register_ci_gate(metric_key="train/train_rollout_kl")
 register_ci_gate(metric_key="rollout/raw_reward")
+register_ci_gate(metric_key="ci/r3_mismatch_fraction")
 
 CASE = CaseConfig(
     use_deepep=False,

--- a/tests/e2e/megatron/test_qwen3_30B_A3B/test_r3_baseline.py
+++ b/tests/e2e/megatron/test_qwen3_30B_A3B/test_r3_baseline.py
@@ -12,6 +12,7 @@ register_ci_gate(metric_key="train/ppo_kl")
 register_ci_gate(metric_key="train/train_rollout_logprob_abs_diff")
 register_ci_gate(metric_key="train/train_rollout_kl")
 register_ci_gate(metric_key="rollout/raw_reward")
+register_ci_gate(metric_key="ci/r3_mismatch_fraction")
 
 CASE = CaseConfig(
     use_deepep=False,

--- a/tests/e2e/megatron/test_qwen3_30B_A3B/test_r3_deepep_fp8.py
+++ b/tests/e2e/megatron/test_qwen3_30B_A3B/test_r3_deepep_fp8.py
@@ -1,6 +1,7 @@
 import os
 
 from tests.ci.ci_register import register_cuda_ci
+from tests.ci.metric_history import register_ci_gate
 from tests.e2e.megatron.test_qwen3_30B_A3B._common import CaseConfig, execute, prepare
 
 # FIXME: fix here
@@ -10,6 +11,8 @@ register_cuda_ci(
     labels=["megatron", "replay"],
     disabled="Failed due to mismatch between fp8 rollout and bf16 training.",
 )
+
+register_ci_gate(metric_key="ci/r3_mismatch_fraction")
 
 CASE = CaseConfig(
     use_deepep=True,

--- a/tests/e2e/megatron/test_qwen3_5_35B_A3B_mtp/test_amd_mtp1_spec_v2_r3.py
+++ b/tests/e2e/megatron/test_qwen3_5_35B_A3B_mtp/test_amd_mtp1_spec_v2_r3.py
@@ -28,6 +28,7 @@ register_ci_gate(metric_key="train/ppo_kl")
 register_ci_gate(metric_key="train/train_rollout_logprob_abs_diff")
 register_ci_gate(metric_key="train/train_rollout_kl")
 register_ci_gate(metric_key="rollout/raw_reward")
+register_ci_gate(metric_key="ci/r3_mismatch_fraction")
 
 CASE = CaseConfig(
     num_gpus_per_node=4,

--- a/tests/e2e/megatron/test_qwen3_5_35B_A3B_mtp/test_mtp1_spec_v2_r3.py
+++ b/tests/e2e/megatron/test_qwen3_5_35B_A3B_mtp/test_mtp1_spec_v2_r3.py
@@ -18,6 +18,7 @@ register_ci_gate(metric_key="train/ppo_kl")
 register_ci_gate(metric_key="train/train_rollout_logprob_abs_diff")
 register_ci_gate(metric_key="train/train_rollout_kl")
 register_ci_gate(metric_key="rollout/raw_reward")
+register_ci_gate(metric_key="ci/r3_mismatch_fraction")
 
 CASE = CaseConfig(
     # tp2/pp2/cp1/ep4: TP=4 hits a Qwen3.5 attention-output-gate sharding bug, so stay at

--- a/tests/fast/backends/megatron_utils/test_model_initialize.py
+++ b/tests/fast/backends/megatron_utils/test_model_initialize.py
@@ -187,3 +187,83 @@ def test_initialize_steps_scheduler_when_checkpoint_did_not_restore_it():
 
     assert result == (model, optimizer, opt_param_scheduler, 100)
     opt_param_scheduler.step.assert_called_once_with(increment=800)
+
+
+def _train_args():
+    return Namespace(
+        debug_disable_optimizer=True,
+        enable_mtp_training=False,
+        manual_gc=False,
+        overlap_param_gather=False,
+        reset_optimizer_states=False,
+        use_distributed_optimizer=False,
+    )
+
+
+def _run_one_train_step(model_module, outcome, *, indep_dp_size=1):
+    model_chunk = MagicMock()
+    data_iterator = MagicMock()
+    parallel_state = types.SimpleNamespace(indep_dp=types.SimpleNamespace(size=indep_dp_size))
+    config = types.SimpleNamespace()
+
+    with ExitStack() as stack:
+        stack.enter_context(patch.object(model_module, "get_args", return_value=_train_args()))
+        stack.enter_context(patch.object(model_module, "get_parallel_state", return_value=parallel_state))
+        stack.enter_context(patch.object(model_module, "get_model_config", return_value=config))
+        stack.enter_context(patch.object(model_module, "train_one_step", return_value=({}, 0.0, outcome)))
+        result = model_module.train(
+            rollout_id=1,
+            model=[model_chunk],
+            optimizer=None,
+            opt_param_scheduler=None,
+            data_iterator=[data_iterator],
+            num_microbatches=[1],
+            num_rollouts=[1],
+            witness_info=None,
+            attempt=0,
+        )
+
+    return result
+
+
+def test_discarded_step_pops_r3_stats_without_reduce_or_log():
+    from miles.backends.megatron_utils import model as model_module
+
+    manager = model_module.routing_replay_manager
+    outcome = model_module.TrainStepOutcome.DISCARDED_SHOULD_RETRY
+    with (
+        patch.object(manager, "enable_check_replay_result", True),
+        patch.object(manager, "pop_check_stats", return_value=(3, 10)) as pop_stats,
+        patch.object(model_module, "get_gloo_group") as get_group,
+        patch.object(model_module, "reduce_check_stats") as reduce_stats,
+        patch.object(model_module, "log_train_step") as log_step,
+    ):
+        result = _run_one_train_step(model_module, outcome, indep_dp_size=2)
+
+    assert result == outcome
+    pop_stats.assert_called_once_with()
+    get_group.assert_not_called()
+    reduce_stats.assert_not_called()
+    log_step.assert_not_called()
+
+
+def test_normal_non_main_rank_reduces_r3_stats_without_logging():
+    from miles.backends.megatron_utils import model as model_module
+
+    manager = model_module.routing_replay_manager
+    outcome = model_module.TrainStepOutcome.NORMAL
+    group = object()
+    with (
+        patch.object(manager, "enable_check_replay_result", True),
+        patch.object(manager, "pop_check_stats", return_value=(3, 10)) as pop_stats,
+        patch.object(model_module, "get_gloo_group", return_value=group),
+        patch.object(model_module, "reduce_check_stats", return_value=(2, 8)) as reduce_stats,
+        patch.object(model_module, "is_first_replica_megatron_main_rank", return_value=False),
+        patch.object(model_module, "log_train_step") as log_step,
+    ):
+        result = _run_one_train_step(model_module, outcome)
+
+    assert result == outcome
+    pop_stats.assert_called_once_with()
+    reduce_stats.assert_called_once_with((3, 10), group)
+    log_step.assert_not_called()

--- a/tests/fast/backends/test_fsdp_routing_replay.py
+++ b/tests/fast/backends/test_fsdp_routing_replay.py
@@ -4,6 +4,7 @@ register_cpu_ci(est_time=60, suite="stage-a-cpu", labels=[])
 
 from argparse import Namespace
 from types import SimpleNamespace
+from unittest.mock import Mock
 
 import pytest
 import torch.nn as nn
@@ -183,6 +184,19 @@ def test_enable_turns_on_the_replay_check_only_under_ci_test():
 
     routing_replay.enable(Namespace(use_routing_replay=True, ci_test=False))
     assert routing_replay_manager.enable_check_replay_result is False
+
+
+def test_pop_and_reduce_check_stats_resets_local_attempt(monkeypatch):
+    group = object()
+    reduce_stats = Mock(return_value=(5, 12))
+    monkeypatch.setattr(routing_replay_manager, "enable_check_replay_result", True)
+    monkeypatch.setattr(routing_replay, "reduce_check_stats", reduce_stats)
+    routing_replay_manager.mismatched_tokens = 2
+    routing_replay_manager.checked_tokens = 5
+
+    assert routing_replay.pop_and_reduce_check_stats(group) == (5, 12)
+    assert routing_replay_manager.pop_check_stats() == (0, 0)
+    reduce_stats.assert_called_once_with((2, 5), group)
 
 
 def test_log_prob_stage_is_fallthrough_when_disabled():

--- a/tests/fast/backends/training_utils/test_log_utils_metric_reduction.py
+++ b/tests/fast/backends/training_utils/test_log_utils_metric_reduction.py
@@ -134,3 +134,19 @@ def test_log_multi_turn_data_passes_explicit_extrema_reductions(monkeypatch):
     assert captured["metric_name"] == "multi_turn"
     assert captured["rollout_id"] == 7
     assert captured["reduction_by_key"] == log_utils._MULTI_TURN_REDUCTION_BY_KEY
+
+
+def test_log_train_step_publishes_preaggregated_r3_fraction():
+    log_dict = log_utils.log_train_step(
+        args=SimpleNamespace(),
+        loss_dict={"loss": 1.0},
+        grad_norm=2.0,
+        rollout_id=3,
+        step_id=1,
+        num_steps_per_rollout=4,
+        r3_mismatch_fraction=0.125,
+        should_log=False,
+    )
+
+    assert log_dict["ci/r3_mismatch_fraction"] == 0.125
+    assert log_dict["train/step"] == 13

--- a/tests/fast/utils/test_replay_base.py
+++ b/tests/fast/utils/test_replay_base.py
@@ -4,7 +4,8 @@ register_cpu_ci(est_time=60, suite="stage-a-cpu", labels=[])
 
 import torch
 
-from miles.utils.replay_base import BaseReplayManager
+from miles.utils import replay_base
+from miles.utils.replay_base import BaseReplayManager, RoutingReplayManager
 
 
 class _FakeReplay:
@@ -51,3 +52,38 @@ def test_get_topk_fn_preserves_partial_padding():
     topk_fn = manager.get_topk_fn(_topk, return_probs=False)
 
     torch.testing.assert_close(topk_fn(scores, 3), replayed_top_indices)
+
+
+def test_check_stats_count_all_rows_and_pop_resets(monkeypatch):
+    manager = RoutingReplayManager()
+    scores = torch.tensor([[0.0, 1.0], [1.0, 0.0]])
+    replayed_top_indices = torch.tensor([[0], [-1]])
+    monkeypatch.setenv("MILES_TEST_R3_THRESHOLD", "1.0")
+
+    manager.check_replay_result(_topk, scores, 1, replayed_top_indices)
+
+    assert manager.pop_check_stats() == (1, 2)
+    assert manager.pop_check_stats() == (0, 0)
+
+
+def test_reduce_check_stats_sums_group(monkeypatch):
+    group = object()
+    captured = {}
+
+    class FakePGUtil:
+        def all_reduce(self, values, actual_group, op):
+            captured.update(group=actual_group, op=op)
+            values += torch.tensor([3, 7])
+
+    def fake_create(actual_group):
+        captured["created_for"] = actual_group
+        return FakePGUtil()
+
+    monkeypatch.setattr(replay_base.GeneralPGUtil, "create", fake_create)
+
+    assert replay_base.reduce_check_stats((2, 5), group) == (5, 12)
+    assert captured == {
+        "created_for": group,
+        "group": group,
+        "op": torch.distributed.ReduceOp.SUM,
+    }


### PR DESCRIPTION
The R3 replay checker only ever reported its mismatch count inside the `AssertionError`, so a passing run recorded nothing:

- zero mismatches returned early and logged nothing at all
- a non-zero count under the threshold logged at most ten per-token lines, never a total

So a check drifting toward its threshold was invisible until it tripped, and two runs that both passed could not be compared.

`BaseReplayManager` now accumulates mismatched/checked token counts, `log_train_metrics` all-reduces them across ranks and emits `ci/r3_mismatch_fraction`, and that key is registered in `TARGET_METRIC_KEYS` so the history gate records it per run. The metric only appears when the checker is on (R3 enabled and `--ci-test`).

Every rank pops the counters even though only rank 0 logs, otherwise the non-logging ranks would accumulate across steps. The checker also runs in the backward stage, whose counts land in the following microbatch; the per-step aggregate is unaffected.

Found while debugging a qwen3.5 routing regression, where two runs differed in mismatch count but only the failing one reported a number.