### PR TITLE
fix(megatron): sync fused shared-outer LoRA main grads

### DIFF
--- a/miles/backends/megatron_utils/bridge_lora_helpers.py
+++ b/miles/backends/megatron_utils/bridge_lora_helpers.py
@@ -15,7 +15,11 @@ from megatron.core.utils import get_attr_wrapped_model
 from miles.utils.hf_config import load_hf_config
 from miles.utils.multi_lora import is_multi_lora_enabled, targets_expert_leaves
 
-from .lora_utils import convert_target_modules_to_hf, patch_param_grad_buffer_for_colocate_mode_lora
+from .lora_utils import (
+    convert_target_modules_to_hf,
+    mark_shared_outer_lora_grads,
+    patch_param_grad_buffer_for_colocate_mode_lora,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -179,6 +183,12 @@ def _setup_lora_model_via_bridge(args: Namespace) -> list:
     def apply_lora_hook(model_chunks):
         transformed = lora(model_chunks, training=True)
         lora.set_params_to_save(transformed)
+        if getattr(args, "experts_shared_outer_loras", False):
+            marked = mark_shared_outer_lora_grads(
+                transformed,
+                gradient_accumulation_fusion=args.gradient_accumulation_fusion,
+            )
+            logger.info("Tagged %d shared-outer expert LoRA factors for main-grad synchronization", marked)
         return transformed
 
     provider.register_pre_wrap_hook(apply_lora_hook)

--- a/miles/backends/megatron_utils/lora_utils.py
+++ b/miles/backends/megatron_utils/lora_utils.py
@@ -1,5 +1,6 @@
 """LoRA utilities for Megatron backend using Megatron-Bridge PEFT integration."""
 
+import hashlib
 import logging
 import os
 from argparse import Namespace
@@ -123,10 +124,102 @@ def sglang_lora_target_all_sentinel(args) -> bool:
 
 
 _marked_lora_grad_params_cache: dict[int, list] = {}
+_INTRA_PP_LORA_GRAD_GROUP = "intra_pp"
+
+
+def mark_shared_outer_lora_grads(
+    model: Sequence[torch.nn.Module],
+    *,
+    gradient_accumulation_fusion: bool,
+) -> int:
+    """Tag fused shared-outer expert factors for optimizer-gradient reduction.
+
+    Megatron Bridge registers an autograd hook for these replicated factors.
+    Fused WGrad bypasses that hook by accumulating the real gradient directly
+    into ``main_grad``, so Miles must reduce the optimizer-facing buffer during
+    final gradient processing instead.
+
+    Returns the number of tagged shared factors.
+    """
+    if not gradient_accumulation_fusion:
+        return 0
+
+    from megatron.bridge.peft.utils import SharedOuterGroupedExpertAdapter
+
+    marked = 0
+    for chunk_index, chunk in enumerate(model):
+        for module_name, module in chunk.named_modules():
+            if not isinstance(module, SharedOuterGroupedExpertAdapter):
+                continue
+
+            factors = (("fc1", module.linear_in.weight), ("fc2", module.linear_out.weight))
+            shared_factors = [(family, weight) for family, weight in factors if weight.ndim == 2]
+            if len(shared_factors) != 1:
+                raise RuntimeError(
+                    "shared-outer expert LoRA expected exactly one 2D replicated factor, "
+                    f"got shapes {[tuple(weight.shape) for _, weight in factors]} for {module_name}"
+                )
+            family, shared_weight = shared_factors[0]
+            shared_weight._lora_grad_sum_group = _INTRA_PP_LORA_GRAD_GROUP
+            shared_weight._lora_grad_sum_family = family
+            shared_weight._lora_grad_sum_key = f"{chunk_index}:{module_name}:{family}"
+            marked += 1
+
+    return marked
+
+
+def _digest_bytes(data: bytes) -> bytes:
+    return hashlib.sha256(data).digest()
+
+
+def _tensor_digest(tensor: torch.Tensor) -> bytes:
+    value_bytes = tensor.detach().contiguous().view(torch.uint8).cpu().numpy().tobytes()
+    return _digest_bytes(value_bytes)
+
+
+def _require_matching_digest(digest: bytes, *, device: torch.device, group, description: str) -> None:
+    token = torch.tensor(list(digest), dtype=torch.uint8, device=device)
+    gathered = [torch.empty_like(token) for _ in range(dist.get_world_size(group=group))]
+    dist.all_gather(gathered, token, group=group)
+    if any(not torch.equal(token, other) for other in gathered):
+        raise RuntimeError(f"{description} differs across intra-pipeline-stage replicas")
+
+
+def _reduce_intra_pp_lora_grads(marked: list[tuple[torch.nn.Parameter, str, str]], group) -> None:
+    """Reduce and verify shared LoRA ``main_grad`` buffers within one PP stage."""
+    marked = sorted(marked, key=lambda item: item[1])
+    keys = [key for _, key, _ in marked]
+    if any(not key for key in keys) or len(keys) != len(set(keys)):
+        raise RuntimeError("shared-outer expert LoRA gradient keys must be non-empty and unique")
+
+    inventory = tuple((key, family, tuple(param.shape), str(param.dtype)) for param, key, family in marked)
+    inventory_digest = _digest_bytes(repr(inventory).encode())
+    _require_matching_digest(
+        inventory_digest,
+        device=marked[0][0].device,
+        group=group,
+        description="shared-outer expert LoRA gradient inventory",
+    )
+
+    representatives: dict[str, torch.Tensor] = {}
+    for param, key, family in marked:
+        grad = getattr(param, "main_grad", None)
+        if grad is None:
+            raise RuntimeError(f"shared-outer expert LoRA parameter {key} has no optimizer-facing main_grad")
+        dist.all_reduce(grad, op=dist.ReduceOp.SUM, group=group)
+        representatives.setdefault(family, grad)
+
+    for family, grad in sorted(representatives.items()):
+        _require_matching_digest(
+            _tensor_digest(grad),
+            device=grad.device,
+            group=group,
+            description=f"shared-outer expert LoRA {family} main_grad",
+        )
 
 
 def reduce_marked_lora_grads(model: Sequence[torch.nn.Module]) -> None:
-    """Sum partial grads of replicated LoRA params over their tagged group ("tp"|"ep"), before the DP reduce-scatter."""
+    """Sum partial grads of tagged replicated LoRA params before optimizer preparation."""
     from megatron.core import parallel_state as ps
 
     key = id(model[0]) if model else 0
@@ -137,20 +230,39 @@ def reduce_marked_lora_grads(model: Sequence[torch.nn.Module]) -> None:
             for param in chunk.parameters():
                 group_name = getattr(param, "_lora_grad_sum_group", None)
                 if group_name is not None and param.requires_grad:
-                    marked.append((param, group_name))
+                    marked.append(
+                        (
+                            param,
+                            group_name,
+                            getattr(param, "_lora_grad_sum_key", ""),
+                            getattr(param, "_lora_grad_sum_family", ""),
+                        )
+                    )
         _marked_lora_grad_params_cache[key] = marked
     if not marked:
         return
-    groups = {
-        "tp": (ps.get_tensor_model_parallel_group(), ps.get_tensor_model_parallel_world_size()),
-        "ep": (ps.get_expert_model_parallel_group(), ps.get_expert_model_parallel_world_size()),
-    }
-    for group_name in ("tp", "ep"):
-        group, size = groups[group_name]
+    for group_name in ("tp", "ep", _INTRA_PP_LORA_GRAD_GROUP):
+        group_marked = [(param, key, family) for param, name, key, family in marked if name == group_name]
+        if not group_marked:
+            continue
+        if group_name == "tp":
+            group = ps.get_tensor_model_parallel_group()
+            size = ps.get_tensor_model_parallel_world_size()
+        elif group_name == "ep":
+            group = ps.get_expert_model_parallel_group()
+            size = ps.get_expert_model_parallel_world_size()
+        else:
+            # This is exactly one pipeline stage. It contains every replica of
+            # Bridge's shared factor while deliberately excluding other stages.
+            group = ps.get_tensor_and_data_parallel_group(with_context_parallel=True)
+            size = dist.get_world_size(group=group)
         if size <= 1:
             continue
+        if group_name == _INTRA_PP_LORA_GRAD_GROUP:
+            _reduce_intra_pp_lora_grads(group_marked, group)
+            continue
         grads = []
-        for param, g_name in marked:
+        for param, g_name, _key, _family in marked:
             if g_name != group_name:
                 continue
             grad = getattr(param, "main_grad", None)
@@ -158,7 +270,7 @@ def reduce_marked_lora_grads(model: Sequence[torch.nn.Module]) -> None:
                 grad = param.grad
             if grad is not None:
                 grads.append(grad)
-        for dt in {g.dtype for g in grads}:
+        for dt in sorted({g.dtype for g in grads}, key=str):
             gs = [g for g in grads if g.dtype == dt]
             if len(gs) == 1:
                 dist.all_reduce(gs[0], op=dist.ReduceOp.SUM, group=group)

--- a/tests/fast/backends/megatron_utils/test_lora_utils.py
+++ b/tests/fast/backends/megatron_utils/test_lora_utils.py
@@ -8,16 +8,21 @@ from argparse import Namespace
 from unittest.mock import MagicMock
 
 import pytest
+import torch
 
 from miles.backends.megatron_utils.lora_utils import (
+    _INTRA_PP_LORA_GRAD_GROUP,
     _get_lora_class_name,
     _is_adapter_param_name,
+    _marked_lora_grad_params_cache,
     build_lora_sync_config,
     convert_target_modules_to_hf,
     convert_target_modules_to_megatron,
     is_lora_enabled,
     is_lora_weight_name,
+    mark_shared_outer_lora_grads,
     parse_exclude_modules,
+    reduce_marked_lora_grads,
 )
 from miles.utils.lora import LORA_ADAPTER_NAME
 
@@ -355,3 +360,148 @@ class TestBuildLoraSyncConfig:
 
 def test_lora_adapter_name_constant():
     assert LORA_ADAPTER_NAME == "miles_lora"
+
+
+# ---------------------------------------------------------------------------
+# shared-outer expert main-grad synchronization
+# ---------------------------------------------------------------------------
+
+
+class _FakeSharedOuterAdapter(torch.nn.Module):
+    def __init__(self, *, is_fc1: bool):
+        super().__init__()
+        self._is_fc1 = is_fc1
+        if is_fc1:
+            self.linear_in = torch.nn.Linear(4, 2, bias=False)
+            self.linear_out = torch.nn.Module()
+            self.linear_out.weight = torch.nn.Parameter(torch.zeros(3, 4, 2))
+        else:
+            self.linear_in = torch.nn.Module()
+            self.linear_in.weight = torch.nn.Parameter(torch.zeros(3, 2, 4))
+            self.linear_out = torch.nn.Linear(2, 4, bias=False)
+
+
+def test_marks_only_shared_factor_for_fused_bridge_adapter(monkeypatch):
+    from megatron.bridge.peft import utils as bridge_utils
+
+    monkeypatch.setattr(bridge_utils, "SharedOuterGroupedExpertAdapter", _FakeSharedOuterAdapter)
+    fc1 = _FakeSharedOuterAdapter(is_fc1=True)
+    fc2 = _FakeSharedOuterAdapter(is_fc1=False)
+
+    marked = mark_shared_outer_lora_grads(
+        [torch.nn.ModuleList([fc1, fc2])],
+        gradient_accumulation_fusion=True,
+    )
+
+    assert marked == 2
+    assert fc1.linear_in.weight._lora_grad_sum_group == _INTRA_PP_LORA_GRAD_GROUP
+    assert fc1.linear_in.weight._lora_grad_sum_family == "fc1"
+    assert fc2.linear_out.weight._lora_grad_sum_group == _INTRA_PP_LORA_GRAD_GROUP
+    assert fc2.linear_out.weight._lora_grad_sum_family == "fc2"
+    assert not hasattr(fc1.linear_out.weight, "_lora_grad_sum_group")
+    assert not hasattr(fc2.linear_in.weight, "_lora_grad_sum_group")
+
+
+def test_does_not_double_reduce_when_wgrad_fusion_is_disabled(monkeypatch):
+    from megatron.bridge.peft import utils as bridge_utils
+
+    monkeypatch.setattr(bridge_utils, "SharedOuterGroupedExpertAdapter", _FakeSharedOuterAdapter)
+    adapter = _FakeSharedOuterAdapter(is_fc1=True)
+
+    assert (
+        mark_shared_outer_lora_grads(
+            [adapter],
+            gradient_accumulation_fusion=False,
+        )
+        == 0
+    )
+    assert not hasattr(adapter.linear_in.weight, "_lora_grad_sum_group")
+
+
+def _tag_shared_fc1(param: torch.nn.Parameter) -> torch.nn.Module:
+    param._lora_grad_sum_group = _INTRA_PP_LORA_GRAD_GROUP
+    param._lora_grad_sum_family = "fc1"
+    param._lora_grad_sum_key = "0:decoder.layers.3.mlp.experts.linear_fc1.adapter:fc1"
+    module = torch.nn.Module()
+    module.register_parameter("shared_lora_a", param)
+    return module
+
+
+def test_second_update_lora_a_reduces_main_grad_at_tp4_pp2(monkeypatch):
+    from megatron.core import parallel_state
+
+    stage_group = object()
+    group_calls = []
+    reduced = []
+    monkeypatch.setattr(
+        parallel_state,
+        "get_tensor_and_data_parallel_group",
+        lambda *, with_context_parallel: group_calls.append(with_context_parallel) or stage_group,
+    )
+    monkeypatch.setattr(
+        parallel_state,
+        "get_pipeline_model_parallel_group",
+        lambda: pytest.fail("shared gradients must not cross pipeline stages"),
+    )
+    monkeypatch.setattr(torch.distributed, "get_world_size", lambda *, group: 4)
+
+    def fake_all_reduce(tensor, *, op, group):
+        assert group is stage_group
+        assert op == torch.distributed.ReduceOp.SUM
+        reduced.append(tensor)
+        tensor.copy_(torch.tensor([10.0, 20.0]))
+
+    def fake_all_gather(outputs, token, *, group):
+        assert group is stage_group
+        for output in outputs:
+            output.copy_(token)
+
+    monkeypatch.setattr(torch.distributed, "all_reduce", fake_all_reduce)
+    monkeypatch.setattr(torch.distributed, "all_gather", fake_all_gather)
+
+    # LoRA-A first gets a real gradient after zero-initialized LoRA-B has
+    # changed. Fused WGrad writes it to main_grad while .grad stays a dummy.
+    param = torch.nn.Parameter(torch.zeros(2))
+    param.grad = torch.zeros(2)
+    param.main_grad = torch.tensor([1.0, 2.0])
+    model = [_tag_shared_fc1(param)]
+    _marked_lora_grad_params_cache.clear()
+
+    reduce_marked_lora_grads(model)
+
+    assert group_calls == [True]
+    assert len(reduced) == 1
+    assert reduced[0] is param.main_grad
+    assert torch.equal(param.main_grad, torch.tensor([10.0, 20.0]))
+    assert torch.equal(param.grad, torch.zeros(2))
+
+
+def test_shared_main_grad_hash_mismatch_fails_closed(monkeypatch):
+    from megatron.core import parallel_state
+
+    stage_group = object()
+    monkeypatch.setattr(
+        parallel_state,
+        "get_tensor_and_data_parallel_group",
+        lambda *, with_context_parallel: stage_group,
+    )
+    monkeypatch.setattr(torch.distributed, "get_world_size", lambda *, group: 2)
+    monkeypatch.setattr(torch.distributed, "all_reduce", lambda tensor, *, op, group: None)
+    gather_count = 0
+
+    def fake_all_gather(outputs, token, *, group):
+        nonlocal gather_count
+        gather_count += 1
+        for output in outputs:
+            output.copy_(token)
+        if gather_count == 2:
+            outputs[1][0] ^= 1
+
+    monkeypatch.setattr(torch.distributed, "all_gather", fake_all_gather)
+    param = torch.nn.Parameter(torch.zeros(2))
+    param.main_grad = torch.tensor([3.0, 4.0])
+    model = [_tag_shared_fc1(param)]
+    _marked_lora_grad_params_cache.clear()
+
+    with pytest.raises(RuntimeError, match="fc1 main_grad differs"):
+        reduce_marked_lora_grads(model)


### PR DESCRIPTION
## Summary

- identify the replicated factor from each Megatron Bridge `SharedOuterGroupedExpertAdapter` during LoRA model construction
- when fused WGrad is enabled, SUM-all-reduce its optimizer-facing `main_grad` over the tensor+data group for the current pipeline stage
- derive the replica group and world size from Megatron rather than assuming a particular TP, DP, CP, EP, or PP layout
- fail closed when the ordered factor inventory or bounded post-reduction fc1/fc2 SHA-256 evidence differs across replicas
- retain the existing Bridge Parameter-hook path when WGrad fusion is disabled, avoiding a double reduction

## Problem

Megatron Bridge registers a Parameter hook to synchronize the shared outer factor of routed-expert LoRA adapters. With fused weight-gradient accumulation, however, the real optimizer gradient is written directly into `param.main_grad`; only a dummy tensor reaches the Parameter hook. The optimizer therefore consumes rank-local shared-factor gradients.

The failure is delayed by LoRA initialization: LoRA-B starts at zero, so shared expert-fc1 LoRA-A first receives a useful gradient only after LoRA-B changes. In a GLM-5.2 TP8/PP4/EP8 run, the first update looked healthy, while the second update split every replicated expert-fc1 LoRA-A tensor into eight TP hashes before publication.

Disabling fusion on the adapter module alone did not repair the optimizer-facing buffer. Moving the SUM collective to final gradient processing did: eight consecutive full-scope updates produced replica-equal fc1/fc2 gradient evidence on all four pipeline stages, nonzero bitwise-equal early/middle/terminal native deltas, and maximum train/rollout absolute difference 0.0474493, KL 0.0162019, and TIS clip fraction 0.0125902. The full scope included routed-expert down-projection LoRA.

## Implementation

Miles already finalizes explicitly tagged LoRA gradients before optimizer preparation. This change extends that mechanism with an intra-pipeline-stage domain matching the Bridge shared-factor ownership contract. Adapter class and factor dimensionality identify the target; model-specific parameter suffixes are not used. Stable per-chunk/module keys order collectives consistently across replicas.

For each present fc1/fc2 family, only one fixed-size SHA-256 digest is gathered after reduction. An inventory digest is gathered first so incompatible layouts fail before the gradient collective sequence.

## Validation

- 66 LoRA utility tests passed
- added TP4/PP2 group-selection coverage that rejects crossing the pipeline axis
- added the second-update LoRA-A case with a dummy `.grad` and the real nonzero gradient in `.main_grad`
- added fc1/fc2 shared-factor discovery, non-fused no-double-reduce, and fail-closed digest tests
- Ruff checks passed
- Python byte-compilation passed
- rebased onto current `main` (`cc92260df`)

## Non-goal

Long sparse-DSA prefill scoring exposed a separate SGLang indexer top-k determinism issue. It is intentionally excluded from this gradient-synchronization PR.