### PR TITLE
[dashboard for amd gpu]: add AMD SMI GPU telemetry

### DIFF
--- a/miles/dashboard/gpu_sampler.py
+++ b/miles/dashboard/gpu_sampler.py
@@ -35,10 +35,7 @@ def _text(value) -> str:
     return value.decode() if isinstance(value, bytes) else str(value)
 
 
-# The two providers adapt one vendor SMI each to the same small interface, in
-# the dashboard's units: initialize() -> (handles, uuids), read_device(handle)
-# -> (util %, mem MiB, power W), read_processes(handle) -> [(pid, name, mem MiB)].
-# Both raise from initialize() when unusable so auto-detection can fall through.
+# Providers share initialize/read_device/read_processes; initialization errors enable auto-detection fallback.
 
 
 class _NvmlProvider:
@@ -86,9 +83,7 @@ class _AmdSmiProvider:
         handles = self._api.amdsmi_get_processor_handles()
         if not handles:
             raise RuntimeError("no AMD SMI devices")
-        # Keep the SMI slot as the dashboard lane id — Ray numbers the node's
-        # GPUs in the same order. Partitioned MI300+ cards repeat one UUID per
-        # physical GPU, so uuids are not necessarily unique.
+        # SMI slot order matches Ray; partitioned MI300+ cards may repeat physical-GPU UUIDs.
         return list(handles), [_text(self._api.amdsmi_get_gpu_device_uuid(handle)) for handle in handles]
 
     def read_device(self, handle) -> tuple[int, int, int]:
@@ -98,8 +93,6 @@ class _AmdSmiProvider:
         try:
             power_w = _amd_socket_power(self._api.amdsmi_get_power_info(handle))
         except Exception:
-            # Power sensors can be unexposed (VM guests, some partition modes)
-            # while activity/VRAM read fine; report 0 W rather than losing the sample.
             power_w = 0
         return util, mem_mb, power_w
 
@@ -116,9 +109,7 @@ class _AmdSmiProvider:
 
 
 def _amd_socket_power(power: dict) -> int:
-    # socket_power reads current power on MI300+ and average power on older
-    # cards; older wrappers only have the split fields. Unavailable sensors
-    # come back as "N/A" (ROCm >= 6.1) or a raw sentinel like 0xFFFF (ROCm 6.0).
+    # Prefer MI300+ socket power, then split fields; unavailable sensors use "N/A" or 0xFFFF.
     for field in ("socket_power", "current_socket_power", "average_socket_power"):
         value = power.get(field, "N/A")
         if value != "N/A" and 0 <= value < 0xFFFF:

--- a/miles/dashboard/gpu_sampler.py
+++ b/miles/dashboard/gpu_sampler.py
@@ -2,17 +2,16 @@
 
 One instance runs per GPU node (the collector spawns it as a Ray actor with
 ``NodeAffinitySchedulingStrategy``; the class itself is plain Python and
-unit-testable). A daemon thread samples every NVML device on the node at
-``interval`` seconds — physical device order, independent of
-``CUDA_VISIBLE_DEVICES`` — buffers locally, and hands batches to the injected
+unit-testable). A daemon thread samples every SMI-visible device on the node at
+``interval`` seconds — physical device order, independent of CUDA/HIP process
+visibility variables — buffers locally, and hands batches to the injected
 ``push(node, batch)`` callable (the collector wraps its own Ray handle) every
-``FLUSH_INTERVAL_SECONDS``, so there is roughly one RPC per node per flush
-rather than one per sample.
+``FLUSH_INTERVAL_SECONDS``, so there is roughly one RPC per node per flush.
 
-Degradation: NVML being unavailable (no pynvml, driver mismatch) disables the
-sampler with a single warning — the timeline just lacks the util band. A
-device that fails mid-run (e.g. during a GPU reset) is skipped for that tick
-with rate-limited warnings; the other devices keep reporting.
+NVML is preferred and AMD SMI is the fallback. Missing libraries or driver
+mismatches disable the sampler with a single warning — the timeline just lacks
+the util band. A device that fails mid-run (e.g. during a GPU reset) is skipped
+for that tick with rate-limited warnings; the other devices keep reporting.
 """
 
 from __future__ import annotations
@@ -21,7 +20,8 @@ import logging
 import threading
 import time
 from collections.abc import Callable
-from typing import ClassVar
+from dataclasses import dataclass
+from typing import ClassVar, Protocol
 
 from miles.dashboard.logging_utils import RateLimitedWarner
 from miles.dashboard.store import GpuProcessSample, GpuSample
@@ -29,11 +29,193 @@ from miles.dashboard.store import GpuProcessSample, GpuSample
 logger = logging.getLogger(__name__)
 
 
+@dataclass(frozen=True)
+class _GpuDevice:
+    index: int
+    handle: object
+    uuid: str
+
+
+@dataclass(frozen=True)
+class _GpuProcess:
+    pid: int
+    name: str
+    memory_bytes: int
+
+
+class _GpuProvider(Protocol):
+    name: str
+
+    def initialize(self) -> list[_GpuDevice]: ...
+
+    def read_device(self, handle: object) -> tuple[int, int, int]: ...
+
+    def read_processes(self, handle: object) -> list[_GpuProcess]: ...
+
+    def shutdown(self) -> None: ...
+
+
+def _text(value) -> str:
+    return value.decode() if isinstance(value, bytes) else str(value)
+
+
+class _NvmlProvider:
+    name = "NVML"
+
+    def __init__(self, api):
+        self._api = api
+        self._initialized = False
+
+    def initialize(self) -> list[_GpuDevice]:
+        try:
+            self._api.nvmlInit()
+            self._initialized = True
+            count = self._api.nvmlDeviceGetCount()
+            if count == 0:
+                raise RuntimeError("no NVML devices")
+            devices = []
+            for index in range(count):
+                handle = self._api.nvmlDeviceGetHandleByIndex(index)
+                devices.append(_GpuDevice(index=index, handle=handle, uuid=_text(self._api.nvmlDeviceGetUUID(handle))))
+            return devices
+        except Exception:
+            self._shutdown_after_init_failure()
+            raise
+
+    def read_device(self, handle: object) -> tuple[int, int, int]:
+        util = int(self._api.nvmlDeviceGetUtilizationRates(handle).gpu)
+        mem_mb = int(self._api.nvmlDeviceGetMemoryInfo(handle).used) >> 20
+        power_w = int(self._api.nvmlDeviceGetPowerUsage(handle)) // 1000
+        return util, mem_mb, power_w
+
+    def read_processes(self, handle: object) -> list[_GpuProcess]:
+        processes = []
+        for process in self._api.nvmlDeviceGetComputeRunningProcesses(handle):
+            pid = int(process.pid)
+            try:
+                name = _text(self._api.nvmlSystemGetProcessName(pid))
+            except Exception:
+                name = f"pid {pid}"
+            processes.append(_GpuProcess(pid=pid, name=name, memory_bytes=int(process.usedGpuMemory or 0)))
+        return processes
+
+    def shutdown(self) -> None:
+        if not self._initialized:
+            return
+        self._initialized = False
+        self._api.nvmlShutdown()
+
+    def _shutdown_after_init_failure(self) -> None:
+        try:
+            self.shutdown()
+        except Exception:
+            logger.debug("NVML shutdown after initialization failure failed", exc_info=True)
+
+
+class _AmdSmiProvider:
+    name = "AMD SMI"
+
+    def __init__(self, api):
+        self._api = api
+        self._initialized = False
+
+    def initialize(self) -> list[_GpuDevice]:
+        try:
+            self._api.amdsmi_init()
+            self._initialized = True
+            handles = self._api.amdsmi_get_processor_handles()
+            if not handles:
+                raise RuntimeError("no AMD SMI devices")
+            # Keep the SMI slot as the dashboard lane id. Ray numbers the GPU
+            # resources visible to its node in the same sequential space; do
+            # not re-apply HIP/CUDA visibility variables or re-index by KFD id.
+            return [
+                _GpuDevice(
+                    index=index,
+                    handle=handle,
+                    uuid=_text(self._api.amdsmi_get_gpu_device_uuid(handle)),
+                )
+                for index, handle in enumerate(handles)
+            ]
+        except Exception:
+            self._shutdown_after_init_failure()
+            raise
+
+    def read_device(self, handle: object) -> tuple[int, int, int]:
+        activity = self._api.amdsmi_get_gpu_activity(handle)
+        util = _bounded_int(activity["gfx_activity"], field="gfx_activity", upper=100)
+
+        # Unlike NVML, this AMD SMI API reports both values in MiB already.
+        vram = self._api.amdsmi_get_gpu_vram_usage(handle)
+        mem_mb = _bounded_int(vram["vram_used"], field="vram_used")
+
+        power = self._api.amdsmi_get_power_info(handle)
+        power_w = _amd_socket_power(power)
+        return util, mem_mb, power_w
+
+    def read_processes(self, handle: object) -> list[_GpuProcess]:
+        processes = []
+        for process in self._api.amdsmi_get_gpu_process_list(handle):
+            pid = int(process["pid"])
+            raw_name = process.get("name")
+            name = str(raw_name) if raw_name and raw_name != "N/A" else f"pid {pid}"
+            memory = process.get("memory_usage") or {}
+            processes.append(_GpuProcess(pid=pid, name=name, memory_bytes=int(memory.get("vram_mem") or 0)))
+        return processes
+
+    def shutdown(self) -> None:
+        if not self._initialized:
+            return
+        self._initialized = False
+        self._api.amdsmi_shut_down()
+
+    def _shutdown_after_init_failure(self) -> None:
+        try:
+            self.shutdown()
+        except Exception:
+            logger.debug("AMD SMI shutdown after initialization failure failed", exc_info=True)
+
+
+def _bounded_int(value, *, field: str, upper: int | None = None) -> int:
+    if value is None or isinstance(value, (str, bool)):
+        raise ValueError(f"unsupported {field}: {value!r}")
+    result = int(value)
+    if result < 0 or (upper is not None and result > upper):
+        raise ValueError(f"invalid {field}: {value!r}")
+    return result
+
+
+def _amd_socket_power(power: dict) -> int:
+    # socket_power selects current power on MI300+ and average power on older
+    # cards. The fallbacks tolerate older Python wrappers with that field absent.
+    for field in ("socket_power", "current_socket_power", "average_socket_power"):
+        try:
+            value = power.get(field)
+            if value == 0xFFFF:  # AMD SMI's raw uint16 "not available" sentinel
+                raise ValueError(f"unsupported {field}: {value!r}")
+            return _bounded_int(value, field=field, upper=100_000)
+        except ValueError:
+            continue
+    raise ValueError(f"AMD SMI socket power unavailable: {power!r}")
+
+
+def _import_nvml():
+    import pynvml
+
+    return pynvml
+
+
+def _import_amdsmi():
+    import amdsmi
+
+    return amdsmi
+
+
 class GpuSampler:
     FLUSH_INTERVAL_SECONDS: ClassVar[float] = 5.0
-    # per-process memory breakdown is a coarser, heavier NVML call (enumerates
+    # Per-process memory breakdown is a coarser, heavier SMI call (enumerates
     # every process) than the plain util/mem read, so it samples on its own,
-    # slower cadence rather than every `interval` tick
+    # slower cadence rather than every `interval` tick.
     PROCESS_SAMPLE_INTERVAL_SECONDS: ClassVar[float] = 5.0
 
     def __init__(
@@ -44,14 +226,16 @@ class GpuSampler:
         interval: float = 1.0,
         nvml=None,
         push_processes: Callable[[str, list[GpuProcessSample]], None] | None = None,
+        amdsmi=None,
     ):
         assert interval > 0, f"{interval=}"
+        assert nvml is None or amdsmi is None, "inject only one GPU telemetry backend"
         self._push = push
         self._push_processes = push_processes
         self.node = node
         self.interval = interval
-        self._nvml = nvml
-        self._handles: list = []
+        self._provider: _GpuProvider | None = None
+        self._devices: list[_GpuDevice] = []
         self._uuids: list[str] = []
         self._buffer: list[GpuSample] = []
         self._process_buffer: list[GpuProcessSample] = []
@@ -59,22 +243,46 @@ class GpuSampler:
         self._stop_event = threading.Event()
         self._thread: threading.Thread | None = None
         self._warner = RateLimitedWarner(logger)
-        self.available = self._init_nvml()
+        self.available = self._init_provider(nvml=nvml, amdsmi=amdsmi)
 
-    def _init_nvml(self) -> bool:
-        try:
-            if self._nvml is None:
-                import pynvml
+    def _init_provider(self, *, nvml, amdsmi) -> bool:
+        if nvml is not None:
+            candidates = [("NVML", lambda: _NvmlProvider(nvml))]
+        elif amdsmi is not None:
+            candidates = [("AMD SMI", lambda: _AmdSmiProvider(amdsmi))]
+        else:
+            candidates = [
+                ("NVML", lambda: _NvmlProvider(_import_nvml())),
+                ("AMD SMI", lambda: _AmdSmiProvider(_import_amdsmi())),
+            ]
 
-                self._nvml = pynvml
-            self._nvml.nvmlInit()
-            count = self._nvml.nvmlDeviceGetCount()
-            self._handles = [self._nvml.nvmlDeviceGetHandleByIndex(i) for i in range(count)]
-            self._uuids = [str(self._nvml.nvmlDeviceGetUUID(handle)) for handle in self._handles]
+        failures = []
+        for name, make_provider in candidates:
+            try:
+                provider = make_provider()
+                devices = provider.initialize()
+            except Exception as error:
+                failures.append(f"{name}: {error}")
+                logger.debug("%s unavailable on %s", name, self.node, exc_info=True)
+                continue
+            self._provider = provider
+            self._devices = devices
+            self._uuids = [device.uuid for device in devices]
             return True
-        except Exception as e:
-            logger.warning("NVML unavailable on %s (%s); GPU utilization will not be collected", self.node, e)
-            return False
+
+        detail = "; ".join(failures)
+        if len(candidates) == 1:
+            logger.warning(
+                "%s unavailable on %s (%s); GPU utilization will not be collected",
+                candidates[0][0],
+                self.node,
+                detail,
+            )
+        else:
+            logger.warning(
+                "GPU telemetry unavailable on %s (%s); GPU utilization will not be collected", self.node, detail
+            )
+        return False
 
     # ------------------------------ lifecycle -------------------------------
 
@@ -82,7 +290,7 @@ class GpuSampler:
         return list(self._uuids)
 
     def start(self) -> bool:
-        """Begin sampling; returns False (and stays inert) when NVML is unavailable."""
+        """Begin sampling; returns False (and stays inert) without a telemetry provider."""
         if not self.available:
             return False
         assert self._thread is None, "sampler already started"
@@ -94,7 +302,30 @@ class GpuSampler:
         self._stop_event.set()
         if self._thread is not None:
             self._thread.join(timeout=self.interval + self.FLUSH_INTERVAL_SECONDS)
-        self.flush()
+            if self._thread.is_alive():
+                # A vendor call can block during a driver reset. Keep the
+                # provider initialized until that call returns rather than
+                # racing its native library teardown from this thread.
+                self.available = False
+                self.flush()
+                logger.warning(
+                    "%s sampler thread did not stop on %s; skipping provider shutdown", self._provider.name, self.node
+                )
+                return
+        try:
+            self.flush()
+        finally:
+            self._shutdown_provider()
+
+    def _shutdown_provider(self) -> None:
+        provider, self._provider = self._provider, None
+        self.available = False
+        if provider is None:
+            return
+        try:
+            provider.shutdown()
+        except Exception:
+            logger.warning("%s shutdown failed on %s", provider.name, self.node, exc_info=True)
 
     def _run(self) -> None:
         next_flush = time.monotonic() + self.FLUSH_INTERVAL_SECONDS
@@ -115,18 +346,26 @@ class GpuSampler:
         """Sample every device once into the buffer. Returns the sample count."""
         if not self.available:
             return 0
+        assert self._provider is not None
         count = 0
-        for gpu, handle in enumerate(self._handles):
+        for device in self._devices:
             try:
-                util = int(self._nvml.nvmlDeviceGetUtilizationRates(handle).gpu)
-                mem_mb = int(self._nvml.nvmlDeviceGetMemoryInfo(handle).used) >> 20
-                power_w = int(self._nvml.nvmlDeviceGetPowerUsage(handle)) // 1000
+                util, mem_mb, power_w = self._provider.read_device(device.handle)
             except Exception:
-                self._warner.warn(f"NVML read failed for gpu {gpu} on {self.node}; skipping this tick")
+                self._warner.warn(
+                    f"{self._provider.name} read failed for gpu {device.index} on {self.node}; skipping this tick"
+                )
                 continue
             with self._buffer_lock:
                 self._buffer.append(
-                    GpuSample(ts=ts, node=self.node, gpu=gpu, util=util, mem_mb=mem_mb, power_w=power_w)
+                    GpuSample(
+                        ts=ts,
+                        node=self.node,
+                        gpu=device.index,
+                        util=util,
+                        mem_mb=mem_mb,
+                        power_w=power_w,
+                    )
                 )
             count += 1
         return count
@@ -136,35 +375,31 @@ class GpuSampler:
         the memory, not just the per-GPU aggregate ``sample_once`` reports."""
         if not self.available:
             return 0
