### PR TITLE
docker: point MEGATRON_BRANCH back at miles-main

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,7 +20,7 @@ ARG SGLANG_BRANCH=sglang-miles
 ARG SGLANG_COMMIT=""
 
 ARG MEGATRON_REPO=radixark/Megatron-LM
-ARG MEGATRON_BRANCH=miles-main-20260819
+ARG MEGATRON_BRANCH=miles-main
 # Empty means the branch HEAD at build time; release builds set it to freeze one commit.
 ARG MEGATRON_COMMIT=""
 


### PR DESCRIPTION
#2673 landed with `MEGATRON_BRANCH=miles-main-20260819`, a temporary name used while `miles-main` still held the pre-bump tree.

On the Megatron side that has now been resolved:
- `miles-backup-20260819` keeps the pre-bump tree (was `miles-main`, `2e64d788b`)
- `miles-main` now points at the bumped tree (`235952df6`)
- `miles-main-20260819` is deleted

So the temporary name no longer resolves, and this puts the Dockerfile back on `miles-main`. Nothing else needs changing: the CI branch defaults, `Dockerfile.rocm`, `docker-build.yml`'s fingerprint and the release lock were never moved off `miles-main`, so they become correct automatically.