### PR TITLE
docs(cli): list the fully async flags in the CLI reference

### DIFF
--- a/docs/user-guide/cli-reference.md
+++ b/docs/user-guide/cli-reference.md
@@ -344,6 +344,11 @@ contract, session behavior, and model-family selection.
 | Flag | Type | Default | Notes |
 |---|---|---|---|
 | `--partial-rollout` | flag | off | Resume aborted rollouts in the next iteration. |
+| `--fully-async` | flag | off | Run fully async rollout: a persistent worker keeps generating while the trainer drains completed groups. Evaluation keeps the standard rollout function. Requires `train_async.py`. |
+| `--async-unused-samples-handler` | enum | `drop` | What to do with a finished group that fully async mode does not train on (aborted, or beyond `--max-weight-staleness`): `drop` discards it, `retry` recycles its prompts into the data source. Groups rejected by `--dynamic-sampling-filter-path` are always dropped. |
+| `--custom-async-data-buffer-path` | str | – | Custom `DataBuffer` subclass replacing the fully async finished-group buffer (see `miles/rollout/fully_async_data_buffer.py`). It takes over dataflow and staleness control, so the `--async-data-buffer-*` flags apply only if the class reads them. |
+| `--update-weights-interval` | int | `1` | Rollout steps between weight updates to the inference engines. |
+| `--pause-generation-mode` | enum | `retract` | How SGLang pauses in-flight requests during a weight update: `abort` terminates them, `retract` returns them to the waiting queue and recomputes their KV cache afterwards, `in_place` freezes them and resumes on the existing cache. Fully async rejects `abort`. |
 
 ### Logging
 


### PR DESCRIPTION
## Summary

- Adds the five fully async flags that the CLI reference did not list: `--fully-async`, `--async-unused-samples-handler`, `--custom-async-data-buffer-path`, `--update-weights-interval`, and `--pause-generation-mode`.
- Takes each type, default, and note from the flag's current help text and from the [fully async guide](/user-guide/fully-async).
- Changes no code.

## Context

The "Async / partial rollout" section of `docs/user-guide/cli-reference.md` has held one row (`--partial-rollout`) since May, before `--fully-async` landed. The five flags above were added without a reference row. The contributor checklist asks for one, so this fills the gap for the flags that exist on `main` today.

Three more fully async flags change semantics in the ownership stack tracked by [issue #2254](https://github.com/radixark/miles/issues/2254): `--async-max-concurrent-samples`, `--async-data-buffer-capacity-factor`, and `--max-weight-staleness`. The commits that change them add their rows, so they are left out here on purpose. Whichever lands second will need a one-line rebase in the same table.

The reference states that it lists every Miles flag. It currently lists about 140 of roughly 350. This PR does not try to close that gap.

Review this change as one commit: [`d9f1ecc1` adds the five rows](https://github.com/ashtonchew/miles/commit/d9f1ecc18). The review invariant is that every note matches the flag's help text on `main`.

## Description

- Adds five rows to the "Async / partial rollout" table.
- `--update-weights-interval` is described from its use in `train_async.py` (`(rollout_id + 1) % interval == 0`).
- `--pause-generation-mode` notes that fully async rejects `abort`, which `miles_validate_args` enforces.

## Test plan

- [x] Docs-only change. `pre-commit run --all-files` is clean at exact head `d9f1ecc18`.
- [x] Each row was checked against `miles/utils/arguments.py` at `851ddba2a`.

## Risks and follow-ups

None beyond the table conflict noted above.

https://claude.ai/code/session_01EPSNDKV1Uzx5Acqg6TPxpg
