### PR TITLE
feat(rollout): support video inputs in SGLang

### DIFF
--- a/miles/backends/sglang_utils/sglang_config.py
+++ b/miles/backends/sglang_utils/sglang_config.py
@@ -5,6 +5,8 @@ import logging
 
 import yaml
 
+from miles.utils.processing_utils import validate_rollout_video_process_config
+
 logger = logging.getLogger(__name__)
 
 
@@ -64,11 +66,20 @@ class ModelConfig:
         """Resolve per-group defaults from model-level then args-level values."""
         default_gpus_per_engine = self.num_gpus_per_engine or args.rollout_num_gpus_per_engine
         default_model_path = self.model_path or args.hf_checkpoint
+        video_process_config = (args.sglang_mm_process_config or {}).get("video") or {}
+        validate_rollout_video_process_config(video_process_config)
         for g in self.server_groups:
             if g.num_gpus_per_engine is None:
                 g.num_gpus_per_engine = default_gpus_per_engine
             if "model_path" not in g.overrides:
                 g.overrides["model_path"] = default_model_path
+            group_video_config = (g.overrides.get("mm_process_config", args.sglang_mm_process_config) or {}).get(
+                "video"
+            ) or {}
+            if g.worker_type != "placeholder" and group_video_config != video_process_config:
+                raise NotImplementedError(
+                    "All SGLang server groups must use the video config from --sglang-mm-process-config"
+                )
 
         if self.server_groups:
             model_paths = {g.overrides["model_path"] for g in self.server_groups}

--- a/miles/rollout/data_source.py
+++ b/miles/rollout/data_source.py
@@ -81,6 +81,7 @@ class RolloutDataSource(DataSource):
                 tool_key=args.tool_key,
                 apply_chat_template=args.apply_chat_template,
                 apply_chat_template_kwargs=args.apply_chat_template_kwargs,
+                video_process_config=(args.sglang_mm_process_config or {}).get("video"),
                 seed=args.rollout_seed,
             )
             if self.args.rollout_shuffle:

--- a/miles/rollout/generate_hub/multi_turn.py
+++ b/miles/rollout/generate_hub/multi_turn.py
@@ -44,6 +44,12 @@ async def generate(input: GenerateFnInput) -> GenerateFnOutput:
 
     # ----------------------- Initial prompts -------------------------
 
+    if input.sample.rollout_video_sources:
+        # Video requests are single-turn only: this path sends the expanded
+        # ids with no video_data, so the engine would read video_pad tokens
+        # as ordinary context and generate against garbage.
+        raise NotImplementedError("video samples are single-turn only; multi-turn video is unsupported")
+
     prompt_tokens_ids = compute_prompt_ids_from_sample(input.state, sample, tools=tool_specs)
 
     sample.tokens = prompt_tokens_ids.copy()

--- a/miles/rollout/generate_hub/single_turn.py
+++ b/miles/rollout/generate_hub/single_turn.py
@@ -6,6 +6,7 @@ from miles.rollout.base_types import GenerateFnInput, GenerateFnOutput
 from miles.rollout.generate_utils.generate_endpoint_utils import (
     compute_prompt_ids_from_sample,
     compute_request_payload,
+    compute_rollout_input_ids,
     compute_routing_headers,
     update_sample_from_response,
 )
@@ -34,12 +35,24 @@ async def generate(input: GenerateFnInput) -> GenerateFnOutput:
     else:
         input_ids = prompt_ids
 
+    rollout_input_ids = compute_rollout_input_ids(sample, input_ids, prompt_ids)
     payload, halt_status = compute_request_payload(
-        args, input_ids=input_ids, sampling_params=sampling_params, multimodal_inputs=sample.multimodal_inputs
+        args,
+        input_ids=input_ids,
+        rollout_input_ids=rollout_input_ids,
+        sampling_params=sampling_params,
+        multimodal_inputs=sample.multimodal_inputs,
+        rollout_video_sources=sample.rollout_video_sources,
     )
     if payload is None:
         sample.status = halt_status
         return GenerateFnOutput(samples=sample)
+
+    # Initialize training tokens from the EXPANDED prompt ids before the
+    # response lands: update_sample_from_response falls back to the payload's
+    # input_ids, which for video samples are the compact rollout ids.
+    if not sample.tokens:
+        sample.tokens = list(prompt_ids)
 
     output = await post(url, payload, headers=compute_routing_headers(args, sample))
     await update_sample_from_response(args, sample, payload=payload, output=output)

--- a/miles/rollout/generate_utils/generate_endpoint_utils.py
+++ b/miles/rollout/generate_utils/generate_endpoint_utils.py
@@ -9,29 +9,72 @@ import numpy as np
 import pybase64
 
 from miles.utils.lora import LORA_ADAPTER_NAME, lora_rollout_enabled
-from miles.utils.processing_utils import encode_image_for_rollout_engine, extract_multimodal_train_inputs
+from miles.utils.processing_utils import (
+    call_processor,
+    encode_image_for_rollout_engine,
+    extract_multimodal_train_inputs,
+)
 from miles.utils.types import Sample
+
+
+def build_rollout_media_payload(
+    multimodal_inputs: dict[str, Any] | None,
+    video_sources: list[str] | None,
+) -> dict[str, list[str]]:
+    payload = {}
+    if images := (multimodal_inputs or {}).get("images"):
+        payload["image_data"] = [encode_image_for_rollout_engine(image) for image in images]
+    if video_sources:
+        payload["video_data"] = video_sources
+    return payload
 
 
 # Make this an isolated function because users may want to compute their own
 def compute_prompt_ids_from_sample(state, sample, tools=None):
     prompt = sample.prompt
+    has_processor_inputs = bool(
+        state.processor
+        and sample.multimodal_inputs
+        and any(value is not None for value in sample.multimodal_inputs.values())
+    )
 