+        assert self._provider is not None
         count = 0
-        for gpu, handle in enumerate(self._handles):
+        for device in self._devices:
             try:
-                procs = self._nvml.nvmlDeviceGetComputeRunningProcesses(handle)
+                processes = self._provider.read_processes(device.handle)
             except Exception:
-                self._warner.warn(f"NVML process query failed for gpu {gpu} on {self.node}; skipping this tick")
+                self._warner.warn(
+                    f"{self._provider.name} process query failed for gpu {device.index} on {self.node}; "
+                    "skipping this tick"
+                )
                 continue
-            for proc in procs:
-                mem_mb = (proc.usedGpuMemory or 0) >> 20
+            for process in processes:
                 with self._buffer_lock:
                     self._process_buffer.append(
                         GpuProcessSample(
                             ts=ts,
                             node=self.node,
-                            gpu=gpu,
-                            pid=proc.pid,
-                            name=self._process_name(proc.pid),
-                            mem_mb=mem_mb,
+                            gpu=device.index,
+                            pid=process.pid,
+                            name=process.name,
+                            mem_mb=process.memory_bytes >> 20,
                         )
                     )
                 count += 1
         return count
-
-    def _process_name(self, pid: int) -> str:
-        try:
-            name = self._nvml.nvmlSystemGetProcessName(pid)
-            return name.decode() if isinstance(name, bytes) else str(name)
-        except Exception:
-            return f"pid {pid}"  # process exited between enumeration and lookup, or name unavailable
 
     def flush(self) -> None:
         with self._buffer_lock:

--- a/miles/dashboard/gpu_sampler.py
+++ b/miles/dashboard/gpu_sampler.py
@@ -18,11 +18,12 @@ the other devices keep reporting.
 
 from __future__ import annotations
 
+import importlib
 import logging
 import threading
 import time
 from collections.abc import Callable
-from typing import ClassVar, Protocol
+from typing import ClassVar
 
 from miles.dashboard.logging_utils import RateLimitedWarner
 from miles.dashboard.store import GpuProcessSample, GpuSample
@@ -30,32 +31,24 @@ from miles.dashboard.store import GpuProcessSample, GpuSample
 logger = logging.getLogger(__name__)
 
 
-class _GpuProvider(Protocol):
-    """Vendor SMI adapter. Returns values in the dashboard's units (util %,
-    VRAM MiB, power W) so the sampler stays vendor-agnostic."""
-
-    name: str
-
-    def initialize(self) -> tuple[list, list[str]]: ...
-
-    def read_device(self, handle) -> tuple[int, int, int]: ...
-
-    def read_processes(self, handle) -> list[tuple[int, str, int]]: ...
-
-
 def _text(value) -> str:
     return value.decode() if isinstance(value, bytes) else str(value)
 
 
+# The two providers adapt one vendor SMI each to the same small interface, in
+# the dashboard's units: initialize() -> (handles, uuids), read_device(handle)
+# -> (util %, mem MiB, power W), read_processes(handle) -> [(pid, name, mem MiB)].
+# Both raise from initialize() when unusable so auto-detection can fall through.
+
+
 class _NvmlProvider:
     name = "NVML"
+    module = "pynvml"
 
     def __init__(self, api):
         self._api = api
 
     def initialize(self) -> tuple[list, list[str]]:
-        """Returns (handles, uuids); raises when NVML is unusable so
-        auto-detection can fall through to the next backend."""
         self._api.nvmlInit()
         count = self._api.nvmlDeviceGetCount()
         if count == 0:
@@ -73,18 +66,17 @@ class _NvmlProvider:
         processes = []
         for proc in self._api.nvmlDeviceGetComputeRunningProcesses(handle):
             pid = int(proc.pid)
-            processes.append((pid, self._process_name(pid), int(proc.usedGpuMemory or 0) >> 20))
+            try:
+                name = _text(self._api.nvmlSystemGetProcessName(pid))
+            except Exception:
+                name = f"pid {pid}"  # process exited between enumeration and lookup, or name unavailable
+            processes.append((pid, name, int(proc.usedGpuMemory or 0) >> 20))
         return processes
-
-    def _process_name(self, pid: int) -> str:
-        try:
-            return _text(self._api.nvmlSystemGetProcessName(pid))
-        except Exception:
-            return f"pid {pid}"  # process exited between enumeration and lookup, or name unavailable
 
 
 class _AmdSmiProvider:
     name = "AMD SMI"
