### PR TITLE
fix(metrics): preserve speculative counters throughout Miles

### DIFF
--- a/miles/dashboard/dump_reader.py
+++ b/miles/dashboard/dump_reader.py
@@ -632,7 +632,7 @@ class DumpReader:
             tool_calls=_tool_call_count(sample),
             non_generation_time=sample.non_generation_time,
             spec_accept_rate=(
-                spec.spec_accept_token_num / spec.spec_draft_token_num if spec.spec_draft_token_num else None
+                spec.spec_num_correct_drafts / spec.spec_num_proposed_drafts if spec.spec_num_proposed_drafts else None
             ),
             prefix_cache_hit_rate=(
                 cache_info.cached_tokens / cache_info.total_prompt_tokens if cache_info.total_prompt_tokens else None

--- a/miles/ray/rollout/metrics.py
+++ b/miles/ray/rollout/metrics.py
@@ -199,11 +199,14 @@ def _compute_zero_std_metrics(args, all_samples: list[Sample]):
 def _compute_spec_metrics(args, all_samples: list[Sample]):
     if args.sglang_speculative_algorithm is None:
         return {}
-    num_samples = len(all_samples)
-    metrics = {}
-    metrics["spec_accept_rate"] = sum(sample.spec_info.spec_accept_rate for sample in all_samples) / num_samples
-    metrics["spec_accept_length"] = sum(sample.spec_info.spec_accept_length for sample in all_samples) / num_samples
-    return metrics
+    num_correct_drafts = sum(sample.spec_info.spec_num_correct_drafts for sample in all_samples)
+    num_proposed_drafts = sum(sample.spec_info.spec_num_proposed_drafts for sample in all_samples)
+    spec_verify_ct = sum(sample.spec_info.spec_verify_ct for sample in all_samples)
+    completion_tokens = sum(sample.spec_info.completion_tokens for sample in all_samples)
+    return {
+        "spec_accept_rate": num_correct_drafts / num_proposed_drafts if num_proposed_drafts > 0 else 0.0,
+        "spec_accept_length": completion_tokens / spec_verify_ct if spec_verify_ct > 0 else 0.0,
+    }
 
 
 def _compute_prefix_cache_metrics(args, all_samples: list[Sample]):

--- a/miles/rollout/generate_utils/sample_utils.py
+++ b/miles/rollout/generate_utils/sample_utils.py
@@ -187,10 +187,10 @@ def _merge_spec_info(a: Sample.SpecInfo, b: Sample.SpecInfo) -> Sample.SpecInfo:
 
     return _create_with_all_fields(
         Sample.SpecInfo,
-        spec_accept_token_num=_merge_plus_value("spec_accept_token_num"),
-        spec_draft_token_num=_merge_plus_value("spec_draft_token_num"),
+        spec_num_correct_drafts=_merge_plus_value("spec_num_correct_drafts"),
+        spec_num_proposed_drafts=_merge_plus_value("spec_num_proposed_drafts"),
         spec_verify_ct=_merge_plus_value("spec_verify_ct"),
-        completion_token_num=_merge_plus_value("completion_token_num"),
+        completion_tokens=_merge_plus_value("completion_tokens"),
     )
 
 

--- a/miles/rollout/session/samples/codec.py
+++ b/miles/rollout/session/samples/codec.py
@@ -39,6 +39,7 @@ SAMPLES_VALUE_SPEC: dict[str, ValueSpec] = {
     "rollout_indexer_topk": ValueSpec("tensor", np.dtype(np.int32), strict=True),
     "status": ValueSpec("json"),
     "weight_versions": ValueSpec("json"),
+    "spec_info": ValueSpec("json"),
     "prefix_cache_info": ValueSpec("json"),
     "metadata": ValueSpec("json"),
 }
@@ -109,6 +110,8 @@ def encode_samples(
             if spec.codec == "json":
                 if field == "status":
                     value = value.value
+                elif field == "spec_info":
+                    value = value.to_dict()
                 elif field == "prefix_cache_info":
                     value = value.to_dict()
                 sample_meta[field] = value
@@ -166,6 +169,8 @@ def decode_samples_and_merge_input_sample(
                     value = Sample.Status(value)
                 elif field == "weight_versions":
                     value = list(value)
+                elif field == "spec_info":
+                    value = Sample.SpecInfo.from_dict(value)
                 elif field == "prefix_cache_info":
                     value = Sample.PrefixCacheInfo.from_dict(value)
                 elif field == "reward":

--- a/miles/utils/test_utils/mock_sglang_server.py
+++ b/miles/utils/test_utils/mock_sglang_server.py
@@ -21,8 +21,8 @@ from miles.utils.test_utils.uvicorn_thread_server import UvicornThreadServer
 class ProcessResultMetaInfo:
     weight_version: str | None = None
     routed_experts: str | None = None
-    spec_accept_token_num: int | None = None
-    spec_draft_token_num: int | None = None
+    spec_num_correct_drafts: int | None = None
+    spec_num_proposed_drafts: int | None = None
     spec_verify_ct: int | None = None
 
     def to_dict(self) -> dict:

--- a/miles/utils/types.py
+++ b/miles/utils/types.py
@@ -83,40 +83,45 @@ class Sample:
 
     @dataclass
     class SpecInfo:
-        spec_accept_token_num: int = 0
-        spec_draft_token_num: int = 0
+        spec_num_correct_drafts: int = 0
+        spec_num_proposed_drafts: int = 0
         spec_verify_ct: int = 0
-        completion_token_num: int = 0
+        completion_tokens: int = 0
 
         @property
         def spec_accept_rate(self) -> float:
-            return self.spec_accept_token_num / self.spec_draft_token_num if self.spec_draft_token_num > 0 else 0.0
+            if self.spec_num_proposed_drafts == 0:
+                return 0.0
+            return self.spec_num_correct_drafts / self.spec_num_proposed_drafts
 
         @property
         def spec_accept_length(self) -> float:
-            return self.completion_token_num / self.spec_verify_ct if self.spec_verify_ct > 0 else 0.0
+            return self.completion_tokens / self.spec_verify_ct if self.spec_verify_ct > 0 else 0.0
 
         def add(self, meta_info: dict):
-            self.spec_accept_token_num += meta_info.get("spec_accept_token_num", 0)
-            self.spec_draft_token_num += meta_info.get("spec_draft_token_num", 0)
-            self.spec_verify_ct += meta_info.get("spec_verify_ct", 0)
-            self.completion_token_num += meta_info.get("completion_tokens", 0)
+            spec_verify_ct = meta_info.get("spec_verify_ct") or 0
+            if spec_verify_ct <= 0:
+                return
+            self.spec_num_correct_drafts += meta_info.get("spec_num_correct_drafts", 0)
+            self.spec_num_proposed_drafts += meta_info.get("spec_num_proposed_drafts", 0)
+            self.spec_verify_ct += spec_verify_ct
+            self.completion_tokens += meta_info.get("completion_tokens", 0)
 
         def to_dict(self):
             return {
-                "spec_accept_token_num": self.spec_accept_token_num,
-                "spec_draft_token_num": self.spec_draft_token_num,
+                "spec_num_correct_drafts": self.spec_num_correct_drafts,
+                "spec_num_proposed_drafts": self.spec_num_proposed_drafts,
                 "spec_verify_ct": self.spec_verify_ct,
-                "completion_token_num": self.completion_token_num,
+                "completion_tokens": self.completion_tokens,
             }
 
         @staticmethod
         def from_dict(data: dict):
             info = Sample.SpecInfo()
-            info.spec_accept_token_num = data.get("spec_accept_token_num", 0)
-            info.spec_draft_token_num = data.get("spec_draft_token_num", 0)
+            info.spec_num_correct_drafts = data.get("spec_num_correct_drafts", data.get("spec_accept_token_num", 0))
+            info.spec_num_proposed_drafts = data.get("spec_num_proposed_drafts", data.get("spec_draft_token_num", 0))
             info.spec_verify_ct = data.get("spec_verify_ct", 0)
-            info.completion_token_num = data.get("completion_token_num", 0)
+            info.completion_tokens = data.get("completion_tokens", data.get("completion_token_num", 0))
             return info
 
     spec_info: SpecInfo = field(default_factory=SpecInfo)

--- a/tests/fast/fixtures/generation_fixtures.py
+++ b/tests/fast/fixtures/generation_fixtures.py
@@ -271,8 +271,8 @@ def generation_env(request, variant):
             meta_info=ProcessResultMetaInfo(
                 weight_version=x.get("weight_version"),
                 routed_experts=x.get("routed_experts"),
-                spec_accept_token_num=x.get("spec_accept_token_num"),
-                spec_draft_token_num=x.get("spec_draft_token_num"),
+                spec_num_correct_drafts=x.get("spec_num_correct_drafts"),
+                spec_num_proposed_drafts=x.get("spec_num_proposed_drafts"),
                 spec_verify_ct=x.get("spec_verify_ct"),
             ),
         )

--- a/tests/fast/ray/rollout/test_metrics.py
+++ b/tests/fast/ray/rollout/test_metrics.py
@@ -6,9 +6,11 @@ from tests.fast.ray.rollout.conftest import make_args, make_samples_grouped
 from miles.ray.rollout.metrics import (
     _compute_metrics_from_samples,
     _compute_passrate_from_samples,
+    _compute_spec_metrics,
     _compute_zero_std_metrics,
     log_rollout_data,
 )
+from miles.utils.types import Sample
 
 
 class TestComputeZeroStdMetrics:
@@ -52,6 +54,31 @@ class TestComputeZeroStdMetrics:
         # No groups → no all_zero/all_one keys (the function guards on total_groups>0).
         assert "zero_std/all_zero_percentage" not in out
         assert "zero_std/all_one_percentage" not in out
+
+
+class TestComputeSpecMetrics:
+    def test_aggregates_sglang_counters_before_computing_ratios(self):
+        args = make_args(sglang_speculative_algorithm="EAGLE")
+        samples = make_samples_grouped(1, 2)
+        samples[0].spec_info = Sample.SpecInfo(
+            spec_num_correct_drafts=1,
+            spec_num_proposed_drafts=2,
+            spec_verify_ct=1,
+            completion_tokens=2,
+        )
+        samples[1].spec_info = Sample.SpecInfo(
+            spec_num_correct_drafts=9,
+            spec_num_proposed_drafts=10,
+            spec_verify_ct=9,
+            completion_tokens=27,
+        )
+
+        out = _compute_spec_metrics(args, samples)
+
+        assert out == {
+            "spec_accept_rate": pytest.approx(10 / 12),
+            "spec_accept_length": pytest.approx(29 / 10),
+        }
 
 
 class TestTitoMismatchMetrics:

--- a/tests/fast/rollout/generate_hub/test_single_turn.py
+++ b/tests/fast/rollout/generate_hub/test_single_turn.py
@@ -248,7 +248,11 @@ class TestMetaInfo:
         [
             {
                 "args_kwargs": {"sglang_speculative_algorithm": "EAGLE"},
-                "process_fn_kwargs": {"spec_accept_token_num": 10, "spec_draft_token_num": 15, "spec_verify_ct": 3},
+                "process_fn_kwargs": {
+                    "spec_num_correct_drafts": 10,
+                    "spec_num_proposed_drafts": 15,
+                    "spec_verify_ct": 3,
+                },
             }
         ],
         indirect=True,
@@ -260,7 +264,10 @@ class TestMetaInfo:
             expected_sample(
                 variant,
                 spec_info=Sample.SpecInfo(
-                    spec_accept_token_num=10, spec_draft_token_num=15, spec_verify_ct=3, completion_token_num=5
+                    spec_num_correct_drafts=10,
+                    spec_num_proposed_drafts=15,
+                    spec_verify_ct=3,
+                    completion_tokens=5,
                 ),
             )
         ]

--- a/tests/fast/rollout/inference_rollout/integration/utils.py
+++ b/tests/fast/rollout/inference_rollout/integration/utils.py
@@ -34,7 +34,10 @@ def expected_sample(*, group_index: int | None) -> Sample:
         train_metadata=None,
         non_generation_time=0.0,
         spec_info=Sample.SpecInfo(
-            spec_accept_token_num=0, spec_draft_token_num=0, spec_verify_ct=0, completion_token_num=0
+            spec_num_correct_drafts=0,
+            spec_num_proposed_drafts=0,
+            spec_verify_ct=0,
+            completion_tokens=0,
         ),
         prefix_cache_info=Sample.PrefixCacheInfo(cached_tokens=0, total_prompt_tokens=7),
     )

