### PR TITLE
fix(lora): check distributed adapter tensors

### DIFF
--- a/docs/advanced/lora.md
+++ b/docs/advanced/lora.md
@@ -122,7 +122,7 @@ vision towers unadapted. Use the model launcher as the source of truth.
 | `--lora-base-cpu-backup` | off | Colocated mode only: keep a CPU mirror of the frozen SGLang base and avoid re-sending base weights. This trades host RAM for faster and more reliable pause/resume. |
 | `--lora-train-only` | off | Train the adapter while keeping ordinary rollout engines on the frozen base policy. |
 | `--experts-shared-outer-loras` | off | Use shared outer factors for grouped MoE experts. This layout is not checkpoint-compatible with per-expert LoRA. |
-| `--check-lora-weight-equal` | off | On the colocated path, verify each synchronized adapter tensor with SHA-256. |
+| `--check-lora-weight-equal` | off | Verify each synchronized adapter tensor with SHA-256, on both transports. |
 | `--update-weights-interval` | `1` | Publish new weights every N rollout/train iterations. This is not LoRA-specific, but it controls when the live adapter is synchronized. |
 
 This argument table describes the general Bridge surface. Current native Inkling

--- a/miles/backends/megatron_utils/update_weight/common.py
+++ b/miles/backends/megatron_utils/update_weight/common.py
@@ -1,4 +1,5 @@
 import dataclasses
+import hashlib
 import inspect
 import logging
 import re
@@ -16,6 +17,16 @@ from miles.backends.training_utils.parallel import get_parallel_state
 from miles.utils.types import ParamInfo
 
 logger = logging.getLogger(__name__)
+
+
+def lora_source_checksums(named_tensors: Sequence[tuple[str, torch.Tensor]]) -> dict[str, str]:
+    """Per-tensor sha256 of the adapter as sent; SGLang hashes what it received the same way."""
+    return {
+        name: hashlib.sha256(
+            tensor.detach().cpu().contiguous().flatten().view(torch.uint8).numpy().tobytes()
+        ).hexdigest()
+        for name, tensor in named_tensors
+    }
 
 
 @dataclasses.dataclass(frozen=True)

--- a/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/broadcast.py
+++ b/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/broadcast.py
@@ -14,8 +14,22 @@ from miles.backends.training_utils.parallel import get_parallel_state
 from miles.utils.distributed_utils import init_process_group
 
 from miles.utils.lora import LORA_ADAPTER_NAME
-from ..common import _check_weight_sync_results
+from ..common import _check_weight_sync_results, lora_source_checksums
 from .mixin import DistBucketedWeightUpdateMixin
+
+
+def _require_checksum_acknowledgement(results: list) -> None:
+    """An SGLang build without the check ignores the manifest and still reports success."""
+    for result in results:
+        verified = (
+            result.get("checksums_verified", False)
+            if isinstance(result, Mapping)
+            else getattr(result, "checksums_verified", False)
+        )
+        if not verified:
+            raise RuntimeError(
+                "--check-lora-weight-equal requires an SGLang build that verifies distributed LoRA checksums"
+            )
 
 
 class UpdateWeightFromDistributed(DistBucketedWeightUpdateMixin):
@@ -138,6 +152,8 @@ class UpdateWeightFromDistributed(DistBucketedWeightUpdateMixin):
         names = [name for name, _ in named_tensors]
         dtypes = [param.dtype for _, param in named_tensors]
         shapes = [list(param.shape) for _, param in named_tensors]
+        check_equal = self.args.check_lora_weight_equal
+        expected_checksums = lora_source_checksums(named_tensors) if check_equal else None
 
         refs = [
             engine.load_lora_adapter_from_distributed.remote(
@@ -147,6 +163,7 @@ class UpdateWeightFromDistributed(DistBucketedWeightUpdateMixin):
                 dtypes=dtypes,
                 shapes=shapes,
                 group_name=self._group_name,
+                expected_checksums=expected_checksums,
             )
             for engine in self.rollout_engines
         ]
@@ -159,7 +176,10 @@ class UpdateWeightFromDistributed(DistBucketedWeightUpdateMixin):
         for handle in handles:
             handle.wait()
 