+    module = "amdsmi"
 
     def __init__(self, api):
         self._api = api
@@ -94,11 +86,9 @@ class _AmdSmiProvider:
         handles = self._api.amdsmi_get_processor_handles()
         if not handles:
             raise RuntimeError("no AMD SMI devices")
-        # Keep the SMI slot as the dashboard lane id. Ray numbers the GPU
-        # resources visible to its node in the same sequential space; do not
-        # re-apply HIP/CUDA visibility variables or re-index by KFD id. Note:
-        # partitioned MI300+ devices share one UUID per physical GPU, so the
-        # uuids are not necessarily unique per lane.
+        # Keep the SMI slot as the dashboard lane id — Ray numbers the node's
+        # GPUs in the same order. Partitioned MI300+ cards repeat one UUID per
+        # physical GPU, so uuids are not necessarily unique.
         return list(handles), [_text(self._api.amdsmi_get_gpu_device_uuid(handle)) for handle in handles]
 
     def read_device(self, handle) -> tuple[int, int, int]:
@@ -126,27 +116,14 @@ class _AmdSmiProvider:
 
 
 def _amd_socket_power(power: dict) -> int:
-    # socket_power selects current power on MI300+ and average power on older
-    # cards; older wrappers lack the field entirely. Unavailable sensors show
-    # up as the string "N/A" (ROCm >= 6.1) or a raw integer sentinel (uint16
-    # 0xFFFF on ROCm 6.0, UINT32_MAX from newer C structs).
+    # socket_power reads current power on MI300+ and average power on older
+    # cards; older wrappers only have the split fields. Unavailable sensors
+    # come back as "N/A" (ROCm >= 6.1) or a raw sentinel like 0xFFFF (ROCm 6.0).
     for field in ("socket_power", "current_socket_power", "average_socket_power"):
-        value = power.get(field)
-        if isinstance(value, (int, float)) and not isinstance(value, bool) and 0 <= value < 0xFFFF:
+        value = power.get(field, "N/A")
+        if value != "N/A" and 0 <= value < 0xFFFF:
             return int(value)
     raise ValueError(f"AMD SMI socket power unavailable: {power!r}")
-
-
-def _import_nvml():
-    import pynvml
-
-    return pynvml
-
-
-def _import_amdsmi():
-    import amdsmi
-
-    return amdsmi
 
 
 class GpuSampler:
@@ -172,7 +149,7 @@ class GpuSampler:
         self._push_processes = push_processes
         self.node = node
         self.interval = interval
-        self._provider: _GpuProvider | None = None
+        self._provider = None  # _NvmlProvider or _AmdSmiProvider once initialized
         self._handles: list = []
         self._uuids: list[str] = []
         self._buffer: list[GpuSample] = []
@@ -185,16 +162,16 @@ class GpuSampler:
 
     def _init_provider(self, *, nvml, amdsmi) -> bool:
         if nvml is not None:
-            candidates = [(_NvmlProvider, lambda: nvml)]
+            candidates = [(_NvmlProvider, nvml)]
         elif amdsmi is not None:
-            candidates = [(_AmdSmiProvider, lambda: amdsmi)]
-        else:
-            candidates = [(_NvmlProvider, _import_nvml), (_AmdSmiProvider, _import_amdsmi)]
+            candidates = [(_AmdSmiProvider, amdsmi)]
+        else:  # auto-detect: try NVML first, then AMD SMI
+            candidates = [(_NvmlProvider, None), (_AmdSmiProvider, None)]
 
         failures = []
-        for cls, import_api in candidates:
+        for cls, api in candidates:
             try:
-                provider = cls(import_api())
+                provider = cls(api if api is not None else importlib.import_module(cls.module))
                 self._handles, self._uuids = provider.initialize()
             except Exception as error:
                 failures.append((cls.name, str(error)))

--- a/miles/dashboard/gpu_sampler.py
+++ b/miles/dashboard/gpu_sampler.py
@@ -6,12 +6,14 @@ unit-testable). A daemon thread samples every SMI-visible device on the node at
 ``interval`` seconds — physical device order, independent of CUDA/HIP process
 visibility variables — buffers locally, and hands batches to the injected
 ``push(node, batch)`` callable (the collector wraps its own Ray handle) every
-``FLUSH_INTERVAL_SECONDS``, so there is roughly one RPC per node per flush.
+``FLUSH_INTERVAL_SECONDS``, so there is roughly one RPC per node per flush
+rather than one per sample.
 
