### PR TITLE
fix(dsv4): fix deepseek v4 hareware branch

### DIFF
--- a/miles/utils/external_utils/command_utils.py
+++ b/miles/utils/external_utils/command_utils.py
@@ -6,6 +6,7 @@ import base64
 import datetime
 import json
 import os
+import platform
 import random
 import shlex
 import socket
@@ -377,6 +378,32 @@ NUM_GPUS_OF_HARDWARE = {
 
 GENERATION_HARDWARE = {
     "H100": "Hopper",
+    "H200": "Hopper",
+    "B200": "Blackwell",
+    "B300": "Blackwell",
     "GB200": "Blackwell",
     "GB300": "Blackwell",
 }
+
+
+def detect_hardware() -> str:
+    """Which NUM_GPUS_OF_HARDWARE entry this node is. Call it where the answer is used: prepare steps run GPU-free."""
+    import torch
+
+    assert torch.cuda.is_available(), "no visible GPU to detect the hardware from, pass --hardware explicitly"
+    name = torch.cuda.get_device_name()
+    if torch.version.hip is not None:
+        detected = next((hardware for hardware in ("MI350X", "MI355X") if hardware in name), None)
+    else:
+        grace = platform.machine() == "aarch64"
+        match torch.cuda.get_device_capability():
+            case (9, 0):
+                detected = "H200" if torch.cuda.get_device_properties(0).total_memory > 100 * 1024**3 else "H100"
+            case (10, 0):
+                detected = "GB200" if grace else "B200"
+            case (10, 3):
+                detected = "GB300" if grace else "B300"
+            case _:
+                detected = None
+    assert detected is not None, f"cannot tell which hardware {name!r} is, pass --hardware explicitly"
+    return detected

--- a/scripts/run_deepseek_v4.py
+++ b/scripts/run_deepseek_v4.py
@@ -454,33 +454,6 @@ def _get_parallel_config(args: ScriptArgs) -> str:
     )
 
 
-def _get_sglang_parallel_config(args: ScriptArgs) -> tuple[int, int, int, int]:
-    if args.model_name == "DeepSeek-V4-Pro-FP8":
-        config = (32, 32, 32, 32)
-    elif args.num_gpus_per_node == 4 and args.rollout_num_gpus >= 8:
-        # Span TP8 across GB300 nodes to avoid the colocated TP4 host-memory OOM.
-        config = (8, 8, 1, 8)
-    else:
-        config = (4, 4, 1, 4)
-
-    world_size, tp_size, dp_size, ep_size = config
-    if world_size > args.rollout_num_gpus:
-        raise ValueError(
-            f"SGLang rollout_num_gpus_per_engine={world_size} exceeds rollout_num_gpus={args.rollout_num_gpus}."
-        )
-    if args.rollout_num_gpus % world_size != 0:
-        raise ValueError(
-            f"rollout_num_gpus={args.rollout_num_gpus} must be divisible by "
-            f"SGLang rollout_num_gpus_per_engine={world_size}."
-        )
-    if tp_size > world_size or ep_size > world_size:
-        raise ValueError(
-            f"SGLang tp_size={tp_size} and ep_size={ep_size} must not exceed "
-            f"rollout_num_gpus_per_engine={world_size}."
-        )
-    return config
-
-
 def _train(args: ScriptArgs):
     if args.train_mxfp8 or args.rollout_mxfp8:
         assert _is_blackwell(args), "MXFP8 requires Blackwell (B200/B300/GB200/GB300)"
@@ -587,7 +560,24 @@ def _train(args: ScriptArgs):
             "--optimizer-cpu-offload " "--use-precision-aware-optimizer " "--overlap-cpu-optimizer-d2h-h2d "
         )
 
