### PR TITLE
fix: stride the pad-token replay fill across experts

### DIFF
--- a/miles/utils/replay_base.py
+++ b/miles/utils/replay_base.py
@@ -99,14 +99,20 @@ class BaseReplayManager:
             if self.enable_check_replay_result:
                 self.check_replay_result(old_topk_fn, scores, topk, top_indices, *args, **kwargs)
 
-            # fill padding tokens with arange to avoid invalid reading
+            # Fill all-(-1) pad rows with in-range indices, striding across pad
+            # rows so repeated per-sample padding does not pile onto the same columns.
+            # Pads are loss-masked, so any in-range index is valid.
             all_invalid = (top_indices == -1).all(dim=-1)
-            if all_invalid.any():
-                ar = (
-                    torch.arange(top_indices.shape[1], device=top_indices.device, dtype=top_indices.dtype)
-                    % scores.shape[1]
-                )
-                top_indices = torch.where(all_invalid.unsqueeze(-1), ar, top_indices)
+            num_invalid = all_invalid.sum().item()
+            if num_invalid:
+                fill = torch.arange(
+                    num_invalid * topk,
+                    device=top_indices.device,
+                    dtype=top_indices.dtype,
+                ).view(num_invalid, topk)
+                fill.remainder_(scores.shape[1])
+                top_indices = top_indices.clone()
+                top_indices[all_invalid] = fill
 
             if return_probs:
                 return scores.gather(1, top_indices), top_indices

--- a/tests/fast/utils/test_replay_base.py
+++ b/tests/fast/utils/test_replay_base.py
@@ -31,15 +31,23 @@ def _make_replay_manager(top_indices):
     return manager
 
 
-def test_get_topk_fn_fills_all_invalid_rows_with_arange():
-    # an all-(-1) row is a masked/pad token; fill it with arange to avoid reading
-    # invalid (-1) positions downstream
-    scores = torch.arange(5, dtype=torch.float32).unsqueeze(0)
-    manager = _make_replay_manager(torch.tensor([[-1, -1, -1]], dtype=torch.int32))
+def test_get_topk_fn_strides_across_noncontiguous_invalid_rows():
+    # BSHD padding can recur at the same position in each sample. Stride by
+    # invalid-row ordinal so those rows do not alias to the same expert block.
+    scores = torch.arange(8, dtype=torch.float32).repeat(8, 1)
+    replayed_top_indices = torch.tensor(
+        [[6, 7], [6, 7], [6, 7], [-1, -1], [6, 7], [6, 7], [6, 7], [-1, -1]],
+        dtype=torch.int32,
+    )
+    manager = _make_replay_manager(replayed_top_indices)
 
     topk_fn = manager.get_topk_fn(_topk, return_probs=False)
 
-    torch.testing.assert_close(topk_fn(scores, 3), torch.tensor([[0, 1, 2]], dtype=torch.int32))
+    expected = torch.tensor(
+        [[6, 7], [6, 7], [6, 7], [0, 1], [6, 7], [6, 7], [6, 7], [2, 3]],
+        dtype=torch.int32,
+    )
+    torch.testing.assert_close(topk_fn(scores, 2), expected)
 
 
 def test_get_topk_fn_preserves_partial_padding():


### PR DESCRIPTION
## Summary
Routing replay reuses stored top-k selections during training. When replay data is padded to the training token layout, fully padded rows are represented as all `-1`; those sentinels must be replaced with in-range indices before downstream gather and dispatch.

The existing repair writes the same `arange(topk) % n_cols` row into every fully padded row. For MoE routing, `n_cols` is the number of experts, so every pad token goes to experts 0..topk-1. Loss masking prevents those rows from affecting the objective, but it does not skip the forward expert dispatch: with `topk <= experts-per-rank`, rank 0 receives `topk x pad_count` synthetic assignments (and larger top-k values concentrate them on the first EP ranks).

This surfaced as a trainer OOM on a 128x H100 DeepSeek-V4-Flash run at 262,144-token context. Modeling the constant fill predicted a hot-rank receive count of 719,029 tokens versus 718,848 observed at the OOM site (0.025% error).

## Fix
Number only the fully invalid rows and fill them by pad-row ordinal:

`fill[pad_row, col] = (pad_row * topk + col) % n_cols`

This makes the synthetic assignments independent of where padding appears in the batch. That distinction matters for BSHD batches, where per-sample padding can recur at regular token positions and an absolute token-position stride can alias back to the same expert block. The `arange` is also sized to the invalid rows rather than the full `[n_tokens, topk]` tensor, and the replay tensor is cloned before assignment.

Fully padded rows are loss-masked, so any in-range selection is semantically valid. Selections remain distinct within each row whenever `topk <= n_cols`. Partially invalid rows remain unchanged for the indexer path, where `-1` has separate meaning; for fully padded indexer rows, `n_cols` denotes KV positions and the same fill remains in range.

## Verification
- The regression test uses noncontiguous pad rows at the same per-sample position. It fails both the constant fill and an absolute token-position stride, and pins the pad-row-ordinal result.
- The existing partial-padding test verifies that rows containing valid indexer selections are not rewritten.
- `python -m pytest -q tests/fast/utils/test_replay_base.py tests/fast/backends/test_fsdp_replay_routers.py`: 13 passed on CPU-only torch.
- `ruff`, `isort`, and `black` pass on both changed files.