-NVML is preferred and AMD SMI is the fallback. Missing libraries or driver
-mismatches disable the sampler with a single warning — the timeline just lacks
-the util band. A device that fails mid-run (e.g. during a GPU reset) is skipped
-for that tick with rate-limited warnings; the other devices keep reporting.
+Degradation: NVML is preferred and AMD SMI is the fallback; neither being
+usable (no pynvml/amdsmi, driver mismatch) disables the sampler with a single
+warning — the timeline just lacks the util band. A device that fails mid-run
+(e.g. during a GPU reset) is skipped for that tick with rate-limited warnings;
+the other devices keep reporting.
 """
 
 from __future__ import annotations
@@ -20,7 +22,6 @@ import logging
 import threading
 import time
 from collections.abc import Callable
-from dataclasses import dataclass
 from typing import ClassVar, Protocol
 
 from miles.dashboard.logging_utils import RateLimitedWarner
@@ -29,30 +30,17 @@ from miles.dashboard.store import GpuProcessSample, GpuSample
 logger = logging.getLogger(__name__)
 
 
-@dataclass(frozen=True)
-class _GpuDevice:
-    index: int
-    handle: object
-    uuid: str
-
-
-@dataclass(frozen=True)
-class _GpuProcess:
-    pid: int
-    name: str
-    memory_bytes: int
-
-
 class _GpuProvider(Protocol):
+    """Vendor SMI adapter. Returns values in the dashboard's units (util %,
+    VRAM MiB, power W) so the sampler stays vendor-agnostic."""
+
     name: str
 
-    def initialize(self) -> list[_GpuDevice]: ...
+    def initialize(self) -> tuple[list, list[str]]: ...
 
-    def read_device(self, handle: object) -> tuple[int, int, int]: ...
+    def read_device(self, handle) -> tuple[int, int, int]: ...
 
-    def read_processes(self, handle: object) -> list[_GpuProcess]: ...
-
-    def shutdown(self) -> None: ...
+    def read_processes(self, handle) -> list[tuple[int, str, int]]: ...
 
 
 def _text(value) -> str:
@@ -64,52 +52,35 @@ class _NvmlProvider:
 
     def __init__(self, api):
         self._api = api
-        self._initialized = False
 
-    def initialize(self) -> list[_GpuDevice]:
-        try:
-            self._api.nvmlInit()
-            self._initialized = True
-            count = self._api.nvmlDeviceGetCount()
-            if count == 0:
-                raise RuntimeError("no NVML devices")
-            devices = []
-            for index in range(count):
-                handle = self._api.nvmlDeviceGetHandleByIndex(index)
-                devices.append(_GpuDevice(index=index, handle=handle, uuid=_text(self._api.nvmlDeviceGetUUID(handle))))
-            return devices
-        except Exception:
-            self._shutdown_after_init_failure()
-            raise
+    def initialize(self) -> tuple[list, list[str]]:
+        """Returns (handles, uuids); raises when NVML is unusable so
+        auto-detection can fall through to the next backend."""
+        self._api.nvmlInit()
+        count = self._api.nvmlDeviceGetCount()
+        if count == 0:
+            raise RuntimeError("no NVML devices")
+        handles = [self._api.nvmlDeviceGetHandleByIndex(i) for i in range(count)]
+        return handles, [_text(self._api.nvmlDeviceGetUUID(handle)) for handle in handles]
 
-    def read_device(self, handle: object) -> tuple[int, int, int]:
+    def read_device(self, handle) -> tuple[int, int, int]:
         util = int(self._api.nvmlDeviceGetUtilizationRates(handle).gpu)
         mem_mb = int(self._api.nvmlDeviceGetMemoryInfo(handle).used) >> 20
         power_w = int(self._api.nvmlDeviceGetPowerUsage(handle)) // 1000
         return util, mem_mb, power_w
 
-    def read_processes(self, handle: object) -> list[_GpuProcess]:
+    def read_processes(self, handle) -> list[tuple[int, str, int]]:
         processes = []
-        for process in self._api.nvmlDeviceGetComputeRunningProcesses(handle):
-            pid = int(process.pid)
-            try:
-                name = _text(self._api.nvmlSystemGetProcessName(pid))
-            except Exception:
-                name = f"pid {pid}"
-            processes.append(_GpuProcess(pid=pid, name=name, memory_bytes=int(process.usedGpuMemory or 0)))
+        for proc in self._api.nvmlDeviceGetComputeRunningProcesses(handle):
+            pid = int(proc.pid)
+            processes.append((pid, self._process_name(pid), int(proc.usedGpuMemory or 0) >> 20))
         return processes
 
-    def shutdown(self) -> None:
-        if not self._initialized:
-            return
-        self._initialized = False
-        self._api.nvmlShutdown()
-
-    def _shutdown_after_init_failure(self) -> None:
+    def _process_name(self, pid: int) -> str:
         try:
-            self.shutdown()
+            return _text(self._api.nvmlSystemGetProcessName(pid))
         except Exception:
-            logger.debug("NVML shutdown after initialization failure failed", exc_info=True)
+            return f"pid {pid}"  # process exited between enumeration and lookup, or name unavailable
 
 
 class _AmdSmiProvider:
@@ -117,85 +88,52 @@ class _AmdSmiProvider:
 
     def __init__(self, api):
         self._api = api
-        self._initialized = False
 
-    def initialize(self) -> list[_GpuDevice]:
+    def initialize(self) -> tuple[list, list[str]]:
+        self._api.amdsmi_init()
+        handles = self._api.amdsmi_get_processor_handles()
+        if not handles:
+            raise RuntimeError("no AMD SMI devices")
+        # Keep the SMI slot as the dashboard lane id. Ray numbers the GPU
+        # resources visible to its node in the same sequential space; do not
+        # re-apply HIP/CUDA visibility variables or re-index by KFD id. Note:
+        # partitioned MI300+ devices share one UUID per physical GPU, so the
+        # uuids are not necessarily unique per lane.
+        return list(handles), [_text(self._api.amdsmi_get_gpu_device_uuid(handle)) for handle in handles]
+
+    def read_device(self, handle) -> tuple[int, int, int]:
+        util = int(self._api.amdsmi_get_gpu_activity(handle)["gfx_activity"])
+        # Unlike NVML, AMD SMI reports VRAM usage in MiB already.
+        mem_mb = int(self._api.amdsmi_get_gpu_vram_usage(handle)["vram_used"])
         try:
-            self._api.amdsmi_init()
-            self._initialized = True
-            handles = self._api.amdsmi_get_processor_handles()
-            if not handles:
-                raise RuntimeError("no AMD SMI devices")
-            # Keep the SMI slot as the dashboard lane id. Ray numbers the GPU
-            # resources visible to its node in the same sequential space; do
-            # not re-apply HIP/CUDA visibility variables or re-index by KFD id.
-            return [
-                _GpuDevice(
-                    index=index,
-                    handle=handle,
-                    uuid=_text(self._api.amdsmi_get_gpu_device_uuid(handle)),
-                )
-                for index, handle in enumerate(handles)
-            ]
+            power_w = _amd_socket_power(self._api.amdsmi_get_power_info(handle))
         except Exception:
-            self._shutdown_after_init_failure()
-            raise
-
-    def read_device(self, handle: object) -> tuple[int, int, int]:
-        activity = self._api.amdsmi_get_gpu_activity(handle)
-        util = _bounded_int(activity["gfx_activity"], field="gfx_activity", upper=100)
-
-        # Unlike NVML, this AMD SMI API reports both values in MiB already.
-        vram = self._api.amdsmi_get_gpu_vram_usage(handle)
-        mem_mb = _bounded_int(vram["vram_used"], field="vram_used")
-
-        power = self._api.amdsmi_get_power_info(handle)
-        power_w = _amd_socket_power(power)
+            # Power sensors can be unexposed (VM guests, some partition modes)
+            # while activity/VRAM read fine; report 0 W rather than losing the sample.
+            power_w = 0
         return util, mem_mb, power_w
 
-    def read_processes(self, handle: object) -> list[_GpuProcess]:
+    def read_processes(self, handle) -> list[tuple[int, str, int]]:
         processes = []
-        for process in self._api.amdsmi_get_gpu_process_list(handle):
-            pid = int(process["pid"])
-            raw_name = process.get("name")
-            name = str(raw_name) if raw_name and raw_name != "N/A" else f"pid {pid}"
-            memory = process.get("memory_usage") or {}
-            processes.append(_GpuProcess(pid=pid, name=name, memory_bytes=int(memory.get("vram_mem") or 0)))
+        for proc in self._api.amdsmi_get_gpu_process_list(handle):
+            mem_mb = int((proc.get("memory_usage") or {}).get("vram_mem") or 0) >> 20
+            if mem_mb == 0:
+                continue  # KFD lists bystander pids holding no VRAM; NVML reports only compute processes
+            pid = int(proc["pid"])
+            name = proc.get("name")
+            processes.append((pid, str(name) if name and name != "N/A" else f"pid {pid}", mem_mb))
         return processes
-
-    def shutdown(self) -> None:
-        if not self._initialized:
-            return
-        self._initialized = False
-        self._api.amdsmi_shut_down()
-
-    def _shutdown_after_init_failure(self) -> None:
-        try:
-            self.shutdown()
-        except Exception:
-            logger.debug("AMD SMI shutdown after initialization failure failed", exc_info=True)
-
-
-def _bounded_int(value, *, field: str, upper: int | None = None) -> int:
-    if value is None or isinstance(value, (str, bool)):
-        raise ValueError(f"unsupported {field}: {value!r}")
-    result = int(value)
-    if result < 0 or (upper is not None and result > upper):
-        raise ValueError(f"invalid {field}: {value!r}")
-    return result
 
 
 def _amd_socket_power(power: dict) -> int:
     # socket_power selects current power on MI300+ and average power on older
-    # cards. The fallbacks tolerate older Python wrappers with that field absent.
+    # cards; older wrappers lack the field entirely. Unavailable sensors show
+    # up as the string "N/A" (ROCm >= 6.1) or a raw integer sentinel (uint16
+    # 0xFFFF on ROCm 6.0, UINT32_MAX from newer C structs).
     for field in ("socket_power", "current_socket_power", "average_socket_power"):
-        try:
-            value = power.get(field)
-            if value == 0xFFFF:  # AMD SMI's raw uint16 "not available" sentinel
-                raise ValueError(f"unsupported {field}: {value!r}")
-            return _bounded_int(value, field=field, upper=100_000)
-        except ValueError:
-            continue
+        value = power.get(field)
+        if isinstance(value, (int, float)) and not isinstance(value, bool) and 0 <= value < 0xFFFF:
+            return int(value)
     raise ValueError(f"AMD SMI socket power unavailable: {power!r}")
 
 
@@ -213,9 +151,9 @@ def _import_amdsmi():
 
 class GpuSampler:
     FLUSH_INTERVAL_SECONDS: ClassVar[float] = 5.0
-    # Per-process memory breakdown is a coarser, heavier SMI call (enumerates
+    # per-process memory breakdown is a coarser, heavier SMI call (enumerates
     # every process) than the plain util/mem read, so it samples on its own,
-    # slower cadence rather than every `interval` tick.
+    # slower cadence rather than every `interval` tick
     PROCESS_SAMPLE_INTERVAL_SECONDS: ClassVar[float] = 5.0
 
     def __init__(
@@ -235,7 +173,7 @@ class GpuSampler:
         self.node = node
         self.interval = interval
         self._provider: _GpuProvider | None = None
-        self._devices: list[_GpuDevice] = []
+        self._handles: list = []
         self._uuids: list[str] = []
         self._buffer: list[GpuSample] = []
         self._process_buffer: list[GpuProcessSample] = []
@@ -247,38 +185,29 @@ class GpuSampler:
 
     def _init_provider(self, *, nvml, amdsmi) -> bool:
         if nvml is not None:
-            candidates = [("NVML", lambda: _NvmlProvider(nvml))]
+            candidates = [(_NvmlProvider, lambda: nvml)]
         elif amdsmi is not None:
-            candidates = [("AMD SMI", lambda: _AmdSmiProvider(amdsmi))]
+            candidates = [(_AmdSmiProvider, lambda: amdsmi)]
         else:
-            candidates = [
-                ("NVML", lambda: _NvmlProvider(_import_nvml())),
-                ("AMD SMI", lambda: _AmdSmiProvider(_import_amdsmi())),
-            ]
+            candidates = [(_NvmlProvider, _import_nvml), (_AmdSmiProvider, _import_amdsmi)]
 
         failures = []
-        for name, make_provider in candidates:
+        for cls, import_api in candidates:
             try:
-                provider = make_provider()
-                devices = provider.initialize()
+                provider = cls(import_api())
+                self._handles, self._uuids = provider.initialize()
             except Exception as error:
-                failures.append(f"{name}: {error}")
-                logger.debug("%s unavailable on %s", name, self.node, exc_info=True)
+                failures.append((cls.name, str(error)))
+                logger.debug("%s unavailable on %s", cls.name, self.node, exc_info=True)
                 continue
             self._provider = provider
-            self._devices = devices
-            self._uuids = [device.uuid for device in devices]
             return True
 
-        detail = "; ".join(failures)
-        if len(candidates) == 1:
-            logger.warning(
-                "%s unavailable on %s (%s); GPU utilization will not be collected",
-                candidates[0][0],
-                self.node,
-                detail,
-            )
+        if len(failures) == 1:
+            name, error = failures[0]
+            logger.warning("%s unavailable on %s (%s); GPU utilization will not be collected", name, self.node, error)
         else:
+            detail = "; ".join(f"{name}: {error}" for name, error in failures)
             logger.warning(
                 "GPU telemetry unavailable on %s (%s); GPU utilization will not be collected", self.node, detail
             )
@@ -290,7 +219,7 @@ class GpuSampler:
         return list(self._uuids)
 
     def start(self) -> bool:
-        """Begin sampling; returns False (and stays inert) without a telemetry provider."""
+        """Begin sampling; returns False (and stays inert) when no SMI backend is usable."""
         if not self.available:
             return False
         assert self._thread is None, "sampler already started"
@@ -302,30 +231,7 @@ class GpuSampler:
         self._stop_event.set()
         if self._thread is not None:
             self._thread.join(timeout=self.interval + self.FLUSH_INTERVAL_SECONDS)
-            if self._thread.is_alive():
-                # A vendor call can block during a driver reset. Keep the
-                # provider initialized until that call returns rather than
-                # racing its native library teardown from this thread.
-                self.available = False
-                self.flush()
-                logger.warning(
-                    "%s sampler thread did not stop on %s; skipping provider shutdown", self._provider.name, self.node
-                )
-                return
-        try:
-            self.flush()
-        finally:
-            self._shutdown_provider()
-
-    def _shutdown_provider(self) -> None:
-        provider, self._provider = self._provider, None
-        self.available = False
-        if provider is None:
-            return
-        try:
-            provider.shutdown()
-        except Exception:
-            logger.warning("%s shutdown failed on %s", provider.name, self.node, exc_info=True)
+        self.flush()
 
     def _run(self) -> None:
         next_flush = time.monotonic() + self.FLUSH_INTERVAL_SECONDS
@@ -346,26 +252,18 @@ class GpuSampler:
         """Sample every device once into the buffer. Returns the sample count."""
         if not self.available:
             return 0
-        assert self._provider is not None
         count = 0
-        for device in self._devices:
+        for gpu, handle in enumerate(self._handles):
             try:
-                util, mem_mb, power_w = self._provider.read_device(device.handle)
+                util, mem_mb, power_w = self._provider.read_device(handle)
             except Exception:
                 self._warner.warn(
-                    f"{self._provider.name} read failed for gpu {device.index} on {self.node}; skipping this tick"
+                    f"{self._provider.name} read failed for gpu {gpu} on {self.node}; skipping this tick"
                 )
                 continue
             with self._buffer_lock:
                 self._buffer.append(
-                    GpuSample(
-                        ts=ts,
-                        node=self.node,
-                        gpu=device.index,
-                        util=util,
-                        mem_mb=mem_mb,
-                        power_w=power_w,
-                    )
+                    GpuSample(ts=ts, node=self.node, gpu=gpu, util=util, mem_mb=mem_mb, power_w=power_w)
                 )
             count += 1
         return count
@@ -375,28 +273,19 @@ class GpuSampler:
         the memory, not just the per-GPU aggregate ``sample_once`` reports."""
         if not self.available:
             return 0
-        assert self._provider is not None
         count = 0
-        for device in self._devices:
+        for gpu, handle in enumerate(self._handles):
             try:
-                processes = self._provider.read_processes(device.handle)
+                processes = self._provider.read_processes(handle)
             except Exception:
                 self._warner.warn(
-                    f"{self._provider.name} process query failed for gpu {device.index} on {self.node}; "
-                    "skipping this tick"
+                    f"{self._provider.name} process query failed for gpu {gpu} on {self.node}; skipping this tick"
                 )
                 continue
