### PR TITLE
fix(ci): unbreak the documented runner setup on a new host

### DIFF
--- a/tests/ci/README.md
+++ b/tests/ci/README.md
@@ -37,9 +37,6 @@ WARN: The `GITHUB_RUNNER_TOKEN` changes after a while.
 
 ### Step 2: Prepare `/home/runner/externals`
 
-Use the same runner version `docker-compose.yml` pins — the externals are
-version-matched, so a bump in Step 3 means redoing this step.
-
 ```shell
 docker run --rm -it --privileged --pid=host -v /:/host_root ubuntu /bin/bash -c 'rm -rf /host_root/home/runner/externals && mkdir -p /host_root/home/runner/externals && chmod -R 777 /host_root/home/runner/externals'
 docker run -d --name temp-runner ghcr.io/actions/actions-runner:2.336.0 tail -f /dev/null

--- a/tests/ci/README.md
+++ b/tests/ci/README.md
@@ -37,9 +37,12 @@ WARN: The `GITHUB_RUNNER_TOKEN` changes after a while.
 
 ### Step 2: Prepare `/home/runner/externals`
 
+Use the same runner version `docker-compose.yml` pins — the externals are
+version-matched, so a bump in Step 3 means redoing this step.
+
 ```shell
 docker run --rm -it --privileged --pid=host -v /:/host_root ubuntu /bin/bash -c 'rm -rf /host_root/home/runner/externals && mkdir -p /host_root/home/runner/externals && chmod -R 777 /host_root/home/runner/externals'
-docker run -d --name temp-runner ghcr.io/actions/actions-runner:2.334.0 tail -f /dev/null
+docker run -d --name temp-runner ghcr.io/actions/actions-runner:2.336.0 tail -f /dev/null
 docker cp temp-runner:/home/runner/externals/. /home/runner/externals
 docker rm -f temp-runner
 ls -alh /home/runner/externals

--- a/tests/ci/github_runner/docker-compose.yml
+++ b/tests/ci/github_runner/docker-compose.yml
@@ -18,12 +18,7 @@
 # silently spins up many runners.
 services:
   runner:
-    # NOTE need to use the latest, o/w the runner will want to upgrade itself.
-    # `--disableupdate` below means a stale pin is not merely suboptimal: GitHub
-    # retires old runner versions server-side, and the broker then answers every
-    # poll with "Runner version vX is deprecated and cannot receive messages".
-    # The runner registers, shows online for a second, and dies. Bump this when
-    # that happens; check https://github.com/actions/runner/releases.
+    # NOTE need to use the latest, o/w the broker rejects it as deprecated
     image: ghcr.io/actions/actions-runner:2.336.0
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
@@ -40,10 +35,6 @@ services:
     # ref: https://github.com/actions/runner/issues/367#issuecomment-2007558723
     # ref: https://github.com/actions/runner
     # args ref: https://github.com/actions/runner/blob/68ff57dbc4c836d50f46602a8a53301fb9513eb4/src/Runner.Listener/CommandSettings.cs#L53
-    # `.runner` lives in the container's writable layer, so `restart: always`
-    # re-runs this entrypoint against an already-configured runner. Guard the
-    # config step or every restart dies with "Cannot configure the runner
-    # because it is already configured" and the container loops.
     entrypoint: >
       sh -c "
       cd /data/miles_ci &&

--- a/tests/ci/github_runner/docker-compose.yml
+++ b/tests/ci/github_runner/docker-compose.yml
@@ -18,8 +18,13 @@
 # silently spins up many runners.
 services:
   runner:
-    # NOTE need to use the latest, o/w the runner will want to upgrade itself
-    image: ghcr.io/actions/actions-runner:2.334.0
+    # NOTE need to use the latest, o/w the runner will want to upgrade itself.
+    # `--disableupdate` below means a stale pin is not merely suboptimal: GitHub
+    # retires old runner versions server-side, and the broker then answers every
+    # poll with "Runner version vX is deprecated and cannot receive messages".
+    # The runner registers, shows online for a second, and dies. Bump this when
+    # that happens; check https://github.com/actions/runner/releases.
+    image: ghcr.io/actions/actions-runner:2.336.0
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - /data/miles_ci:/data/miles_ci
@@ -35,9 +40,15 @@ services:
     # ref: https://github.com/actions/runner/issues/367#issuecomment-2007558723
     # ref: https://github.com/actions/runner
     # args ref: https://github.com/actions/runner/blob/68ff57dbc4c836d50f46602a8a53301fb9513eb4/src/Runner.Listener/CommandSettings.cs#L53
+    # `.runner` lives in the container's writable layer, so `restart: always`
+    # re-runs this entrypoint against an already-configured runner. Guard the
+    # config step or every restart dies with "Cannot configure the runner
+    # because it is already configured" and the container loops.
     entrypoint: >
       sh -c "
       cd /data/miles_ci &&
-      /home/runner/config.sh --url ${GITHUB_RUNNER_URL} --token ${GITHUB_RUNNER_TOKEN} --unattended --work /data/miles_ci/runner_$(hostname) --disableupdate &&
+      if [ ! -f /home/runner/.runner ]; then
+        /home/runner/config.sh --url ${GITHUB_RUNNER_URL} --token ${GITHUB_RUNNER_TOKEN} --unattended --work /data/miles_ci/runner_$(hostname) --disableupdate;
+      fi &&
       /home/runner/run.sh
       "


### PR DESCRIPTION
Setting up a brand-new CI host by following `tests/ci/README.md` verbatim does not work today. Two independent bugs, both hit while bringing up a new host; fixing them is unrelated to that host.

## 1. The pinned runner version is retired server-side

`docker-compose.yml` pinned `ghcr.io/actions/actions-runner:2.334.0`. GitHub has since retired it. The failure is misleading rather than obvious — registration **succeeds**, the runner shows **online** in Settings → Runners, and then its first poll returns:

```
An error occurred: Runner version v2.334.0 is deprecated and cannot receive messages.
GitHub.DistributedTask.WebApi.AccessDeniedException
Runner listener exit with terminated error, stop the service, no retry needed.
```

The listener exits immediately. Because the entrypoint passes `--disableupdate`, the runner cannot climb out on its own, so a stale pin is a hard failure rather than a warning.

Bumped to `2.336.0`, and the comment next to the pin now states the failure mode and where to check for new releases, since this will recur.

## 2. The entrypoint re-configures on every restart

`config.sh` ran unconditionally. `.runner` lives in the container's writable layer, so `restart: always` re-runs the entrypoint against an already-configured runner:

```
Cannot configure the runner because it is already configured.
[ERR Runner] System.InvalidOperationException
```

Exit 1 → restart → same error, forever. `docker ps` shows `Restarting (1)`.

`README.md` already documented the guard this adds (`the entrypoint guards config.sh with if [ ! -f /home/runner/.runner ]`), so the docs were describing behavior the file never had.

## Blast radius

Existing hosts are unaffected: `scitix-73` / `novita` use the external `gh-runner` image and never read this compose file, and `scitix-72` registered long ago so its `.runner` already exists. Only a from-scratch host hits either bug.

## Also

`README.md` Step 2 now notes that `/home/runner/externals` is version-matched to the runner image, so a future bump means redoing that step rather than leaving a half-upgraded host.

## Testing

Both fixes verified end to end on a fresh host: the runner registers, stays `online`, and reaches `Listening for Jobs` with `Current runner version: '2.336.0'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)