--- a/tests/fast/rollout/session/test_samples_codec.py
+++ b/tests/fast/rollout/session/test_samples_codec.py
@@ -11,7 +11,12 @@ import pytest
 import safetensors.numpy
 from safetensors import SafetensorError
 
-from miles.rollout.session.samples.codec import decode_samples_and_merge_input_sample, encode_samples
+from miles.rollout.session.samples.codec import (
+    COMPUTED_FIELDS,
+    COMPUTED_FIELDS_V2,
+    decode_samples_and_merge_input_sample,
+    encode_samples,
+)
 from miles.utils.types import Sample
 
 
@@ -89,6 +94,20 @@ class TestSamplesWireCodec:
         assert out.train_metadata == {"loss": "ppo"}
         # the input template itself is never mutated
         assert template.tokens == [] and template.metadata == {"task": "t", "lifecycle": "stale"}
+
+    @pytest.mark.parametrize("fields", [COMPUTED_FIELDS, COMPUTED_FIELDS_V2])
+    def test_spec_info_round_trips(self, fields):
+        spec_info = Sample.SpecInfo(
+            spec_num_correct_drafts=3,
+            spec_num_proposed_drafts=5,
+            spec_verify_ct=2,
+            completion_tokens=7,
+        )
+
+        payload = encode_samples([_computed_sample(spec_info=spec_info)], {}, fields=fields)
+        (out,) = decode_samples_and_merge_input_sample(payload, Sample(), fields=fields).samples
+
+        assert out.spec_info.to_dict() == spec_info.to_dict()
 
     def test_multi_sample_reply_keeps_per_sample_tensors(self):
         a = _computed_sample(metadata={"server_only": {"sample": "a"}})

