### PR TITLE
feat(ci): add stage-c-8-gpu-b200 for the Blackwell runner

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -320,3 +320,29 @@ jobs:
         --labels ${{ needs.resolve-ci-policy.outputs.raw_labels }}
         ${{ github.event_name == 'workflow_dispatch' && '--match-all-labels' || '' }}
     secrets: inherit
+
+  # The Blackwell fleet is one unpartitioned 8-GPU host: an 8-GPU runner cannot
+  # coexist with 2/4-GPU runners on the same node, since GitHub would dispatch
+  # jobs onto overlapping devices. Tests needing fewer than 8 GPUs therefore
+  # register against this suite too. No partition matrix: one runner serialises
+  # shards anyway, and the suite's current budget is far inside the job timeout.
+  stage-c-8-gpu-b200:
+    needs: [resolve-ci-policy, resolve-ci-image, stage-a-cpu]
+    if: |
+      always() && !cancelled() &&
+      needs.resolve-ci-policy.result == 'success' &&
+      needs.resolve-ci-image.result == 'success' &&
+      !contains(fromJSON(needs.resolve-ci-policy.outputs.skipped_stages || '[]'), 'stage-c-8-gpu-b200') &&
+      (needs.stage-a-cpu.result == 'success' ||
+        needs.resolve-ci-policy.outputs.bypass_fastfail == 'true')
+    uses: ./.github/workflows/_run-ci.yml
+    with:
+      runs_on: '["b200", "8gpu"]'
+      container_image: ${{ needs.resolve-ci-image.outputs.container_image }}
+      ref: ${{ inputs.ref || '' }}
+      execute_command: >-
+        python tests/ci/run_suite.py --hw cuda --suite stage-c-8-gpu-b200
+        --cadence ${{ needs.resolve-ci-policy.outputs.cadence }}
+        --labels ${{ needs.resolve-ci-policy.outputs.raw_labels }}
+        ${{ github.event_name == 'workflow_dispatch' && '--match-all-labels' || '' }}
+    secrets: inherit

--- a/docs/ci/00-stage.md
+++ b/docs/ci/00-stage.md
@@ -12,7 +12,7 @@ The mapping is kept in sync by hand on both sides:
 - A `suite=` with no matching job never runs.
 - A stage job whose suite no test uses runs zero tests and exits 0 (intended during incremental migration).
 
-Stage names follow `stage-<tier>-<gpus>-<hw>` (or `stage-<tier>-<hw>` for CPU, e.g. `stage-a-cpu`): `tier ∈ {a, b, c}` classifies cost/role, `gpus` is the GPU count the test needs, `hw ∈ {cpu, h100, h200, mi350}` is the hardware class. A `nightly-` prefix marks a suite that only the external MI350 nightly schedules, keeping its registrations in a separate namespace from the ones this repository's own workflows consume.
+Stage names follow `stage-<tier>-<gpus>-<hw>` (or `stage-<tier>-<hw>` for CPU, e.g. `stage-a-cpu`): `tier ∈ {a, b, c}` classifies cost/role, `gpus` is the GPU count the test needs, `hw ∈ {cpu, h100, h200, b200, mi350}` is the hardware class. A `nightly-` prefix marks a suite that only the external MI350 nightly schedules, keeping its registrations in a separate namespace from the ones this repository's own workflows consume.
 
 ## Stage roster
 
