### PR TITLE
test(verifiers): cover default rollout path

### DIFF
--- a/tests/e2e/long/test_qwen3_0.6B_verifiers.py
+++ b/tests/e2e/long/test_qwen3_0.6B_verifiers.py
@@ -68,7 +68,7 @@ def execute():
             f"--hf-checkpoint {MODEL_DIR}/{MODEL_NAME}",
             "--sglang-tokenizer-path Qwen/Qwen3-0.6B",
             f"--ref-load {MODEL_DIR}/{MODEL_NAME}_torch_dist",
-            "--rollout-function-path verifiers_rollout.generate_rollout",
+            "--rollout-function-path verifiers_rollout.VerifiersRolloutFn",
             "--disable-rollout-global-dataset",
             "--num-rollout 1",
             "--rollout-batch-size 3",
@@ -112,7 +112,6 @@ def execute():
         num_gpus_per_node=NUM_GPUS,
         megatron_model_type=MODEL_TYPE,
         extra_env_vars={
-            "MILES_USE_LEGACY_ROLLOUT_V1": "1",
             "PYTHONPATH": (
                 f"{VERIFIERS_SITE_PACKAGES}:{CODE_GOLF_DIR}:{MEGATRON_PATH}:{ADAPTER_DIR}:{U.repo_base_dir}"
             ),


### PR DESCRIPTION
## What

Run the existing Verifiers training E2E through `verifiers_rollout.VerifiersRolloutFn`, the shipped default, and stop forcing the legacy rollout path.

## Why

The sole Verifiers training E2E still selects `verifiers_rollout.generate_rollout` and sets `MILES_USE_LEGACY_ROLLOUT_V1=1`. Unit tests check how the launcher selects a rollout function, but they do not run the default adapter through Verifiers, SGLang, and the Miles training loop.

This patch keeps the existing sample, log-probability, trainability, and reward assertions unchanged.

## Validation

- `PYTHONPATH=. python3.11 -m pytest tests/fast/examples/experimental/verifiers/test_run.py -q --confcutdir=tests/fast/examples/experimental/verifiers`: 4 passed
- `python3 -m py_compile tests/e2e/long/test_qwen3_0.6B_verifiers.py`: passed
- `PYTHONPATH=. python3 tests/ci/run_suite.py --hw cuda --suite stage-c-2-gpu-h200 --match-all-labels --list-only`: test enabled
- `uvx --python 3.11 pre-commit run --files tests/e2e/long/test_qwen3_0.6B_verifiers.py`: passed
- `git diff --check`: passed

The 2xH200 E2E has not run on this fork. Maintainers, please approve the held CI run so the default adapter is exercised before merge.

## Tracking

Closes #2560
