### PR TITLE
fix(lora): let a resumed disaggregated run reach the rollout engine

### DIFF
--- a/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/broadcast.py
+++ b/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/broadcast.py
@@ -127,7 +127,7 @@ class UpdateWeightFromDistributed(DistBucketedWeightUpdateMixin):
             pbar.update(1)
 
     def _update_lora_weight_implementation(self, named_tensors: list[tuple[str, torch.Tensor]]) -> None:
-        """Send adapter metadata over Ray, then broadcast the tensors (src=0).
+        """Upsert adapter metadata over Ray, then broadcast the tensors (src=0).
 
         Reuses the base broadcast group (``self._model_update_groups`` /
         ``self._group_name``); base and adapter syncs are strictly sequential, so
@@ -147,6 +147,7 @@ class UpdateWeightFromDistributed(DistBucketedWeightUpdateMixin):
                 dtypes=dtypes,
                 shapes=shapes,
                 group_name=self._group_name,
+                upsert=True,
             )
             for engine in self.rollout_engines
         ]

--- a/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/mixin.py
+++ b/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/mixin.py
@@ -86,7 +86,6 @@ class DistBucketedWeightUpdateMixin:
                 f"--pipeline-model-parallel-size 1 (got {args.pipeline_model_parallel_size})."
             )
             self._lora_config = build_lora_sync_config(args)
-            self._lora_loaded = False
             self._hf_weight_iterator = HfWeightIteratorBase.create(
                 args=args,
                 model=model,
@@ -258,12 +257,16 @@ class DistBucketedWeightUpdateMixin:
                 "(no lora_A/lora_B names found). Check weight iterator."
             )
 
-        if self._lora_loaded:
+        # An engine that preloaded --lora-adapter-path already holds the adapter, which
+        # this updater cannot know, and the load below is not an upsert. Always attempt
+        # the unload and tolerate its absence, matching UpdateWeightFromTensor.
+        try:
             ray.get(
                 [engine.unload_lora_adapter.remote(lora_name=LORA_ADAPTER_NAME) for engine in self.rollout_engines]
             )
+        except Exception as unload_err:
+            logger.debug("lora unload before load skipped: %s", unload_err)
         self._update_lora_weight_implementation(accumulated_named_tensors)
-        self._lora_loaded = True
 
     def _update_multi_lora_weights(self) -> None:
         """Upsert the actor-selected adapters; the push set is identical on every rank so TP collectives align."""

--- a/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/mixin.py
+++ b/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/mixin.py
@@ -9,7 +9,6 @@ from tqdm import tqdm
 
 from miles.backends.training_utils.parallel import get_parallel_state
 from miles.utils.distributed_utils import get_gloo_group
-from miles.utils.lora import LORA_ADAPTER_NAME
 from miles.utils.timer import timer
 
 from ...lora_utils import _is_adapter_param_name, build_lora_sync_config, is_lora_weight_name
@@ -54,8 +53,8 @@ class DistBucketedWeightUpdateMixin:
             engines (via NCCL broadcast, p2p write, etc.).
         self._update_lora_weight_implementation(named_tensors) -> None
             Transfer the full LoRA adapter (HF-format ``(name, tensor)`` pairs) to
-            rollout engines. Only required when ``is_lora``; the
-            unload-before-reload is handled by ``_update_lora_weights``.
+            rollout engines with insert-or-refresh semantics. Only required when
+            ``is_lora``.
         self._update_multi_lora_weight_implementation(named_tensors, *, lora_name, lora_config) -> None
             Multi-LoRA variant: transfers one adapter under its per-slot engine
             name with the adapter's own config, upserting in place. Only
@@ -86,7 +85,6 @@ class DistBucketedWeightUpdateMixin:
                 f"--pipeline-model-parallel-size 1 (got {args.pipeline_model_parallel_size})."
             )
             self._lora_config = build_lora_sync_config(args)
-            self._lora_loaded = False
             self._hf_weight_iterator = HfWeightIteratorBase.create(
                 args=args,
                 model=model,
@@ -258,12 +256,7 @@ class DistBucketedWeightUpdateMixin:
                 "(no lora_A/lora_B names found). Check weight iterator."
             )
 