-            for process in processes:
+            for pid, name, mem_mb in processes:
                 with self._buffer_lock:
                     self._process_buffer.append(
-                        GpuProcessSample(
-                            ts=ts,
-                            node=self.node,
-                            gpu=device.index,
-                            pid=process.pid,
-                            name=process.name,
-                            mem_mb=process.memory_bytes >> 20,
-                        )
+                        GpuProcessSample(ts=ts, node=self.node, gpu=gpu, pid=pid, name=name, mem_mb=mem_mb)
                     )
                 count += 1
         return count

--- a/tests/fast-gpu/test_gpu_sampler_hw.py
+++ b/tests/fast-gpu/test_gpu_sampler_hw.py
@@ -1,13 +1,3 @@
-"""Dashboard GPU sampler smoke test on real hardware.
-
-Runs on both CI GPU fleets with no backend injected, so GpuSampler's own
-auto-detection must pick the vendor path matching the runner: NVML on the
-NVIDIA suite, AMD SMI on the MI350 suite. The fake-backed unit tests live in
-tests/fast/dashboard/test_gpu_sampler.py; this file only covers what a CPU
-worker cannot — that the real vendor library initializes, reports every
-device, and returns sane telemetry.
-"""
-
 from tests.ci.ci_register import register_cuda_ci, register_rocm_ci
 
 register_cuda_ci(est_time=60, suite="stage-b-2-gpu-h200", labels=["short"])

--- a/tests/fast-gpu/test_gpu_sampler_hw.py
+++ b/tests/fast-gpu/test_gpu_sampler_hw.py
@@ -1,0 +1,65 @@
+"""Dashboard GPU sampler smoke test on real hardware.
+
+Runs on both CI GPU fleets with no backend injected, so GpuSampler's own
+auto-detection must pick the vendor path matching the runner: NVML on the
+NVIDIA suite, AMD SMI on the MI350 suite. The fake-backed unit tests live in
+tests/fast/dashboard/test_gpu_sampler.py; this file only covers what a CPU
+worker cannot — that the real vendor library initializes, reports every
+device, and returns sane telemetry.
+"""
+
+from tests.ci.ci_register import register_cuda_ci, register_rocm_ci
+
+register_cuda_ci(est_time=60, suite="stage-b-2-gpu-h200", labels=["short"])
+register_rocm_ci(est_time=60, suite="stage-c-4-gpu-mi350", labels=["amd"])
+
+import torch
+
+from miles.dashboard.gpu_sampler import GpuSampler
+
+
+class PushSpy:
+    def __init__(self):
+        self.calls = []
+
+    def __call__(self, node, batch):
+        self.calls.append((node, batch))
+
+
+def test_auto_detection_picks_the_backend_matching_the_hardware():
+    sampler = GpuSampler(PushSpy(), node="ci")
+    assert sampler.available, "no GPU telemetry backend initialized on a GPU runner"
+    expected = "AMD SMI" if torch.version.hip else "NVML"
+    assert sampler._provider.name == expected
+
+
+def test_every_device_reports_telemetry_and_processes():
+    push = PushSpy()
+    push_processes = PushSpy()
+    sampler = GpuSampler(push, node="ci", push_processes=push_processes)
+    assert sampler.available
+
+    uuids = sampler.gpu_uuids()
+    count = len(uuids)
+    assert count >= 2, f"expected a multi-GPU CI runner, saw {count} device(s)"
+    assert all(uuids)
+
+    assert sampler.sample_once(ts=1.0) == count
+    assert sampler.sample_processes_once(ts=1.0) >= 0
+    sampler.flush()
+    [(_, batch)] = push.calls
+    assert [sample.gpu for sample in batch] == list(range(count))
+    for sample in batch:
+        assert 0 <= sample.util <= 100
+        assert sample.mem_mb >= 0 and sample.power_w >= 0
+    if push_processes.calls:
+        for process_sample in push_processes.calls[0][1]:
+            assert process_sample.pid > 0 and process_sample.mem_mb >= 0 and process_sample.name
+
+
+if __name__ == "__main__":
+    import sys
+
+    import pytest
+
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/tests/fast/dashboard/test_gpu_sampler.py
+++ b/tests/fast/dashboard/test_gpu_sampler.py
@@ -79,8 +79,7 @@ class FakeAmdSmi:
         return {"vram_total": 192 * 1024, "vram_used": (handle + 1) * 2048}
 
     def amdsmi_get_power_info(self, handle):
-        # socket_power carries current power on MI300+; all three fields kept
-        # distinct so tests catch the sampler selecting the wrong key.
+        # Keep values distinct to catch selection of the wrong power field.
         return {
             "socket_power": 500 + handle,
             "current_socket_power": 475 + handle,
@@ -96,8 +95,6 @@ class FakeAmdSmi:
                 "name": f"amd-proc-{handle}" if handle == 0 else "N/A",
                 "memory_usage": {"vram_mem": (handle + 1) * 768 * 1024 * 1024},
             },
-            # KFD lists pids that merely opened the device; they hold no VRAM
-            # and must not become dashboard rows.
             {"pid": 9000 + handle, "name": "kfd-bystander", "memory_usage": {"vram_mem": 0}},
         ]
 
@@ -175,8 +172,6 @@ def test_amd_socket_power_raises_when_all_fields_unavailable():
 def test_amd_unavailable_power_reports_zero_but_keeps_util_and_mem():
     push = PushSpy()
     amdsmi = FakeAmdSmi(count=1)
-    # ROCm >= 6.1 reports each unavailable sensor as "N/A"; the sample must
-    # still flow with util/mem intact rather than being dropped.
     amdsmi.amdsmi_get_power_info = lambda handle: {"socket_power": "N/A", "current_socket_power": "N/A"}
     sampler = GpuSampler(push, node="n", amdsmi=amdsmi)
 
@@ -286,8 +281,6 @@ def test_amd_failing_device_is_skipped_while_others_report(caplog):
     ],
 )
 def test_amd_degraded_metric_value_skips_device_while_others_report(method, payload, caplog):
-    # The amdsmi wrapper substitutes "N/A" for unsupported metrics instead of
-    # raising; such a device must be skipped without silencing its siblings.
     push = PushSpy()
     amdsmi = FakeAmdSmi(count=2)
     original = getattr(amdsmi, method)
@@ -381,9 +374,6 @@ def test_amd_failing_device_is_skipped_for_process_sampling(caplog):
 
 
 def test_process_batch_dropped_silently_without_push_processes():
-    # sampling still works if called directly, but flush() must not crash or
-    # invent a push destination — the buffer is just discarded (design: the
-    # feature is a no-op end-to-end when the collector never wires it up)
     push = PushSpy()
     sampler = GpuSampler(push, node="n", nvml=FakeNvml(count=1))
     assert sampler.sample_processes_once(ts=1.0) == 1
@@ -426,8 +416,6 @@ def test_real_nvml_when_gpus_present():
 
 
 def test_real_amdsmi_when_gpus_present():
-    # Guards the fake against the API installed by the ROCm dashboard image
-    # (ROCm >= 6.1 dict shapes); skips on the ordinary CPU/NVIDIA fast-test workers.
     amdsmi = pytest.importorskip("amdsmi")
     push = PushSpy()
     push_processes = ProcessPushSpy()

--- a/tests/fast/dashboard/test_gpu_sampler.py
+++ b/tests/fast/dashboard/test_gpu_sampler.py
@@ -1,4 +1,5 @@
 import logging
+import sys
 import time
 
 import pytest
@@ -217,8 +218,8 @@ def test_zero_devices_disable_sampler(backend):
 
 
 def test_production_auto_detection_falls_back_from_nvml_to_amdsmi(monkeypatch):
-    monkeypatch.setattr(gpu_sampler_module, "_import_nvml", lambda: FakeNvml(fail_init=True))
-    monkeypatch.setattr(gpu_sampler_module, "_import_amdsmi", lambda: FakeAmdSmi(count=1))
+    monkeypatch.setitem(sys.modules, "pynvml", FakeNvml(fail_init=True))
+    monkeypatch.setitem(sys.modules, "amdsmi", FakeAmdSmi(count=1))
 
     sampler = GpuSampler(PushSpy(), node="n")
 
@@ -227,11 +228,11 @@ def test_production_auto_detection_falls_back_from_nvml_to_amdsmi(monkeypatch):
 
 
 def test_explicit_injection_does_not_probe_the_other_backend(monkeypatch):
-    monkeypatch.setattr(
-        gpu_sampler_module,
-        "_import_amdsmi",
-        lambda: pytest.fail("explicit NVML injection must not probe AMD SMI"),
-    )
+    class BoomAmdSmi:
+        def amdsmi_init(self):
+            pytest.fail("explicit NVML injection must not probe AMD SMI")
+
+    monkeypatch.setitem(sys.modules, "amdsmi", BoomAmdSmi())
 
     sampler = GpuSampler(PushSpy(), node="n", nvml=FakeNvml(fail_init=True))
 
@@ -239,14 +240,9 @@ def test_explicit_injection_does_not_probe_the_other_backend(monkeypatch):
 
 
 def test_missing_optional_backends_disable_sampler(monkeypatch, caplog):
-    def missing_nvml():
-        raise ImportError("pynvml is not installed")
-
-    def missing_amdsmi():
-        raise ImportError("amdsmi is not installed")
-
-    monkeypatch.setattr(gpu_sampler_module, "_import_nvml", missing_nvml)
-    monkeypatch.setattr(gpu_sampler_module, "_import_amdsmi", missing_amdsmi)
+    # None in sys.modules makes `import pynvml` raise ImportError, as if absent.
+    monkeypatch.setitem(sys.modules, "pynvml", None)
+    monkeypatch.setitem(sys.modules, "amdsmi", None)
     with caplog.at_level(logging.WARNING):
         sampler = GpuSampler(PushSpy(), node="n")
 

--- a/tests/fast/dashboard/test_gpu_sampler.py
+++ b/tests/fast/dashboard/test_gpu_sampler.py
@@ -9,34 +9,26 @@ from miles.dashboard.store import GpuProcessSample, GpuSample
 
 
 class FakeNvml:
-    """Just enough of pynvml for the sampler: handle == device index."""
+    """Just enough of pynvml for the sampler: handle == device index. UUIDs
+    and process names come back as bytes, as the real pynvml returns them."""
 
-    def __init__(self, count=2, fail_init=False, fail_count=False, failing_devices=()):
+    def __init__(self, count=2, fail_init=False, failing_devices=()):
         self.count = count
         self.fail_init = fail_init
-        self.fail_count = fail_count
         self.failing_devices = set(failing_devices)
-        self.init_calls = 0
-        self.shutdown_calls = 0
 
     def nvmlInit(self):
-        self.init_calls += 1
         if self.fail_init:
             raise RuntimeError("driver/library version mismatch")
 
-    def nvmlShutdown(self):
-        self.shutdown_calls += 1
-
     def nvmlDeviceGetCount(self):