-    sglang_world_size, sglang_tp_size, sglang_dp_size, sglang_ep_size = _get_sglang_parallel_config(args)
+    is_4layer = args.model_name == "DeepSeek-V4-Flash-FP8-4layer"
+    is_gb300_profile = args.actor_num_gpus_per_node == 4 and not is_4layer
+    if args.model_name == "DeepSeek-V4-Pro-FP8":
+        sglang_world_size = 32
+        sglang_tp_size = 32
+        sglang_dp_size = 32
+        sglang_ep_size = 32
+    elif is_gb300_profile:
+        # GB300, use tp=8. tp=4 causes CPU OOM when colocate
+        sglang_world_size = 8
+        sglang_tp_size = 8
+        sglang_dp_size = 1
+        sglang_ep_size = 8
+    else:
+        sglang_world_size = 4
+        sglang_tp_size = 4
+        sglang_dp_size = 1
+        sglang_ep_size = 4
     # MXFP8 rollout dense GEMM uses the cutlass backend and routed MoE uses
     # FlashInfer's TRT-LLM kernel (mirrors the pre-rebase MXFP8 recipe).
     if args.rollout_mxfp8:

--- a/scripts/run_deepseek_v4.py
+++ b/scripts/run_deepseek_v4.py
@@ -63,7 +63,6 @@ _MEGATRON_MODEL_TYPE = {
 _PRO_MODEL_NAMES = ("DeepSeek-V4-Pro-FP8",)
 _MXFP4_MODEL_NAMES = ("DeepSeek-V4-Flash-0731",)
 _FLASH_FULL_MODEL_NAMES = ("DeepSeek-V4-Flash-FP8", "DeepSeek-V4-Flash-0731")
-_BLACKWELL_HARDWARE = ("B200", "B300", "GB200", "GB300")
 
 _DSV4_TE_PRECISION_CONFIG = """
 configs:
@@ -191,16 +190,8 @@ class ScriptArgs(U.ExecuteTrainConfig):
         return self.bf16_name
 
 
-def _is_blackwell(args: ScriptArgs) -> bool:
-    if args.hardware != "auto":
-        return args.hardware in _BLACKWELL_HARDWARE
-
-    import torch
-
-    if not torch.cuda.is_available():
-        raise RuntimeError("Cannot auto-detect hardware because CUDA is not available. Pass --hardware explicitly.")
-    major, _minor = torch.cuda.get_device_capability()
-    return major >= 10
+def _hardware(args: ScriptArgs) -> str:
+    return U.detect_hardware() if args.hardware == "auto" else args.hardware
 
 
 def _download_dataset(args: ScriptArgs):
@@ -297,7 +288,7 @@ def _prepare_mxfp8(args: ScriptArgs):
     """
     if not args.rollout_mxfp8:
         return
-    assert _is_blackwell(args), "rollout_mxfp8 requires Blackwell (B200/B300/GB200/GB300)"
+    assert U.GENERATION_HARDWARE[_hardware(args)] == "Blackwell", "rollout_mxfp8 requires Blackwell"
     U.exec_command_gpu(
         f"python tools/convert_hf_to_mxfp8.py "
         f"--model-dir {args.model_dir}/{args.bf16_name} "
@@ -408,7 +399,6 @@ def _get_parallel_config(args: ScriptArgs) -> str:
             "--expert-tensor-parallel-size 1 "
         )
 
-    # GB300: 4 GPUs/node
     if actor_num_gpus_per_node == 4:
         if total_gpus == 32:  # 8 nodes x 4 GPUs
             return (
@@ -423,7 +413,6 @@ def _get_parallel_config(args: ScriptArgs) -> str:
                 "--expert-tensor-parallel-size 1 "
             )
 
-    # H200: 8 GPUs/node
     if actor_num_gpus_per_node == 8:
         if total_gpus == 64:  # 8 nodes x 8 GPUs
             return (
@@ -456,7 +445,7 @@ def _get_parallel_config(args: ScriptArgs) -> str:
 
 def _train(args: ScriptArgs):
     if args.train_mxfp8 or args.rollout_mxfp8:
-        assert _is_blackwell(args), "MXFP8 requires Blackwell (B200/B300/GB200/GB300)"
+        assert U.GENERATION_HARDWARE[_hardware(args)] == "Blackwell", "MXFP8 requires Blackwell"
     if not args.rollout_fp8 or args.hf_checkpoint is None or args.model_name in _MXFP4_MODEL_NAMES:
         rollout_checkpoint = f"{args.model_local_dir}/{args.rollout_name}"
         if args.hf_checkpoint != rollout_checkpoint:
@@ -560,15 +549,13 @@ def _train(args: ScriptArgs):
             "--optimizer-cpu-offload " "--use-precision-aware-optimizer " "--overlap-cpu-optimizer-d2h-h2d "
         )
 
-    is_4layer = args.model_name == "DeepSeek-V4-Flash-FP8-4layer"
-    is_gb300_profile = args.actor_num_gpus_per_node == 4 and not is_4layer
     if args.model_name == "DeepSeek-V4-Pro-FP8":
         sglang_world_size = 32
         sglang_tp_size = 32
         sglang_dp_size = 32
         sglang_ep_size = 32
-    elif is_gb300_profile:
-        # GB300, use tp=8. tp=4 causes CPU OOM when colocate
+    elif _hardware(args) in ("GB200", "GB300") and args.rollout_num_gpus >= 8:
+        # Grace, use tp=8. tp=4 causes CPU OOM when colocate
         sglang_world_size = 8
         sglang_tp_size = 8
         sglang_dp_size = 1
@@ -578,6 +565,9 @@ def _train(args: ScriptArgs):
         sglang_tp_size = 4
         sglang_dp_size = 1
         sglang_ep_size = 4
+    assert (
+        sglang_world_size <= args.rollout_num_gpus
+    ), f"a {sglang_world_size}-GPU engine cannot start on {args.rollout_num_gpus} rollout GPUs"
     # MXFP8 rollout dense GEMM uses the cutlass backend and routed MoE uses
     # FlashInfer's TRT-LLM kernel (mirrors the pre-rebase MXFP8 recipe).
     if args.rollout_mxfp8:

--- a/scripts/run_deepseek_v4.py
+++ b/scripts/run_deepseek_v4.py
@@ -454,6 +454,33 @@ def _get_parallel_config(args: ScriptArgs) -> str:
     )
 
 
