### PR TITLE
fix: retain colocated LoRA CUDA-IPC exporter storage

### DIFF
--- a/miles/backends/megatron_utils/update_weight/update_weight_from_tensor.py
+++ b/miles/backends/megatron_utils/update_weight/update_weight_from_tensor.py
@@ -113,6 +113,10 @@ class UpdateWeightFromTensor:
             self._lora_config = build_lora_sync_config(args)
             self._lora_loaded = False
             self._lora_base_synced = False
+            # CUDA-IPC consumers may keep exporter handles alive after the load
+            # request returns. Keep the payload owned by this updater and reuse
+            # its storage instead of reclaiming it between publications.
+            self._lora_ipc_live_tensors: list[dict[str, torch.Tensor]] | None = None
 
         self._mm_tower_cache: list[tuple[str, torch.Tensor]] | None = None
 
@@ -233,6 +237,38 @@ class UpdateWeightFromTensor:
         out = self.__dict__.pop("update_weight_metrics", {})
         return out
 
+    def _prepare_lora_ipc_payload_for_reuse(self) -> None:
+        """Unload the consumer and make the retained exporter safe to refresh."""
+        group = self._ipc_gather_group
+        if group is None:
+            return
+        if self._lora_ipc_live_tensors is None:
+            raise RuntimeError("loaded colocated LoRA adapter has no retained CUDA-IPC payload")
+
+        rank = dist.get_rank()
+        unload_error: list[str | None] = [None]
+        if rank == self._ipc_gather_src:
+            try:
+                if self._ipc_engine is None:
+                    raise RuntimeError("colocated LoRA IPC source has no rollout engine")
+                ray.get(self._ipc_engine.unload_lora_adapter.remote(lora_name=LORA_ADAPTER_NAME))
+            except Exception as exc:
+                unload_error[0] = f"{type(exc).__name__}: {exc}"
+
+        # Propagate source-side RPC failures before the group enters a barrier;
+        # otherwise peer ranks can wait forever after an unload failure.
+        dist.broadcast_object_list(
+            unload_error,
+            src=self._ipc_gather_src,
+            group=group,
+        )
+        if unload_error[0] is not None:
+            raise RuntimeError(f"failed to unload colocated LoRA adapter: {unload_error[0]}")
+
+        dist.barrier(group=group)
+        torch.cuda.synchronize()
+        self._lora_loaded = False
+
     @torch.no_grad()
     def update_weights(self) -> None:
         """
@@ -300,13 +336,21 @@ class UpdateWeightFromTensor:
 
             accumulated_named_tensors = _pp_assemble_full_adapter(accumulated_named_tensors)
 
-            refs, long_lived_tensors = self._send_lora_params(accumulated_named_tensors)
+            if self._lora_loaded:
+                self._prepare_lora_ipc_payload_for_reuse()
+
+            pp_size = dist.get_world_size(group=get_parallel_state().pp.group)
+            refs, long_lived_tensors = self._send_lora_params(
+                accumulated_named_tensors,
+                repack_lora_for_ipc=getattr(self.args, "offload_train", False) or pp_size > 1,
+            )
+            # Retain exported storage before waiting for the consumer. Even a
+            # failed load may have imported CUDA-IPC handles before returning.
+            self._lora_ipc_live_tensors = long_lived_tensors
             results = ray.get(refs)
             _check_weight_sync_results(results, is_lora=True)
-            del long_lived_tensors
+            self._lora_loaded = self._ipc_gather_group is not None
             del accumulated_named_tensors
-            torch.cuda.ipc_collect()
-            torch.cuda.empty_cache()
 
             if not self._lora_base_synced:
                 self._lora_base_synced = True
@@ -386,7 +430,12 @@ class UpdateWeightFromTensor:
                 refs = (refs or []) + refs_distributed
         return refs or [], long_lived_tensors
 
-    def _send_lora_params(self, hf_named_tensors) -> tuple[list[ObjectRef], Any]:
+    def _send_lora_params(
+        self,
+        hf_named_tensors,
+        *,
+        repack_lora_for_ipc: bool = False,
+    ) -> tuple[list[ObjectRef], Any]:
         if not any(is_lora_weight_name(n) for n, _ in hf_named_tensors):
             raise RuntimeError(
                 "LoRA weight sync failed: chunk contains no LoRA weights "
@@ -394,6 +443,12 @@ class UpdateWeightFromTensor:
             )
         if self.use_distribute and self._is_distributed_src_rank:
             raise NotImplementedError("LoRA weight sync is not yet supported for distributed (non-colocated) engines")
+
+        reusable_lora_payload = None
+        if repack_lora_for_ipc and self._lora_ipc_live_tensors is not None:
+            if len(self._lora_ipc_live_tensors) != 1:
+                raise RuntimeError("colocated LoRA IPC payload must contain exactly one tensor mapping")
+            reusable_lora_payload = self._lora_ipc_live_tensors[0]
 
         refs, long_lived_tensors = _send_to_colocated_engine(
             hf_named_tensors=hf_named_tensors,
@@ -403,11 +458,10 @@ class UpdateWeightFromTensor:
             selector=weight_update_selector(self.args),
             lora_config=self._lora_config,
             lora_name=LORA_ADAPTER_NAME,
-            lora_loaded=self._lora_loaded,
             check_equal=getattr(self.args, "check_lora_weight_equal", False),
-            repack_lora_for_ipc=getattr(self.args, "offload_train", False),
+            repack_lora_for_ipc=repack_lora_for_ipc,
+            reusable_lora_payload=reusable_lora_payload,
         )
-        self._lora_loaded = True
         return refs or [], long_lived_tensors
 
 
@@ -447,6 +501,39 @@ def _repack_onto_fresh_storage(
     return {name: views.get(name, tensor) for name, tensor in named_tensors}
 
 
+def _refresh_lora_ipc_payload(
+    named_tensors: list[tuple[str, torch.Tensor]],
+    payload: dict[str, torch.Tensor],
+) -> dict[str, torch.Tensor]:
+    """Copy current LoRA values into an existing CUDA-IPC exporter payload."""
+    names = [name for name, _ in named_tensors]
+    if len(payload) != len(names) or set(payload) != set(names):
+        raise RuntimeError("colocated LoRA IPC payload names changed across publications")
+
+    for name, tensor in named_tensors:
+        target = payload[name]
+        if target.shape != tensor.shape or target.dtype != tensor.dtype or target.device != tensor.device:
+            raise RuntimeError(
+                f"colocated LoRA IPC payload layout changed for {name}: "
+                f"old={(target.shape, target.dtype, target.device)} "
+                f"new={(tensor.shape, tensor.dtype, tensor.device)}"
+            )
+
+    cuda_devices: set[torch.device] = set()
+    for name, tensor in named_tensors:
+        target = payload[name]
+        target.copy_(tensor)
+        if target.is_cuda:
+            cuda_devices.add(target.device)
+
+    # PyTorch records the CUDA-IPC synchronization event when a storage is
+    # shared for the first time. Reusing that storage therefore requires an
+    # explicit producer-stream synchronization before it is serialized again.
+    for device in cuda_devices:
+        torch.cuda.current_stream(device=device).synchronize()
+    return payload
+
+
 def _send_to_colocated_engine(
     hf_named_tensors: list[tuple[str, torch.Tensor]],
     *,
@@ -456,10 +543,10 @@ def _send_to_colocated_engine(
     weight_version=None,
     lora_config: dict | None = None,
     lora_name: str | None = None,
-    lora_loaded: bool = False,
     check_equal: bool = False,
     selector: str = "all",
     repack_lora_for_ipc: bool = False,
+    reusable_lora_payload: dict[str, torch.Tensor] | None = None,
 ) -> tuple[list[ObjectRef], Any]:
     # Placeholder ranks (GPU slots reserved but no engine) have no gather group.
     # gather_object is only collective among group members, so we skip entirely.
@@ -471,7 +558,14 @@ def _send_to_colocated_engine(
     long_live_tensors = []
 
     if is_lora:
-        payload = _repack_onto_fresh_storage(hf_named_tensors) if repack_lora_for_ipc else dict(hf_named_tensors)
+        if repack_lora_for_ipc:
+            payload = (
+                _repack_onto_fresh_storage(hf_named_tensors)
+                if reusable_lora_payload is None
+                else _refresh_lora_ipc_payload(hf_named_tensors, reusable_lora_payload)
+            )
+        else:
+            payload = dict(hf_named_tensors)
         long_live_tensors.append(payload)
         converted_named_tensors_by_dtypes = {}
         serialized_lora = MultiprocessingSerializer.serialize(payload, output_str=True)
@@ -506,11 +600,6 @@ def _send_to_colocated_engine(
     refs = []
     if is_gather_src:
         if is_lora:
-            try:
-                ray.get(ipc_engine.unload_lora_adapter.remote(lora_name=lora_name))
-            except Exception as _unload_err:
-                logger.debug("lora unload before load skipped: %s", _unload_err)
-
             expected_checksums = None
             if check_equal:
                 expected_checksums = {

--- a/tests/fast/backends/megatron_utils/test_lora_weight_sync_validation.py
+++ b/tests/fast/backends/megatron_utils/test_lora_weight_sync_validation.py
@@ -24,7 +24,10 @@ from miles.backends.megatron_utils.update_weight.update_weight_from_distributed.
 from miles.backends.megatron_utils.update_weight.update_weight_from_distributed.mixin import (
     DistBucketedWeightUpdateMixin,
 )
-from miles.backends.megatron_utils.update_weight.update_weight_from_tensor import UpdateWeightFromTensor
+from miles.backends.megatron_utils.update_weight.update_weight_from_tensor import (
+    UpdateWeightFromTensor,
+    _refresh_lora_ipc_payload,
+)
 from miles.utils.lora import LORA_ADAPTER_NAME
 
 _UW_MODULE = "miles.backends.megatron_utils.update_weight.update_weight_from_tensor"
@@ -72,6 +75,149 @@ def _make_args(**overrides):
     )
     defaults.update(overrides)
     return Namespace(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# Colocated LoRA CUDA-IPC payload lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestColocatedLoraIpcPayloadLifecycle:
+    def test_refresh_preserves_storage_and_updates_values(self):
+        payload = {
+            "layer.lora_A.weight": torch.empty(2, 3),
+            "layer.lora_B.weight": torch.empty(3, 2),
+        }
+        storage_ptrs = {name: tensor.untyped_storage().data_ptr() for name, tensor in payload.items()}
+        current = [
+            ("layer.lora_A.weight", torch.full((2, 3), 1.5)),
+            ("layer.lora_B.weight", torch.full((3, 2), -2.0)),
+        ]
+
+        refreshed = _refresh_lora_ipc_payload(current, payload)
+
+        assert refreshed is payload
+        assert {name: tensor.untyped_storage().data_ptr() for name, tensor in payload.items()} == storage_ptrs
+        assert torch.equal(payload["layer.lora_A.weight"], current[0][1])
+        assert torch.equal(payload["layer.lora_B.weight"], current[1][1])
+
+        next_values = [(name, tensor + 3.0) for name, tensor in current]
+        _refresh_lora_ipc_payload(next_values, payload)
+
+        assert {name: tensor.untyped_storage().data_ptr() for name, tensor in payload.items()} == storage_ptrs
+        assert torch.equal(payload["layer.lora_A.weight"], next_values[0][1])
+        assert torch.equal(payload["layer.lora_B.weight"], next_values[1][1])
+
+    def test_refresh_synchronizes_reused_cuda_storage_before_serialization(self):
+        device = torch.device("cuda:0")
+        target = MagicMock(shape=(2, 3), dtype=torch.bfloat16, device=device, is_cuda=True)
+        current = MagicMock(shape=(2, 3), dtype=torch.bfloat16, device=device)
+        stream = MagicMock()
+
+        with patch(f"{_UW_MODULE}.torch.cuda.current_stream", return_value=stream) as current_stream:
+            _refresh_lora_ipc_payload([("layer.lora_A.weight", current)], {"layer.lora_A.weight": target})
+
+        target.copy_.assert_called_once_with(current)
+        current_stream.assert_called_once_with(device=device)
+        stream.synchronize.assert_called_once_with()
+
+    def test_refresh_accepts_order_changes(self):
+        payload = {
+            "layer.lora_A.weight": torch.empty(2, 3),
+            "layer.lora_B.weight": torch.empty(3, 2),
+        }
+        reordered = [
+            ("layer.lora_B.weight", torch.empty(3, 2)),
+            ("layer.lora_A.weight", torch.empty(2, 3)),
+        ]
+
+        assert _refresh_lora_ipc_payload(reordered, payload) is payload
+
+    def test_refresh_rejects_name_changes(self):
+        payload = {"layer.lora_A.weight": torch.empty(2, 3)}
+
+        with pytest.raises(RuntimeError, match="payload names changed"):
+            _refresh_lora_ipc_payload([("other.lora_A.weight", torch.empty(2, 3))], payload)
+
+    @pytest.mark.parametrize(
+        "replacement",
+        [
+            torch.empty(3, 3),
+            torch.empty(3, 2, dtype=torch.float64),
+        ],
+    )
+    def test_refresh_rejects_incompatible_layout(self, replacement):
+        payload = {
+            "layer.lora_A.weight": torch.full((2, 3), 7.0),
+            "layer.lora_B.weight": torch.full((3, 2), 8.0),
+        }
+
+        with pytest.raises(RuntimeError, match="payload layout changed"):
+            _refresh_lora_ipc_payload(
+                [
+                    ("layer.lora_A.weight", torch.zeros(2, 3)),
+                    ("layer.lora_B.weight", replacement),
+                ],
+                payload,
+            )
+
+        assert torch.equal(payload["layer.lora_A.weight"], torch.full((2, 3), 7.0))
+
+    def test_reuse_waits_for_unload_and_group_cuda_sync(self):
+        events = []
+        unload = MagicMock()
+        unload.remote.side_effect = lambda **_kwargs: events.append("unload_submit") or "unload_ref"
+        updater = SimpleNamespace(
+            _ipc_gather_group="ipc_group",
+            _ipc_gather_src=3,
+            _ipc_engine=SimpleNamespace(unload_lora_adapter=unload),
+            _lora_ipc_live_tensors=[{"layer.lora_A.weight": torch.empty(2, 3)}],
+            _lora_loaded=True,
+        )
+
+        with (
+            patch(f"{_UW_MODULE}.dist") as dist_mock,
+            patch(f"{_UW_MODULE}.ray") as ray_mock,
+            patch(f"{_UW_MODULE}.torch.cuda.synchronize") as synchronize_mock,
+        ):
+            dist_mock.get_rank.return_value = 3
+            ray_mock.get.side_effect = lambda ref: events.append("unload_ack") if ref == "unload_ref" else None
+            dist_mock.broadcast_object_list.side_effect = lambda *_args, **_kwargs: events.append("broadcast")
+            dist_mock.barrier.side_effect = lambda **_kwargs: events.append("barrier")
+            synchronize_mock.side_effect = lambda: events.append("cuda_sync")
+
+            UpdateWeightFromTensor._prepare_lora_ipc_payload_for_reuse(updater)
+
+        assert events == ["unload_submit", "unload_ack", "broadcast", "barrier", "cuda_sync"]
+        assert updater._lora_loaded is False
+
+    def test_unload_failure_is_broadcast_and_fails_closed(self):
+        unload = MagicMock()
+        unload.remote.return_value = "unload_ref"
+        updater = SimpleNamespace(
+            _ipc_gather_group="ipc_group",
+            _ipc_gather_src=0,
+            _ipc_engine=SimpleNamespace(unload_lora_adapter=unload),
+            _lora_ipc_live_tensors=[{"layer.lora_A.weight": torch.empty(2, 3)}],
+            _lora_loaded=True,
+        )
+
+        with (
+            patch(f"{_UW_MODULE}.dist") as dist_mock,
+            patch(f"{_UW_MODULE}.ray") as ray_mock,
+            patch(f"{_UW_MODULE}.torch.cuda.synchronize") as synchronize_mock,
+        ):
+            dist_mock.get_rank.return_value = 0
+            ray_mock.get.side_effect = RuntimeError("engine unavailable")
+
+            with pytest.raises(RuntimeError, match="failed to unload.*engine unavailable"):
+                UpdateWeightFromTensor._prepare_lora_ipc_payload_for_reuse(updater)
+
+        error_status = dist_mock.broadcast_object_list.call_args.args[0]
+        assert error_status[0] == "RuntimeError: engine unavailable"
+        dist_mock.barrier.assert_not_called()
+        synchronize_mock.assert_not_called()
+        assert updater._lora_loaded is True
 
 
 # ---------------------------------------------------------------------------
@@ -170,6 +316,34 @@ class TestSendHfParamsEmptyLoraDetection:
         # Should not raise; mock_send was called with the LoRA tensors
         assert mock_send.called
 
+    @patch(f"{_UW_MODULE}._send_to_colocated_engine", return_value=([], []))
+    @patch(f"{_UW_MODULE}.dist")
+    @patch(f"{_UW_MODULE}.HfWeightIteratorBase")
+    def test_reuses_retained_payload_when_repacking(self, mock_iter_base, mock_dist, mock_send):
+        mock_dist.get_world_size.return_value = 1
+        mock_dist.get_rank.return_value = 0
+        mock_dist.new_group.return_value = MagicMock()
+        mock_iter_base.create.return_value = MagicMock()
+
+        updater = UpdateWeightFromTensor(
+            args=_make_args(),
+            model=[MagicMock()],
+            weights_getter=lambda: {},
+            model_name="qwen",
+            quantization_config=None,
+            is_lora=True,
+        )
+        updater._ipc_engine = MagicMock()
+        updater._ipc_gather_src = 0
+        updater._ipc_gather_group = MagicMock()
+        updater.use_distribute = False
+        retained_payload = {name: tensor.clone() for name, tensor in SAMPLE_LORA_WEIGHTS}
+        updater._lora_ipc_live_tensors = [retained_payload]
+
+        updater._send_lora_params(SAMPLE_LORA_WEIGHTS, repack_lora_for_ipc=True)
+
+        assert mock_send.call_args.kwargs["reusable_lora_payload"] is retained_payload
+
 
 # ---------------------------------------------------------------------------
 # update_weights: zero-chunk detection
@@ -240,6 +414,57 @@ class TestUpdateWeightsZeroChunks:
         updater.use_distribute = False
 
         updater.update_weights()
+
+
+class TestUpdateWeightsLoraIpcRetention:
+    @patch("miles.backends.megatron_utils.update_weight.common.ray")
+    @patch(f"{_UW_MODULE}.get_gloo_group", return_value=MagicMock())
+    @patch(f"{_UW_MODULE}.ray")
+    @patch(f"{_UW_MODULE}.dist")
+    @patch(f"{_UW_MODULE}.HfWeightIteratorBase")
+    def test_retains_exporter_before_waiting_for_load_result(
+        self, mock_iter_base, mock_dist, mock_ray, mock_gloo, mock_common_ray
+    ):
+        mock_dist.get_world_size.return_value = 1
+        mock_dist.get_rank.return_value = 0
+        mock_dist.new_group.return_value = MagicMock()
+
+        iterator = MagicMock()
+        iterator.get_hf_weight_chunks.side_effect = lambda _weights, *, weight_type: iter(
+            [] if weight_type == "base" else [SAMPLE_LORA_WEIGHTS]
+        )
+        mock_iter_base.create.return_value = iterator
+
+        updater = UpdateWeightFromTensor(
+            args=_make_args(),
+            model=[MagicMock()],
+            weights_getter=lambda: {},
+            model_name="qwen",
+            quantization_config=None,
+            is_lora=True,
+        )
+        updater.rollout_engines = [MagicMock()]
+        updater.use_distribute = False
+        load_ref = object()
+        retained_buffers = [{name: tensor.clone() for name, tensor in SAMPLE_LORA_WEIGHTS}]
+        updater._send_lora_params = MagicMock(return_value=([load_ref], retained_buffers))
+
+        def ray_get(refs):
+            if len(refs) == 1 and refs[0] is load_ref:
+                raise RuntimeError("load failed after importing handles")
+            return []
+
+        mock_ray.get.side_effect = ray_get
+
+        parallel_state = SimpleNamespace(pp=SimpleNamespace(group=MagicMock()))
+        with (
+            patch(f"{_UW_MODULE}.get_parallel_state", return_value=parallel_state),
+            pytest.raises(RuntimeError, match="load failed after importing handles"),
+        ):
+            updater.update_weights()
+
+        assert updater._lora_ipc_live_tensors is retained_buffers
+        assert updater._lora_loaded is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fix the colocated LoRA CUDA-IPC exporter lifetime in
`UpdateWeightFromTensor`.

The current full-adapter path releases its exporter tensors and calls
`torch.cuda.ipc_collect()` immediately after the SGLang load acknowledgement.
The consumer can still be releasing imported handles at that point, so later
allocator reuse can race stale CUDA-IPC handles.

This change:

- keeps the exported adapter payload owned by the updater for the process
  lifetime;
- unloads the previous adapter and waits for the source RPC, propagates a
  source-side failure to the gather group, then barriers and synchronizes CUDA
  before reuse;
- allocates normal CUDA storage once and refreshes it in place for
  `--offload-train` or PP > 1, where restored/assembled adapter tensors are
  otherwise temporary;
- validates tensor names, shapes, dtypes, and devices before an in-place
  refresh;
- synchronizes the producer stream before serializing reused storage;
- retains the exporter before waiting for the load result; and
- removes eager `ipc_collect()` / `empty_cache()` reclamation from this path.

## Relation to #1923

This is the same lifecycle invariant and failure family reported in #1923:
keep one exporter allocation stable instead of rotating and reclaiming
CUDA-IPC handles mid-run.

The integration is different enough that this is a current-`main`
implementation rather than a cherry-pick. #1923 targets the older
`kimi-k3` chunked transport with a module-global 512 MiB flat transfer buffer
and a per-chunk acknowledgement. Current `main` sends one full named-tensor
adapter after PP assembly. This PR therefore retains an exact-layout payload
on each updater and adds explicit unload/error-broadcast/group-barrier
ordering around refresh.

## Validation

Focused CPU coverage:

- repeated refresh preserves storage identity and updates values;
- producer-stream synchronization;
- reordered names;
- incompatible names/layouts;
- unload acknowledgement, error propagation, barrier, and CUDA ordering;
- retained payload reuse; and
- retention before the consumer load result.

`14 passed, 19 deselected`; Ruff, Black, `py_compile`, and
`git diff --check` pass.

GPU validation used current `main` at
`778227d6d7cf7b581d1eb07910c873516b6baca9` on 4 nodes / 32 H200s:

- PP4 / TP8 / EP8, all-linear LoRA, CPU offload: three complete
  full-adapter publications (two reuse cycles);
- PP1 / TP8 / EP32, attention LoRA, disk offload: three complete
  publications (two reuse cycles).

Both Ray submissions and both Sky jobs succeeded. All trainer-rank
publications returned successfully. Post-run checks found zero GPU processes,
zero pod restarts, zero cgroup OOM events, and no CUDA-IPC error, Xid, OOM,
NCCL failure, or actor restart.

## Follow-up all-linear LoRA parity resolution

This PR only fixes publication/storage lifetime. It does **not** address
trainer/rollout numerical parity.

The subsequent GLM-5.2 investigation found two independent correctness
problems outside this PR:

- long sparse-DSA prefills were non-repeatable under SGLang's default
  `sgl-kernel` indexer top-k; deterministic FlashInfer top-k with stable
  tie-breaking made the exact scorer batch repeatable; and
- Megatron fused WGrad accumulation wrote the real shared-outer expert-LoRA
  gradient directly into `param.main_grad`, bypassing the existing Parameter
  hook and allowing replicated LoRA factors to diverge after the second update.
  That Miles defect is addressed by
  [PR #2723](https://github.com/radixark/miles/pull/2723).

With deterministic top-k and the optimizer-boundary shared-factor collective,
the complete attention/MLA, dense-MLP, routed-expert gate/up, and routed-expert
down LoRA scope passed an eight-update sustained canary with every publication
returning successfully. The original expert-`down_proj` hypothesis and
incomplete-mask status are therefore superseded.

PR #2707 remains intentionally scoped to the colocated CUDA-IPC exporter
lifetime; PR #2723 carries the later Miles gradient-synchronization fix.