-        if self.fail_count:
-            raise RuntimeError("device enumeration failed")
         return self.count
 
     def nvmlDeviceGetHandleByIndex(self, index):
         return index
 
     def nvmlDeviceGetUUID(self, handle):
-        return f"GPU-fake-{handle}"
+        return f"GPU-fake-{handle}".encode()
 
     def nvmlDeviceGetUtilizationRates(self, handle):
         if handle in self.failing_devices:
@@ -55,45 +47,25 @@ class FakeNvml:
         return [type("Proc", (), {"pid": 1000 + handle, "usedGpuMemory": (handle + 1) * 512 * 1024 * 1024})()]
 
     def nvmlSystemGetProcessName(self, pid):
-        return f"proc-{pid}"
+        return f"proc-{pid}".encode()
 
 
 class FakeAmdSmi:
-    """AMD SMI API shapes used by ROCm 7.0 and 7.2; handle == device index."""
+    """Just enough of the amdsmi API (ROCm >= 6.1 dict shapes); handle == device index."""
 
-    def __init__(
-        self,
-        count=2,
-        *,
-        fail_init=False,
-        fail_enumeration=False,
-        fail_uuid_devices=(),
-        failing_devices=(),
-    ):
+    def __init__(self, count=2, *, fail_init=False, failing_devices=()):
         self.count = count
         self.fail_init = fail_init
-        self.fail_enumeration = fail_enumeration
-        self.fail_uuid_devices = set(fail_uuid_devices)
         self.failing_devices = set(failing_devices)
-        self.init_calls = 0
-        self.shutdown_calls = 0
 
     def amdsmi_init(self):
-        self.init_calls += 1
         if self.fail_init:
             raise RuntimeError("AMD SMI initialization failed")
 
-    def amdsmi_shut_down(self):
-        self.shutdown_calls += 1
-
     def amdsmi_get_processor_handles(self):
-        if self.fail_enumeration:
-            raise RuntimeError("device enumeration failed")
         return list(range(self.count))
 
     def amdsmi_get_gpu_device_uuid(self, handle):
-        if handle in self.fail_uuid_devices:
-            raise RuntimeError("UUID unavailable")
         return f"GPU-amd-{handle}"
 
     def amdsmi_get_gpu_activity(self, handle):
@@ -106,11 +78,11 @@ class FakeAmdSmi:
         return {"vram_total": 192 * 1024, "vram_used": (handle + 1) * 2048}
 
     def amdsmi_get_power_info(self, handle):
-        # MI300+ exposes current socket power through socket_power. Keep the
-        # legacy field different so the test catches selecting the wrong key.
+        # socket_power carries current power on MI300+; all three fields kept
+        # distinct so tests catch the sampler selecting the wrong key.
         return {
             "socket_power": 500 + handle,
-            "current_socket_power": 500 + handle,
+            "current_socket_power": 475 + handle,
             "average_socket_power": 250 + handle,
         }
 
@@ -122,7 +94,10 @@ class FakeAmdSmi:
                 "pid": 2000 + handle,
                 "name": f"amd-proc-{handle}" if handle == 0 else "N/A",
                 "memory_usage": {"vram_mem": (handle + 1) * 768 * 1024 * 1024},
-            }
+            },
+            # KFD lists pids that merely opened the device; they hold no VRAM
+            # and must not become dashboard rows.
+            {"pid": 9000 + handle, "name": "kfd-bystander", "memory_usage": {"vram_mem": 0}},
         ]
 
 
@@ -160,8 +135,7 @@ def test_sample_once_converts_units():
 
 def test_amd_sample_once_preserves_native_units_and_uuids():
     push = PushSpy()
-    amdsmi = FakeAmdSmi(count=2)
-    sampler = GpuSampler(push, node="amd-node", amdsmi=amdsmi)
+    sampler = GpuSampler(push, node="amd-node", amdsmi=FakeAmdSmi(count=2))
     assert sampler.available
     assert sampler.gpu_uuids() == ["GPU-amd-0", "GPU-amd-1"]
 
@@ -174,24 +148,41 @@ def test_amd_sample_once_preserves_native_units_and_uuids():
         GpuSample(ts=11.0, node="amd-node", gpu=1, util=71, mem_mb=4096, power_w=501),
     ]
 
-    sampler.stop()
-    assert amdsmi.shutdown_calls == 1
+
+@pytest.mark.parametrize(
+    "power,expected",
+    [
+        # MI300+/ROCm 7.x: the unified field carries current power and wins.
+        ({"socket_power": 500, "current_socket_power": 475, "average_socket_power": 250}, 500),
+        # ROCm 7.x with the unified sensor unavailable ("N/A" per field).
+        ({"socket_power": "N/A", "current_socket_power": 475, "average_socket_power": 250}, 475),
+        # ROCm 6.0 numeric uint16 sentinel; no unified field on 6.x.
+        ({"current_socket_power": 0xFFFF, "average_socket_power": 250}, 250),
+        # Pre-MI300 6.x wrappers only expose the average.
+        ({"average_socket_power": 250}, 250),
+    ],
+)
+def test_amd_socket_power_prefers_current_then_falls_back(power, expected):
+    assert gpu_sampler_module._amd_socket_power(power) == expected
 
 
-def test_amd_socket_power_falls_back_from_unavailable_unified_field():
+def test_amd_socket_power_raises_when_all_fields_unavailable():
+    with pytest.raises(ValueError, match="socket power unavailable"):
+        gpu_sampler_module._amd_socket_power({"socket_power": "N/A", "current_socket_power": 0xFFFF})
+
+
+def test_amd_unavailable_power_reports_zero_but_keeps_util_and_mem():
     push = PushSpy()
     amdsmi = FakeAmdSmi(count=1)
-    amdsmi.amdsmi_get_power_info = lambda handle: {
-        "socket_power": 0xFFFF,
-        "current_socket_power": 475,
-        "average_socket_power": 200,
-    }
+    # ROCm >= 6.1 reports each unavailable sensor as "N/A"; the sample must
+    # still flow with util/mem intact rather than being dropped.
+    amdsmi.amdsmi_get_power_info = lambda handle: {"socket_power": "N/A", "current_socket_power": "N/A"}
     sampler = GpuSampler(push, node="n", amdsmi=amdsmi)
 
     assert sampler.sample_once(ts=1.0) == 1
     sampler.flush()
-    assert push.calls[0][1][0].power_w == 475
-    sampler.stop()
+    [sample] = push.calls[0][1]
+    assert (sample.util, sample.mem_mb, sample.power_w) == (70, 2048, 0)
 
 
 def test_flush_clears_buffer_and_skips_empty():
@@ -217,46 +208,22 @@ def test_nvml_init_failure_disables_sampler(caplog):
     assert any("NVML unavailable" in r.message for r in caplog.records)
 
 
-@pytest.mark.parametrize("provider_name", ["nvml", "amdsmi"])
-def test_partial_initialization_failure_shuts_down_provider(provider_name):
-    if provider_name == "nvml":
-        provider = FakeNvml(fail_count=True)
-    else:
-        provider = FakeAmdSmi(fail_enumeration=True)
-
-    sampler = GpuSampler(PushSpy(), node="n", **{provider_name: provider})
-
-    assert not sampler.available
-    assert provider.init_calls == 1
-    assert provider.shutdown_calls == 1
-    sampler.stop()
-    assert provider.shutdown_calls == 1
-
-
-def test_amd_uuid_failure_after_init_shuts_down_provider():
-    amdsmi = FakeAmdSmi(count=2, fail_uuid_devices={1})
-
-    sampler = GpuSampler(PushSpy(), node="n", amdsmi=amdsmi)
-
+@pytest.mark.parametrize("backend", ["nvml", "amdsmi"])
+def test_zero_devices_disable_sampler(backend):
+    fake = FakeNvml(count=0) if backend == "nvml" else FakeAmdSmi(count=0)
+    sampler = GpuSampler(PushSpy(), node="n", **{backend: fake})
     assert not sampler.available
     assert sampler.gpu_uuids() == []
-    assert amdsmi.shutdown_calls == 1
 
 
 def test_production_auto_detection_falls_back_from_nvml_to_amdsmi(monkeypatch):
-    nvml = FakeNvml(fail_init=True)
-    amdsmi = FakeAmdSmi(count=1)
-    monkeypatch.setattr(gpu_sampler_module, "_import_nvml", lambda: nvml)
-    monkeypatch.setattr(gpu_sampler_module, "_import_amdsmi", lambda: amdsmi)
+    monkeypatch.setattr(gpu_sampler_module, "_import_nvml", lambda: FakeNvml(fail_init=True))
+    monkeypatch.setattr(gpu_sampler_module, "_import_amdsmi", lambda: FakeAmdSmi(count=1))
 
     sampler = GpuSampler(PushSpy(), node="n")
 
     assert sampler.available
     assert sampler.gpu_uuids() == ["GPU-amd-0"]
-    assert nvml.init_calls == 1
-    assert amdsmi.init_calls == 1
-    sampler.stop()
-    assert amdsmi.shutdown_calls == 1
 
 
 def test_explicit_injection_does_not_probe_the_other_backend(monkeypatch):
@@ -313,7 +280,29 @@ def test_amd_failing_device_is_skipped_while_others_report(caplog):
     [(_, batch)] = push.calls
     assert [sample.gpu for sample in batch] == [0, 2]
     assert any("AMD SMI read failed for gpu 1" in record.message for record in caplog.records)
-    sampler.stop()
+
+
+@pytest.mark.parametrize(
+    "method,payload",
+    [
+        ("amdsmi_get_gpu_activity", {"gfx_activity": "N/A", "umc_activity": 10, "mm_activity": 0}),
+        ("amdsmi_get_gpu_vram_usage", {"vram_total": 192 * 1024, "vram_used": "N/A"}),
+    ],
+)
+def test_amd_degraded_metric_value_skips_device_while_others_report(method, payload, caplog):
+    # The amdsmi wrapper substitutes "N/A" for unsupported metrics instead of
+    # raising; such a device must be skipped without silencing its siblings.
+    push = PushSpy()
+    amdsmi = FakeAmdSmi(count=2)
+    original = getattr(amdsmi, method)
+    setattr(amdsmi, method, lambda handle: payload if handle == 0 else original(handle))
+    sampler = GpuSampler(push, node="n", amdsmi=amdsmi)
+
+    with caplog.at_level(logging.WARNING):
+        assert sampler.sample_once(ts=1.0) == 1
+    sampler.flush()
+    assert [sample.gpu for sample in push.calls[0][1]] == [1]
+    assert any("AMD SMI read failed for gpu 0" in record.message for record in caplog.records)
 
 
 def test_amd_uses_smi_visible_order_without_refiltering_process_env(monkeypatch):
