### PR TITLE
[multi-lora] 1/n - 8, fix: skip base-weight update session for LoRA sync

### DIFF
--- a/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/mixin.py
+++ b/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/mixin.py
@@ -307,7 +307,7 @@ class DistBucketedWeightUpdateMixin:
         )
 
     def _pause_and_prepare_engines(self) -> None:
-        """Pause rollout engines, flush cache, and open the weight-update session."""
+        """Pause rollout engines and prepare base weights when they will be updated."""
         self._weight_update_selector = weight_update_selector(self.args)
         if dist.get_rank() == 0:
             mode = self.args.pause_generation_mode
@@ -315,10 +315,11 @@ class DistBucketedWeightUpdateMixin:
             if mode != "in_place":
                 ray.get([engine.flush_cache.remote() for engine in self.rollout_engines])
 
-            begin_weight_update(self.rollout_engines, self._weight_update_selector)
+            if not self.is_lora:
+                begin_weight_update(self.rollout_engines, self._weight_update_selector)
 
     def _finalize_and_resume_engines(self) -> None:
-        """Close the weight-update session and resume rollout engines."""
+        """Finalize base weights when updated and resume rollout engines."""
         if dist.get_rank() == 0:
             # unify update weight version here to cover both full param and lora update
             ray.get(
@@ -327,7 +328,8 @@ class DistBucketedWeightUpdateMixin:
                     for engine in self.rollout_engines
                 ]
             )
-            end_weight_update(self.rollout_engines)
+            if not self.is_lora:
+                end_weight_update(self.rollout_engines)
             ray.get([engine.continue_generation.remote() for engine in self.rollout_engines])
 
     def pop_metrics(self) -> dict[str, float]:

--- a/tests/fast/backends/megatron_utils/test_lora_weight_sync_validation.py
+++ b/tests/fast/backends/megatron_utils/test_lora_weight_sync_validation.py
@@ -455,6 +455,39 @@ class TestDistLoraUpdateOrchestration:
         assert fake_self._lora_loaded is False
 
 
+@pytest.mark.parametrize("is_lora", [False, True])
+def test_distributed_lora_skips_base_weight_update_session(is_lora):
+    engine = MagicMock()
+    updater = SimpleNamespace(
+        args=SimpleNamespace(pause_generation_mode="retract"),
+        rollout_engines=[engine],
+        weight_version=7,
+        is_lora=is_lora,
+    )
+
+    with (
+        patch(f"{_MIXIN_MODULE}.dist") as dist_mock,
+        patch(f"{_MIXIN_MODULE}.ray") as ray_mock,
+        patch(f"{_MIXIN_MODULE}.begin_weight_update") as begin_mock,
+        patch(f"{_MIXIN_MODULE}.end_weight_update") as end_mock,
+    ):
+        dist_mock.get_rank.return_value = 0
+        ray_mock.get.side_effect = lambda refs: refs
+        DistBucketedWeightUpdateMixin._pause_and_prepare_engines(updater)
+        DistBucketedWeightUpdateMixin._finalize_and_resume_engines(updater)
+
+    if is_lora:
+        begin_mock.assert_not_called()
+        end_mock.assert_not_called()
+    else:
+        begin_mock.assert_called_once_with([engine], "all")
+        end_mock.assert_called_once_with([engine])
+    engine.pause_generation.remote.assert_called_once_with(mode="retract")
+    engine.flush_cache.remote.assert_called_once_with()
+    engine.update_weight_version.remote.assert_called_once_with(weight_version="7")
+    engine.continue_generation.remote.assert_called_once_with()
+
+
 class TestBroadcastLoraImplementation:
     """Broadcast transport ``UpdateWeightFromDistributed._update_lora_weight_implementation``:
     send metadata over Ray, then ``dist.broadcast`` each adapter tensor over the


### PR DESCRIPTION
## Summary

- keep pause/cache-flush, adapter transfer, weight-version update, and resume unchanged
- skip `begin_weight_update` / `end_weight_update` for LoRA-only distributed sync
- preserve the existing base-weight session for full-parameter sync
- cover both lifecycle paths with a focused regression test

This is intentionally a small PR against `main`; the stacked Multi-LoRA PR #2273 can rebase onto it.

## Why

The distributed LoRA path sends only adapter tensors (`lora_A` / `lora_B`). It never refills base-model weights, so it must not open a base-weight update session.

On W4A16 MoE models, SGLang's `begin_weight_update` restores the quantized base buffers to checkpoint shapes, while `end_weight_update` runs post-load packing again. With no base weights loaded between those calls, already-packed Marlin bytes/scales are interpreted and packed a second time, corrupting the frozen base model. A zero-initialized LoRA does not prevent this because the corruption happens in the base session itself.

## Full-model reproduction

Reproduced on the official full `moonshotai/Kimi-K2.5` checkpoint (61 layers, W4A16), current `sglang-miles@cb05a44f35a7`, TP8 on 8x H200:

1. Baseline bare generation was coherent; checksum was `2218b65dab1fa8c0ba4139e47ba30407eab0c9002ba3459bce2556b1c28b08a4`.
2. Loaded a rank-32 identity LoRA covering `q_a_proj` in all 61 layers (`lora_B=0`) without a base-weight session. The checksum and deterministic bare generation were unchanged.
3. Ran an otherwise empty `begin_weight_update -> end_weight_update` session. The checksum changed to `b17b4e8b6e0066480873dd373ba2cb039deba301a6f7180aeb1ab945b0e9c400`, and bare generation immediately became repeated `Python` tokens.

Across all eight TP ranks, exactly 240 tensors changed: layers 1-60 x `{w13_weight_packed, w13_weight_scale, w2_weight_packed, w2_weight_scale}`. No tensor changed in the LoRA-only control.

## Validation

Run on an H200 Linux devbox:

- focused test file: 25 passed
- all `tests/fast/backends/megatron_utils`: 263 passed
- pre-commit on both changed files: passed
