### PR TITLE
fix(train): skip optimizer and scheduler for eval-only

### DIFF
--- a/miles/backends/fsdp_utils/actor.py
+++ b/miles/backends/fsdp_utils/actor.py
@@ -174,7 +174,11 @@ class FSDPTrainRayActor(TrainRayActor):
         if args.gradient_checkpointing:
             self.model.gradient_checkpointing_enable()
 
-        if args.optimizer == "adam":
+        if args.num_rollout == 0:
+            args.no_load_optim = True
+            self.optimizer = None
+            self.lr_scheduler = None
+        elif args.optimizer == "adam":
             self.optimizer = torch.optim.AdamW(
                 self.model.parameters(),
                 lr=args.lr,
@@ -182,11 +186,9 @@ class FSDPTrainRayActor(TrainRayActor):
                 eps=args.adam_eps,
                 weight_decay=args.weight_decay,
             )
+            self.lr_scheduler = get_lr_scheduler(args, self.optimizer)
         else:
             raise ValueError(f"Unsupported optimizer: {args.optimizer}. Supported options: 'adam'")
-
-        # Initialize LR scheduler
-        self.lr_scheduler = get_lr_scheduler(args, self.optimizer)
 
         self.global_step = 0
         self.micro_step = 0
@@ -326,7 +328,8 @@ class FSDPTrainRayActor(TrainRayActor):
         print_memory("before offload model")
 
         self.model.cpu()
-        move_torch_optimizer(self.optimizer, "cpu")
+        if self.optimizer is not None:
+            move_torch_optimizer(self.optimizer, "cpu")
         clear_memory()
         dist.barrier(group=get_gloo_group())
         print_memory("after offload model")
@@ -338,7 +341,8 @@ class FSDPTrainRayActor(TrainRayActor):
             return
 
         self.model.cuda()
-        move_torch_optimizer(self.optimizer, "cuda")
+        if self.optimizer is not None:
+            move_torch_optimizer(self.optimizer, "cuda")
         dist.barrier(group=get_gloo_group())
         print_memory("after wake_up model")
 

--- a/miles/backends/fsdp_utils/checkpoint.py
+++ b/miles/backends/fsdp_utils/checkpoint.py
@@ -120,7 +120,9 @@ def load(actor: Any) -> dict[str, Any] | None:
         return None
 
     # Load optimizer state (optional)
-    load_optimizer = not getattr(actor.args, "no_load_optim", False) and hasattr(actor, "optimizer")
+    load_optimizer = (
+        not getattr(actor.args, "no_load_optim", False) and getattr(actor, "optimizer", None) is not None
+    )
     if load_optimizer and optimizer_dir.exists():
         optimizer_state = OptimizerState(actor.model, actor.optimizer)
         optim_state_dict = {"optim_state": optimizer_state}
@@ -133,7 +135,7 @@ def load(actor: Any) -> dict[str, Any] | None:
         logger.info(f"[FSDP] Optimizer checkpoint not found at {optimizer_dir}, skipping optimizer load.")
 
     # Load LR scheduler state (optional)
-    load_lr_scheduler = hasattr(actor, "lr_scheduler") and lr_scheduler_dir.exists()
+    load_lr_scheduler = getattr(actor, "lr_scheduler", None) is not None and lr_scheduler_dir.exists()
     if load_lr_scheduler:
         lr_scheduler_state = LRSchedulerState(actor.lr_scheduler)
         lr_scheduler_state_dict = {"lr_scheduler_state": lr_scheduler_state}
@@ -142,7 +144,7 @@ def load(actor: Any) -> dict[str, Any] | None:
             logger.info(f"[FSDP] Loaded LR scheduler from {lr_scheduler_dir}")
         except Exception as e:
             logger.warning(f"[FSDP] Failed to load LR scheduler from {lr_scheduler_dir}: {e}")
-    elif hasattr(actor, "lr_scheduler"):
+    elif getattr(actor, "lr_scheduler", None) is not None:
         logger.info(f"[FSDP] LR scheduler checkpoint not found at {lr_scheduler_dir}, skipping LR scheduler load.")
 
     rng_state = None

--- a/miles/backends/megatron_utils/model.py
+++ b/miles/backends/megatron_utils/model.py
@@ -161,6 +161,10 @@ def setup_model_and_optimizer(
             provider_func = wrap_model_provider_with_inkling_lora(provider_func, args)
         model = get_model(provider_func, ModelType.encoder_or_decoder)
 
+    if args.num_rollout == 0:
+        args.no_load_optim = True
+        return model, None, None
+
     if args.debug_disable_optimizer:
         if is_first_replica_megatron_main_rank():
             logger.warning(

--- a/miles/ray/placement_group.py
+++ b/miles/ray/placement_group.py
@@ -153,7 +153,8 @@ async def create_training_models(args, pgs, rollout_manager):
     )
     actor_start_rollout_ids = await actor_model.init()
 
-    if args.use_critic:
+    critic_model = None
+    if args.use_critic and args.num_rollout != 0:
         critic_args = copy.deepcopy(args)
         critic_args.kl_coef = 0
         critic_args.use_opd = False
@@ -168,10 +169,8 @@ async def create_training_models(args, pgs, rollout_manager):
             rollout_manager=None,
         )
         critic_start_rollout_ids = await critic_model.init()
-    else:
-        critic_model = None
 
-    start_rollout_ids = critic_start_rollout_ids if args.use_critic else actor_start_rollout_ids
+    start_rollout_ids = critic_start_rollout_ids if critic_model is not None else actor_start_rollout_ids
 
     assert len(set(start_rollout_ids)) == 1
     if args.start_rollout_id is None:


### PR DESCRIPTION
Replaces #1494. Twin of THUDM/slime#2296.

## Desired vs bug

Eval-only is intended. `train.py` already has:

```python
# special case for eval-only
if args.num_rollout == 0 and args.eval_interval is not None:
    await rollout_manager.eval.remote(rollout_id=0)
```

The train loop is `range(..., num_rollout)`, so this correctly does **zero** training steps. Eval still needs the actor loaded and `update_weights()` into the rollout engines, so `create_training_models` runs first.

The bug is that bring-up always constructed the optimizer and LR scheduler. With `--num-rollout 0`, `train_iters` is 0 → `lr_decay_steps` is 0, and both Megatron and `FSDPLRScheduler` assert `lr_decay_steps > 0`. You never reach the eval special case.

## Why not `train_iters = 1`

That was #1494. It lies to the scheduler, then still runs zero train steps. Eval-only does not train, so it should not build a train stack.

## Change

- Megatron `setup_model_and_optimizer`: after `get_model`, if `num_rollout == 0`, set `no_load_optim` and return `(model, None, None)`. Same pattern as `--debug-disable-optimizer`.
- FSDP actor: skip AdamW / LR scheduler; offload and checkpoint load ignore a null optimizer.
- `create_training_models`: do not allocate a critic when `num_rollout == 0`.

`num_rollout > 0` is unchanged.

## Test plan

- [ ] `--num-rollout 0 --eval-interval 1` loads the actor, skips optimizer/scheduler, hits `rollout_manager.eval`
- [ ] A normal Megatron and FSDP training run still builds optimizer + scheduler

Made with [Cursor](https://cursor.com)