+def _get_sglang_parallel_config(args: ScriptArgs) -> tuple[int, int, int, int]:
+    if args.model_name == "DeepSeek-V4-Pro-FP8":
+        config = (32, 32, 32, 32)
+    elif args.num_gpus_per_node == 4 and args.rollout_num_gpus >= 8:
+        # Span TP8 across GB300 nodes to avoid the colocated TP4 host-memory OOM.
+        config = (8, 8, 1, 8)
+    else:
+        config = (4, 4, 1, 4)
+
+    world_size, tp_size, dp_size, ep_size = config
+    if world_size > args.rollout_num_gpus:
+        raise ValueError(
+            f"SGLang rollout_num_gpus_per_engine={world_size} exceeds rollout_num_gpus={args.rollout_num_gpus}."
+        )
+    if args.rollout_num_gpus % world_size != 0:
+        raise ValueError(
+            f"rollout_num_gpus={args.rollout_num_gpus} must be divisible by "
+            f"SGLang rollout_num_gpus_per_engine={world_size}."
+        )
+    if tp_size > world_size or ep_size > world_size:
+        raise ValueError(
+            f"SGLang tp_size={tp_size} and ep_size={ep_size} must not exceed "
+            f"rollout_num_gpus_per_engine={world_size}."
+        )
+    return config
+
+
 def _train(args: ScriptArgs):
     if args.train_mxfp8 or args.rollout_mxfp8:
         assert _is_blackwell(args), "MXFP8 requires Blackwell (B200/B300/GB200/GB300)"
@@ -560,22 +587,7 @@ def _train(args: ScriptArgs):
             "--optimizer-cpu-offload " "--use-precision-aware-optimizer " "--overlap-cpu-optimizer-d2h-h2d "
         )
 
-    if args.model_name == "DeepSeek-V4-Pro-FP8":
-        sglang_world_size = 32
-        sglang_tp_size = 32
-        sglang_dp_size = 32
-        sglang_ep_size = 32
-    elif args.num_gpus_per_node == 4:
-        # GB300, use tp=8. tp=4 causes CPU OOM when colocate
-        sglang_world_size = 8
-        sglang_tp_size = 8
-        sglang_dp_size = 1
-        sglang_ep_size = 8
-    else:
-        sglang_world_size = 4
-        sglang_tp_size = 4
-        sglang_dp_size = 1
-        sglang_ep_size = 4
+    sglang_world_size, sglang_tp_size, sglang_dp_size, sglang_ep_size = _get_sglang_parallel_config(args)
     # MXFP8 rollout dense GEMM uses the cutlass backend and routed MoE uses
     # FlashInfer's TRT-LLM kernel (mirrors the pre-rebase MXFP8 recipe).
     if args.rollout_mxfp8:

