### PR TITLE
[multi-lora] 1/n - 4, refactor: role-separated rollout construction seam

### DIFF
--- a/miles/ray/rollout/components.py
+++ b/miles/ray/rollout/components.py
@@ -1,0 +1,95 @@
+"""Role-separated rollout construction: PR #1842 role names now, Legacy adapters over one combined RolloutManager."""
+
+from dataclasses import dataclass
+from typing import Protocol
+
+
+@dataclass(frozen=True)
+class InferenceEndpoint:
+    """Where sampling requests go (the SGLang router)."""
+
+    host: str
+    port: int
+
+    @property
+    def base_url(self) -> str:
+        return f"http://{self.host}:{self.port}"
+
+
+class InferenceControllerPort(Protocol):
+    async def get_inference_endpoint(self) -> InferenceEndpoint: ...
+
+    async def prepare_rollout(self, rollout_id: int) -> None:
+        """Called before every generate; no-op in the legacy adapter (PR #1842 moves engine preparation here)."""
+        ...
+
+
+class RolloutExecutorPort(Protocol):
+    async def generate(self, rollout_id: int): ...
+
+
+class RolloutLifecyclePort(Protocol):
+    async def dispose_once(self) -> None: ...
+
+
+class LegacyInferenceControllerAdapter:
+    """Inference-owner role view over the combined RolloutManager; the raw handle rides only weight_update_owner."""
+
+    def __init__(self, manager) -> None:
+        self._manager = manager
+
+    async def get_inference_endpoint(self) -> InferenceEndpoint:
+        host, port = await self._manager.get_router_address.remote()
+        return InferenceEndpoint(host=host, port=port)
+
+    async def prepare_rollout(self, rollout_id: int) -> None:
+        """No-op: the combined manager prepares inside generate(); PR #1842 moves that preparation here."""
+
+
+class LegacyRolloutExecutorAdapter:
+    """Execution role view over the same combined RolloutManager."""
+
+    def __init__(self, manager) -> None:
+        self._manager = manager
+
+    async def generate(self, rollout_id: int):
+        return await self._manager.generate.remote(rollout_id)
+
+
+class LegacyRolloutLifecycle:
+    """Exactly-once disposal of the SHARED underlying actor: two role views must never each dispose it."""
+
+    def __init__(self, manager) -> None:
+        self._manager = manager
+        self._disposed = False
+
+    async def dispose_once(self) -> None:
+        if self._disposed:
+            return
+        self._disposed = True
+        await self._manager.dispose.remote()
+
+
+@dataclass
+class RolloutComponents:
+    inference_controller: InferenceControllerPort
+    rollout_executor: RolloutExecutorPort
+    lifecycle: RolloutLifecyclePort
+    # Opaque weight-update owner/target (today the combined manager handle); passed verbatim, never introspected.
+    weight_update_owner: object
+
+    async def dispose(self) -> None:
+        await self.lifecycle.dispose_once()
+
+
+def create_rollout_components(args, pg) -> RolloutComponents:
+    """One construction seam: legacy manager + role views today, PR #1842's pair later; call sites never change."""
+    from miles.ray.placement_group import create_rollout_manager
+
+    rollout_manager, _num_rollout_per_epoch = create_rollout_manager(args, pg)
+    return RolloutComponents(
+        inference_controller=LegacyInferenceControllerAdapter(rollout_manager),
+        rollout_executor=LegacyRolloutExecutorAdapter(rollout_manager),
+        lifecycle=LegacyRolloutLifecycle(rollout_manager),
+        weight_update_owner=rollout_manager,
+    )

--- a/tests/fast/ray/rollout/test_components.py
+++ b/tests/fast/ray/rollout/test_components.py
@@ -1,0 +1,55 @@
+import asyncio
+from types import SimpleNamespace
+
+from miles.ray.rollout.components import InferenceEndpoint, create_rollout_components
+
+
+class Remote:
+    def __init__(self, log, name, value=None):
+        self._log, self._name, self._value = log, name, value
+
+    async def remote(self, *args):
+        self._log.append((self._name, args))
+        return self._value
+
+
+def make_fake_manager(log):
+    return SimpleNamespace(
+        get_router_address=Remote(log, "get_router_address", ("10.0.0.7", 30001)),
+        generate=Remote(log, "generate", {"batch": 1}),
+        dispose=Remote(log, "dispose"),
+    )
+
+
+def build(monkeypatch, log):
+    manager = make_fake_manager(log)
+    monkeypatch.setattr(
+        "miles.ray.placement_group.create_rollout_manager", lambda args, pg: (manager, 7), raising=True
+    )
+    components = create_rollout_components(SimpleNamespace(), pg=None)
+    return components, manager
+
+
+def test_factory_builds_two_role_views_over_one_legacy_handle(monkeypatch):
+    log: list = []
+    components, manager = build(monkeypatch, log)
+
+    assert components.inference_controller is not components.rollout_executor
+    assert components.weight_update_owner is manager
+    assert not hasattr(components.inference_controller, "manager")
+
+    endpoint = asyncio.run(components.inference_controller.get_inference_endpoint())
+    assert endpoint == InferenceEndpoint(host="10.0.0.7", port=30001)
+    assert endpoint.base_url == "http://10.0.0.7:30001"
+
+    asyncio.run(components.inference_controller.prepare_rollout(3))
+    assert asyncio.run(components.rollout_executor.generate(3)) == {"batch": 1}
+    assert ("generate", (3,)) in log
+
+
+def test_bundle_disposes_the_shared_actor_exactly_once(monkeypatch):
+    log: list = []
+    components, _ = build(monkeypatch, log)
+    asyncio.run(components.dispose())
+    asyncio.run(components.dispose())
+    assert [name for name, _ in log].count("dispose") == 1


### PR DESCRIPTION
Adds `InferenceControllerPort`/`RolloutExecutorPort`/`RolloutLifecyclePort` role views with legacy adapters over the combined `RolloutManager`, behind one construction seam (`create_rollout_components`) so call sites stay unchanged when PR #1842 splits the roles for real. Disposal of the shared underlying actor is exactly-once across the role views.

Extracted from #2273; the stack rebases after this merges.