-        if self._lora_loaded:
-            ray.get(
-                [engine.unload_lora_adapter.remote(lora_name=LORA_ADAPTER_NAME) for engine in self.rollout_engines]
-            )
         self._update_lora_weight_implementation(accumulated_named_tensors)
-        self._lora_loaded = True
 
     def _update_multi_lora_weights(self) -> None:
         """Upsert the actor-selected adapters; the push set is identical on every rank so TP collectives align."""

--- a/miles/backends/sglang_utils/sglang_engine.py
+++ b/miles/backends/sglang_utils/sglang_engine.py
@@ -777,10 +777,18 @@ def _compute_server_args(
         else:
             kwargs["lora_target_modules"] = convert_target_modules_to_hf(args.target_modules)
 
-        if args.lora_adapter_path is not None and kwargs.get("load_format") != "dummy":
+        # A resumed checkpoint can hold only Megatron-native shards, because the HF
+        # PEFT export is best-effort and Bridge declines some MoE adapter layouts.
+        # SGLang would abort at startup on the missing adapter_config.json, so preload
+        # only a directory it can actually read; either way the adapter arrives through
+        # the weight sync that both drivers run before the first rollout.
+        peft_export_available = args.lora_adapter_path is not None and os.path.isfile(
+            os.path.join(args.lora_adapter_path, "adapter_config.json")
+        )
+        if peft_export_available and kwargs.get("load_format") != "dummy":
             kwargs["lora_paths"] = {LORA_ADAPTER_NAME: args.lora_adapter_path}
         elif args.lora_adapter_path is not None:
-            logger.info("dummy base load: skipping startup lora_paths; adapter comes via weight-sync")
+            logger.info("skipping startup lora_paths; adapter comes via weight-sync")
         else:
             logger.info("No pre-trained LoRA adapter_path provided, will use random initial weights")
 

--- a/miles/backends/sglang_utils/sglang_engine.py
+++ b/miles/backends/sglang_utils/sglang_engine.py
@@ -24,7 +24,7 @@ from miles.ray.ray_actor import RayActor
 from miles.ray.rollout.sglang_server_actor import SGLangServerActor
 from miles.utils.env_report import collect_and_print_node_env_report
 from miles.utils.http_utils import get_host_info
-from miles.utils.lora import LORA_ADAPTER_NAME, lora_rollout_enabled
+from miles.utils.lora import lora_rollout_enabled
 from miles.utils.multi_lora import is_multi_lora_enabled
 
 logger = logging.getLogger(__name__)
@@ -844,10 +844,11 @@ def _compute_server_args(
         else:
             kwargs["lora_target_modules"] = convert_target_modules_to_hf(args.target_modules)
 
-        if args.lora_adapter_path is not None and kwargs.get("load_format") != "dummy":
-            kwargs["lora_paths"] = {LORA_ADAPTER_NAME: args.lora_adapter_path}
-        elif args.lora_adapter_path is not None:
-            logger.info("dummy base load: skipping startup lora_paths; adapter comes via weight-sync")
+        # Both drivers publish the trainer's current adapter before the first rollout.
+        # Starting from the base model avoids treating a partial best-effort PEFT export
+        # as preloadable and gives native-only and PEFT-producing resumes one path.
+        if args.lora_adapter_path is not None:
+            logger.info("skipping startup lora_paths; adapter comes via initial weight-sync")
         else:
             logger.info("No pre-trained LoRA adapter_path provided, will use random initial weights")
 

--- a/tests/fast/backends/megatron_utils/test_lora_weight_sync_validation.py
+++ b/tests/fast/backends/megatron_utils/test_lora_weight_sync_validation.py
@@ -361,10 +361,13 @@ class TestFlattenedTensorBucketRoundTrip:
 class _FakeRemote:
     def __init__(self, result=None):
         self.calls = []
+        self.side_effect = None
         self._result = result
 
     def remote(self, **kwargs):
         self.calls.append(kwargs)
+        if self.side_effect is not None:
+            raise self.side_effect
         return self._result
 
 
@@ -378,18 +381,17 @@ class TestDistLoraUpdateOrchestration:
     """Shared ``_update_lora_weights``: transport-agnostic orchestration.
 
     It must enforce the silent-failure guards (zero chunks, no LoRA names), gate
-    on the source rank, unload a stale adapter before reload, and delegate the
+    on the source rank, unload any resident adapter before reload, and delegate the
     actual transmit to ``_update_lora_weight_implementation`` (mocked here).
     """
 
     @staticmethod
-    def _make_self(*, engines, chunks=None, is_source=True, lora_loaded=False):
+    def _make_self(*, engines, chunks=None, is_source=True):
         if chunks is None:
             chunks = [SAMPLE_LORA_WEIGHTS]
         return SimpleNamespace(
             _hf_weight_iterator=SimpleNamespace(get_hf_weight_chunks=lambda *a, **k: iter(chunks)),
             _is_lora_source=is_source,
-            _lora_loaded=lora_loaded,
             rollout_engines=engines,
             _update_lora_weight_implementation=MagicMock(name="impl"),
         )
@@ -407,7 +409,6 @@ class TestDistLoraUpdateOrchestration:
         fake_self._update_lora_weight_implementation.assert_called_once()
         (sent,) = fake_self._update_lora_weight_implementation.call_args.args
         assert sent == SAMPLE_LORA_WEIGHTS
-        assert fake_self._lora_loaded is True
 
     def test_non_source_rank_does_not_transmit(self):
         # Non-source ranks still iterate the bridge (TP collectives) but must not
@@ -432,27 +433,22 @@ class TestDistLoraUpdateOrchestration:
             self._run(fake_self)
         fake_self._update_lora_weight_implementation.assert_not_called()
 
-    def test_reload_unloads_existing_adapter_first(self):
-        # When an adapter is already loaded, the stale one must be unloaded before
-        # the new weights are pushed, else SGLang rejects the duplicate name.
+    def test_every_update_unloads_before_load(self):
+        # An engine that preloaded --lora-adapter-path is already holding the adapter
+        # on the very first update, so the unload cannot be skipped: SGLang rejects a
+        # duplicate name and the load is not an upsert.
         engines = [_FakeEngine()]
-        fake_self = self._make_self(engines=engines, lora_loaded=True)
+        fake_self = self._make_self(engines=engines)
         self._run(fake_self)
         assert engines[0].unload_lora_adapter.calls == [{"lora_name": LORA_ADAPTER_NAME}]
         fake_self._update_lora_weight_implementation.assert_called_once()
 
-    def test_first_load_does_not_unload(self):
+    def test_missing_adapter_does_not_block_load(self):
         engines = [_FakeEngine()]
-        fake_self = self._make_self(engines=engines, lora_loaded=False)
+        engines[0].unload_lora_adapter.side_effect = ValueError("adapter not found")
+        fake_self = self._make_self(engines=engines)
         self._run(fake_self)
-        assert engines[0].unload_lora_adapter.calls == []
-
-    def test_lora_loaded_stays_false_when_implementation_raises(self):
-        fake_self = self._make_self(engines=[_FakeEngine()])
-        fake_self._update_lora_weight_implementation.side_effect = RuntimeError("boom")
-        with pytest.raises(RuntimeError, match="boom"):
-            self._run(fake_self)
-        assert fake_self._lora_loaded is False
+        fake_self._update_lora_weight_implementation.assert_called_once()
 
 
 class TestBroadcastLoraImplementation:

--- a/tests/fast/backends/megatron_utils/test_lora_weight_sync_validation.py
+++ b/tests/fast/backends/megatron_utils/test_lora_weight_sync_validation.py
@@ -378,18 +378,17 @@ class TestDistLoraUpdateOrchestration:
     """Shared ``_update_lora_weights``: transport-agnostic orchestration.
 
     It must enforce the silent-failure guards (zero chunks, no LoRA names), gate
-    on the source rank, unload a stale adapter before reload, and delegate the
-    actual transmit to ``_update_lora_weight_implementation`` (mocked here).
+    on the source rank, and delegate the actual transmit to
+    ``_update_lora_weight_implementation`` (mocked here).
     """
 
     @staticmethod
-    def _make_self(*, engines, chunks=None, is_source=True, lora_loaded=False):
+    def _make_self(*, engines, chunks=None, is_source=True):
         if chunks is None:
             chunks = [SAMPLE_LORA_WEIGHTS]
         return SimpleNamespace(
             _hf_weight_iterator=SimpleNamespace(get_hf_weight_chunks=lambda *a, **k: iter(chunks)),
             _is_lora_source=is_source,
-            _lora_loaded=lora_loaded,
             rollout_engines=engines,
             _update_lora_weight_implementation=MagicMock(name="impl"),
         )
@@ -407,7 +406,6 @@ class TestDistLoraUpdateOrchestration:
         fake_self._update_lora_weight_implementation.assert_called_once()
         (sent,) = fake_self._update_lora_weight_implementation.call_args.args
         assert sent == SAMPLE_LORA_WEIGHTS
-        assert fake_self._lora_loaded is True
 
     def test_non_source_rank_does_not_transmit(self):
         # Non-source ranks still iterate the bridge (TP collectives) but must not
@@ -431,28 +429,6 @@ class TestDistLoraUpdateOrchestration:
         with pytest.raises(RuntimeError, match="no LoRA weights"):
             self._run(fake_self)
         fake_self._update_lora_weight_implementation.assert_not_called()
-
-    def test_reload_unloads_existing_adapter_first(self):
-        # When an adapter is already loaded, the stale one must be unloaded before
-        # the new weights are pushed, else SGLang rejects the duplicate name.
-        engines = [_FakeEngine()]
-        fake_self = self._make_self(engines=engines, lora_loaded=True)
-        self._run(fake_self)
-        assert engines[0].unload_lora_adapter.calls == [{"lora_name": LORA_ADAPTER_NAME}]
-        fake_self._update_lora_weight_implementation.assert_called_once()
-
-    def test_first_load_does_not_unload(self):
-        engines = [_FakeEngine()]
-        fake_self = self._make_self(engines=engines, lora_loaded=False)
-        self._run(fake_self)
-        assert engines[0].unload_lora_adapter.calls == []
-
-    def test_lora_loaded_stays_false_when_implementation_raises(self):
-        fake_self = self._make_self(engines=[_FakeEngine()])
-        fake_self._update_lora_weight_implementation.side_effect = RuntimeError("boom")
-        with pytest.raises(RuntimeError, match="boom"):
-            self._run(fake_self)
-        assert fake_self._lora_loaded is False
 
 
 class TestBroadcastLoraImplementation:
@@ -491,6 +467,7 @@ class TestBroadcastLoraImplementation:
         assert kwargs["lora_name"] == LORA_ADAPTER_NAME
         assert kwargs["config_dict"] == fake_self._lora_config
         assert kwargs["group_name"] == "miles-pp_0"
+        assert kwargs["upsert"] is True
         # Metadata describes every adapter tensor, no IPC payload.
         assert kwargs["names"] == [n for n, _ in SAMPLE_LORA_WEIGHTS]
         assert kwargs["dtypes"] == [t.dtype for _, t in SAMPLE_LORA_WEIGHTS]

--- a/tests/fast/backends/sglang_utils/test_compute_server_args.py
+++ b/tests/fast/backends/sglang_utils/test_compute_server_args.py
@@ -5,6 +5,7 @@ from types import SimpleNamespace
 import pytest
 
 from miles.backends.sglang_utils.sglang_engine import _compute_server_args
+from miles.utils.lora import LORA_ADAPTER_NAME
 
 
 def make_args(**overrides) -> SimpleNamespace:
@@ -76,3 +77,25 @@ class TestSglangOverridePrecedence:
         assert server_args["dtype"] == "float16"
         assert server_args["enable_lora"] is True
         assert server_args["mem_fraction_static"] == 0.7
+
+
+class TestLoraAdapterPreload:
+    """Startup preload is optional: the adapter also arrives through the first weight sync."""
+
+    def test_preloads_a_directory_sglang_can_read(self, tmp_path):
+        (tmp_path / "adapter_config.json").write_text("{}")
+        args = make_args(lora_rank=8, lora_adapter_path=str(tmp_path))
+
+        server_args = compute(args)
+
+        assert server_args["lora_paths"] == {LORA_ADAPTER_NAME: str(tmp_path)}
+
+    def test_skips_a_native_only_checkpoint(self, tmp_path):
+        # Bridge declines the HF export for some MoE adapter layouts, and SGLang
+        # aborts at startup on the missing adapter_config.json.
+        (tmp_path / "adapter_megatron_tp0_pp0_ep0.pt").write_bytes(b"")
+        args = make_args(lora_rank=8, lora_adapter_path=str(tmp_path))
+
+        server_args = compute(args)
+
+        assert "lora_paths" not in server_args

--- a/tests/fast/backends/sglang_utils/test_compute_server_args.py
+++ b/tests/fast/backends/sglang_utils/test_compute_server_args.py
@@ -76,3 +76,32 @@ class TestSglangOverridePrecedence:
         assert server_args["dtype"] == "float16"
         assert server_args["enable_lora"] is True
         assert server_args["mem_fraction_static"] == 0.7
+
+
+class TestLoraAdapterStartup:
+    """The mandatory initial weight sync is the only resume loading path."""
+
+    def test_skips_a_complete_peft_export(self, tmp_path):
+        (tmp_path / "adapter_config.json").write_text("{}")
+        (tmp_path / "adapter_model.safetensors").write_bytes(b"weights")
+        args = make_args(lora_rank=8, lora_adapter_path=str(tmp_path))
+
+        server_args = compute(args)
+
+        assert "lora_paths" not in server_args
+
+    def test_skips_a_partial_peft_export(self, tmp_path):
+        (tmp_path / "adapter_config.json").write_text("{}")
+        args = make_args(lora_rank=8, lora_adapter_path=str(tmp_path))
+
+        server_args = compute(args)
+
+        assert "lora_paths" not in server_args
+
+    def test_skips_a_native_only_checkpoint(self, tmp_path):
+        (tmp_path / "adapter_megatron_tp0_pp0_ep0.pt").write_bytes(b"")
+        args = make_args(lora_rank=8, lora_adapter_path=str(tmp_path))
+
+        server_args = compute(args)
+
+        assert "lora_paths" not in server_args


### PR DESCRIPTION
Part of #2705.

## Problem

A disaggregated LoRA run resumed with `--lora-adapter-path` can fail before its first rollout: native-only checkpoints cannot be preloaded by SGLang, partial best-effort PEFT output can look preloadable, and a preloaded adapter collides with the mandatory initial publish.

## Change

Normal train drivers start resumed rollout engines from the base model and let the mandatory initial weight publish install the trainer's restored adapter. Publish single LoRA adapters with SGLang's existing `upsert=True` contract so fresh startup and later refreshes use one path without unload churn. `--debug-rollout-only`, which skips the publish, remains a blocker before this PR is ready.

## Validation

- 28 focused fast tests covering complete, partial and native-only resume directories
- Full Qwen3-30B-A3B, 4 trainer + 4 rollout MI350X: restored four EP shards (`384` tensors each), optimizer, scheduler and global-dataset cursor from `iter_29`; continued at rollout 30, completed two optimizer steps, saved `iter_30`, and republished the trained adapter (`grad_norm=0.0152`, train/rollout abs diff `0.0210`-`0.0237`)
- Full Qwen3-4B, 4+4 MI350X: a 30-rollout run resumed at `iter_4` and `iter_14`, restored `288` tensors plus optimizer/scheduler/data cursor, and completed through `iter_29`
- Dense held-out DAPO accuracy `0.711 → 0.789`, truncation `0.211 → 0.078`; train/rollout abs diff mean `0.01265`, max `0.01419`
- Checkpoints at 4/14/29 each contain one finite TP0/PP0 native shard and distinct adapter hashes