--- a/scripts/run_deepseek_v4.py
+++ b/scripts/run_deepseek_v4.py
@@ -554,12 +554,10 @@ def _train(args: ScriptArgs):
         sglang_tp_size = 32
         sglang_dp_size = 32
         sglang_ep_size = 32
-    elif _hardware(args) in ("GB200", "GB300") and args.rollout_num_gpus >= 8:
-        # Grace, use tp=8. tp=4 causes CPU OOM when colocate
-        sglang_world_size = 8
-        sglang_tp_size = 8
+    elif _hardware(args) in ("GB200", "GB300"):
+        # Grace, prefer tp=8. tp=4 causes CPU OOM when colocate
+        sglang_world_size = sglang_tp_size = sglang_ep_size = min(args.rollout_num_gpus, 8)
         sglang_dp_size = 1
-        sglang_ep_size = 8
     else:
         sglang_world_size = 4
         sglang_tp_size = 4

--- a/tests/e2e/megatron/model_scripts/test_deepseek_v4_flash_4layer_ci.py
+++ b/tests/e2e/megatron/model_scripts/test_deepseek_v4_flash_4layer_ci.py
@@ -37,6 +37,7 @@ def _args() -> ScriptArgs:
         enable_eval=False,
         num_nodes=1,
         num_gpus_per_node=4,
