### PR TITLE
[multi-lora] 1/n - 5, fix: skip zero-std metrics for reward-less samples

### DIFF
--- a/miles/ray/rollout/metrics.py
+++ b/miles/ray/rollout/metrics.py
@@ -173,6 +173,10 @@ def _compute_zero_std_metrics(args, all_samples: list[Sample]):
     if args.advantage_estimator == "ppo":
         return {}
 
+    # Reward-less batches have no reward plane: zero-std over missing rewards is meaningless, not zero.
+    if any(sample.get_reward_value(args) is None for sample in all_samples):
+        return {}
+
     def _is_zero_std(samples: list[Sample]):
         rewards = [sample.get_reward_value(args) for sample in samples]
         return len(rewards) == 0 or all(rewards[0] == r for r in rewards)

--- a/tests/fast/ray/rollout/test_metrics.py
+++ b/tests/fast/ray/rollout/test_metrics.py
@@ -46,6 +46,11 @@ class TestComputeZeroStdMetrics:
         assert out["zero_std/all_zero_percentage"] == 0.0
         assert out["zero_std/all_one_percentage"] == 0.0
 
+    def test_reward_less_samples_yield_no_zero_std_metrics(self):
+        args = make_args(advantage_estimator="grpo", reward_key=None)
+        samples = make_samples_grouped(2, 4, rewards=[1.0] * 4 + [None] * 4)
+        assert _compute_zero_std_metrics(args, samples) == {}
+
     def test_empty_samples_does_not_crash(self):
         args = make_args(advantage_estimator="grpo", reward_key=None)
         out = _compute_zero_std_metrics(args, [])


### PR DESCRIPTION
Batches whose samples carry no reward have no reward plane: treating missing rewards as zero-std groups is meaningless, and the `round()` bucketing crashes on `None`. Return no zero-std metrics for such batches instead.

Extracted from #2273; the stack rebases after this merges.