### PR TITLE
fix: pad bshd samples to their own length, not the rollout-global max

### DIFF
--- a/miles/backends/training_utils/data.py
+++ b/miles/backends/training_utils/data.py
@@ -76,18 +76,21 @@ def get_rollout_data(
         ]
 
     if args.qkv_format == "bshd":
-        # TODO: micro-batch wise dynamic, possibly move to @data.py:get_data_iterator
-        max_seq_len = max(rollout_data["total_lengths"])
-
         # pad to reduce memory fragmentation and maybe make the computation faster
         pad_size = parallel_state.tp.size * args.data_pad_size_multiplier
         max_compress_ratio = max(args.compress_ratios) if args.compress_ratios else 0
         if max_compress_ratio:
             local_seqlen_multiple = max_compress_ratio * (2 if parallel_state.cp.size > 1 else 1)
             pad_size = max(pad_size, local_seqlen_multiple * parallel_state.cp.size)
-        max_seq_len = (max_seq_len + pad_size - 1) // pad_size * pad_size
-
-        rollout_data["max_seq_lens"] = [max_seq_len] * len(rollout_data["tokens"])
+        # Padding every sample to the rollout max multiplies short samples' token
+        # counts at long context, and pad tokens still dispatch through MoE, so
+        # each sample pads to its own length. Consumers assert that each bshd
+        # microbatch keeps a single padded length.
+        # TODO: compute a per-microbatch max at composition time to support
+        # mixed-length microbatches.
+        rollout_data["max_seq_lens"] = [
+            (length + pad_size - 1) // pad_size * pad_size for length in rollout_data["total_lengths"]
+        ]
 
     # Full-response SGLang OPD fields share rollout CP slicing but retain float32 precision.
     for key in ("rollout_log_probs", "teacher_log_probs", "opd_reverse_kl"):
