### PR TITLE
[multi-lora] 1/n - 1, feat: per-token loss-weight/advantage sample channels

### DIFF
--- a/miles/backends/training_utils/data.py
+++ b/miles/backends/training_utils/data.py
@@ -90,7 +90,7 @@ def get_rollout_data(
         rollout_data["max_seq_lens"] = [max_seq_len] * len(rollout_data["tokens"])
 
     # Full-response SGLang OPD fields share rollout CP slicing but retain float32 precision.
-    for key in ("rollout_log_probs", "teacher_log_probs", "opd_reverse_kl"):
+    for key in ("rollout_log_probs", "teacher_log_probs", "opd_reverse_kl", "loss_weights", "advantages"):
         if key in rollout_data:
             dtype = _rollout_logprob_dtype(args) if key == "rollout_log_probs" else torch.float32
             rollout_data[key] = [

--- a/miles/ray/rollout/train_data_conversion.py
+++ b/miles/ray/rollout/train_data_conversion.py
@@ -19,6 +19,9 @@ ROLLOUT_DATA_TENSOR_DTYPES = {
     "rollout_log_probs": "float32",
     "teacher_log_probs": "float32",
     "opd_reverse_kl": "float32",
+    # Client-supplied per-token float channels; the binary loss_masks stay int32.
+    "loss_weights": "float32",
+    "advantages": "float32",
     "rollout_routed_experts": "int32",
     "rollout_indexer_topk": "int32",
 }

--- a/miles/rollout/generate_utils/sample_utils.py
+++ b/miles/rollout/generate_utils/sample_utils.py
@@ -161,6 +161,9 @@ def _merge_sample_pair(a: Sample, b: Sample, tokenizer) -> Sample:
             rollout_log_probs=a.rollout_log_probs + [0.0] * obs_len + b.rollout_log_probs,
             teacher_log_probs=_merge_optional_per_token("teacher_log_probs"),
             opd_reverse_kl=_merge_optional_per_token("opd_reverse_kl"),
+            # Response-aligned per-token channels: zero weight/advantage over the injected observation span.
+            loss_weights=_merge_optional_per_token("loss_weights"),
+            advantages=_merge_optional_per_token("advantages"),
             rollout_routed_experts=b.rollout_routed_experts,
             rollout_indexer_topk=b.rollout_indexer_topk,
             remove_sample=_merge_equal_value("remove_sample"),

--- a/miles/utils/types.py
+++ b/miles/utils/types.py
@@ -12,6 +12,9 @@ class AdapterRef:
 
     name: str
     slot: int
+    # Registration-scoped serving identity: a re-registered name is a new tenant, and the version keys the KV cache.
+    registration_id: str = ""
+    serving_version: int = 0
 
 
 @dataclass(frozen=True)
@@ -53,6 +56,9 @@ class Sample:
     remove_sample: bool = False
     teacher_log_probs: list[float] | None = None  # Log probabilities from teacher model for OPD
     opd_reverse_kl: list[float] | None = None  # Precomputed per-token OPD reverse-KL estimate
+    # Client-supplied per-token channels, response-aligned like loss_mask; weights may be fractional or negative.
+    loss_weights: list[float] | None = None
+    advantages: list[float] | None = None
 
     class Status(Enum):
         PENDING = "pending"
@@ -175,7 +181,8 @@ class Sample:
         return sample
 
     def get_reward_value(self, args) -> float:
-        return self.reward if not args.reward_key else self.reward[args.reward_key]
+        reward_key = getattr(args, "reward_key", None)
+        return self.reward if not reward_key else self.reward[reward_key]
 
     @property
     def effective_response_length(self):

--- a/tests/fast/utils/test_tinker_sample_channels.py
+++ b/tests/fast/utils/test_tinker_sample_channels.py
@@ -1,0 +1,59 @@
+from miles.ray.rollout.train_data_conversion import ROLLOUT_DATA_TENSOR_DTYPES
+from miles.utils.types import Sample
+
+
+def test_wire_dtypes_keep_binary_mask_and_add_float_channels():
+    assert ROLLOUT_DATA_TENSOR_DTYPES["loss_masks"] == "int32"
+    assert ROLLOUT_DATA_TENSOR_DTYPES["loss_weights"] == "float32"
+    assert ROLLOUT_DATA_TENSOR_DTYPES["advantages"] == "float32"
+
+
+def test_sample_round_trips_the_channels():
+    sample = Sample.from_dict(
+        {
+            "prompt": "p",
+            "tokens": [1, 2, 3],
+            "response_length": 2,
+            "loss_mask": [1, 1],
+            "loss_weights": [0.5, -1.0],
+            "advantages": [2.0, 0.0],
+            "status": "completed",
+        }
+    )
+    assert sample.loss_weights == [0.5, -1.0]
+    assert sample.advantages == [2.0, 0.0]
+    assert Sample.from_dict(sample.to_dict()).loss_weights == [0.5, -1.0]
+
+
+def test_merge_pads_the_channels_over_the_observation_span(monkeypatch):
+    from miles.rollout.generate_utils.sample_utils import merge_samples
+
+    class _Tok:
+        def decode(self, tokens):
+            return "obs"
+
+    a = Sample(
+        prompt="p",
+        status=Sample.Status.COMPLETED,
+        tokens=[1, 2, 3],
+        response="x",
+        response_length=1,
+        loss_mask=[1],
+        loss_weights=[0.5],
+        advantages=[1.0],
+        rollout_log_probs=[-0.1],
+    )
+    b = Sample(
+        prompt="p",
+        status=Sample.Status.COMPLETED,
+        tokens=[1, 2, 3, 9, 4, 5],
+        response="y",
+        response_length=2,
+        loss_mask=[1, 1],
+        loss_weights=[1.5, 2.5],
+        advantages=[0.0, -1.0],
+        rollout_log_probs=[-0.2, -0.3],
+    )
+    merged = merge_samples([a, b], tokenizer=_Tok())
+    assert merged.loss_weights == [0.5, 0.0, 1.5, 2.5]
+    assert merged.advantages == [1.0, 0.0, 0.0, -1.0]


### PR DESCRIPTION
Adds client-supplied per-token channels to the sample data format: `Sample.loss_weights`/`Sample.advantages` (response-aligned like `loss_mask`, float32 on the wire while the binary `loss_masks` stay int32), CP-slice coverage, and observation-span zero-padding in multi-turn merges. `AdapterRef` gains registration-scoped serving-identity fields and `get_reward_value` tolerates arg namespaces without `reward_key`. All additions are inert until a rollout path populates them.

Extracted from #2273; the stack rebases after this merges.