--- a/tests/fast/router/test_session_samples_op.py
+++ b/tests/fast/router/test_session_samples_op.py
@@ -207,6 +207,27 @@ async def test_assembled_sample_golden(core):
     assert reply.empty_reason is None
 
 
+async def test_spec_info_crosses_samples_wire(core, monkeypatch):
+    output_token_ids = [10, 11, 12, 13, 14, 15, 16]
+    record = _make_record(prompt_token_ids=[1, 2, 3], output_token_ids=output_token_ids)
+    record.response["choices"][0]["meta_info"].update(
+        {"spec_num_correct_drafts": 3, "spec_num_proposed_drafts": 5, "spec_verify_ct": 2}
+    )
+    monkeypatch.setattr(core.args, "sglang_speculative_algorithm", "EAGLE")
+    sid = await _make_session(core, [record], [1, 2, 3, *output_token_ids])
+
+    status, payload = await _collect_via_op(core, sid)
+    assert status == 200
+    (sample,), _ = _new_pipeline(payload, _input_sample())
+
+    assert sample.spec_info.to_dict() == {
+        "spec_num_correct_drafts": 3,
+        "spec_num_proposed_drafts": 5,
+        "spec_verify_ct": 2,
+        "completion_tokens": 7,
+    }
+
+
 async def test_truncation_golden(core):
     """max_seq_len=8 strips one output token off the second turn (a turn-level
     budget applied before merge): the final sample ends TRUNCATED at 8 tokens

--- a/tests/fast/router/test_session_samples_op_v2.py
+++ b/tests/fast/router/test_session_samples_op_v2.py
@@ -218,6 +218,27 @@ async def test_assembled_samples_golden_merged(core):
     assert reply.session_metadata["agent"] == _AGENT_METADATA
 
 
+async def test_spec_info_crosses_samples_wire(core, monkeypatch):
+    output_token_ids = [10, 11, 12, 13, 14, 15, 16]
+    record = _make_record(prompt_token_ids=[1, 2, 3], output_token_ids=output_token_ids)
+    record.response["choices"][0]["meta_info"].update(
+        {"spec_num_correct_drafts": 3, "spec_num_proposed_drafts": 5, "spec_verify_ct": 2}
+    )
+    monkeypatch.setattr(core.args, "sglang_speculative_algorithm", "EAGLE")
+    sid = await _make_session(core, [record], [1, 2, 3, *output_token_ids])
+
+    status, payload = await _collect_via_op(core, sid)
+    assert status == 200
+    (sample,), _ = _new_pipeline(payload, _input_sample())
+
+    assert sample.spec_info.to_dict() == {
+        "spec_num_correct_drafts": 3,
+        "spec_num_proposed_drafts": 5,
+        "spec_verify_ct": 2,
+        "completion_tokens": 7,
+    }
+
+
 async def test_truncation_golden(core):
     """max_seq_len=8 strips one output token off the second turn (a turn-level
     budget applied before merge): the merged sample ends TRUNCATED at 8 tokens

