### PR TITLE
fix(disk-delta): reject noncanonical tensor layouts

### DIFF
--- a/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/delta.py
+++ b/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/delta.py
@@ -28,6 +28,43 @@ from .mixin import DistBucketedWeightUpdateMixin
 
 logger = logging.getLogger(__name__)
 
+# Safetensors stores its own dtype codes in the file header but does not expose a
+# public torch-dtype encoder. Disk-delta needs the exact code because it patches
+# raw bytes without rewriting that header.
+_SAFETENSORS_DTYPE_BY_TORCH_DTYPE = {
+    torch.float64: "F64",
+    torch.float32: "F32",
+    torch.float16: "F16",
+    torch.bfloat16: "BF16",
+    torch.int64: "I64",
+    torch.int32: "I32",
+    torch.int16: "I16",
+    torch.int8: "I8",
+    torch.uint8: "U8",
+    torch.bool: "BOOL",
+    torch.complex64: "C64",
+    **{
+        getattr(torch, torch_dtype_name): safetensors_dtype
+        for torch_dtype_name, safetensors_dtype in (
+            ("float8_e4m3fn", "F8_E4M3"),
+            ("float8_e4m3fnuz", "F8_E4M3FNUZ"),
+            ("float8_e5m2", "F8_E5M2"),
+            ("float8_e5m2fnuz", "F8_E5M2FNUZ"),
+            ("uint64", "U64"),
+            ("uint32", "U32"),
+            ("uint16", "U16"),
+        )
+        if hasattr(torch, torch_dtype_name)
+    },
+}
+
+
+def _safetensors_dtype(dtype: torch.dtype) -> str:
+    try:
+        return _SAFETENSORS_DTYPE_BY_TORCH_DTYPE[dtype]
+    except KeyError:
+        raise ValueError(f"Disk-delta does not support trainer tensor dtype {dtype}") from None
+
 
 class UpdateWeightFromDiskDelta(DistBucketedWeightUpdateMixin):
     """
@@ -120,9 +157,10 @@ class UpdateWeightFromDiskDelta(DistBucketedWeightUpdateMixin):
         """Capture the baseline snapshot the first delta diffs against (no publish), and clear any
         stale stream from a prior run. Seeds from hf_checkpoint — what each host materializes its
         base from — so the invariant ``snapshot == engine base`` holds even where the megatron->HF
-        round-trip trims vocab-padding rows (embed/lm_head). A tensor absent there (rare) falls back
-        to the gathered value. pull_weights(0) makes each host materialize its local base now,
-        overlapped with the snapshot gather, so the first real sync only pays the delta apply."""
+        round-trip trims vocab-padding rows (embed/lm_head). Every emitted tensor must have the same
+        layout as that canonical checkpoint because deltas operate on raw bytes. pull_weights(0)
+        makes each host materialize its local base now, overlapped with the snapshot gather, so the
+        first real sync only pays the delta apply."""
         # a prior run's versions would apply against the wrong base; start the dir clean
         pulls = []
         if dist.get_rank() == 0:
@@ -133,17 +171,57 @@ class UpdateWeightFromDiskDelta(DistBucketedWeightUpdateMixin):
             pulls = [engine.pull_weights.remote(target_version=0) for engine in self.rollout_engines]
         dist.barrier(group=get_gloo_group())
 
-        read_hf = make_tensor_reader(self.args.hf_checkpoint)  # index the HF headers once
+        read_hf = None
+        local_error: ValueError | None = None
+        if self._is_source:
+            try:
+                read_hf = make_tensor_reader(self.args.hf_checkpoint)  # index the HF headers once
+            except ValueError as error:
+                local_error = error
 
         def seed_bucket(converted_named_tensors: list[tuple[str, torch.Tensor]], pbar: tqdm | None = None) -> None:
-            for name, tensor in converted_named_tensors:
-                try:
-                    self._snapshot[name] = read_hf(name)
-                except KeyError:
-                    self._snapshot[name] = tensor.detach().cpu().contiguous().view(torch.uint8).numpy().reshape(-1)
-                    logger.warning("seed: %s absent from hf_checkpoint; seeding from current weights", name)
+            nonlocal local_error
+            if local_error is not None:
+                return
+            assert read_hf is not None
+            try:
+                for name, tensor in converted_named_tensors:
+                    try:
+                        baseline = read_hf(
+                            name,
+                            expected_dtype=_safetensors_dtype(tensor.dtype),
+                            expected_shape=tuple(tensor.shape),
+                        )
+                    except KeyError as error:
+                        raise ValueError(
+                            f"Trainer emitted {name!r}, but it is absent from the canonical checkpoint"
+                        ) from error
+                    emitted_nbytes = tensor.numel() * tensor.element_size()
+                    if emitted_nbytes != baseline.nbytes:
+                        raise ValueError(
+                            f"Checkpoint tensor {name!r} has {baseline.nbytes} bytes; "
+                            f"trainer emitted {emitted_nbytes} bytes"
+                        )
+                    self._snapshot[name] = baseline
+            except ValueError as error:
+                # Source ranks run the callback, but every rank joins the surrounding gathers.
+                # Defer the error until those collectives finish, then make every rank fail.
+                local_error = error
 
         self._for_each_hf_bucket(seed_bucket)