@@ -325,7 +314,6 @@ def test_amd_uses_smi_visible_order_without_refiltering_process_env(monkeypatch)
     assert sampler.sample_once(ts=1.0) == 3
     sampler.flush()
     assert [sample.gpu for sample in push.calls[0][1]] == [0, 1, 2]
-    sampler.stop()
 
 
 def test_thread_lifecycle_flushes_on_stop():
@@ -337,21 +325,6 @@ def test_thread_lifecycle_flushes_on_stop():
     assert push.calls, "stop() must flush buffered samples"
     total = sum(len(batch) for _, batch in push.calls)
     assert total >= 3  # ~8 ticks at 10ms; generous margin against scheduler jitter
-
-
-def test_stop_is_idempotent_and_flushes_once():
-    push = PushSpy()
-    amdsmi = FakeAmdSmi(count=1)
-    sampler = GpuSampler(push, node="n", amdsmi=amdsmi)
-    sampler.sample_once(ts=1.0)
-
-    sampler.stop()
-    sampler.stop()
-
-    assert len(push.calls) == 1
-    assert amdsmi.shutdown_calls == 1
-    assert not sampler.available
-    assert sampler.sample_once(ts=2.0) == 0
 
 
 def test_sample_processes_once_converts_units():
@@ -368,24 +341,19 @@ def test_sample_processes_once_converts_units():
     ]
 
 
-def test_amd_processes_use_nested_vram_bytes_and_name_fallback():
+def test_amd_processes_convert_bytes_fall_back_on_name_and_drop_zero_vram():
     push_processes = ProcessPushSpy()
-    sampler = GpuSampler(
-        PushSpy(),
-        node="n",
-        amdsmi=FakeAmdSmi(count=2),
-        push_processes=push_processes,
-    )
+    sampler = GpuSampler(PushSpy(), node="n", amdsmi=FakeAmdSmi(count=2), push_processes=push_processes)
 
     assert sampler.sample_processes_once(ts=5.0) == 2
     sampler.flush()
     [(node, batch)] = push_processes.calls
     assert node == "n"
+    # the zero-VRAM kfd-bystander pids are filtered out
     assert batch == [
         GpuProcessSample(ts=5.0, node="n", gpu=0, pid=2000, name="amd-proc-0", mem_mb=768),
         GpuProcessSample(ts=5.0, node="n", gpu=1, pid=2001, name="pid 2001", mem_mb=1536),
     ]
-    sampler.stop()
 
 
 def test_failing_device_skipped_for_process_sampling(caplog):
@@ -414,7 +382,6 @@ def test_amd_failing_device_is_skipped_for_process_sampling(caplog):
     [(_, batch)] = push_processes.calls
     assert [sample.gpu for sample in batch] == [0, 2]
     assert any("AMD SMI process query failed for gpu 1" in record.message for record in caplog.records)
-    sampler.stop()
 
 
 def test_process_batch_dropped_silently_without_push_processes():
@@ -460,12 +427,11 @@ def test_real_nvml_when_gpus_present():
     if push_processes.calls:
         proc_sample = push_processes.calls[0][1][0]
         assert proc_sample.pid > 0 and proc_sample.mem_mb >= 0 and proc_sample.name
-    sampler.stop()
 
 
 def test_real_amdsmi_when_gpus_present():
-    # Guards the fake against the API installed by the ROCm dashboard image;
-    # skips on the ordinary CPU/NVIDIA fast-test workers.
+    # Guards the fake against the API installed by the ROCm dashboard image
+    # (ROCm >= 6.1 dict shapes); skips on the ordinary CPU/NVIDIA fast-test workers.
     amdsmi = pytest.importorskip("amdsmi")
     push = PushSpy()
     push_processes = ProcessPushSpy()
@@ -473,17 +439,14 @@ def test_real_amdsmi_when_gpus_present():
     if not sampler.available:
         pytest.skip("no usable AMD SMI device")
 
-    try:
-        assert sampler.sample_once(ts=1.0) >= 1
-        assert sampler.sample_processes_once(ts=1.0) >= 0
-        sampler.flush()
-        [(_, batch)] = push.calls
-        sample = batch[0]
-        assert 0 <= sample.util <= 100
-        assert sample.mem_mb >= 0 and sample.power_w >= 0
-        assert sampler.gpu_uuids()[0]
-        if push_processes.calls:
-            proc_sample = push_processes.calls[0][1][0]
-            assert proc_sample.pid > 0 and proc_sample.mem_mb >= 0 and proc_sample.name
-    finally:
-        sampler.stop()
+    assert sampler.sample_once(ts=1.0) >= 1
+    assert sampler.sample_processes_once(ts=1.0) >= 0
+    sampler.flush()
+    [(_, batch)] = push.calls
+    sample = batch[0]
+    assert 0 <= sample.util <= 100
+    assert sample.mem_mb >= 0 and sample.power_w >= 0
+    assert sampler.gpu_uuids()[0]
+    if push_processes.calls:
+        proc_sample = push_processes.calls[0][1][0]
+        assert proc_sample.pid > 0 and proc_sample.mem_mb > 0 and proc_sample.name

--- a/tests/fast/dashboard/test_gpu_sampler.py
+++ b/tests/fast/dashboard/test_gpu_sampler.py
@@ -3,6 +3,7 @@ import time
 
 import pytest
 
+from miles.dashboard import gpu_sampler as gpu_sampler_module
 from miles.dashboard.gpu_sampler import GpuSampler
 from miles.dashboard.store import GpuProcessSample, GpuSample
 
@@ -10,16 +11,25 @@ from miles.dashboard.store import GpuProcessSample, GpuSample
 class FakeNvml:
     """Just enough of pynvml for the sampler: handle == device index."""
 
-    def __init__(self, count=2, fail_init=False, failing_devices=()):
+    def __init__(self, count=2, fail_init=False, fail_count=False, failing_devices=()):
         self.count = count
         self.fail_init = fail_init
+        self.fail_count = fail_count
         self.failing_devices = set(failing_devices)
+        self.init_calls = 0
+        self.shutdown_calls = 0
 
     def nvmlInit(self):
+        self.init_calls += 1
         if self.fail_init:
             raise RuntimeError("driver/library version mismatch")
 
+    def nvmlShutdown(self):
+        self.shutdown_calls += 1
+
     def nvmlDeviceGetCount(self):
+        if self.fail_count:
+            raise RuntimeError("device enumeration failed")
         return self.count
 
     def nvmlDeviceGetHandleByIndex(self, index):
@@ -46,6 +56,74 @@ class FakeNvml:
 
     def nvmlSystemGetProcessName(self, pid):
         return f"proc-{pid}"
+
+
+class FakeAmdSmi:
+    """AMD SMI API shapes used by ROCm 7.0 and 7.2; handle == device index."""
+
+    def __init__(
+        self,
+        count=2,
+        *,
+        fail_init=False,
+        fail_enumeration=False,
+        fail_uuid_devices=(),
+        failing_devices=(),
+    ):
+        self.count = count
+        self.fail_init = fail_init
+        self.fail_enumeration = fail_enumeration
+        self.fail_uuid_devices = set(fail_uuid_devices)
+        self.failing_devices = set(failing_devices)
+        self.init_calls = 0
+        self.shutdown_calls = 0
+
+    def amdsmi_init(self):
+        self.init_calls += 1
+        if self.fail_init:
+            raise RuntimeError("AMD SMI initialization failed")
+
+    def amdsmi_shut_down(self):
+        self.shutdown_calls += 1
+
+    def amdsmi_get_processor_handles(self):
+        if self.fail_enumeration:
+            raise RuntimeError("device enumeration failed")
+        return list(range(self.count))
+
+    def amdsmi_get_gpu_device_uuid(self, handle):
+        if handle in self.fail_uuid_devices:
+            raise RuntimeError("UUID unavailable")
+        return f"GPU-amd-{handle}"
+
+    def amdsmi_get_gpu_activity(self, handle):
+        if handle in self.failing_devices:
+            raise RuntimeError("GPU is lost")
+        return {"gfx_activity": 70 + handle, "umc_activity": 10, "mm_activity": 0}
+
+    def amdsmi_get_gpu_vram_usage(self, handle):
+        # AMD SMI reports vram_used in MiB, not bytes.
+        return {"vram_total": 192 * 1024, "vram_used": (handle + 1) * 2048}
+
+    def amdsmi_get_power_info(self, handle):
+        # MI300+ exposes current socket power through socket_power. Keep the
+        # legacy field different so the test catches selecting the wrong key.
+        return {
+            "socket_power": 500 + handle,
+            "current_socket_power": 500 + handle,
+            "average_socket_power": 250 + handle,
+        }
+
+    def amdsmi_get_gpu_process_list(self, handle):
+        if handle in self.failing_devices:
+            raise RuntimeError("GPU is lost")
+        return [
+            {
+                "pid": 2000 + handle,
+                "name": f"amd-proc-{handle}" if handle == 0 else "N/A",
+                "memory_usage": {"vram_mem": (handle + 1) * 768 * 1024 * 1024},
+            }
+        ]
 
 
 class PushSpy:
@@ -80,6 +158,42 @@ def test_sample_once_converts_units():
     ]
 
 
+def test_amd_sample_once_preserves_native_units_and_uuids():
+    push = PushSpy()
+    amdsmi = FakeAmdSmi(count=2)
+    sampler = GpuSampler(push, node="amd-node", amdsmi=amdsmi)
+    assert sampler.available
+    assert sampler.gpu_uuids() == ["GPU-amd-0", "GPU-amd-1"]
+
+    assert sampler.sample_once(ts=11.0) == 2
+    sampler.flush()
+    [(node, batch)] = push.calls
+    assert node == "amd-node"
+    assert batch == [
+        GpuSample(ts=11.0, node="amd-node", gpu=0, util=70, mem_mb=2048, power_w=500),
+        GpuSample(ts=11.0, node="amd-node", gpu=1, util=71, mem_mb=4096, power_w=501),
+    ]
+
+    sampler.stop()
+    assert amdsmi.shutdown_calls == 1
+
+
+def test_amd_socket_power_falls_back_from_unavailable_unified_field():
+    push = PushSpy()
+    amdsmi = FakeAmdSmi(count=1)
+    amdsmi.amdsmi_get_power_info = lambda handle: {
+        "socket_power": 0xFFFF,
+        "current_socket_power": 475,
+        "average_socket_power": 200,
+    }
+    sampler = GpuSampler(push, node="n", amdsmi=amdsmi)
+
+    assert sampler.sample_once(ts=1.0) == 1
+    sampler.flush()
+    assert push.calls[0][1][0].power_w == 475
+    sampler.stop()
+
+
 def test_flush_clears_buffer_and_skips_empty():
     push = PushSpy()
     sampler = GpuSampler(push, node="n", nvml=FakeNvml(count=1))
@@ -103,6 +217,82 @@ def test_nvml_init_failure_disables_sampler(caplog):
     assert any("NVML unavailable" in r.message for r in caplog.records)
 
 
