### PR TITLE
[multi-lora] 1/n - 6, feat: typed DP-padding postprocess policy

### DIFF
--- a/miles/ray/rollout/rollout_data_conversion.py
+++ b/miles/ray/rollout/rollout_data_conversion.py
@@ -1,3 +1,4 @@
+import copy
 import itertools
 import logging
 
@@ -7,7 +8,7 @@ from miles.utils.types import Sample
 logger = logging.getLogger(__name__)
 
 
-def postprocess_rollout_data(args, data, train_parallel_config):
+def postprocess_rollout_data(args, data, train_parallel_config, pad_to_dp: bool = False):
     metadata = {}
 
     validate_compact_rollout_ids(data)
@@ -24,6 +25,9 @@ def postprocess_rollout_data(args, data, train_parallel_config):
     # flatten the data if it is a list of lists
     while isinstance(data[0], list):
         data = list(itertools.chain.from_iterable(data))
+
+    if pad_to_dp and (dp_size := (train_parallel_config or {}).get("dp_size")):
+        data = _pad_samples_to_dp(data, dp_size)
 
     # Compact rollouts must not be trimmed by sample count; the schedule drops
     # whole trailing rollouts instead.
@@ -80,6 +84,23 @@ def _nested_sample_count(group) -> int:
     if not isinstance(group, list):
         return 1
     return sum(_nested_sample_count(item) for item in group)
+
+
+def _pad_samples_to_dp(data: list[Sample], dp_size: int) -> list[Sample]:
+    deficit = -len(data) % dp_size
+    if deficit == 0:
+        return data
+
+    donor = data[-1]
+    padded = list(data)
+    for _ in range(deficit):
+        pad = copy.deepcopy(donor)
+        pad.index = -1
+        pad.rollout_id = None
+        pad.loss_mask = [0] * pad.response_length
+        padded.append(pad)
+    logger.info(f"Padded rollout batch from {len(data)} to {len(padded)} samples for DP alignment")
+    return padded
 
 
 def _compute_dynamic_global_batch_size(args, train_parallel_config, num_samples: int) -> int:

--- a/miles/ray/rollout/rollout_manager.py
+++ b/miles/ray/rollout/rollout_manager.py
@@ -25,6 +25,7 @@ from miles.rollout.base_types import (
     RolloutFnConstructorInput,
     RolloutFnEvalInput,
     RolloutFnTrainInput,
+    RolloutPostprocessOptions,
     call_rollout_fn,
 )
 from miles.rollout.checkpoint_eval import CheckpointEvalFn, EvalSkip
@@ -256,9 +257,13 @@ class RolloutManager:
                     call_rollout_fn, self.generate_rollout, self.args, rollout_id, self.data_source, evaluation=False
                 )
             metrics = data.metrics
+            postprocess = getattr(data, "postprocess", None) or RolloutPostprocessOptions()
             data = data.samples
             data, metadata = postprocess_rollout_data(
-                self.args, data, train_parallel_config=self.train_parallel_config
+                self.args,
+                data,
+                train_parallel_config=self.train_parallel_config,
+                pad_to_dp=postprocess.pad_to_dp,
             )
             if RolloutDataInjectionUtil.should_inject(self.args, rollout_id):
                 generated_data = data

--- a/miles/rollout/base_types.py
+++ b/miles/rollout/base_types.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from argparse import Namespace
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
 from miles.rollout.data_source import DataSource
@@ -49,11 +49,24 @@ class RolloutFnEvalInput(RolloutFnBaseInput):
         return True
 
 
+@dataclass(frozen=True)
+class RolloutPostprocessOptions:
+    """Postprocessing policy declared by a rollout function for its output.
+
+    ``pad_to_dp`` appends zero-loss sentinel samples until the flattened batch
+    is divisible by the data-parallel size. Negative sample indices mark
+    padding for downstream correlation.
+    """
+
+    pad_to_dp: bool = False
+
+
 # TODO make it frozen
 @dataclass
 class RolloutFnTrainOutput:
     samples: list[list[Sample]]
     metrics: dict[str, Any] = None
+    postprocess: RolloutPostprocessOptions = field(default_factory=RolloutPostprocessOptions)
 
 
 # TODO make it frozen