--- a/tests/fast/utils/test_types.py
+++ b/tests/fast/utils/test_types.py
@@ -1,4 +1,4 @@
-"""Unit tests for Sample.strip_last_output_tokens."""
+"""Unit tests for Sample helpers."""
 
 from unittest.mock import MagicMock
 
@@ -105,3 +105,32 @@ class TestStripLastOutputTokens:
         original_tokens = list(s.tokens)
         s.strip_last_output_tokens(-1, tokenizer)
         assert s.tokens == original_tokens
+
+
+class TestSpecInfo:
+    def test_add_ignores_completion_without_speculative_verification(self):
+        info = Sample.SpecInfo()
+
+        info.add({"completion_tokens": 1})
+
+        assert info == Sample.SpecInfo()
+
+    def test_from_dict_reads_legacy_miles_fields(self):
+        sample = Sample.from_dict(
+            {
+                "status": "completed",
+                "spec_info": {
+                    "spec_accept_token_num": 3,
+                    "spec_draft_token_num": 5,
+                    "spec_verify_ct": 2,
+                    "completion_token_num": 7,
+                },
+            }
+        )
+
+        assert sample.spec_info == Sample.SpecInfo(
+            spec_num_correct_drafts=3,
+            spec_num_proposed_drafts=5,
+            spec_verify_ct=2,
+            completion_tokens=7,
+        )

