### PR TITLE
fix(deepseekv3): match router dtype for disk-delta export

### DIFF
--- a/miles/backends/megatron_utils/megatron_to_hf/deepseekv3.py
+++ b/miles/backends/megatron_utils/megatron_to_hf/deepseekv3.py
@@ -3,6 +3,16 @@ import re
 import torch
 
 
+def _convert_router_weight(args, param):
+    if getattr(args, "update_weight_transfer_mode", None) != "disk-delta":
+        return param
+    if getattr(args, "bf16", False):
+        return param.to(torch.bfloat16)
+    if getattr(args, "fp16", False):
+        return param.to(torch.float16)
+    return param
+
+
 def convert_deepseekv3_to_hf(args, name, param):
     if name == "module.module.embedding.word_embeddings.weight":
         return [("model.embed_tokens.weight", param)]
@@ -130,7 +140,7 @@ def convert_deepseekv3_to_hf(args, name, param):
         elif rest == "pre_mlp_layernorm.weight":
             return [(f"model.layers.{layer_idx}.post_attention_layernorm.weight", param)]
         elif rest == "mlp.router.weight":
-            return [(f"model.layers.{layer_idx}.mlp.gate.weight", param)]
+            return [(f"model.layers.{layer_idx}.mlp.gate.weight", _convert_router_weight(args, param))]
         elif rest == "mlp.router.expert_bias":
             return [(f"model.layers.{layer_idx}.mlp.gate.e_score_correction_bias", param)]
 

--- a/tests/fast/backends/megatron_utils/test_deepseekv3_to_hf.py
+++ b/tests/fast/backends/megatron_utils/test_deepseekv3_to_hf.py
@@ -1,0 +1,72 @@
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+
+def _load_converter():
+    module_path = (
+        Path(__file__).resolve().parents[4]
+        / "miles"
+        / "backends"
+        / "megatron_utils"
+        / "megatron_to_hf"
+        / "deepseekv3.py"
+    )
+    spec = importlib.util.spec_from_file_location("test_deepseekv3_to_hf_module", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module.convert_deepseekv3_to_hf
+
+
+convert_deepseekv3_to_hf = _load_converter()
+
+
+def _args(**kwargs):
+    defaults = {
+        "update_weight_transfer_mode": "disk-delta",
+        "bf16": True,
+        "fp16": False,
+        "kv_channels": 128,
+        "num_attention_heads": 64,
+        "num_query_groups": 1,
+        "indexer_rope_interleave": False,
+    }
+    return SimpleNamespace(**(defaults | kwargs))
+
+
+@pytest.mark.parametrize(
+    ("args", "expected_dtype"),
+    [
+        (_args(), torch.bfloat16),
+        (_args(bf16=False, fp16=True), torch.float16),
+        (_args(update_weight_transfer_mode="nccl"), torch.float32),
+    ],
+)
+def test_router_weight_dtype(args, expected_dtype):
+    weight = torch.zeros((256, 16), dtype=torch.float32)
+
+    [(name, converted)] = convert_deepseekv3_to_hf(
+        args,
+        "module.module.decoder.layers.3.mlp.router.weight",
+        weight,
+    )
+
+    assert name == "model.layers.3.mlp.gate.weight"
+    assert converted.dtype == expected_dtype
+
+
+def test_disk_delta_preserves_router_expert_bias_dtype():
+    bias = torch.zeros(256, dtype=torch.float32)
+
+    [(name, converted)] = convert_deepseekv3_to_hf(
+        _args(),
+        "module.module.decoder.layers.3.mlp.router.expert_bias",
+        bias,
+    )
+
+    assert name == "model.layers.3.mlp.gate.e_score_correction_bias"
+    assert converted.dtype == torch.float32


### PR DESCRIPTION
## Summary

- preserve the FP32 Megatron router for existing weight-transfer modes
- cast the DeepSeek/GLM router to the configured BF16 or FP16 dtype when exporting raw disk-delta bytes
- cover BF16, FP16, non-disk-delta, and expert-bias behavior

## Why

Megatron keeps the MoE router weight in FP32, while the canonical HF checkpoint stores the gate weight in the model dtype. Disk-delta applies byte-level deltas to that canonical checkpoint, so its exported tensor must use the checkpoint layout. The expert correction bias remains FP32 and is intentionally unchanged.

## Test plan

- `python -m pytest tests/fast/backends/megatron_utils/test_deepseekv3_to_hf.py -q -p no:cacheprovider`
- pre-commit hooks on changed files