+        group = get_gloo_group()
+        error_messages: list[str | None] = [None] * dist.get_world_size(group=group)
+        local_error_message = None if local_error is None else f"{type(local_error).__name__}: {local_error}"
+        dist.all_gather_object(error_messages, local_error_message, group=group)
+        if any(error_messages):
+            failed_rank, error_message = next(
+                (rank, message) for rank, message in enumerate(error_messages) if message is not None
+            )
+            error = RuntimeError(f"Disk-delta baseline validation failed on rank {failed_rank}: {error_message}")
+            if local_error is not None:
+                raise error from local_error
+            raise error
+
         if dist.get_rank() == 0:
             _check_weight_sync_results(ray.get(pulls), is_lora=False)
             if self.args.check_weight_update_equal:
@@ -325,7 +403,7 @@ class UpdateWeightFromDiskDelta(DistBucketedWeightUpdateMixin):
 
         def encode_bucket(converted_named_tensors: list[tuple[str, torch.Tensor]], pbar: tqdm | None = None) -> None:
             for name, tensor in converted_named_tensors:
-                flat = tensor.detach().contiguous().view(torch.uint8).reshape(-1)
+                flat = tensor.detach().contiguous().reshape(-1).view(torch.uint8)
                 nbytes = int(flat.numel())
                 if use_pinned and nbytes <= max_bytes:
                     buf = free_q.get()  # blocks when all buffers are in flight -> backpressures the gather

--- a/miles/utils/disk_delta.py
+++ b/miles/utils/disk_delta.py
@@ -58,9 +58,9 @@ def checksum(algorithm: str, buf) -> str:
     return hasher.hexdigest()
 
 
-def _tensor_locations(ckpt_dir: str) -> dict[str, tuple[str, int, int]]:
-    """Map each tensor name to (file, byte offset, nbytes) by reading every safetensors header."""
-    locations: dict[str, tuple[str, int, int]] = {}
+def _tensor_locations(ckpt_dir: str) -> dict[str, tuple[str, int, int, str, tuple[int, ...]]]:
+    """Index each tensor's byte range and declared safetensors layout."""
+    locations: dict[str, tuple[str, int, int, str, tuple[int, ...]]] = {}
     for path in glob.glob(os.path.join(ckpt_dir, "*.safetensors")):
         with open(path, "rb") as f:
             (header_len,) = struct.unpack("<Q", f.read(8))
@@ -69,17 +69,34 @@ def _tensor_locations(ckpt_dir: str) -> dict[str, tuple[str, int, int]]:
             if name == "__metadata__":
                 continue
             begin, end = info["data_offsets"]
-            locations[name] = (path, 8 + header_len + begin, end - begin)
+            locations[name] = (
+                path,
+                8 + header_len + begin,
+                end - begin,
+                info["dtype"],
+                tuple(info["shape"]),
+            )
     return locations
 
 
 def make_tensor_reader(ckpt_dir: str):
-    """Index the headers once, then return ``read(name) -> uint8 bytes`` that seeks straight to the
-    tensor — for reading many tensors without rescanning every header. KeyError if absent."""
+    """Index headers once and return a layout-aware raw tensor reader."""
     locations = _tensor_locations(ckpt_dir)
 
-    def read(name: str) -> np.ndarray:
-        path, offset, nbytes = locations[name]
+    def read(
+        name: str,
+        *,
+        expected_dtype: str | None = None,
+        expected_shape: tuple[int, ...] | None = None,
+    ) -> np.ndarray:
+        path, offset, nbytes, dtype, shape = locations[name]
+        if (expected_dtype is not None and dtype != expected_dtype) or (
+            expected_shape is not None and shape != expected_shape
+        ):
+            raise ValueError(
+                f"Checkpoint tensor {name!r} has dtype={dtype}, shape={shape}; "
+                f"trainer emitted dtype={expected_dtype}, shape={expected_shape}"
+            )
         with open(path, "rb") as f:
             f.seek(offset)
             return np.frombuffer(f.read(nbytes), dtype=np.uint8)

--- a/tests/fast/utils/test_disk_delta.py
+++ b/tests/fast/utils/test_disk_delta.py
@@ -1,0 +1,19 @@
+import numpy as np
+import pytest
+import safetensors.numpy
+
+from miles.utils.disk_delta import make_tensor_reader
+
+
+def test_tensor_reader_validates_declared_layout(tmp_path):
+    expected = np.arange(6, dtype=np.float16).reshape(2, 3)
+    safetensors.numpy.save_file({"weight": expected}, tmp_path / "model.safetensors")
+    read = make_tensor_reader(str(tmp_path))
+
+    actual = read("weight", expected_dtype="F16", expected_shape=(2, 3))
+    np.testing.assert_array_equal(actual, expected.view(np.uint8).reshape(-1))
+
+    with pytest.raises(ValueError, match="dtype=F16, shape=\\(2, 3\\)"):
+        read("weight", expected_dtype="BF16", expected_shape=(2, 3))
+    with pytest.raises(ValueError, match="dtype=F16, shape=\\(2, 3\\)"):
+        read("weight", expected_dtype="F16", expected_shape=(3, 2))


### PR DESCRIPTION
## Summary

- index safetensors dtype and shape with each canonical checkpoint tensor
- require every trainer-emitted tensor to exist in the canonical checkpoint with the same dtype, shape, and byte count
- remove the fallback that seeded missing tensors from trainer weights
- flatten raw tensor bytes in an order that also supports scalar tensors

## Why

Disk-delta encodes changes over raw bytes and applies them under the canonical safetensors header. A missing tensor or a dtype/shape mismatch cannot be repaired by byte-level XOR: it either has no destination in the checkpoint or makes the header interpret the payload incorrectly. Failing during baseline capture prevents publishing a corrupt or incomplete update stream.

## Test plan

- `python -m pytest tests/fast/utils/test_disk_delta.py -q -p no:cacheprovider`
- pre-commit hooks on changed files