--- a/tests/fast/utils/test_utils/test_mock_sglang_server.py
+++ b/tests/fast/utils/test_utils/test_mock_sglang_server.py
@@ -42,23 +42,23 @@ class TestProcessResultMetaInfo:
         assert ProcessResultMetaInfo(weight_version="v1").to_dict() == {"weight_version": "v1"}
 
     def test_to_dict_partial_fields(self):
-        assert ProcessResultMetaInfo(weight_version="v1", spec_accept_token_num=10).to_dict() == {
+        assert ProcessResultMetaInfo(weight_version="v1", spec_num_correct_drafts=10).to_dict() == {
             "weight_version": "v1",
-            "spec_accept_token_num": 10,
+            "spec_num_correct_drafts": 10,
         }
 
     def test_to_dict_all_fields(self):
         assert ProcessResultMetaInfo(
             weight_version="v1",
             routed_experts="abc",
-            spec_accept_token_num=10,
-            spec_draft_token_num=15,
+            spec_num_correct_drafts=10,
+            spec_num_proposed_drafts=15,
             spec_verify_ct=3,
         ).to_dict() == {
             "weight_version": "v1",
             "routed_experts": "abc",
-            "spec_accept_token_num": 10,
-            "spec_draft_token_num": 15,
+            "spec_num_correct_drafts": 10,
+            "spec_num_proposed_drafts": 15,
             "spec_verify_ct": 3,
         }
 
@@ -190,8 +190,8 @@ class TestGenerateEndpoint:
                 meta_info=ProcessResultMetaInfo(
                     weight_version="v2.0",
                     routed_experts="encoded_data",
-                    spec_accept_token_num=10,
-                    spec_draft_token_num=15,
+                    spec_num_correct_drafts=10,
+                    spec_num_proposed_drafts=15,
                     spec_verify_ct=3,
                 ),
             )