@@ -25,10 +25,13 @@ Stage names follow `stage-<tier>-<gpus>-<hw>` (or `stage-<tier>-<hw>` for CPU, e
 | `stage-c-4-gpu-h200` | 4× H200 | `["h200","4gpu"]` | 3 | both resolvers, `stage-a-cpu` |
 | `stage-c-8-gpu-h100` | 8× H100 | `["h100","8gpu"]` | 2 | both resolvers, `stage-a-cpu` |
 | `stage-c-8-gpu-h200` | 8× H200 | `["h200","8gpu"]` | 2 | both resolvers, `stage-a-cpu` |
+| `stage-c-8-gpu-b200` | 8× B200 | `["b200","8gpu"]` | 1 | both resolvers, `stage-a-cpu` |
 | `stage-c-4-gpu-mi350` | 4× MI350 | `["self-hosted","amd","mi350","4gpu"]` | 2 | both resolvers |
 | `nightly-stage-c-2-gpu-mi350` | 2× MI350 | external nightly | — | — |
 | `nightly-stage-c-4-gpu-mi350` | 4× MI350 | external nightly | — | — |
 | `nightly-stage-c-8-gpu-mi350` | 8× MI350 | external nightly | — | — |
+
+`stage-c-8-gpu-b200` is the only Blackwell stage: the Blackwell fleet is a single unpartitioned host, and an 8-GPU runner cannot share a node with 2/4-GPU runners without both claiming the same physical GPUs. Blackwell tests needing fewer than eight GPUs therefore register against this suite too and leave the surplus idle, which is correct because a test declares its own GPU budget (`ray start --num-gpus`, `torchrun --nproc-per-node`) rather than inferring one from the devices it can see.
 
 In `pr-test.yml`, `tier a` (CPU fast) gates PR-image preparation and the NVIDIA GPU fleet; its GPU stages (`b` / `c`) all depend on both resolvers and `stage-a-cpu`, and run concurrently with each other — the `b` / `c` letters classify role, they are not a sequential pipeline. The MI350 stage has no CPU-test gate.
 

--- a/docs/ci/contributor-guide.md
+++ b/docs/ci/contributor-guide.md
@@ -31,6 +31,7 @@ Pick the `suite` by the hardware your test needs. The simplest reliable choice i
 | `stage-c-2-gpu-h200` | 2× H200 | 2-GPU tests |
 | `stage-c-4-gpu-h200` | 4× H200 | 4-GPU tests |
 | `stage-c-8-gpu-h100` | 8× H100 | 8-GPU tests |
+| `stage-c-8-gpu-b200` | 8× B200 | tests that need Blackwell (nvfp4, mxfp8) — any GPU count |
 
 ### Verify it definitely runs
 

--- a/tests/ci/README.md
+++ b/tests/ci/README.md
@@ -89,6 +89,12 @@ Host conventions:
   CVD intentionally left unset so jobs see all 8 GPUs. The bare
   `--env CUDA_VISIBLE_DEVICES` forwards the "unset" state, and CUDA defaults
   to seeing every visible device.
+* **b200-oma-8gpu-0** (B200, 1 runner, externally managed via `gh-runner` image):
+  whole node, CVD unset like the novita hosts. Deliberately not partitioned —
+  the 8-GPU runner would otherwise share physical GPUs with any 2/4-GPU runner
+  on the same host, and GitHub has no cross-runner resource lock. Tests needing
+  fewer than 8 GPUs still run here correctly, because a test declares its own
+  budget via `ray start --num-gpus` / `torchrun --nproc-per-node`.
 
 ## /data/miles_ci path identity rule
 

--- a/tests/ci/file_run.py
+++ b/tests/ci/file_run.py
@@ -25,6 +25,7 @@ CUDA_SUITE_RUNS_ON = {
     "stage-c-8-gpu-h200": ["h200", "8gpu"],
     "stage-c-4-gpu-h200": ["h200", "4gpu"],
     "stage-c-2-gpu-h200": ["h200", "2gpu"],
+    "stage-c-8-gpu-b200": ["b200", "8gpu"],
 }
 
 # Same shape the pr-test.yml resolve-ci-image step enforces for a Docker tag.

--- a/tests/ci/run_suite.py
+++ b/tests/ci/run_suite.py
@@ -31,10 +31,12 @@ HW_MAPPING = {
 # suite, not a second suite inventory.
 #
 # CUDA suites: each is served by a matching workflow job in
-# .github/workflows/pr-test.yml. `stage-c-8-gpu-h100` and `stage-c-8-gpu-h200`
-# run on full-node 8-GPU hosts; the split H200 fleet is one 8-GPU node divided
-# into 2+2+4 workers via per-runner CUDA_VISIBLE_DEVICES (see pr-test.yml
-# stage-c-4-gpu-h200 / stage-b-2-gpu-h200 / stage-c-2-gpu-h200 job comments).
+# .github/workflows/pr-test.yml. `stage-c-8-gpu-h100`, `stage-c-8-gpu-h200` and
+# `stage-c-8-gpu-b200` run on full-node 8-GPU hosts; the split H200 fleet is one
+# 8-GPU node divided into 2+2+4 workers via per-runner CUDA_VISIBLE_DEVICES (see
+# pr-test.yml stage-c-4-gpu-h200 / stage-b-2-gpu-h200 / stage-c-2-gpu-h200 job
+# comments). The single Blackwell host is not partitioned, so 2- and 4-GPU
+# Blackwell tests also register against the 8-GPU suite.
 CI_SUITES = {
     HWBackend.CPU: [
         "stage-a-cpu",
@@ -46,6 +48,7 @@ CI_SUITES = {
         "stage-c-8-gpu-h200",
         "stage-c-4-gpu-h200",
         "stage-c-2-gpu-h200",
+        "stage-c-8-gpu-b200",
     ],
     HWBackend.ROCM: [
         # Consumed by pr-test-rocm.yml.

--- a/tests/ci/stage_selection.py
+++ b/tests/ci/stage_selection.py
@@ -18,6 +18,7 @@ PR_GPU_STAGES = frozenset(
         "stage-c-4-gpu-h200",
         "stage-c-8-gpu-h100",
         "stage-c-8-gpu-h200",
+        "stage-c-8-gpu-b200",
         "stage-c-4-gpu-mi350",
     }
 )

--- a/tests/ci/test/test_run_suite.py
+++ b/tests/ci/test/test_run_suite.py
@@ -102,6 +102,7 @@ class TestCISuites:
             "stage-c-8-gpu-h200",
             "stage-c-4-gpu-h200",
             "stage-c-2-gpu-h200",
+            "stage-c-8-gpu-b200",
         ]
 
     def test_no_legacy_suite_names_remain(self):
@@ -268,7 +269,7 @@ class TestWorkflowScopeSeam:
     def test_every_stage_consumes_resolved_policy(self):
         workflow = self._workflow()
         commands = workflow.split("execute_command:")[1:]
-        assert len(commands) == 7, "stage inventory changed; update this lock test"
+        assert len(commands) == 8, "stage inventory changed; update this lock test"
         for block in commands:
             cmd = block.split("secrets:")[0]
             assert "--cadence ${{ needs.resolve-ci-policy.outputs.cadence }}" in cmd
@@ -290,7 +291,7 @@ class TestWorkflowScopeSeam:
     def test_cpu_and_gpu_stages_use_dedicated_reusable_workflows(self):
         workflow = self._workflow()
         assert workflow.count("uses: ./.github/workflows/_run-cpu-ci.yml") == 2
-        assert workflow.count("uses: ./.github/workflows/_run-ci.yml") == 5
+        assert workflow.count("uses: ./.github/workflows/_run-ci.yml") == 6
         assert workflow.count("uses: ./.github/workflows/_build-pr-ci-image.yml") == 1
         assert "cpu_runner" not in workflow
 
@@ -392,15 +393,15 @@ class TestWorkflowScopeSeam:
         assert "ci_scope" not in dispatch_inputs
         manual_scope = "${{ github.event_name == 'workflow_dispatch' && '--match-all-labels' || '' }}"
         cuda_stages = workflow.split("  stage-b-2-gpu-h200:", 1)[1]
-        assert cuda_stages.count(manual_scope) == 5
+        assert cuda_stages.count(manual_scope) == 6
 
     def test_gpu_gates_consume_shared_bypass_output(self):
         workflow = self._workflow()
         gpu_stages = workflow.split("  stage-b-2-gpu-h200:", 1)[1]
         bypass_gate = "needs.resolve-ci-policy.outputs.bypass_fastfail == 'true'"
-        assert gpu_stages.count(bypass_gate) == 5
-        assert gpu_stages.count("needs.resolve-ci-policy.result == 'success'") == 5
-        assert gpu_stages.count("needs.resolve-ci-image.result == 'success'") == 5
+        assert gpu_stages.count(bypass_gate) == 6
+        assert gpu_stages.count("needs.resolve-ci-policy.result == 'success'") == 6
+        assert gpu_stages.count("needs.resolve-ci-image.result == 'success'") == 6
         assert "needs.stage-a-cpu.result == 'failure'" not in gpu_stages
 
     def test_each_cuda_stage_consumes_the_fail_open_skip_list(self):


### PR DESCRIPTION
**Chain 1/5** — Blackwell CI. Stacked: `main` ← **b200-ci-runner** ← `b200-ci-hardware-axis` ← `b200-ci-baseline-identity` ← `b200-ci-dispatch` ← `b200-ci-enable-tests`.

Registers the new 8× B200 host as a CI stage: one row each in `CI_SUITES`, `PR_GPU_STAGES` and `CUDA_SUITE_RUNS_ON`, plus a single-shard job in `pr-test.yml` on `runs_on: '["b200", "8gpu"]'`.

The host is deliberately **unpartitioned**. An 8-GPU runner cannot share a node with 2/4-GPU runners without both claiming the same devices, and GitHub has no cross-runner resource lock. Sub-8-GPU Blackwell tests register against this suite too and leave the surplus idle, which is correct because a test declares its own budget via `ray start --num-gpus` / `torchrun --nproc-per-node` rather than reading the devices it can see.

No enabled test targets the suite yet, so the stage collects nothing and exits 0 until 5/5.

## Prerequisite (done)

The runner must exist before this merges. On a PR, `select_skipped_gpu_stages` prunes a stage with no enabled registrations, but `skipped_stages` is empty for `schedule`, so the nightly cron would queue a `["b200","8gpu"]` job that no runner can claim.

`b200-oma-8gpu-0` is online, and `radixark/miles:dev` is verified on sm100 — torch 2.11.0+cu130, capability `(10, 0)`, 8 devices, bf16 matmul.

🤖 Generated with [Claude Code](https://claude.com/claude-code)