--- a/tests/fast/ray/rollout/real_ray/test_rollout_manager.py
+++ b/tests/fast/ray/rollout/real_ray/test_rollout_manager.py
@@ -20,7 +20,13 @@ import ray
 from tests.fast.ray.rollout.conftest import make_args, make_samples_grouped
 
 from miles.ray.rollout.rollout_manager import RolloutManager
-from miles.rollout.base_types import RolloutFnEvalInput, RolloutFnEvalOutput, RolloutFnTrainInput, RolloutFnTrainOutput
+from miles.rollout.base_types import (
+    RolloutFnEvalInput,
+    RolloutFnEvalOutput,
+    RolloutFnTrainInput,
+    RolloutFnTrainOutput,
+    RolloutPostprocessOptions,
+)
 
 
 @pytest.fixture
@@ -625,6 +631,34 @@ class TestGenerate:
             assert "loss_masks" in partition
             # 8 samples / 2 dp = 4 per rank
             assert len(partition["tokens"]) == 4
+
+    async def test_rollout_postprocess_policy_drives_dp_padding(
+        self,
+        ray_local_mode,
+        placement_group_factory,
+        tmp_path,
+        patch_low_level,
+    ):
+        args = _make_test_args(tmp_path, models=[("actor", True)])
+        args.global_batch_size = 8
+        pg = placement_group_factory(2)
+
+        manager = _make_manager(args, pg)
+        manager.train_parallel_config = {"dp_size": 2}
+
+        def fake_rollout_fn(input):
+            return RolloutFnTrainOutput(
+                samples=[make_samples_grouped(n_groups=7, group_size=1)],
+                postprocess=RolloutPostprocessOptions(pad_to_dp=True),
+            )
+
+        manager.generate_rollout = fake_rollout_fn
+
+        result = await manager.generate(rollout_id=7)
+
+        assert result["sample_indices"] == [0, 1, 2, 3, 4, 5, 6, -1]
+        partitions = ray.get([box.inner for box in result["data_ref"]])
+        assert [len(partition["tokens"]) for partition in partitions] == [4, 4]
 
 
 @pytest.mark.asyncio

--- a/tests/fast/ray/rollout/test_rollout_data_conversion.py
+++ b/tests/fast/ray/rollout/test_rollout_data_conversion.py
@@ -77,6 +77,23 @@ class TestPostprocessRolloutData:
         out, _meta = postprocess_rollout_data(args, nested, train_parallel_config={"dp_size": 1})
         assert len(out) == 3
 
+    def test_pad_to_dp_adds_zero_loss_rows_before_dynamic_batch_sizing(self):
+        args = make_args(global_batch_size=8, disable_rollout_trim_samples=False, use_dynamic_global_batch_size=True)
+        data = [make_sample(index=i, response_length=2, loss_mask=[1, 1]) for i in range(5)]
+
+        out, meta = postprocess_rollout_data(
+            args,
+            data,
+            train_parallel_config={"dp_size": 4},
+            pad_to_dp=True,
+        )
+
+        assert [sample.index for sample in out] == [0, 1, 2, 3, 4, -1, -1, -1]
+        assert all(sample.rollout_id is None for sample in out[-3:])
+        assert all(sample.loss_mask == [0, 0] for sample in out[-3:])
+        assert data[-1].index == 4 and data[-1].loss_mask == [1, 1]
+        assert meta["dynamic_global_batch_size"] == len(out) == 8
+
 
 class TestValidateRolloutIdAnnotated:
     def test_flat_list_skips_validation(self):


### PR DESCRIPTION
## Summary

- add a default-off `RolloutPostprocessOptions` policy to `RolloutFnTrainOutput`
- let rollout producers request zero-loss sentinel padding to the data-parallel grid
- apply padding before dynamic global-batch sizing and forward the policy through `RolloutManager`

## Motivation

Whole-batch rollout producers may need every real row to survive DP alignment. This extracts the
parameterization-neutral postprocessing seam from #2273 so it can be reviewed and merged
independently. No production rollout opts in here, and the default path remains unchanged.

After this merges, #2273 can update its `main` baseline while retaining its Multi-LoRA producer and
Tinker-specific loss/result handling.

## Validation

- H200 devbox CUDA sanity check passed
- focused rollout conversion, compatibility, and manager tests: **34 passed**
- `pre-commit run --files` for all five changed files: passed

Part of the [multi-lora] 1/n merge train: #2273 carries the same (or dependent) content and rebases after this merges.
