### PR TITLE
Fix distributed HTTP poster actor lifetime

### DIFF
--- a/miles/utils/http_utils.py
+++ b/miles/utils/http_utils.py
@@ -334,7 +334,7 @@ def _init_ray_distributed_post(args):
         for _ in range(args.num_gpus_per_node):
             actor = _HttpPosterActor.options(
                 name=None,
-                lifetime="detached",
+                lifetime="non_detached",
                 scheduling_strategy=scheduling,
                 max_concurrency=per_actor_conc,
                 # Use tiny CPU to schedule

--- a/tests/fast/utils/test_http_utils.py
+++ b/tests/fast/utils/test_http_utils.py
@@ -1,4 +1,4 @@
-"""Tests for wait_for_server_ready in http_utils.
+"""Tests for HTTP utilities.
 
 wait_for_server_ready() polls a TCP port in a loop until the server is
 accepting connections.  Each iteration:
@@ -23,13 +23,43 @@ This lets us simulate 20 seconds of polling in <1ms of real time.
 
 import multiprocessing
 import socket
+import sys
 import threading
 import time
+from types import ModuleType, SimpleNamespace
 from unittest.mock import patch
 
 import pytest
 
+from miles.utils import http_utils
 from miles.utils.http_utils import wait_for_server_ready
+
+
+def test_distributed_post_actors_configure_non_detached_lifetime(monkeypatch):
+    actor_options = []
+
+    class FakeRemoteActor:
+        def options(self, **options):
+            actor_options.append(options)
+            return SimpleNamespace(remote=lambda concurrency: object())
+
+    ray = ModuleType("ray")
+    ray.nodes = lambda: [{"Alive": True, "NodeID": "node"}]
+    ray.remote = lambda actor_class: FakeRemoteActor()
+
+    ray_util = ModuleType("ray.util")
+    scheduling_strategies = ModuleType("ray.util.scheduling_strategies")
+    scheduling_strategies.NodeAffinitySchedulingStrategy = lambda node_id, soft: (node_id, soft)
+    monkeypatch.setitem(sys.modules, "ray", ray)
+    monkeypatch.setitem(sys.modules, "ray.util", ray_util)
+    monkeypatch.setitem(sys.modules, "ray.util.scheduling_strategies", scheduling_strategies)
+    monkeypatch.setattr(http_utils, "_post_actors", [])
+    monkeypatch.setattr(http_utils, "_client_concurrency", 1)
+
+    http_utils._init_ray_distributed_post(SimpleNamespace(num_gpus_per_node=1))
+
+    assert actor_options
+    assert all(options["lifetime"] == "non_detached" for options in actor_options)
 
 
 def _find_free_port() -> int:


### PR DESCRIPTION
## Summary

- make distributed HTTP poster actors non-detached so they terminate with their creator
- add a deterministic regression test for the Ray actor lifetime configuration

## Why

These actors are anonymous and their handles live only in the RolloutManager process. With `lifetime="detached"`, they can outlive that sole owner; once the process exits, later jobs cannot recover the handles. Repeated jobs on a persistent Ray cluster can therefore accumulate unusable actors, their HTTP connection pools, and their CPU reservations.

A non-detached actor follows Ray owner fate-sharing. Runtime behavior is unchanged while RolloutManager is alive, and actor resources are reclaimed when that owner exits.

This PR does not change HTTP retry or fallback behavior.

## Verification

- `PYTHONPATH="$PWD" python -m pytest --noconftest tests/fast/utils/test_http_utils.py -q` (11 passed)
- `ruff check miles/utils/http_utils.py tests/fast/utils/test_http_utils.py`
- `black --check miles/utils/http_utils.py tests/fast/utils/test_http_utils.py`
- `isort --check-only --profile black miles/utils/http_utils.py tests/fast/utils/test_http_utils.py`
- `autoflake --check miles/utils/http_utils.py tests/fast/utils/test_http_utils.py`
- `git diff --check`

Ray accepts `lifetime="non_detached"` and maps it to an owner-scoped actor. A real process-death integration test is intentionally not added; the focused test verifies our configuration wiring, while actor reclamation remains Ray behavior.