### PR TITLE
fix: treat temperature=0 as greedy selection, untempered logprobs

### DIFF
--- a/miles/backends/training_utils/loss_hub/logit_processors.py
+++ b/miles/backends/training_utils/loss_hub/logit_processors.py
@@ -8,6 +8,12 @@ from miles.backends.training_utils.loss_hub.math_utils import calculate_log_prob
 from miles.backends.training_utils.parallel import get_parallel_state
 
 
+def apply_rollout_temperature(logits: torch.Tensor, temperature: float) -> torch.Tensor:
+    if temperature == 0.0 or temperature == 1.0:
+        return logits
+    return logits.div(temperature)
+
+
 def get_responses(
     logits: torch.Tensor,
     *,
@@ -52,8 +58,8 @@ def get_responses(
         assert max_seq_lens is not None
         logits = logits.view(-1, logits.size(-1))
 
-    if logits.size(-1) > 1 and args.rollout_temperature > 0 and args.rollout_temperature != 1.0:
-        logits = logits.div(args.rollout_temperature)
+    if logits.size(-1) > 1:
+        logits = apply_rollout_temperature(logits, args.rollout_temperature)
     if args.true_on_policy_mode:
         if getattr(args, "bf16", False):
             logits = logits.to(torch.bfloat16)

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -505,7 +505,7 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 "--rollout-temperature",
                 type=float,
                 default=1.0,
-                help="the temperature for the inference engine during rollout.",
+                help="the temperature for the inference engine during rollout. 0 is greedy; log-probs stay untempered.",
             )
             parser.add_argument(
                 "--rollout-top-p", type=float, default=1.0, help="the top-p for the inference engine during rollout."


### PR DESCRIPTION
Twin of THUDM/slime#2197.

## Problem

`get_responses` scaled logits by `rollout_temperature` whenever it was not 1.0 **and** `> 0`. That silently skips T=0 (avoids divide-by-zero) without stating the contract.

SGLang treats T=0 as greedy token selection, but still returns finite untempered model log-probs. slime/Miles store those as `rollout_log_probs` and build PPO ratios from `exp(log π_θ − log π_old)`. Value heads already skip scaling because they have last-dim 1.

## Change

`apply_rollout_temperature` is the shared rule:

- T in {0, 1}: leave logits unchanged
- otherwise: `logits / T`

Behavior at T=0 matches the previous `> 0` guard; the rule is now explicit, same as SGLang.

## Test plan

- [ ] T=0 and T=1 leave policy logits unchanged; T=0.5 divides
- [ ] Value heads (`last dim == 1`) still skip temperature

Made with [Cursor](https://cursor.com)