-    if state.processor and sample.multimodal_inputs and any(v is not None for v in sample.multimodal_inputs.values()):
-        processor_output = state.processor(text=prompt, **sample.multimodal_inputs)
-        prompt_ids = processor_output["input_ids"][0]
-
-        # TODO shall we move it to other places? then can make this function immutable
-        sample.multimodal_train_inputs = extract_multimodal_train_inputs(processor_output)
-
-        return prompt_ids
-    else:
+    if not has_processor_inputs:
         if not isinstance(prompt, str):
             prompt = state.tokenizer.apply_chat_template(
-                prompt, tokenize=False, add_generation_prompt=True, tools=tools
+                prompt,
+                tokenize=False,
+                add_generation_prompt=True,
+                tools=tools,
             )
 
+        sample.rollout_prompt_ids = None
         return state.tokenizer.encode(prompt, add_special_tokens=False)
+
+    if sample.rollout_video_sources:
+        if not isinstance(prompt, str):
+            prompt = state.tokenizer.apply_chat_template(
+                prompt,
+                tokenize=False,
+                add_generation_prompt=True,
+                tools=tools,
+            )
+
+        sample.rollout_prompt_ids = state.tokenizer.encode(
+            prompt,
+            add_special_tokens=False,
+        )
+    else:
+        sample.rollout_prompt_ids = None
+
+    processor_output = call_processor(state.processor, prompt, sample.multimodal_inputs)
+    prompt_ids = processor_output["input_ids"][0]
+    if hasattr(prompt_ids, "tolist"):
+        prompt_ids = prompt_ids.tolist()
+
+    # TODO shall we move it to other places? then can make this function immutable
+    sample.multimodal_train_inputs = extract_multimodal_train_inputs(processor_output)
+
+    return prompt_ids
 
 
 def policy_uses_routing_key(args) -> bool:
@@ -54,6 +97,8 @@ def compute_request_payload(
     input_ids: list[int],
     sampling_params: dict,
     multimodal_inputs: dict | None = None,
+    rollout_video_sources: list[str] | None = None,
+    rollout_input_ids: list[int] | None = None,
 ) -> tuple[dict[str, Any] | None, Sample.Status | None]:
     sampling_params = deepcopy(sampling_params)
     max_new_tokens = sampling_params.pop("max_new_tokens", args.rollout_max_response_len)