-        _check_weight_sync_results(ray.get(refs), is_lora=True)
+        results = ray.get(refs)
+        _check_weight_sync_results(results, is_lora=True)
+        if check_equal:
+            _require_checksum_acknowledgement(results)
 
     def _update_multi_lora_weight_implementation(
         self,

--- a/miles/backends/megatron_utils/update_weight/update_weight_from_tensor.py
+++ b/miles/backends/megatron_utils/update_weight/update_weight_from_tensor.py
@@ -1,4 +1,3 @@
-import hashlib
 import logging
 import math
 import os
@@ -22,7 +21,13 @@ from miles.utils.distributed_utils import get_gloo_group
 from miles.utils.lora import LORA_ADAPTER_NAME
 
 from ..sglang import FlattenedTensorBucket, MultiprocessingSerializer
-from .common import _check_weight_sync_results, begin_weight_update, end_weight_update, weight_update_selector
+from .common import (
+    _check_weight_sync_results,
+    begin_weight_update,
+    end_weight_update,
+    lora_source_checksums,
+    weight_update_selector,
+)
 from .hf_weight_iterator_base import HfWeightIteratorBase
 
 from .update_weight_from_distributed.broadcast import (
@@ -511,14 +516,7 @@ def _send_to_colocated_engine(
             except Exception as _unload_err:
                 logger.debug("lora unload before load skipped: %s", _unload_err)
 
-            expected_checksums = None
-            if check_equal:
-                expected_checksums = {
-                    n: hashlib.sha256(
-                        t.detach().cpu().contiguous().flatten().view(torch.uint8).numpy().tobytes()
-                    ).hexdigest()
-                    for n, t in hf_named_tensors
-                }
+            expected_checksums = lora_source_checksums(hf_named_tensors) if check_equal else None
 
             refs.append(
                 ipc_engine.load_lora_adapter_from_tensors.remote(

--- a/miles/backends/sglang_utils/sglang_engine.py
+++ b/miles/backends/sglang_utils/sglang_engine.py
@@ -476,6 +476,7 @@ class SGLangEngine(RayActor):
         pinned: bool = False,
         added_tokens_config: dict | None = None,
         upsert: bool = False,
+        expected_checksums: dict[str, str] | None = None,
     ):
         """Load a LoRA adapter: only metadata is sent; weights arrive via NCCL broadcast over ``group_name``.
         With ``upsert``, the already-loaded ``lora_name`` is overwritten in place (no unload/register)."""
@@ -491,6 +492,8 @@ class SGLangEngine(RayActor):
         }
         if added_tokens_config is not None:
             payload["added_tokens_config"] = added_tokens_config
+        if expected_checksums is not None:
+            payload["expected_checksums"] = expected_checksums
 
         return self._make_request(
             "load_lora_adapter_from_distributed",

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -2229,12 +2229,11 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 action="store_true",
                 default=False,
                 help=(
-                    "Verify the megatron->sglang LoRA adapter weight-sync on the colocated "
-                    "(from_tensors) path: on every sync the trainer ships a per-tensor sha256 "
-                    "manifest of the adapter it sends, and each rollout engine hashes the "
-                    "tensors it received and fails the load on any mismatch/missing/extra "
-                    "name. The LoRA analogue of --check-weight-update-equal, which only "
-                    "covers base weights."
+                    "Verify megatron->sglang LoRA adapter weight sync on every transport: "
+                    "the trainer ships a per-tensor sha256 manifest on every sync, and each "
+                    "rollout engine hashes the tensors it received and fails the load on any "
+                    "mismatch/missing/extra name. The LoRA analogue of "
+                    "--check-weight-update-equal, which only covers base weights."
                 ),
             )
             parser.add_argument(

--- a/tests/fast/backends/megatron_utils/test_lora_weight_sync_validation.py
+++ b/tests/fast/backends/megatron_utils/test_lora_weight_sync_validation.py
@@ -8,6 +8,7 @@ Verifies that silent failures are caught:
 - Distributed (disaggregate) sync broadcasts the adapter over NCCL (no CUDA IPC)
 """
 
+import hashlib
 from argparse import Namespace
 from dataclasses import dataclass
 from types import SimpleNamespace
@@ -54,6 +55,7 @@ class _FakeEngineResult:
 
     success: bool
     error_message: str | None = None
+    checksums_verified: bool = False
 
 
 def _make_args(**overrides):
@@ -462,12 +464,13 @@ class TestBroadcastLoraImplementation:
     """
 
     @staticmethod
-    def _make_self(*, engines):
+    def _make_self(*, engines, check_equal=False):
         return SimpleNamespace(
             rollout_engines=engines,
             _lora_config={"peft_type": "LORA", "r": 32, "lora_alpha": 32},
             _group_name="miles-pp_0",
             _model_update_groups=MagicMock(name="base_nccl_group"),
+            args=Namespace(check_lora_weight_equal=check_equal),
         )
 
     @staticmethod
@@ -500,6 +503,40 @@ class TestBroadcastLoraImplementation:
         for call in dist_mock.broadcast.call_args_list:
             assert call.args[1] == 0
             assert call.kwargs["group"] is fake_self._model_update_groups
+
+    def test_checker_sends_checksums_and_requires_acknowledgement(self):
+        engines = [
+            _FakeEngine(
+                load_result=_FakeEngineResult(
+                    success=True,
+                    checksums_verified=True,
+                )
+            )
+        ]
+        fake_self = self._make_self(engines=engines, check_equal=True)
+
+        self._run(fake_self, SAMPLE_LORA_WEIGHTS)
+
+        checksums = engines[0].load_lora_adapter_from_distributed.calls[0]["expected_checksums"]
+        assert set(checksums) == {name for name, _ in SAMPLE_LORA_WEIGHTS}
+        name, tensor = SAMPLE_LORA_WEIGHTS[0]
+        assert (
+            checksums[name]
+            == hashlib.sha256(
+                tensor.detach().cpu().contiguous().flatten().view(torch.uint8).numpy().tobytes()
+            ).hexdigest()
+        )
+
+    @pytest.mark.parametrize(
+        "load_result",
+        [_FakeEngineResult(success=True), {"success": True}],
+        ids=["attrs", "mapping"],
+    )
+    def test_checker_rejects_sglang_without_checksum_acknowledgement(self, load_result):
+        fake_self = self._make_self(engines=[_FakeEngine(load_result=load_result)], check_equal=True)
+
+        with pytest.raises(RuntimeError, match="requires an SGLang build"):
+            self._run(fake_self, SAMPLE_LORA_WEIGHTS)
 
     def test_each_engine_gets_one_rpc(self):
         engines = [_FakeEngine(), _FakeEngine()]


### PR DESCRIPTION
Part of #2705. Requires [SGLang #36190](https://github.com/sgl-project/sglang/pull/36190).

## Problem

`--check-lora-weight-equal` verifies the colocated tensor route but is a no-op for NCCL adapter broadcasts. Sending a checksum field from Miles alone is not enough: SGLang's request decoder is built with `extra_behavior="ignore"`, so a build without the receiver-side check drops the field and still returns success — the flag reads as verified while verifying nothing.

## Change

When the checker is enabled, hash the adapter as sent, forward the manifest to every distributed engine, and require each engine's explicit `checksums_verified` acknowledgement. The manifest itself moves to `update_weight/common.py` so both transports share one hash recipe instead of two copies of the expression. Normal publishes do no hashing and keep their current payload.

## Validation

- 26 fast tests in `tests/fast/backends/megatron_utils/test_lora_weight_sync_validation.py`, covering the checksum payload and a missing acknowledgement from both the attribute-style and Mapping-style engine results; SGLang #36190 carries the receiver-side tests for peer mismatch and receive failure
- 8x MI350X, Qwen3-4B, four trainer + two TP2 rollout engines: TP0 and TP1 on both engines verified `504/504` tensors before rollout 0 and after its optimizer step; rollout, nonzero gradient and checkpoint completed
- 8x MI350X, Qwen3-4B, four trainer + four TP1 rollout engines: every engine verified `504/504` tensors on both the restored initial publish and the post-training publish
- 8x MI350X, Qwen3-30B-A3B, four trainer + four TP1 rollout engines: every engine verified `37,248/37,248` tensors before resumed rollout 30 and after its two optimizer steps

## Reviewer notes

- Failing loudly against an older SGLang is deliberate: a silent pass is the exact failure this closes. The flag is off by default, so only runs that asked for the check are affected.
- Land after #2708. Both insert a keyword argument on the same `load_lora_adapter_from_distributed` call, so they collide on one line in either order; the resolution is to keep both.
