### PR TITLE
fix(ci): use local UCX transports for RDT test

### DIFF
--- a/tests/e2e/megatron/test_qwen3_30B_A3B_rdt.py
+++ b/tests/e2e/megatron/test_qwen3_30B_A3B_rdt.py
@@ -125,6 +125,10 @@ def execute():
         num_gpus_per_node=NUM_GPUS,
         megatron_model_type=MODEL_TYPE,
         train_script="train_async.py",
+        # This single-node test only needs CUDA IPC. The Novita H100 runner
+        # exposes an unusable mlx5 bond that makes UCX backend creation fail
+        # before NIXL can select its same-node data path.
+        extra_env_vars={"UCX_TLS": "sm,self,tcp,cuda_copy,cuda_ipc"},
     )
 
 


### PR DESCRIPTION
## Summary

Constrain the single-node RDT E2E test to UCX transports available on its H100 runner.

## Symptom & Reproduction

- **Symptom:** [`stage-c-8-gpu-h100 (0) / run`](https://github.com/radixark/miles/actions/runs/32663732898/job/97254763288) failed at revision `1b756a756fa942d716a6826e7066d479ab23187e` with `uct_iface_open(rc_verbs/mlx5_bond_0:1) failed: Address not valid`, followed by `NIXL_ERR_BACKEND`.
- **Reproduction:** Run `python3 tests/e2e/megatron/test_qwen3_30B_A3B_rdt.py` on `novita-host2`; expected same-node NIXL transfer, observed UCX backend creation failure.

## Root Cause

1. `NixlTensorTransport.get_nixl_agent()` initializes UCX before any transfer.
2. `novita-host2` exposes unusable `mlx5_bond_0:1` inside the CI container.
3. Without an explicit `UCX_TLS`, auto-discovery aborts before selecting the same-node CUDA IPC lane.

## Fix

Pass `UCX_TLS=sm,self,tcp,cuda_copy,cuda_ipc` through the test's Ray runtime environment. This preserves shared-memory/TCP control traffic and CUDA IPC data transfer while avoiding the unusable verbs device. Production RDT configuration, including cross-node transports, is unchanged.

## Verification

- `python3 -m py_compile tests/e2e/megatron/test_qwen3_30B_A3B_rdt.py`: passed.
- `ruff check tests/e2e/megatron/test_qwen3_30B_A3B_rdt.py`: passed.
- A two-GPU Ray/NIXL H200 probe with the same `UCX_TLS` transferred `torch.arange(1024)` and returned `523776`.

## Review Focus

- `tests/e2e/megatron/test_qwen3_30B_A3B_rdt.py`: the transport restriction stays test-local and single-node.