+        hardware="H200",
         skip_saving=True,
         use_fault_tolerance=False,
         extra_args=(

--- a/tests/fast/launch_scripts/py_harness.py
+++ b/tests/fast/launch_scripts/py_harness.py
@@ -17,6 +17,7 @@ import miles.utils.external_utils.command_utils as command_utils
 from miles.utils.external_utils.model_args_utils import import_module_from_path
 
 FROZEN_RUN_ID = "260101-000000-000"
+FROZEN_HARDWARE = "H200"
 
 _GPU_COUNT_ANY_WAIT_LOOP_ACCEPTS = "1000000"
 _FROZEN_PID = 1000
@@ -111,6 +112,7 @@ def freeze_environment(monkeypatch) -> None:
         monkeypatch.setenv(key, value)
     for key in CLEARED_ENV:
         monkeypatch.delenv(key, raising=False)
+    monkeypatch.setattr(command_utils, "detect_hardware", lambda: FROZEN_HARDWARE)
 
 
 def install_command_recorder(monkeypatch) -> Recording:

--- a/tests/fast/launch_scripts/test_run_deepseek_v4.py
+++ b/tests/fast/launch_scripts/test_run_deepseek_v4.py
@@ -1,0 +1,54 @@
+import pytest
+
+from tests.fast.launch_scripts.py_harness import (
+    REPO_ROOT,
+    call_entrypoint,
+    freeze_environment,
+    import_launch_script,
+    install_command_recorder,
+)
+
+
+@pytest.mark.parametrize(
+    ("overrides", "expected_size"),
+    [
+        (
+            {"model_name": "DeepSeek-V4-Flash-FP8-4layer", "num_nodes": 1, "num_gpus_per_node": 4},
+            4,
+        ),
+        ({"model_name": "DeepSeek-V4-Flash-FP8", "num_nodes": 8, "num_gpus_per_node": 4}, 8),
+    ],
+)
+def test_four_gpu_node_rollout_topology_matches_available_resources(monkeypatch, tmp_path, overrides, expected_size):
+    freeze_environment(monkeypatch)
+    recording = install_command_recorder(monkeypatch)
+    module = import_launch_script(REPO_ROOT / "scripts/run_deepseek_v4.py")
+
+    call_entrypoint(module, "train", overrides, sandbox=tmp_path)
+
+    train_command = recording.commands[-1]
+    assert f"--rollout-num-gpus-per-engine {expected_size}" in train_command
+    assert f"--sglang-tp-size {expected_size}" in train_command
+    assert f"--sglang-ep-size {expected_size}" in train_command
+
+
+def test_rollout_topology_rejects_engine_larger_than_pool():
+    module = import_launch_script(REPO_ROOT / "scripts/run_deepseek_v4.py")
+    args = module.ScriptArgs(model_name="DeepSeek-V4-Pro-FP8", num_nodes=1, num_gpus_per_node=8)
+
+    with pytest.raises(
+        ValueError,
+        match="SGLang rollout_num_gpus_per_engine=32 exceeds rollout_num_gpus=8",
+    ):
+        module._get_sglang_parallel_config(args)
+
+
+def test_rollout_topology_rejects_partial_engine():
+    module = import_launch_script(REPO_ROOT / "scripts/run_deepseek_v4.py")
+    args = module.ScriptArgs(model_name="DeepSeek-V4-Flash-FP8", num_nodes=3, num_gpus_per_node=4)
+
+    with pytest.raises(
+        ValueError,
+        match="rollout_num_gpus=12 must be divisible by SGLang rollout_num_gpus_per_engine=8",
+    ):
+        module._get_sglang_parallel_config(args)

--- a/tests/fast/launch_scripts/test_run_deepseek_v4.py
+++ b/tests/fast/launch_scripts/test_run_deepseek_v4.py
@@ -12,16 +12,29 @@ from tests.fast.launch_scripts.py_harness import (
 @pytest.mark.parametrize(
     ("overrides", "expected_size"),
     [
+        ({"hardware": "H200", "num_nodes": 8, "num_gpus_per_node": 4}, 4),
+        ({"hardware": "GB300", "num_nodes": 8, "num_gpus_per_node": 4}, 8),
         (
-            {"model_name": "DeepSeek-V4-Flash-FP8-4layer", "num_nodes": 1, "num_gpus_per_node": 4},
+            {
+                "hardware": "H200",
+                "model_name": "DeepSeek-V4-Flash-FP8-4layer",
+                "num_nodes": 1,
+                "num_gpus_per_node": 4,
+            },
             4,
         ),
-        ({"model_name": "DeepSeek-V4-Flash-FP8", "num_nodes": 8, "num_gpus_per_node": 4}, 8),
+        (
+            {
+                "hardware": "GB300",
+                "model_name": "DeepSeek-V4-Flash-FP8-4layer",
+                "num_nodes": 1,
+                "num_gpus_per_node": 4,
+            },
+            4,
+        ),
     ],
 )
-def test_four_gpu_node_rollout_topology_distinguishes_4layer_from_gb300(
-    monkeypatch, tmp_path, overrides, expected_size
-):
+def test_the_rollout_profile_follows_the_hardware(monkeypatch, tmp_path, overrides, expected_size):
     freeze_environment(monkeypatch)
     recording = install_command_recorder(monkeypatch)
     module = import_launch_script(REPO_ROOT / "scripts/run_deepseek_v4.py")

--- a/tests/fast/launch_scripts/test_run_deepseek_v4.py
+++ b/tests/fast/launch_scripts/test_run_deepseek_v4.py
@@ -19,7 +19,9 @@ from tests.fast.launch_scripts.py_harness import (
         ({"model_name": "DeepSeek-V4-Flash-FP8", "num_nodes": 8, "num_gpus_per_node": 4}, 8),
     ],
 )
-def test_four_gpu_node_rollout_topology_matches_available_resources(monkeypatch, tmp_path, overrides, expected_size):
+def test_four_gpu_node_rollout_topology_distinguishes_4layer_from_gb300(
+    monkeypatch, tmp_path, overrides, expected_size
+):
     freeze_environment(monkeypatch)
     recording = install_command_recorder(monkeypatch)
     module = import_launch_script(REPO_ROOT / "scripts/run_deepseek_v4.py")
@@ -30,25 +32,3 @@ def test_four_gpu_node_rollout_topology_matches_available_resources(monkeypatch,
     assert f"--rollout-num-gpus-per-engine {expected_size}" in train_command
     assert f"--sglang-tp-size {expected_size}" in train_command
     assert f"--sglang-ep-size {expected_size}" in train_command
-
-
-def test_rollout_topology_rejects_engine_larger_than_pool():
-    module = import_launch_script(REPO_ROOT / "scripts/run_deepseek_v4.py")
-    args = module.ScriptArgs(model_name="DeepSeek-V4-Pro-FP8", num_nodes=1, num_gpus_per_node=8)
-
-    with pytest.raises(
-        ValueError,
-        match="SGLang rollout_num_gpus_per_engine=32 exceeds rollout_num_gpus=8",
-    ):
-        module._get_sglang_parallel_config(args)
-
-
-def test_rollout_topology_rejects_partial_engine():
-    module = import_launch_script(REPO_ROOT / "scripts/run_deepseek_v4.py")
-    args = module.ScriptArgs(model_name="DeepSeek-V4-Flash-FP8", num_nodes=3, num_gpus_per_node=4)
-
-    with pytest.raises(
-        ValueError,
-        match="rollout_num_gpus=12 must be divisible by SGLang rollout_num_gpus_per_engine=8",
-    ):
-        module._get_sglang_parallel_config(args)

--- a/tests/fast/utils/test_command_utils.py
+++ b/tests/fast/utils/test_command_utils.py
@@ -1,8 +1,13 @@
+import ast
 import json
 import os
+import platform
 import shlex
+import sys
+from types import SimpleNamespace
 
 import pytest
+from tests.fast.launch_scripts.py_harness import iter_py_launch_scripts
 from tests.fast.utils.command_recorder import record_commands
 
 import miles.utils.external_utils.command_utils as command_utils
@@ -628,12 +633,84 @@ class TestEncodePseudoFile:
         assert shlex.split(f"--custom-config-path {encoded}")[1] == encoded
 
 
+def _hardware_launchers_accept() -> set[str]:
+    """Every value any launcher's `--hardware` takes, minus the sentinel run_deepseek_v4 resolves itself."""
+    values = set()
+    for script in iter_py_launch_scripts():
+        for node in ast.walk(ast.parse(script.path.read_text())):
+            if isinstance(node, ast.AnnAssign) and getattr(node.target, "id", None) == "hardware":
+                literal = node.annotation.slice
+                values.update(e.value for e in (literal.elts if isinstance(literal, ast.Tuple) else [literal]))
+    return values - {"auto"}
+
+
 class TestHardwareTables:
-    @pytest.mark.parametrize("hardware", ["H100", "GB200", "GB300", "MI350X", "MI355X"])
-    def test_every_supported_hardware_declares_its_gpus_per_node(self, hardware):
-        """A launcher whose default hardware is missing here raises KeyError before doing anything."""
-        assert command_utils.NUM_GPUS_OF_HARDWARE[hardware] > 0
+    def test_every_hardware_a_launcher_accepts_declares_its_gpus_per_node(self):
+        """A launcher whose hardware is missing here raises KeyError before doing anything."""
+        assert _hardware_launchers_accept() <= command_utils.NUM_GPUS_OF_HARDWARE.keys()
 
     def test_every_hardware_with_a_generation_also_has_a_gpu_count(self):
         """Every launcher reads the GPU count, while only some read the generation."""
         assert command_utils.GENERATION_HARDWARE.keys() <= command_utils.NUM_GPUS_OF_HARDWARE.keys()
+
+
+def _fake_torch(monkeypatch, *, capability, machine, total_memory=141 * 1024**3, name="fake", hip=None):
+    monkeypatch.setattr(platform, "machine", lambda: machine)
+    monkeypatch.setitem(
+        sys.modules,
+        "torch",
+        SimpleNamespace(
+            version=SimpleNamespace(hip=hip),
+            cuda=SimpleNamespace(
+                is_available=lambda: True,
+                get_device_name=lambda: name,
+                get_device_capability=lambda: capability,
+                get_device_properties=lambda device: SimpleNamespace(total_memory=total_memory),
+            ),
+        ),
+    )
+
+
+class TestDetectHardware:
+    @pytest.mark.parametrize(
+        ("capability", "machine", "expected"),
+        [
+            ((10, 0), "x86_64", "B200"),
+            ((10, 0), "aarch64", "GB200"),
+            ((10, 3), "x86_64", "B300"),
+            ((10, 3), "aarch64", "GB300"),
+        ],
+    )
+    def test_grace_is_what_separates_the_superchip_from_the_pcie_part(
+        self, monkeypatch, capability, machine, expected
+    ):
+        """GB200/GB300 carry the same die as B200/B300, so the host CPU is the only signal."""
+        _fake_torch(monkeypatch, capability=capability, machine=machine)
+
+        assert command_utils.detect_hardware() == expected
+
+    @pytest.mark.parametrize(("total_memory", "expected"), [(80 * 1024**3, "H100"), (141 * 1024**3, "H200")])
+    def test_hopper_is_split_by_memory(self, monkeypatch, total_memory, expected):
+        """H100 and H200 share sm90; only the HBM capacity tells them apart."""
+        _fake_torch(monkeypatch, capability=(9, 0), machine="x86_64", total_memory=total_memory)
+
+        assert command_utils.detect_hardware() == expected
+
+    def test_rocm_reads_the_device_name(self, monkeypatch):
+        _fake_torch(monkeypatch, capability=(9, 5), machine="x86_64", name="AMD Instinct MI355X", hip="6.4")
+
+        assert command_utils.detect_hardware() == "MI355X"
+
+    def test_an_unrecognized_device_asks_for_an_explicit_hardware(self, monkeypatch):
+        """Silently guessing the wrong profile costs a whole run; a launcher flag is one word."""
+        _fake_torch(monkeypatch, capability=(12, 0), machine="x86_64", name="NVIDIA GeForce RTX 5090")
+
+        with pytest.raises(AssertionError, match="pass --hardware"):
+            command_utils.detect_hardware()
+
+    def test_every_detectable_hardware_is_a_table_entry(self, monkeypatch):
+        """A detected name the tables do not carry is a KeyError at the first lookup."""
+        for capability in ((9, 0), (10, 0), (10, 3)):
+            for machine in ("x86_64", "aarch64"):
+                _fake_torch(monkeypatch, capability=capability, machine=machine)
+                assert command_utils.detect_hardware() in command_utils.NUM_GPUS_OF_HARDWARE


### PR DESCRIPTION
<!-- lint: profile=normal -->
## Summary

Keep the 4-layer H200 smoke test out of the GB300 TP8 rollout profile.

## Symptom & Reproduction

- **Symptom:** `stage-c-4-gpu-h200 (0)` in [nightly run 32743697384, attempt 1](https://github.com/radixark/miles/actions/runs/32743697384/job/97486158879) failed at revision `851ddba2a7dbaef22bb090e12efd12d8a65af2c3` after only `4/8 clients joined`.
- **Reproduction:** `test_deepseek_v4_flash_4layer_ci.py` launches one 4-GPU H200 node but generated `rollout_num_gpus_per_engine=8`/TP8/EP8.

## Root Cause

1. [`010e77993`](https://github.com/radixark/miles/commit/010e77993282b5d95cfb3152189e6fdc3d910da4) in [#2717](https://github.com/radixark/miles/pull/2717) used `num_gpus_per_node == 4` for GB300 TP8.
2. `DeepSeek-V4-Flash-FP8-4layer` also uses four GPUs/node, so four ranks entered TP8/EP8.

## Fix

`is_gb300_profile` now requires four actor GPUs per node and excludes `is_4layer`. Full-model GB300 runs keep TP8/EP8; the 4-layer H200 smoke test returns to TP4/EP4, with all other profiles unchanged.

## Verification

- `tests/fast/launch_scripts/test_run_deepseek_v4.py`: `2 passed`, covering 1x4 4-layer H200 and 8x4 full-model GB300 command generation.
- Targeted `scripts/run_deepseek_v4.py::train` launcher snapshot: `1 passed`.
- `ruff check` and `black --check` on both changed files: passed.

## Review Focus

- `is_gb300_profile`: the 4-layer profile must stay excluded while the 8x4 full-model profile keeps TP8/EP8.