@@ -63,7 +108,7 @@ def compute_request_payload(
         return None, Sample.Status.TRUNCATED
 
     payload = {
-        "input_ids": input_ids,
+        "input_ids": rollout_input_ids if rollout_input_ids is not None else input_ids,
         "sampling_params": {**sampling_params, "max_new_tokens": max_new_tokens},
         "return_logprob": True,
         "return_routed_experts": args.use_rollout_routing_replay,
@@ -71,10 +116,37 @@ def compute_request_payload(
     }
     if lora_rollout_enabled(args):
         payload["lora_path"] = LORA_ADAPTER_NAME
-    if image_data := (multimodal_inputs or {}).get("images"):
-        payload["image_data"] = [encode_image_for_rollout_engine(image) for image in image_data]
+    payload.update(build_rollout_media_payload(multimodal_inputs, rollout_video_sources))
 
     return payload, None
+
+
+def compute_rollout_input_ids(sample: Sample, input_ids: list[int], processor_prompt_ids: list[int]) -> list[int]:
+    if sample.rollout_prompt_ids is None:
+        return input_ids
+
+    return sample.rollout_prompt_ids + input_ids[len(processor_prompt_ids) :]
+
+
+def validate_video_prompt_expansion(sample: Sample, meta_info: dict[str, Any]) -> None:
+    """Ensure SGLang and the trainer expanded a compact video prompt identically."""
+    if sample.rollout_prompt_ids is None:
+        return
+
+    engine_prompt_tokens = meta_info.get("prompt_tokens")
+    if isinstance(engine_prompt_tokens, bool):
+        engine_prompt_tokens = None
+    try:
+        engine_prompt_tokens = int(engine_prompt_tokens)
+    except (TypeError, ValueError):
+        engine_prompt_tokens = -1
+
+    if engine_prompt_tokens != len(sample.tokens):
+        raise RuntimeError(
+            "engine/trainer video expansion mismatch: engine prompt is "
+            f"{engine_prompt_tokens} tokens, trainer expansion is "
+            f"{len(sample.tokens)}; frame sampling or timestamp conventions differ"
+        )
 
 
 async def update_sample_from_response(
@@ -83,6 +155,8 @@ async def update_sample_from_response(
     # Initialize sample.tokens for the first turn
     if (len(sample.response) == 0) and not sample.tokens:
         sample.tokens = payload["input_ids"]
+
+    validate_video_prompt_expansion(sample, output["meta_info"])
 
     if x := output["meta_info"].get("output_token_logprobs"):
         new_response_tokens = [item[1] for item in x]

--- a/miles/rollout/generate_utils/prefill_logprobs.py
+++ b/miles/rollout/generate_utils/prefill_logprobs.py
@@ -4,12 +4,17 @@ from collections import defaultdict
 from collections.abc import Mapping
 from typing import Any
 
-from miles.rollout.generate_utils.generate_endpoint_utils import compute_routing_headers, policy_uses_routing_key
+from miles.rollout.generate_utils.generate_endpoint_utils import (
+    compute_routing_headers,
+    policy_uses_routing_key,
+    validate_video_prompt_expansion,
+)
 from miles.utils.http_utils import post
 from miles.utils.lora import LORA_ADAPTER_NAME, lora_rollout_enabled
 from miles.utils.multi_lora import slot_lora_name
-from miles.utils.processing_utils import encode_image_for_rollout_engine
 from miles.utils.types import Sample
+
+from .generate_endpoint_utils import build_rollout_media_payload
 
 
 def _lora_path_for_sample(args: Any, sample: Sample) -> str | None:
@@ -33,8 +38,13 @@ def _build_prefill_scoring_payload(
             f"tokens={len(sample.tokens)}, response_length={sample.response_length}"
         )
 
+    rollout_input_ids = (
+        sample.rollout_prompt_ids + sample.tokens[prompt_len:]
+        if sample.rollout_prompt_ids is not None
+        else sample.tokens
+    )
     payload = {
-        "input_ids": sample.tokens,
+        "input_ids": rollout_input_ids,
         "sampling_params": {
             **dict(sampling_params),
             "max_new_tokens": 0,
@@ -44,16 +54,17 @@ def _build_prefill_scoring_payload(
         "return_logprob": True,
         # SGLang returns input_token_logprobs aligned to tokens from logprob_start_len,
         # with the first value None. Start one token before the response so the
-        # returned tail contains every response-token logprob.
+        # returned tail contains every response-token logprob. For video samples the
+        # wire input_ids are the COMPACT rollout ids, but the server expands them
+        # before applying logprob_start_len, so the offset stays in EXPANDED
+        # (sample.tokens) space.
         "logprob_start_len": prompt_len - 1,
     }
 
     if (lora_path := _lora_path_for_sample(args, sample)) is not None:
         payload["lora_path"] = lora_path
 
-    if sample.multimodal_inputs and sample.multimodal_inputs.get("images"):
-        image_data = sample.multimodal_inputs["images"]
-        payload["image_data"] = [encode_image_for_rollout_engine(image) for image in image_data]
+    payload.update(build_rollout_media_payload(sample.multimodal_inputs, sample.rollout_video_sources))
 
     return payload
 
@@ -61,7 +72,13 @@ def _build_prefill_scoring_payload(
 def _can_batch_prefill_score(args: Any, samples: list[Sample]) -> bool:
     if policy_uses_routing_key(args):
         return False
-    return not any(sample.multimodal_inputs and sample.multimodal_inputs.get("images") for sample in samples)
+
+    for sample in samples:
+        multimodal_inputs = sample.multimodal_inputs or {}
+        if multimodal_inputs.get("images") or multimodal_inputs.get("videos") or sample.rollout_video_sources:
+            return False
+
+    return True
 
 
 def _build_batch_prefill_scoring_payload(
@@ -130,6 +147,7 @@ async def recompute_rollout_logprobs_via_prefill(
 
     payload = _build_prefill_scoring_payload(args, sample, sampling_params)
     output = await post(url, payload, headers=headers)
+    validate_video_prompt_expansion(sample, output["meta_info"])
     sample.rollout_log_probs = _extract_response_logprobs(sample, output["meta_info"])
     sample.metadata["rollout_log_probs_source"] = "sglang_prefill_recompute"
 

--- a/miles/rollout/generate_utils/sample_utils.py
+++ b/miles/rollout/generate_utils/sample_utils.py
@@ -151,6 +151,8 @@ def _merge_sample_pair(a: Sample, b: Sample, tokenizer) -> Sample:
             prompt=b.prompt,
             tokens=b.tokens,
             multimodal_inputs=_merge_equal_value("multimodal_inputs"),
+            rollout_video_sources=_merge_equal_value("rollout_video_sources"),
+            rollout_prompt_ids=_merge_equal_value("rollout_prompt_ids"),
             multimodal_train_inputs=_merge_equal_value("multimodal_train_inputs"),
             response=a.response + obs_text + b.response,
             response_length=a.response_length + obs_len + b.response_length,

--- a/miles/rollout/inference_rollout/inference_rollout_eval.py
+++ b/miles/rollout/inference_rollout/inference_rollout_eval.py
@@ -61,6 +61,7 @@ async def eval_rollout_single_dataset(
             tool_key=dataset_cfg.tool_key,
             apply_chat_template=args.apply_chat_template,
             apply_chat_template_kwargs=args.apply_chat_template_kwargs,
+            video_process_config=(args.sglang_mm_process_config or {}).get("video"),
         )
     dataset = prompt_dataset_cache[cache_key]
 

--- a/miles/rollout/sglang_rollout.py
+++ b/miles/rollout/sglang_rollout.py
@@ -27,7 +27,6 @@ from miles.utils.misc import SingletonMeta, call_agent_abort_hook, load_function
 from miles.utils.multi_lora import make_rid, slot_lora_name
 from miles.utils.processing_utils import (
     call_processor,
-    encode_image_for_rollout_engine,
     extract_multimodal_train_inputs,
     load_processor,
     load_tokenizer,
@@ -35,9 +34,12 @@ from miles.utils.processing_utils import (
 from miles.utils.types import Sample
 
 from .generate_utils.generate_endpoint_utils import (
+    build_rollout_media_payload,
+    compute_rollout_input_ids,
     compute_routing_headers,
     get_indexer_topk_from_response,
     policy_uses_routing_key,
+    validate_video_prompt_expansion,
 )
 from .generate_utils.prefill_logprobs import recompute_samples_rollout_logprobs_via_prefill
 from .generate_utils.sample_utils import reward_log_summary, sample_text_preview
@@ -154,11 +156,22 @@ async def generate(args: Namespace, sample: Sample, sampling_params: dict[str, A
         isinstance(sample.prompt, (list, tuple))
         or (sample.multimodal_inputs and any(v is not None for v in sample.multimodal_inputs.values()))
     ):
-        processor_output = call_processor(state.processor, sample.prompt, sample.multimodal_inputs)
+        prompt = sample.prompt
+        if sample.rollout_video_sources:
+            # Videos go to the engine as raw sources plus COMPACT tokenizer ids
+            # (one video_pad per video); the engine expands them server-side.
+            # The processor-expanded ids below stay the training tokens.
+            if not isinstance(prompt, str):
+                prompt = state.tokenizer.apply_chat_template(prompt, tokenize=False, add_generation_prompt=True)
+            sample.rollout_prompt_ids = state.tokenizer.encode(prompt, add_special_tokens=False)
+        else:
+            sample.rollout_prompt_ids = None
+        processor_output = call_processor(state.processor, prompt, sample.multimodal_inputs)
         prompt_ids = processor_output["input_ids"][0]
         prompt_ids = prompt_ids.tolist() if hasattr(prompt_ids, "tolist") else list(prompt_ids)
         sample.multimodal_train_inputs = extract_multimodal_train_inputs(processor_output)
     else:
+        sample.rollout_prompt_ids = None
         prompt_ids = state.tokenizer.encode(sample.prompt, add_special_tokens=False)
 
     if len(sample.response) > 0:
@@ -204,9 +217,7 @@ async def generate(args: Namespace, sample: Sample, sampling_params: dict[str, A
     if getattr(args, "use_rollout_indexer_replay", False):
         payload["return_indexer_topk"] = True
 
-    if sample.multimodal_inputs and sample.multimodal_inputs["images"]:
-        image_data = sample.multimodal_inputs["images"]
-        payload["image_data"] = [encode_image_for_rollout_engine(image) for image in image_data]
+    payload.update(build_rollout_media_payload(sample.multimodal_inputs, sample.rollout_video_sources))
 
     if sample.multimodal_inputs and sample.multimodal_inputs.get("audios"):
         import base64 as _b64
@@ -217,11 +228,12 @@ async def generate(args: Namespace, sample: Sample, sampling_params: dict[str, A
 
     # Use existing tokens for multi-turn or tokenize the new prompt
     if len(sample.response) > 0:
-        payload["input_ids"] = sample.tokens
+        input_ids = sample.tokens
     else:
-        payload["input_ids"] = prompt_ids
+        input_ids = prompt_ids
         if not sample.tokens:  # Initialize sample.tokens for the first turn
-            sample.tokens = prompt_ids
+            sample.tokens = prompt_ids.copy()
+    payload["input_ids"] = compute_rollout_input_ids(sample, input_ids, prompt_ids)
 
     headers = compute_routing_headers(args, sample)
 
@@ -237,6 +249,8 @@ async def generate(args: Namespace, sample: Sample, sampling_params: dict[str, A
         new_response_log_probs = [item[0] for item in output["meta_info"]["output_token_logprobs"]]
     else:
         new_response_tokens, new_response_log_probs = [], []
+
+    validate_video_prompt_expansion(sample, output["meta_info"])
 
     # Update sample with tokens directly - avoiding re-tokenization
     sample.tokens = sample.tokens + new_response_tokens
@@ -595,6 +609,7 @@ async def eval_rollout_single_dataset(
             tool_key=dataset_cfg.tool_key,
             apply_chat_template=args.apply_chat_template,
             apply_chat_template_kwargs=args.apply_chat_template_kwargs,
+            video_process_config=(args.sglang_mm_process_config or {}).get("video"),
         )
     dataset = EVAL_PROMPT_DATASET[cache_key]
 

--- a/miles/utils/data.py
+++ b/miles/utils/data.py
@@ -108,11 +108,12 @@ def filter_long_prompt(origin_samples: list[Sample], tokenizer, processor, max_l
                 if len(input_ids) <= max_length:
                     filtered_samples.append(sample)
         if multimodal:
-            from miles.utils.processing_utils import process_vision_info
+            from miles.utils.processing_utils import call_processor
 
+            # Samples already carry decoded multimodal_inputs; re-running
+            # process_vision_info here would decode every video a second time.
             for sample in multimodal:
-                multimodal_inputs = process_vision_info(sample.prompt, processor)
-                processor_output = processor(text=sample.prompt, **multimodal_inputs)
+                processor_output = call_processor(processor, sample.prompt, sample.multimodal_inputs)
                 input_ids = processor_output["input_ids"][0]
                 if len(input_ids) <= max_length:
                     filtered_samples.append(sample)
@@ -199,6 +200,7 @@ class Dataset:
         seed=42,
         apply_chat_template=False,
         apply_chat_template_kwargs=None,
+        video_process_config=None,
     ):
         origin_samples = []
         for data in read_file(path):
@@ -230,14 +232,16 @@ class Dataset:
                 output_prompt = prompt
 
             if processor:
-                from miles.utils.processing_utils import process_vision_info
+                from miles.utils.processing_utils import prepare_rollout_video_sources, process_vision_info
 
                 assert isinstance(
                     prompt, list
                 ), f"prompt must be a list when processor is not None, got {type(prompt)} instead"
+                rollout_video_sources = prepare_rollout_video_sources(prompt, video_process_config)
                 multimodal_inputs = process_vision_info(prompt, processor)
             else:
                 multimodal_inputs = None
+                rollout_video_sources = None
 
             origin_samples.append(
                 Sample(
@@ -245,6 +249,7 @@ class Dataset:
                     label=data[label_key] if label_key is not None else None,
                     metadata=metadata,
                     multimodal_inputs=multimodal_inputs,
+                    rollout_video_sources=rollout_video_sources,
                 )
             )
 

--- a/miles/utils/processing_utils.py
+++ b/miles/utils/processing_utils.py
@@ -102,6 +102,7 @@ def build_processor_kwargs(multimodal_inputs: dict | None = None) -> dict:
     modality_forced = {"return_tensors": "pt"}
 
     result = dict(multimodal_inputs) if multimodal_inputs else {}
+    video_metadata = result.pop("video_metadata", None)
 
     # return_tensors=None for text (input_ids), "pt" for modality-specific outputs.
     # Use per-modality dicts to avoid transformers >=5.0 duplicate kwarg error.
@@ -111,6 +112,16 @@ def build_processor_kwargs(multimodal_inputs: dict | None = None) -> dict:
             result[key] = {**result[key], **modality_forced}
         else:
             result[key] = modality_forced.copy()
+
+    if video_metadata is not None:
+        # Frames were already decoded and sampled (process_vision_info); hand the
+        # processor the metadata so timestamp tokens match the rollout engine's
+        # server-side expansion, and stop it from re-sampling.
+        result["videos_kwargs"] = {
+            **result["videos_kwargs"],
+            "video_metadata": list(video_metadata),
+            "do_sample_frames": False,
+        }
 
     return result
 
@@ -165,6 +176,66 @@ def load_processor(name_or_path: str, **kwargs):
     return proc
 
 
+ROLLOUT_VIDEO_PROCESSING_OPTIONS = frozenset({"fps", "min_frames", "max_frames"})
+
+
+def validate_rollout_video_process_config(video_process_config: dict | None) -> None:
+    """Reject config that the rollout engine and trainer cannot both consume."""
+    unsupported_config = set(video_process_config or {}) - ROLLOUT_VIDEO_PROCESSING_OPTIONS
+    if unsupported_config:
+        raise ValueError(
+            "Unsupported rollout video processing options: "
+            f"{sorted(unsupported_config)}. Supported options are "
+            f"{sorted(ROLLOUT_VIDEO_PROCESSING_OPTIONS)}"
+        )
+
+
+def prepare_rollout_video_sources(prompt: list[dict], video_process_config: dict | None = None) -> list[str] | None:
+    video_process_config = video_process_config or {}
+    validate_rollout_video_process_config(video_process_config)
+
+    video_sources = []
+    for message in prompt:
+        if not isinstance(message, dict):
+            raise ValueError(f"Multimodal prompt messages must be dicts, got {type(message).__name__}")
+
+        content = message.get("content")
+        if not isinstance(content, list):
+            continue
+
+        for item in content:
+            if not isinstance(item, dict):
+                raise ValueError(f"Multimodal content items must be dicts, got {type(item).__name__}")
+            if item.get("type") != "video":
+                continue
+
+            video_source = item.get("video")
+            if not isinstance(video_source, str) or not video_source:
+                raise NotImplementedError("Rollout video sources must be non-empty paths or URLs")
+
+            item_options = item.keys() - {"type", "video"}
+            unsupported_options = item_options - ROLLOUT_VIDEO_PROCESSING_OPTIONS
+            if unsupported_options:
+                raise NotImplementedError(f"Unsupported per-video processing options: {sorted(unsupported_options)}")
+
+            # TODO: Extend SGLang /generate to accept per-video processing options.
+            mismatched_options = {
+                key
+                for key in item_options
+                if key not in video_process_config or item[key] != video_process_config[key]
+            }
+            if mismatched_options:
+                raise NotImplementedError(
+                    "Per-video processing options must match --sglang-mm-process-config: "
+                    f"{sorted(mismatched_options)}"
+                )
+
+            item.update(video_process_config)
+            video_sources.append(video_source)
+
+    return video_sources or None
+
+
 def process_vision_info(prompt, processor):
     if hasattr(processor, "extract_media"):
         return processor.extract_media(prompt)
@@ -177,8 +248,21 @@ def process_vision_info(prompt, processor):
     else:
         logger.info(f"Using default patch size: {DEFAULT_PATCH_SIZE}")
         image_patch_size = DEFAULT_PATCH_SIZE
-    images, videos = qwen_process_vision_info(prompt, image_patch_size=image_patch_size)
+    # return_video_metadata: qwen3-family processors derive per-frame timestamp
+    # tokens from the decode metadata. The rollout engine decodes server-side and
+    # feeds ITS processor pre-sampled frames + metadata (do_sample_frames done),
+    # so the local expansion must do the same or the two expansions diverge.
+    images, videos, _ = qwen_process_vision_info(
+        prompt,
+        image_patch_size=image_patch_size,
+        return_video_kwargs=True,
+        return_video_metadata=True,
+    )
     multimodal_inputs = {"images": images, "videos": videos}
+    if videos:
+        tensors, metadata = zip(*videos, strict=False)
+        multimodal_inputs["videos"] = list(tensors)
+        multimodal_inputs["video_metadata"] = list(metadata)
     return multimodal_inputs
 
 

--- a/miles/utils/types.py
+++ b/miles/utils/types.py
@@ -34,7 +34,9 @@ class Sample:
     # prompt
     prompt: str | list[dict[str, str]] = ""
     tokens: list[int] = field(default_factory=list)
-    multimodal_inputs: dict[str, Any] = None  # raw multimodal data, e.g. images, videos, etc.
+    multimodal_inputs: dict[str, Any] = None
+    rollout_video_sources: list[str] | None = None
+    rollout_prompt_ids: list[int] | None = None  # Tokenizer-only IDs paired with raw video for rollout.
     multimodal_train_inputs: dict[str, Any] = None  # processed multimodal data, e.g. pixel_values, etc.
     # response
     response: str = ""
@@ -247,10 +249,12 @@ class Sample:
         """Reset generated outputs so the original prompt can be re-sampled.
 
         Keeps identity / prompt fields (group_index, index, prompt, label,
-        multimodal_inputs, metadata, generate_function_path, routing_key) and
-        restores everything else to dataclass defaults.
+        multimodal_inputs, rollout_video_sources, metadata,
+        generate_function_path, routing_key) and restores everything else to
+        dataclass defaults.
         """
         self.tokens = []
+        self.rollout_prompt_ids = None
         self.multimodal_train_inputs = None
         self.response = ""
         self.response_length = 0

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ pybase64
 pylatexenc
 pytest-asyncio
 pyyaml
-qwen_vl_utils # for VLM
+qwen_vl_utils>=0.0.14 # for VLM; video metadata support keeps trainer/rollout token expansion aligned
 ray[default]>=2.56.0
 ring_flash_attn; platform_system == "Linux"
 safetensors>=0.8.0  # samples-reply wire codec; malformed-payload exception contract validated on 0.8.0

--- a/tests/fast/ray/rollout/conftest.py
+++ b/tests/fast/ray/rollout/conftest.py
@@ -79,6 +79,7 @@ def make_args(**overrides: Any) -> Namespace:
         sglang_router_request_timeout_secs=600,
         sglang_dp_size=1,
         sglang_speculative_algorithm=None,
+        sglang_mm_process_config=None,
         sglang_config=None,
         sglang_model_routers=None,
         prefill_num_servers=None,

--- a/tests/fast/ray/rollout/test_config_matrix.py
+++ b/tests/fast/ray/rollout/test_config_matrix.py
@@ -134,6 +134,27 @@ class TestModelConfigResolve:
         m.resolve(args)
         assert m.update_weights is False  # not flipped
 
+    def test_resolve_rejects_a_different_server_group_video_config(self):
+        m = ModelConfig(
+            name="actor",
+            server_groups=[
+                ServerGroupConfig(
+                    worker_type="regular", num_gpus=4, overrides={"mm_process_config": {"video": {"fps": 2}}}
+                )
+            ],
+        )
+        with pytest.raises(NotImplementedError, match="--sglang-mm-process-config"):
+            m.resolve(make_args(sglang_mm_process_config={"video": {"fps": 4}}))
+
+    def test_resolve_rejects_video_config_the_processor_cannot_consume(self):
+        m = ModelConfig(
+            name="actor",
+            server_groups=[ServerGroupConfig(worker_type="regular", num_gpus=4)],
+        )
+
+        with pytest.raises(ValueError, match="total_pixels"):
+            m.resolve(make_args(sglang_mm_process_config={"video": {"total_pixels": 12_288_000}}))
+
 
 # ----------------------------- has_pd_disaggregation aggregation -----------------
 

--- a/tests/fast/rollout/generate_utils/test_multimodal.py
+++ b/tests/fast/rollout/generate_utils/test_multimodal.py
@@ -1,0 +1,204 @@
+from types import SimpleNamespace
+
+import pytest
+from PIL import Image
+
+from miles.rollout import sglang_rollout
+from miles.rollout.base_types import GenerateFnInput
+from miles.rollout.generate_hub import multi_turn, single_turn
+from miles.rollout.generate_utils.generate_endpoint_utils import (
+    build_rollout_media_payload,
+    compute_prompt_ids_from_sample,
+    compute_request_payload,
+)
+from miles.utils.types import Sample
+
+PROCESSOR_PROMPT_IDS = [100, 101, 102]
+ROLLOUT_PROMPT_IDS = [1, 2]
+
+
+class _Processor:
+    def __init__(self):
+        self.text = None
+
+    def __call__(self, text, **kwargs):
+        self.text = text
+        return {"input_ids": [PROCESSOR_PROMPT_IDS], "pixel_values_videos": "train-only"}
+
+
+class _Tokenizer:
+    def apply_chat_template(self, prompt, **kwargs):
+        return "<video>rendered prompt"
+
+    def encode(self, text, add_special_tokens):
+        assert add_special_tokens is False
+        return ROLLOUT_PROMPT_IDS
+
+
+def _args(**overrides):
+    defaults = dict(
+        sglang_router_ip="127.0.0.1",
+        sglang_router_port=30000,
+        rollout_max_response_len=16,
+        rollout_max_context_len=None,
+        use_rollout_routing_replay=False,
+        use_rollout_indexer_replay=False,
+        lora_rank=0,
+        lora_adapter_path=None,
+        sglang_speculative_algorithm=None,
+        sglang_router_policy="round_robin",
+        ci_test=False,
+        partial_rollout=False,
+        mask_offpolicy_in_partial_rollout=False,
+    )
+    return SimpleNamespace(**(defaults | overrides))
+
+
+def _video_sample():
+    return Sample(
+        prompt="<video>describe it",
+        multimodal_inputs={"videos": [object()]},
+        rollout_video_sources=["video.mp4"],
+    )
+
+
+def test_multimodal_request_contract():
+    image = Image.new("RGB", (2, 2), color="red")
+    media_payload = build_rollout_media_payload(
+        {"images": [image], "videos": [object()]},
+        ["https://example.test/video.mp4"],
+    )
+    request, status = compute_request_payload(
+        _args(rollout_max_context_len=5),
+        input_ids=PROCESSOR_PROMPT_IDS,
+        rollout_input_ids=ROLLOUT_PROMPT_IDS,
+        sampling_params={"max_new_tokens": 10},
+    )
+
+    assert media_payload["image_data"][0].startswith("data:image/png;base64,")
+    assert media_payload["video_data"] == ["https://example.test/video.mp4"]
+    assert status is None
+    assert request["input_ids"] == ROLLOUT_PROMPT_IDS
+    assert request["sampling_params"]["max_new_tokens"] == 2
+
+
+def test_prompt_processing_keeps_training_and_rollout_ids_separate():
+    sample = _video_sample()
+    sample.prompt = [{"role": "user", "content": [{"type": "video", "video": "video.mp4"}]}]
+    processor = _Processor()
+    state = SimpleNamespace(processor=processor, tokenizer=_Tokenizer())
+
+    prompt_ids = compute_prompt_ids_from_sample(state, sample)
+
+    assert prompt_ids == PROCESSOR_PROMPT_IDS
+    assert sample.rollout_prompt_ids == ROLLOUT_PROMPT_IDS
+    assert sample.multimodal_train_inputs == {"pixel_values_videos": "train-only"}
+    assert processor.text == "<video>rendered prompt"
+
+
+def test_image_only_keeps_the_existing_request_contract():
+    image = Image.new("RGB", (2, 2), color="red")
+    sample = Sample(prompt="<image>describe it", multimodal_inputs={"images": [image]})
+    state = SimpleNamespace(processor=_Processor(), tokenizer=_Tokenizer())
+    prompt_ids = compute_prompt_ids_from_sample(state, sample)
+
+    payload, _ = compute_request_payload(
+        _args(), prompt_ids, {"max_new_tokens": 4}, multimodal_inputs=sample.multimodal_inputs
+    )
+
+    assert sample.rollout_prompt_ids is None
+    assert payload["input_ids"] == PROCESSOR_PROMPT_IDS
+    assert payload["image_data"][0].startswith("data:image/png;base64,")
+
+
+@pytest.mark.asyncio
+async def test_single_turn_sends_rollout_ids_but_keeps_processor_ids(monkeypatch):
+    requests = []
+
+    async def fake_post(url, payload, headers=None):
+        requests.append(payload)
+        return {
+            "text": "answer",
+            "meta_info": {
+                "output_token_logprobs": [(-0.1, 20)],
+                "finish_reason": {"type": "stop"},
+                # The engine's post-expansion prompt length; must equal the
+                # trainer's processor expansion.
+                "prompt_tokens": len(PROCESSOR_PROMPT_IDS),
+            },
+        }
+
+    monkeypatch.setattr(single_turn, "post", fake_post)
+    args = _args()
+    sample = _video_sample()
+    state = SimpleNamespace(args=args, processor=_Processor(), tokenizer=_Tokenizer())
+
+    output = await single_turn.generate(
+        GenerateFnInput(state=state, sample=sample, sampling_params={"max_new_tokens": 4}, evaluation=False)
+    )
+
+    assert requests[0]["input_ids"] == ROLLOUT_PROMPT_IDS
+    assert requests[0]["video_data"] == ["video.mp4"]
+    assert output.samples.tokens == PROCESSOR_PROMPT_IDS + [20]
+
+
+@pytest.mark.asyncio
+async def test_single_turn_rejects_engine_trainer_expansion_mismatch(monkeypatch):
+    async def fake_post(url, payload, headers=None):
+        return {
+            "text": "answer",
+            "meta_info": {
+                "output_token_logprobs": [(-0.1, 20)],
+                "finish_reason": {"type": "stop"},
+                # One token off the trainer's expansion: frame sampling or
+                # timestamp conventions differ between engine and trainer.
+                "prompt_tokens": len(PROCESSOR_PROMPT_IDS) + 1,
+            },
+        }
+
+    monkeypatch.setattr(single_turn, "post", fake_post)
+    sample = _video_sample()
+    state = SimpleNamespace(args=_args(), processor=_Processor(), tokenizer=_Tokenizer())
+
+    with pytest.raises(RuntimeError, match="expansion mismatch"):
+        await single_turn.generate(
+            GenerateFnInput(state=state, sample=sample, sampling_params={"max_new_tokens": 4}, evaluation=False)
+        )
+
+
+@pytest.mark.asyncio
+async def test_legacy_single_turn_rejects_engine_trainer_expansion_mismatch(monkeypatch):
+    requests = []
+
+    async def fake_post(url, payload, headers=None):
+        requests.append(payload)
+        return {
+            "text": "answer",
+            "meta_info": {
+                "output_token_logprobs": [(-0.1, 20)],
+                "finish_reason": {"type": "stop"},
+                "prompt_tokens": len(PROCESSOR_PROMPT_IDS) + 1,
+            },
+        }
+
+    state = SimpleNamespace(processor=_Processor(), tokenizer=_Tokenizer())
+    monkeypatch.setattr(sglang_rollout, "GenerateState", lambda args: state)
+    monkeypatch.setattr(sglang_rollout, "post", fake_post)
+
+    with pytest.raises(RuntimeError, match="expansion mismatch"):
+        await sglang_rollout.generate(_args(), _video_sample(), {"max_new_tokens": 4})
+
+    assert requests[0]["input_ids"] == ROLLOUT_PROMPT_IDS
+    assert requests[0]["video_data"] == ["video.mp4"]
+
+
+@pytest.mark.asyncio
+async def test_multi_turn_rejects_video_before_sending_a_request():
+    state = SimpleNamespace(args=_args(), processor=_Processor(), tokenizer=_Tokenizer())
+
+    with pytest.raises(NotImplementedError, match="single-turn only"):
+        await multi_turn.generate(
+            GenerateFnInput(
+                state=state, sample=_video_sample(), sampling_params={"max_new_tokens": 4}, evaluation=False
+            )
+        )

--- a/tests/fast/rollout/generate_utils/test_prefill_logprobs.py
+++ b/tests/fast/rollout/generate_utils/test_prefill_logprobs.py
@@ -266,3 +266,53 @@ async def test_recompute_samples_batches_by_logprob_start_len(monkeypatch):
     assert calls[1][1]["input_ids"] == [[10, 11, 20], [10, 11, 22]]
     assert calls[3][1]["logprob_start_len"] == 2
     assert calls[3][1]["input_ids"] == [[10, 11, 12, 21]]
+
+
+def test_video_prefill_uses_rollout_prompt_ids_and_expanded_logprob_offset():
+    sample = Sample(
+        tokens=[100, 101, 102, 20, 21],
+        response_length=2,
+        status=Sample.Status.COMPLETED,
+        multimodal_inputs={"videos": [object()]},
+        rollout_video_sources=["video.mp4"],
+        rollout_prompt_ids=[1, 2],
+    )
+    args = SimpleNamespace(sglang_enable_lora=False, sglang_router_policy="round_robin")
+
+    payload = prefill_logprobs._build_prefill_scoring_payload(args, sample, {})
+
+    assert payload["input_ids"] == [1, 2, 20, 21]
+    assert payload["video_data"] == ["video.mp4"]
+    assert payload["logprob_start_len"] == 2
+    assert prefill_logprobs._can_batch_prefill_score(args, [sample]) is False
+
+
+@pytest.mark.asyncio
+async def test_video_prefill_rejects_engine_trainer_expansion_mismatch(monkeypatch):
+    sample = Sample(
+        tokens=[100, 101, 102, 20],
+        response_length=1,
+        status=Sample.Status.COMPLETED,
+        multimodal_inputs={"videos": [object()]},
+        rollout_video_sources=["video.mp4"],
+        rollout_prompt_ids=[1, 2],
+    )
+    args = SimpleNamespace(recompute_logprobs_via_prefill=True, sglang_enable_lora=False)
+
+    async def fake_post(url, payload, headers=None):
+        return {
+            "meta_info": {
+                "prompt_tokens": len(sample.tokens) + 1,
+                "input_token_logprobs": [(None, 102), (-0.1, 20)],
+            }
+        }
+
+    monkeypatch.setattr(prefill_logprobs, "post", fake_post)
+
+    with pytest.raises(RuntimeError, match="expansion mismatch"):
+        await prefill_logprobs.recompute_rollout_logprobs_via_prefill(
+            args,
+            sample,
+            url="http://localhost/generate",
+            sampling_params={},
+        )

--- a/tests/fast/utils/test_processing_utils.py
+++ b/tests/fast/utils/test_processing_utils.py
@@ -2,7 +2,17 @@ from tests.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=20, suite="stage-a-cpu", labels=[])
 
-from miles.utils.processing_utils import extract_multimodal_train_inputs
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from miles.utils.processing_utils import (
+    build_processor_kwargs,
+    extract_multimodal_train_inputs,
+    prepare_rollout_video_sources,
+    process_vision_info,
+)
 
 
 def test_extract_multimodal_train_inputs_drops_qwen3_vl_token_metadata():
@@ -30,3 +40,112 @@ def test_extract_multimodal_train_inputs_drops_qwen3_vl_token_metadata():
         )
         is None
     )
+
+
+def test_video_config_is_shared_by_local_processing_and_rollout(monkeypatch):
+    calls = {}
+
+    def fake_process_vision_info(prompt, image_patch_size, return_video_kwargs, return_video_metadata):
+        calls["prompt"] = prompt
+        calls["image_patch_size"] = image_patch_size
+        calls["return_video_kwargs"] = return_video_kwargs
+        calls["return_video_metadata"] = return_video_metadata
+        videos = [("processed-video-1", {"fps": 1.0}), ("processed-video-2", {"fps": 2.0})]
+        return ["resolved-image"], videos, {"do_sample_frames": False}
+
+    monkeypatch.setitem(
+        sys.modules,
+        "qwen_vl_utils",
+        SimpleNamespace(process_vision_info=fake_process_vision_info),
+    )
+    prompt = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "video", "video": "first.mp4", "fps": 4},
+                {"type": "image", "image": "image.png"},
+                {"type": "video", "video": "https://example.test/second.mp4"},
+            ],
+        }
+    ]
+    processor = SimpleNamespace(image_processor=SimpleNamespace(patch_size=16))
+
+    rollout_video_sources = prepare_rollout_video_sources(prompt, {"fps": 4})
+    processor_inputs = process_vision_info(prompt, processor)
+
+    assert processor_inputs == {
+        "images": ["resolved-image"],
+        "videos": ["processed-video-1", "processed-video-2"],
+        "video_metadata": [{"fps": 1.0}, {"fps": 2.0}],
+    }
+    assert rollout_video_sources == ["first.mp4", "https://example.test/second.mp4"]
+    assert [item["fps"] for item in prompt[0]["content"] if item["type"] == "video"] == [4, 4]
+    assert calls == {
+        "prompt": prompt,
+        "image_patch_size": 16,
+        "return_video_kwargs": True,
+        "return_video_metadata": True,
+    }
+
+
+def test_process_vision_info_keeps_image_only_contract(monkeypatch):
+    def fake_process_vision_info(prompt, image_patch_size, return_video_kwargs, return_video_metadata):
+        return ["resolved-image"], None, {"do_sample_frames": False}
+
+    monkeypatch.setitem(
+        sys.modules,
+        "qwen_vl_utils",
+        SimpleNamespace(process_vision_info=fake_process_vision_info),
+    )
+    prompt = [{"role": "user", "content": [{"type": "image", "image": "image.png"}]}]
+    processor = SimpleNamespace(image_processor=SimpleNamespace(patch_size=16))
+
+    assert process_vision_info(prompt, processor) == {"images": ["resolved-image"], "videos": None}
+
+
+def test_video_metadata_routes_into_videos_kwargs():
+    kwargs = build_processor_kwargs(
+        {
+            "videos": ["decoded-video"],
+            "video_metadata": [{"fps": 1.0, "frames_indices": [0, 1]}],
+        }
+    )
+
+    # The metadata must reach the processor as videos_kwargs (matching the
+    # rollout engine's server-side call) and never as a top-level kwarg.
+    assert "video_metadata" not in kwargs
+    assert kwargs["videos_kwargs"]["video_metadata"] == [{"fps": 1.0, "frames_indices": [0, 1]}]
+    assert kwargs["videos_kwargs"]["do_sample_frames"] is False
+    assert kwargs["videos_kwargs"]["return_tensors"] == "pt"
+    assert kwargs["videos"] == ["decoded-video"]
+
+
+@pytest.mark.parametrize("video_item", [{"fps": 2}, {"video_start": 1}])
+def test_per_video_options_must_match_the_sglang_config(video_item):
+    prompt = [{"role": "user", "content": [{"type": "video", "video": "video.mp4", **video_item}]}]
+    with pytest.raises(NotImplementedError):
+        prepare_rollout_video_sources(prompt, {"fps": 4})
+
+
+@pytest.mark.parametrize("unsupported_option", ["nframes", "min_pixels", "max_pixels", "total_pixels"])
+def test_video_config_rejects_options_forwarded_illegally_by_sglang(unsupported_option):
+    prompt = [{"role": "user", "content": [{"type": "video", "video": "video.mp4"}]}]
+
+    with pytest.raises(ValueError, match=unsupported_option):
+        prepare_rollout_video_sources(prompt, {unsupported_option: 4})
+
+
+@pytest.mark.parametrize(
+    "prompt,expected_error",
+    [
+        (["not-a-message"], ValueError),
+        ([{"role": "user", "content": ["not-an-item"]}], ValueError),
+        (
+            [{"role": "user", "content": [{"type": "video", "video": ["frame-1.png", "frame-2.png"]}]}],
+            NotImplementedError,
+        ),
+    ],
+)
+def test_rollout_video_sources_reject_malformed_or_in_memory_inputs(prompt, expected_error):
+    with pytest.raises(expected_error):
+        prepare_rollout_video_sources(prompt, {"fps": 2})

--- a/tests/fast/utils/test_sglang_config.py
+++ b/tests/fast/utils/test_sglang_config.py
@@ -37,7 +37,7 @@ class TestSglangConfigUpdateWeights:
         # Before resolve, update_weights is None (not yet inferred)
         assert config.models[0].update_weights is None
         # After resolve with matching hf_checkpoint, defaults to True
-        args = Namespace(hf_checkpoint="/path/to/model", rollout_num_gpus_per_engine=1)
+        args = Namespace(hf_checkpoint="/path/to/model", rollout_num_gpus_per_engine=1, sglang_mm_process_config=None)
         config.models[0].resolve(args)
         assert config.models[0].update_weights is True
 


### PR DESCRIPTION
## Summary

Based on #1689, with the original authorship preserved, this completes the single-turn SGLang video rollout path:

- Sends raw video paths/URLs and compact prompt IDs to SGLang while retaining processor-expanded IDs, training tensors, and Qwen video metadata.
- Keeps truncation and prefill scoring in expanded-token space, and fails if engine/trainer video expansion diverges.
- Shares `fps`/`min_frames`/`max_frames` between server and local processing, preserves image behavior, and explicitly rejects unsupported or multi-turn video inputs.

Requires SGLang support for `video_data` and `ServerArgs.mm_process_config`, plus `qwen_vl_utils>=0.0.14`.

## Validation

- 22 focused fast tests and pre-commit checks.
- Qwen3.5-4B runs in 1-GPU colocated and 2-GPU disaggregated configurations, for 175 steps.