@@ -176,6 +179,13 @@ def get_batch(
     cp_size = parallel_state.cp.size
 
     if qkv_format == "bshd":
+        # max_seq_lens is per-sample, and build-time CP slicing of the rollout
+        # log probs used each sample's own padded length, so mixing padded
+        # lengths inside one bshd microbatch would misalign silently.
+        assert len(set(batch["max_seq_lens"])) == 1, (
+            f"bshd microbatch mixes padded lengths {batch['max_seq_lens']}; "
+            "use 1 sample per microbatch or bucket samples by padded length"
+        )
         max_seqlen = batch["max_seq_lens"][0]
         assert max([t.size(0) for t in tokens]) <= max_seqlen
 

--- a/miles/backends/training_utils/replay_data.py
+++ b/miles/backends/training_utils/replay_data.py
@@ -86,6 +86,11 @@ def fill_replay_data(
         cp_size = parallel_state.cp.size
         cp_rank = parallel_state.cp.rank
         if qkv_format == "bshd":
+            # Same padded-length guard as get_batch: max_seq_lens is per-sample.
+            assert len(set(batch["max_seq_lens"])) == 1, (
+                f"bshd microbatch mixes padded lengths {batch['max_seq_lens']}; "
+                "use 1 sample per microbatch or bucket samples by padded length"
+            )
             max_seqlen = batch["max_seq_lens"][0]
             if args.allgather_cp and cp_size > 1:
                 assert max_seqlen % cp_size == 0, f"max_seqlen {max_seqlen} must be divisible by cp_size {cp_size}"

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -3526,6 +3526,12 @@ def miles_validate_args(args):
         assert (
             args.use_dynamic_batch_size is False
         ), "Dynamic batch size is not supported for bshd format. Please specify --micro-batch-size instead."
+        if args.micro_batch_size > 1:
+            logger.warning(
+                "bshd with --micro-batch-size > 1 requires every sample in a microbatch to pad to the same "
+                "length; microbatches with multiple padded lengths are rejected during batch preparation. "
+                "Use --micro-batch-size 1 unless samples are bucketed by padded length."
+            )
 
     if args.skip_actor_forward_only:
         validate_skip_actor_forward_only(args)

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -3516,6 +3516,12 @@ def miles_validate_args(args):
         assert (
             args.use_dynamic_batch_size is False
         ), "Dynamic batch size is not supported for bshd format. Please specify --micro-batch-size instead."
+        if args.micro_batch_size > 1:
+            logger.warning(
+                "bshd with --micro-batch-size > 1 requires every sample in a microbatch to pad to the same "
+                "length; microbatches with multiple padded lengths are rejected during batch preparation. "
+                "Use --micro-batch-size 1 unless samples are bucketed by padded length."
+            )
 
     if args.skip_actor_forward_only:
         validate_skip_actor_forward_only(args)

--- a/tests/fast/backends/training_utils/test_bshd_per_sample_pad.py
+++ b/tests/fast/backends/training_utils/test_bshd_per_sample_pad.py
@@ -1,0 +1,119 @@
+"""bshd padded lengths are per-sample, not one rollout-global max; CUDA is stubbed to run on CPU."""
+
+from argparse import Namespace
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+import miles.backends.training_utils.cp_utils as cp_utils_mod
+import miles.backends.training_utils.data as data_mod
+import miles.backends.training_utils.replay_data as replay_data_mod
+from miles.backends.training_utils.data import get_batch, get_rollout_data
+from miles.backends.training_utils.replay_data import fill_replay_data
+
+
+def _parallel_state(cp_rank: int = 0, cp_size: int = 1, tp_size: int = 1) -> SimpleNamespace:
+    return SimpleNamespace(
+        cp=SimpleNamespace(rank=cp_rank, size=cp_size),
+        tp=SimpleNamespace(rank=0, size=tp_size),
+        effective_dp=SimpleNamespace(rank=0, size=1),
+    )
+
+
+class _FakeIterator:
+    def __init__(self, batch: dict):
+        self._batch = batch
+        self.rollout_data = {}
+
+    def get_next(self, keys):
+        return {key: self._batch[key] for key in keys}
+
+    def reset(self):
+        return self
+
+
+KEYS = ["tokens", "loss_masks", "total_lengths", "response_lengths", "max_seq_lens"]
+
+
+def _make_batch(lengths: list[int], max_seq_lens: list[int]) -> dict:
+    response_lengths = [max(1, length // 2) for length in lengths]
+    return {
+        "tokens": [torch.arange(1, length + 1, dtype=torch.long) for length in lengths],
+        "loss_masks": [torch.ones(r, dtype=torch.int) for r in response_lengths],
+        "total_lengths": list(lengths),
+        "response_lengths": response_lengths,
+        "max_seq_lens": list(max_seq_lens),
+        "adapter_slots": None,
+    }
+
+
+@pytest.fixture(autouse=True)
+def _stub_cuda(monkeypatch):
+    monkeypatch.setattr(torch.Tensor, "cuda", lambda self, *args, **kwargs: self, raising=False)
+    monkeypatch.setattr(torch.cuda, "current_device", lambda: "cpu", raising=False)
+
+
+def _patch_state(monkeypatch, state: SimpleNamespace) -> None:
+    monkeypatch.setattr(data_mod, "get_parallel_state", lambda: state)
+    monkeypatch.setattr(cp_utils_mod, "get_parallel_state", lambda: state)
+    monkeypatch.setattr(replay_data_mod, "get_parallel_state", lambda: state)
+
+
+def test_rollout_max_seq_lens_are_per_sample(monkeypatch):
+    # Regression: every sample used to be padded to the rollout-global max, so
+    # one 130-token outlier multiplied the short samples' padded lengths.
+    total_lengths = [7, 130, 24]
+    rollout_data = {
+        "tokens": [list(range(length)) for length in total_lengths],
+        "loss_masks": [[1] * max(1, length // 2) for length in total_lengths],
+        "total_lengths": list(total_lengths),
+        "response_lengths": [max(1, length // 2) for length in total_lengths],
+    }
+    _patch_state(monkeypatch, _parallel_state())
+    monkeypatch.setattr(data_mod, "process_rollout_data", lambda *args, **kwargs: (rollout_data, None))
+    args = Namespace(qkv_format="bshd", enable_witness=False, data_pad_size_multiplier=8, compress_ratios=[])
+
+    out, _ = get_rollout_data(args, rollout_data_ref=None)
+
+    assert out["max_seq_lens"] == [8, 136, 24]
+
+
+def test_get_batch_bshd_accepts_shared_padded_length(monkeypatch):
+    _patch_state(monkeypatch, _parallel_state())
+
+    out = get_batch(_FakeIterator(_make_batch([7, 8], [8, 8])), KEYS, pad_multiplier=8, qkv_format="bshd")
+
+    assert out["tokens"].shape == (2, 8)
+    assert out["full_loss_masks"].shape == (2, 8)
+    assert torch.equal(out["tokens"][0, :7], torch.arange(1, 8, dtype=torch.long))
+    assert torch.all(out["tokens"][0, 7:] == 0)
+    assert torch.equal(out["tokens"][1], torch.arange(1, 9, dtype=torch.long))
+
+
+def test_get_batch_bshd_rejects_mixed_padded_lengths(monkeypatch):
+    # Build-time CP slicing uses each sample's own padded length, so mixing
+    # padded lengths inside one bshd microbatch must fail loudly, not misalign.
+    _patch_state(monkeypatch, _parallel_state())
+    batch = _make_batch([7, 130], [8, 136])
+
+    with pytest.raises(AssertionError, match="mixes padded lengths"):
+        get_batch(_FakeIterator(batch), KEYS, pad_multiplier=8, qkv_format="bshd")
+
+
+def test_fill_replay_data_bshd_rejects_mixed_padded_lengths(monkeypatch):
+    _patch_state(monkeypatch, _parallel_state())
+    batch = _make_batch([7, 130], [8, 136])
+    batch["routing"] = [torch.zeros(length - 1, 1, 1) for length in batch["total_lengths"]]
+
+    with pytest.raises(AssertionError, match="mixes padded lengths"):
+        fill_replay_data(
+            args=Namespace(qkv_format="bshd"),
+            models=None,
+            data_iterator=[_FakeIterator(batch)],
+            num_microbatches=[1],
+            rollout_data=batch,
+            data_key="routing",
+            replay_list=[],
+            register_replay_list_func=lambda *_args, **_kwargs: None,
+        )

--- a/tests/fast/utils/test_arguments.py
+++ b/tests/fast/utils/test_arguments.py
@@ -323,6 +323,17 @@ class TestRdtValidation:
             self._validate(extra)
 
 
+def test_bshd_multi_sample_microbatch_warns(caplog):
+    parser = argparse.ArgumentParser()
+    get_miles_extra_args_provider()(parser)
+    args = parser.parse_args(["--qkv-format", "bshd", "--micro-batch-size", "2", "--num-rollout", "1"] + REQUIRED_ARGS)
+
+    with caplog.at_level(logging.WARNING, logger="miles.utils.arguments"):
+        miles_validate_args(args)
+
+    assert "Use --micro-batch-size 1 unless samples are bucketed by padded length." in caplog.text
+
+
 class TestCriticSaveDerivation:
     def _validate(self, extra):
         parser = argparse.ArgumentParser()

--- a/tests/fast/utils/test_arguments.py
+++ b/tests/fast/utils/test_arguments.py
@@ -286,6 +286,17 @@ def test_dynamic_global_batch_size_requires_dynamic_batch_size():
         miles_validate_args(args)
 
 
+def test_bshd_multi_sample_microbatch_warns(caplog):
+    parser = argparse.ArgumentParser()
+    get_miles_extra_args_provider()(parser)
+    args = parser.parse_args(["--qkv-format", "bshd", "--micro-batch-size", "2", "--num-rollout", "1"] + REQUIRED_ARGS)
+
+    with caplog.at_level(logging.WARNING, logger="miles.utils.arguments"):
+        miles_validate_args(args)
+
+    assert "Use --micro-batch-size 1 unless samples are bucketed by padded length." in caplog.text
+
+
 class TestCriticSaveDerivation:
     def _validate(self, extra):
         parser = argparse.ArgumentParser()


### PR DESCRIPTION
## Summary
`bshd` uses a rectangular `[batch, sequence, heads, head-dim]` tensor. Miles previously chose that sequence dimension from the longest sample in the entire rollout, so one long outlier forced even unrelated short samples in other microbatches to carry the same padding. This changes `max_seq_lens` from a repeated rollout-global maximum to each sample's own aligned padded length.

## Symptom
Measured on a 128x H100 DeepSeek-V4-Flash run at 262,144-token context: a 14,010-token sample padded to 132,096 OOMed the expert MLP at 79 GB. Pad tokens still dispatch through MoE. With per-sample padded lengths, the same step peaks at 38.5 GB.

## Root Cause
`get_rollout_data` computed `max(total_lengths)`, rounded it for the existing TP/CP/compression alignment requirements, and copied that value into every entry of `max_seq_lens`. Because padding was sized across the rollout rather than at the microbatch that consumes a sample, a single outlier inflated every sample's token count (about 9.4x in the measured case).

`max_seq_lens` is also layout metadata, not only a memory hint: token tensors, rollout log probabilities, replay tensors, and response-logit offsets must use the same padded length when applying context-parallel slicing.

## Fix
- In `get_rollout_data`, round each sample's own `total_length` up with the existing `pad_size` rule. This preserves all current alignment constraints while avoiding padding across unrelated samples.
- Keep `max_seq_lens` as the single source of BSHD padding geometry. Existing per-sample consumers continue to read the corresponding entry, including build-time CP slicing of rollout log probabilities.
- In `get_batch` and `fill_replay_data`, assert that every sample in one BSHD microbatch has the same padded length. BSHD is rectangular, and these paths currently form the batch from `max_seq_lens[0]`; accepting different padded lengths would make token, log-probability, and replay layouts disagree silently.
- Warn during argument validation for BSHD with `--micro-batch-size > 1`, with remediation to use one sample or bucket samples by padded length.

## Why This Shape
The change is intentionally made at the existing `max_seq_lens` producer, before rollout-derived tensors are CP-sliced. Computing a larger value only later in `get_batch` would be incorrect because those tensors would already have been sliced using different per-sample geometry. The guards therefore fail closed at the two remaining rectangular-batch consumers instead of hiding a layout mismatch.

This is the smallest change that fixes the production configuration without introducing a second padding owner or reorganizing scheduling. It supports:

- BSHD with one sample per microbatch, used by the checked-in BSHD recipes.
- Multi-sample BSHD microbatches when the samples round to the same padded length.

Multi-sample microbatches with different padded lengths are rejected with a targeted error. Fully general support requires establishing the final microbatch membership before CP slicing, assigning one shared maximum to that group, and then slicing every dependent field with that same value. The TODO at the producer records that separate scheduling/data-flow change; taking `max()` only at batch consumption would not be sufficient.

## Performance Trade-off

Per-sample padding can produce more BSHD sequence shapes than one rollout-global target. That reduces dense token work and memory, but may trade away some kernel, execution-plan, or compilation-cache reuse. This PR therefore claims the measured memory result above, not a universal step-time improvement. `--data-pad-size-multiplier` remains the existing granularity control: increasing it coarsens aligned-length buckets, trading more padding for fewer distinct shapes. A separate global-max mode is not added without evidence that its cache benefit outweighs the observed OOM risk in a Miles workload.

## Verification
New CPU coverage in `tests/fast/backends/training_utils/test_bshd_per_sample_pad.py` verifies:

- Per-sample aligned values are produced.
- Different true lengths that share one padded length form the expected rectangular batch.
- Different padded lengths are rejected by both `get_batch` and `fill_replay_data`.

The focused regression file and the complete argument-validation test file pass 146/146 locally on CPU-only torch. The 38.5 GB result above is the same change validated on the H100 run.

## Remaining Boundary
`max_seq_lens` is still computed before multimodal token expansion, matching the previous ordering rather than introducing a regression. No checked-in BSHD recipe uses multimodal token expansion; supporting that combination should recompute the padded lengths after expansion.