+@pytest.mark.parametrize("provider_name", ["nvml", "amdsmi"])
+def test_partial_initialization_failure_shuts_down_provider(provider_name):
+    if provider_name == "nvml":
+        provider = FakeNvml(fail_count=True)
+    else:
+        provider = FakeAmdSmi(fail_enumeration=True)
+
+    sampler = GpuSampler(PushSpy(), node="n", **{provider_name: provider})
+
+    assert not sampler.available
+    assert provider.init_calls == 1
+    assert provider.shutdown_calls == 1
+    sampler.stop()
+    assert provider.shutdown_calls == 1
+
+
+def test_amd_uuid_failure_after_init_shuts_down_provider():
+    amdsmi = FakeAmdSmi(count=2, fail_uuid_devices={1})
+
+    sampler = GpuSampler(PushSpy(), node="n", amdsmi=amdsmi)
+
+    assert not sampler.available
+    assert sampler.gpu_uuids() == []
+    assert amdsmi.shutdown_calls == 1
+
+
+def test_production_auto_detection_falls_back_from_nvml_to_amdsmi(monkeypatch):
+    nvml = FakeNvml(fail_init=True)
+    amdsmi = FakeAmdSmi(count=1)
+    monkeypatch.setattr(gpu_sampler_module, "_import_nvml", lambda: nvml)
+    monkeypatch.setattr(gpu_sampler_module, "_import_amdsmi", lambda: amdsmi)
+
+    sampler = GpuSampler(PushSpy(), node="n")
+
+    assert sampler.available
+    assert sampler.gpu_uuids() == ["GPU-amd-0"]
+    assert nvml.init_calls == 1
+    assert amdsmi.init_calls == 1
+    sampler.stop()
+    assert amdsmi.shutdown_calls == 1
+
+
+def test_explicit_injection_does_not_probe_the_other_backend(monkeypatch):
+    monkeypatch.setattr(
+        gpu_sampler_module,
+        "_import_amdsmi",
+        lambda: pytest.fail("explicit NVML injection must not probe AMD SMI"),
+    )
+
+    sampler = GpuSampler(PushSpy(), node="n", nvml=FakeNvml(fail_init=True))
+
+    assert not sampler.available
+
+
+def test_missing_optional_backends_disable_sampler(monkeypatch, caplog):
+    def missing_nvml():
+        raise ImportError("pynvml is not installed")
+
+    def missing_amdsmi():
+        raise ImportError("amdsmi is not installed")
+
+    monkeypatch.setattr(gpu_sampler_module, "_import_nvml", missing_nvml)
+    monkeypatch.setattr(gpu_sampler_module, "_import_amdsmi", missing_amdsmi)
+    with caplog.at_level(logging.WARNING):
+        sampler = GpuSampler(PushSpy(), node="n")
+
+    assert not sampler.available
+    assert sampler.start() is False
+    assert any("GPU telemetry unavailable" in record.message for record in caplog.records)
+
+
+def test_only_one_backend_may_be_injected():
+    with pytest.raises(AssertionError, match="inject only one"):
+        GpuSampler(PushSpy(), node="n", nvml=FakeNvml(), amdsmi=FakeAmdSmi())
+
+
 def test_failing_device_is_skipped_others_report(caplog):
     push = PushSpy()
     sampler = GpuSampler(push, node="n", nvml=FakeNvml(count=3, failing_devices={1}))
@@ -114,6 +304,30 @@ def test_failing_device_is_skipped_others_report(caplog):
     assert any("skipping this tick" in r.message for r in caplog.records)
 
 
+def test_amd_failing_device_is_skipped_while_others_report(caplog):
+    push = PushSpy()
+    sampler = GpuSampler(push, node="n", amdsmi=FakeAmdSmi(count=3, failing_devices={1}))
+    with caplog.at_level(logging.WARNING):
+        assert sampler.sample_once(ts=1.0) == 2
+    sampler.flush()
+    [(_, batch)] = push.calls
+    assert [sample.gpu for sample in batch] == [0, 2]
+    assert any("AMD SMI read failed for gpu 1" in record.message for record in caplog.records)
+    sampler.stop()
+
+
+def test_amd_uses_smi_visible_order_without_refiltering_process_env(monkeypatch):
+    monkeypatch.setenv("HIP_VISIBLE_DEVICES", "2")
+    monkeypatch.setenv("ROCR_VISIBLE_DEVICES", "2")
+    push = PushSpy()
+    sampler = GpuSampler(push, node="n", amdsmi=FakeAmdSmi(count=3))
+
+    assert sampler.sample_once(ts=1.0) == 3
+    sampler.flush()
+    assert [sample.gpu for sample in push.calls[0][1]] == [0, 1, 2]
+    sampler.stop()
+
+
 def test_thread_lifecycle_flushes_on_stop():
     push = PushSpy()
     sampler = GpuSampler(push, node="n", interval=0.01, nvml=FakeNvml(count=1))
@@ -123,6 +337,21 @@ def test_thread_lifecycle_flushes_on_stop():
     assert push.calls, "stop() must flush buffered samples"
     total = sum(len(batch) for _, batch in push.calls)
     assert total >= 3  # ~8 ticks at 10ms; generous margin against scheduler jitter
+
+
+def test_stop_is_idempotent_and_flushes_once():
+    push = PushSpy()
+    amdsmi = FakeAmdSmi(count=1)
+    sampler = GpuSampler(push, node="n", amdsmi=amdsmi)
+    sampler.sample_once(ts=1.0)
+
+    sampler.stop()
+    sampler.stop()
+
+    assert len(push.calls) == 1
+    assert amdsmi.shutdown_calls == 1
+    assert not sampler.available
+    assert sampler.sample_once(ts=2.0) == 0
 
 
 def test_sample_processes_once_converts_units():
@@ -139,6 +368,26 @@ def test_sample_processes_once_converts_units():
     ]
 
 
+def test_amd_processes_use_nested_vram_bytes_and_name_fallback():
+    push_processes = ProcessPushSpy()
+    sampler = GpuSampler(
+        PushSpy(),
+        node="n",
+        amdsmi=FakeAmdSmi(count=2),
+        push_processes=push_processes,
+    )
+
+    assert sampler.sample_processes_once(ts=5.0) == 2
+    sampler.flush()
+    [(node, batch)] = push_processes.calls
+    assert node == "n"
+    assert batch == [
+        GpuProcessSample(ts=5.0, node="n", gpu=0, pid=2000, name="amd-proc-0", mem_mb=768),
+        GpuProcessSample(ts=5.0, node="n", gpu=1, pid=2001, name="pid 2001", mem_mb=1536),
+    ]
+    sampler.stop()
+
+
 def test_failing_device_skipped_for_process_sampling(caplog):
     push = PushSpy()
     push_processes = ProcessPushSpy()
@@ -149,6 +398,23 @@ def test_failing_device_skipped_for_process_sampling(caplog):
     [(_, batch)] = push_processes.calls
     assert [s.gpu for s in batch] == [0, 2]
     assert any("skipping this tick" in r.message for r in caplog.records)
+
+
+def test_amd_failing_device_is_skipped_for_process_sampling(caplog):
+    push_processes = ProcessPushSpy()
+    sampler = GpuSampler(
+        PushSpy(),
+        node="n",
+        amdsmi=FakeAmdSmi(count=3, failing_devices={1}),
+        push_processes=push_processes,
+    )
+    with caplog.at_level(logging.WARNING):
+        assert sampler.sample_processes_once(ts=1.0) == 2
+    sampler.flush()
+    [(_, batch)] = push_processes.calls
+    assert [sample.gpu for sample in batch] == [0, 2]
+    assert any("AMD SMI process query failed for gpu 1" in record.message for record in caplog.records)
+    sampler.stop()
 
 
 def test_process_batch_dropped_silently_without_push_processes():
@@ -194,3 +460,30 @@ def test_real_nvml_when_gpus_present():
     if push_processes.calls:
         proc_sample = push_processes.calls[0][1][0]
         assert proc_sample.pid > 0 and proc_sample.mem_mb >= 0 and proc_sample.name
+    sampler.stop()
+
+
+def test_real_amdsmi_when_gpus_present():
+    # Guards the fake against the API installed by the ROCm dashboard image;
+    # skips on the ordinary CPU/NVIDIA fast-test workers.
+    amdsmi = pytest.importorskip("amdsmi")
+    push = PushSpy()
+    push_processes = ProcessPushSpy()
+    sampler = GpuSampler(push, node="local", amdsmi=amdsmi, push_processes=push_processes)
+    if not sampler.available:
+        pytest.skip("no usable AMD SMI device")
+
+    try:
+        assert sampler.sample_once(ts=1.0) >= 1
+        assert sampler.sample_processes_once(ts=1.0) >= 0
+        sampler.flush()
+        [(_, batch)] = push.calls
+        sample = batch[0]
+        assert 0 <= sample.util <= 100
+        assert sample.mem_mb >= 0 and sample.power_w >= 0
+        assert sampler.gpu_uuids()[0]
+        if push_processes.calls:
+            proc_sample = push_processes.calls[0][1][0]
+            assert proc_sample.pid > 0 and proc_sample.mem_mb >= 0 and proc_sample.name
+    finally:
+        sampler.stop()


### PR DESCRIPTION
## Summary

- prefer NVML for GPU telemetry and fall back to AMD SMI on ROCm nodes
- normalize AMD GPU activity, VRAM, socket power, UUID, and per-process VRAM into the existing Dashboard schema
- keep optional vendor imports inside the sampler actor, isolate per-device failures, and clean up partially initialized providers
- add fake-backend coverage plus real NVML/AMD SMI hardware smoke tests

## Reproduction and validation

Tested on a 4 x MI350X devbox with `rocm/sgl-dev:miles-rocm720-mi35x@sha256:e156a62c4161d6517fa243b2a8818c029e0d4cd5062d22f79f12116df759eab2`.

Before this change, a Megatron Dashboard run logged `NVML Shared Library Not Found` and `/api/timeline/gpu` returned no lanes. After the change, the same 1-GPU Qwen3-0.6B Megatron Bridge run completed two rollout/train steps and the Dashboard reported all four node GPUs. The training GPU reached 90% utilization, 187695 MiB VRAM, and 356 W. The browser UI showed four utilization lanes and no console warnings or errors.

- `python -m pytest --confcutdir=tests/fast/dashboard tests/fast/dashboard -q` with `RAY_ADDRESS=local`: 239 passed, 3 skipped
- final focused run on MI350X: 24 passed, 1 skipped; the real AMD SMI probe passed
- local focused run: 23 passed, 2 skipped
- Black, Ruff, and `git diff --check`: passed

## Scope

The Dashboard API and frontend remain unchanged; this patch supplies the existing telemetry schema from AMD SMI when NVML is unavailable.