@@ -213,8 +213,8 @@ class TestGenerateEndpoint:
                     "output_token_logprobs": [[-0.0, 562]],
                     "weight_version": "v2.0",
                     "routed_experts": "encoded_data",
-                    "spec_accept_token_num": 10,
-                    "spec_draft_token_num": 15,
+                    "spec_num_correct_drafts": 10,
+                    "spec_num_proposed_drafts": 15,
                     "spec_verify_ct": 3,
                 },
             }


### PR DESCRIPTION
## Summary

Preserve SGLang speculative counters through generation, sessions, and rollout metrics.

## Symptom & Reproduction

- **Symptom:** Rollout metrics averaged per-sample speculative ratios, while session v1/v2 assembled nonzero `Sample.spec_info` counters but the shared samples wire decoded them as zeros on the driver.
- **Reproduction:** Send `spec_num_correct_drafts=3`, `spec_num_proposed_drafts=5`, `spec_verify_ct=2`, and `completion_tokens=7` through either session wire; expected `{3,5,2,7}`, observed `{0,0,0,0}` before the wire fix.

## Root Cause

1. `Sample.SpecInfo` stored speculative counters under legacy names.
2. `_compute_spec_metrics` averaged per-sample ratios instead of raw counters.
3. `SAMPLES_VALUE_SPEC` omitted `spec_info` from the shared session wire.
4. `decode_samples_and_merge_input_sample` therefore left driver counters at zero.

## Fix

Use SGLang's canonical counter names in `Sample.SpecInfo`, compute acceptance metrics from aggregate raw counters, and transport `spec_info` as required JSON through the shared v1 samples contract inherited by v2. Direct generation behavior and the existing prefix-cache, reward, and tensor wire fields remain unchanged. This includes #2598's counter update and adds the missing session transport needed for the end-to-end contract.

## Verification

- `python3 -m pytest -q tests/fast/rollout/session/test_samples_codec.py tests/fast/router/test_session_samples_op.py tests/fast/router/test_session_samples_op_v2.py tests/fast/ray/rollout/test_metrics.py tests/fast/utils/test_types.py tests/fast/utils/test_utils/test_mock_sglang_server.py tests/fast/rollout/generate_hub/test_single_turn.py`: 171 passed, 10 skipped.
- Direct v1/v2 samples-wire probe: both decoded `{'spec_num_correct_drafts': 3, 'spec_num_proposed_drafts': 5, 'spec_verify_ct': 2, 'completion_tokens': 7}`.
- `python3 -m black --check miles/rollout/session/samples/codec.py tests/fast/rollout/session/test_samples_codec.py tests/fast/router/test_session_samples_op.py tests/fast/router/test_session_samples_op_v2.py`: 4 files unchanged.
- `git diff --check`: passed. Ruff was unavailable locally and on the devbox; a live external SGLang session server was not launched.

## Review Focus

- `Sample.SpecInfo` / `_compute_spec_metrics`: canonical counter names and aggregate denominators match SGLang semantics.
- `SAMPLES_VALUE_SPEC` / `SAMPLES_VALUE_SPEC_V2`: the shared required field survives both server versions without a missing-field fallback.
- Session endpoint tests: nonzero counters reach driver decode rather than only passing a codec unit test.
