### PR TITLE
feat: resolve --hardware from the node in every launcher

### DIFF
--- a/examples/retool_v2/run_retool_multi_turn.py
+++ b/examples/retool_v2/run_retool_multi_turn.py
@@ -14,7 +14,7 @@ WANDB_GROUP = "sft-multi-turn-batch-32"
 class ScriptArgs(U.ExecuteTrainConfig):
     mode: Literal["normal", "debug_minimal"] = "normal"
     run_id: str = field(default_factory=U.create_run_id)
-    hardware: Literal["H100", "GB200", "GB300"] = "H100"
+    hardware: Literal["auto", "H100", "GB200", "GB300"] = "auto"
     num_gpus_per_node: int | None = None
     use_sft_model: bool = True
     save_path: str = "/root/Qwen3-4B_miles/retool_v2_multi_turn"
@@ -28,6 +28,7 @@ class ScriptArgs(U.ExecuteTrainConfig):
     ref_load: str = field(init=False)
 
     def __post_init__(self):
+        self.hardware = U.resolve_hardware(self)
         self.num_gpus_per_node = self.num_gpus_per_node or U.NUM_GPUS_OF_HARDWARE[self.hardware]
         if self.use_sft_model:
             self.hf_checkpoint = "/root/font-info/qwen3-4b-sft"

--- a/miles/utils/external_utils/command_utils.py
+++ b/miles/utils/external_utils/command_utils.py
@@ -13,6 +13,7 @@ import socket
 from dataclasses import dataclass, field
 from functools import partial
 from pathlib import Path
+from typing import get_args
 
 from miles.utils.external_utils.exec_command import exec_command_cpu, exec_command_gpu, exec_command_multi_node
 from miles.utils.external_utils.model_args_utils import shell_safe_model_args
@@ -407,3 +408,15 @@ def detect_hardware() -> str:
                 detected = None
     assert detected is not None, f"cannot tell which hardware {name!r} is, pass --hardware explicitly"
     return detected
+
+
+def resolve_hardware(config: ExecuteTrainConfig) -> str:
+    """`auto` asks the node the launcher runs on; anything explicit overrides it."""
+    if config.hardware == "auto":
+        hardware = detect_hardware()
+        print(f"detected --hardware {hardware}")
+    else:
+        hardware = config.hardware
+    supported = get_args(config.__dataclass_fields__["hardware"].type)
+    assert hardware in supported, f"{type(config).__name__} has no verified profile for {hardware}"
+    return hardware

--- a/miles/utils/external_utils/command_utils.py
+++ b/miles/utils/external_utils/command_utils.py
@@ -6,6 +6,7 @@ import base64
 import datetime
 import json
 import os
+import platform
 import random
 import shlex
 import socket
@@ -377,6 +378,32 @@ NUM_GPUS_OF_HARDWARE = {
 
 GENERATION_HARDWARE = {
     "H100": "Hopper",
+    "H200": "Hopper",
+    "B200": "Blackwell",
+    "B300": "Blackwell",
     "GB200": "Blackwell",
     "GB300": "Blackwell",
 }
+
+
+def detect_hardware() -> str:
+    """Which NUM_GPUS_OF_HARDWARE entry this node is. Call it where the answer is used: prepare steps run GPU-free."""
+    import torch
+
+    assert torch.cuda.is_available(), "no visible GPU to detect the hardware from, pass --hardware explicitly"
+    name = torch.cuda.get_device_name()
+    if torch.version.hip is not None:
+        detected = next((hardware for hardware in ("MI350X", "MI355X") if hardware in name), None)
+    else:
+        grace = platform.machine() == "aarch64"
+        match torch.cuda.get_device_capability():
+            case (9, 0):
+                detected = "H200" if torch.cuda.get_device_properties(0).total_memory > 100 * 1024**3 else "H100"
+            case (10, 0):
+                detected = "GB200" if grace else "B200"
+            case (10, 3):
+                detected = "GB300" if grace else "B300"
+            case _:
+                detected = None
+    assert detected is not None, f"cannot tell which hardware {name!r} is, pass --hardware explicitly"
+    return detected

--- a/scripts/amd/run_qwen3_30b_a3b.py
+++ b/scripts/amd/run_qwen3_30b_a3b.py
@@ -13,7 +13,7 @@ class ScriptArgs(U.ExecuteTrainConfig):
     model_name: str = "Qwen3-30B-A3B"
     megatron_model_type: str = "qwen3-30B-A3B"
     num_gpus_per_node: int | None = None
-    hardware: Literal["MI350X", "MI355X"] = "MI355X"
+    hardware: Literal["auto", "MI350X", "MI355X"] = "auto"
     enable_eval: bool = True
     extra_args: str = ""
     data_dir: str = "/root/datasets"
@@ -27,6 +27,7 @@ class ScriptArgs(U.ExecuteTrainConfig):
     tis_use_rs: bool = True
 
     def __post_init__(self):
+        self.hardware = U.resolve_hardware(self)
         self.num_gpus_per_node = self.num_gpus_per_node or U.NUM_GPUS_OF_HARDWARE[self.hardware]
 
 

--- a/scripts/amd/run_qwen3_4b.py
+++ b/scripts/amd/run_qwen3_4b.py
@@ -38,7 +38,7 @@ class ScriptArgs(U.ExecuteTrainConfig):
     model_name: str = "Qwen3-4B"
     megatron_model_type: str = "qwen3-4B"
     num_gpus_per_node: int | None = None
-    hardware: Literal["MI350X", "MI355X"] = "MI355X"
+    hardware: Literal["auto", "MI350X", "MI355X"] = "auto"
     enable_eval: bool = True
     num_rollout: int = 3000
     extra_args: str = ""
@@ -47,6 +47,7 @@ class ScriptArgs(U.ExecuteTrainConfig):
     megatron_path: str = "/root/Megatron-LM"
 
     def __post_init__(self):
+        self.hardware = U.resolve_hardware(self)
         self.num_gpus_per_node = self.num_gpus_per_node or U.NUM_GPUS_OF_HARDWARE[self.hardware]
 
 

--- a/scripts/run_deepseek_v32.py
+++ b/scripts/run_deepseek_v32.py
@@ -26,11 +26,11 @@ class ScriptArgs(U.ExecuteTrainConfig):
     megatron_model_type: str = "deepseek-v32"
     from_bf16_ckpt: bool = False
     use_single_node: bool = False
-    num_gpus_per_node: int = 8
+    num_gpus_per_node: int | None = None
     actor_num_nodes: int | None = None
     actor_num_gpus_per_node: int | None = 8
     rollout_num_gpus: int | None = None
-    hardware: Literal["B200", "B300", "GB200", "GB300", "H100", "H200"] = "B200"
+    hardware: Literal["auto", "B200", "B300", "GB200", "GB300", "H100", "H200"] = "auto"
     enable_eval: bool = False
     extra_args: str = ""
     data_dir: str = "/root/datasets"
@@ -47,6 +47,8 @@ class ScriptArgs(U.ExecuteTrainConfig):
     tis_use_rs: bool = True
 
     def __post_init__(self):
+        self.hardware = U.resolve_hardware(self)
+        self.num_gpus_per_node = self.num_gpus_per_node or U.NUM_GPUS_OF_HARDWARE[self.hardware]
         if self.use_single_node:
             self.actor_num_nodes = 1
             self.actor_num_gpus_per_node = 4

--- a/scripts/run_deepseek_v4.py
+++ b/scripts/run_deepseek_v4.py
@@ -102,7 +102,7 @@ class ScriptArgs(U.ExecuteTrainConfig):
     megatron_path: str = "/root/Megatron-LM"
 
     # performance configs
-    num_gpus_per_node: int = 8
+    num_gpus_per_node: int | None = None
     hardware: Literal["auto", "H100", "H200", "B200", "B300", "GB200", "GB300"] = "auto"
     # use colocate by default. will switch to disaggregated mode when 0 < rollout_num_nodes < num_nodes
     rollout_num_nodes: int = 0
@@ -137,6 +137,8 @@ class ScriptArgs(U.ExecuteTrainConfig):
     extra_args: str = ""
 
     def __post_init__(self):
+        self.hardware = U.resolve_hardware(self)
+        self.num_gpus_per_node = self.num_gpus_per_node or U.NUM_GPUS_OF_HARDWARE[self.hardware]
         if not self.model_org:
             self.model_org = _DEFAULT_MODEL_ORG[self.model_name]
         if self.model_local_dir is None:
@@ -188,10 +190,6 @@ class ScriptArgs(U.ExecuteTrainConfig):
         if self.rollout_fp8:
             return self.fp8_name
         return self.bf16_name
-
-
-def _hardware(args: ScriptArgs) -> str:
-    return U.detect_hardware() if args.hardware == "auto" else args.hardware
 
 
 def _download_dataset(args: ScriptArgs):
@@ -288,7 +286,7 @@ def _prepare_mxfp8(args: ScriptArgs):
     """
     if not args.rollout_mxfp8:
         return
-    assert U.GENERATION_HARDWARE[_hardware(args)] == "Blackwell", "rollout_mxfp8 requires Blackwell"
+    assert U.GENERATION_HARDWARE[args.hardware] == "Blackwell", "rollout_mxfp8 requires Blackwell"
     U.exec_command_gpu(
         f"python tools/convert_hf_to_mxfp8.py "
         f"--model-dir {args.model_dir}/{args.bf16_name} "
@@ -445,7 +443,7 @@ def _get_parallel_config(args: ScriptArgs) -> str:
 
 def _train(args: ScriptArgs):
     if args.train_mxfp8 or args.rollout_mxfp8:
-        assert U.GENERATION_HARDWARE[_hardware(args)] == "Blackwell", "MXFP8 requires Blackwell"
+        assert U.GENERATION_HARDWARE[args.hardware] == "Blackwell", "MXFP8 requires Blackwell"
     if not args.rollout_fp8 or args.hf_checkpoint is None or args.model_name in _MXFP4_MODEL_NAMES:
         rollout_checkpoint = f"{args.model_local_dir}/{args.rollout_name}"
         if args.hf_checkpoint != rollout_checkpoint:
@@ -554,7 +552,7 @@ def _train(args: ScriptArgs):
         sglang_tp_size = 32
         sglang_dp_size = 32
         sglang_ep_size = 32
-    elif _hardware(args) in ("GB200", "GB300"):
+    elif args.hardware in ("GB200", "GB300"):
         # Grace, prefer tp=8. tp=4 causes CPU OOM when colocate
         sglang_world_size = sglang_tp_size = sglang_ep_size = min(args.rollout_num_gpus, 8)
         sglang_dp_size = 1

--- a/scripts/run_deepseek_v4.py
+++ b/scripts/run_deepseek_v4.py
@@ -454,33 +454,6 @@ def _get_parallel_config(args: ScriptArgs) -> str:
     )
 
 
-def _get_sglang_parallel_config(args: ScriptArgs) -> tuple[int, int, int, int]:
-    if args.model_name == "DeepSeek-V4-Pro-FP8":
-        config = (32, 32, 32, 32)
-    elif args.num_gpus_per_node == 4 and args.rollout_num_gpus >= 8:
-        # Span TP8 across GB300 nodes to avoid the colocated TP4 host-memory OOM.
-        config = (8, 8, 1, 8)
-    else:
-        config = (4, 4, 1, 4)
-
-    world_size, tp_size, dp_size, ep_size = config
-    if world_size > args.rollout_num_gpus:
-        raise ValueError(
-            f"SGLang rollout_num_gpus_per_engine={world_size} exceeds rollout_num_gpus={args.rollout_num_gpus}."
-        )
-    if args.rollout_num_gpus % world_size != 0:
-        raise ValueError(
-            f"rollout_num_gpus={args.rollout_num_gpus} must be divisible by "
-            f"SGLang rollout_num_gpus_per_engine={world_size}."
-        )
-    if tp_size > world_size or ep_size > world_size:
-        raise ValueError(
-            f"SGLang tp_size={tp_size} and ep_size={ep_size} must not exceed "
-            f"rollout_num_gpus_per_engine={world_size}."
-        )
-    return config
-
-
 def _train(args: ScriptArgs):
     if args.train_mxfp8 or args.rollout_mxfp8:
         assert _is_blackwell(args), "MXFP8 requires Blackwell (B200/B300/GB200/GB300)"
@@ -587,7 +560,24 @@ def _train(args: ScriptArgs):
             "--optimizer-cpu-offload " "--use-precision-aware-optimizer " "--overlap-cpu-optimizer-d2h-h2d "
         )
 
-    sglang_world_size, sglang_tp_size, sglang_dp_size, sglang_ep_size = _get_sglang_parallel_config(args)
+    is_4layer = args.model_name == "DeepSeek-V4-Flash-FP8-4layer"
+    is_gb300_profile = args.actor_num_gpus_per_node == 4 and not is_4layer
+    if args.model_name == "DeepSeek-V4-Pro-FP8":
+        sglang_world_size = 32
+        sglang_tp_size = 32
+        sglang_dp_size = 32
+        sglang_ep_size = 32
+    elif is_gb300_profile:
+        # GB300, use tp=8. tp=4 causes CPU OOM when colocate
+        sglang_world_size = 8
+        sglang_tp_size = 8
+        sglang_dp_size = 1
+        sglang_ep_size = 8
+    else:
+        sglang_world_size = 4
+        sglang_tp_size = 4
+        sglang_dp_size = 1
+        sglang_ep_size = 4
     # MXFP8 rollout dense GEMM uses the cutlass backend and routed MoE uses
     # FlashInfer's TRT-LLM kernel (mirrors the pre-rebase MXFP8 recipe).
     if args.rollout_mxfp8:

--- a/scripts/run_deepseek_v4.py
+++ b/scripts/run_deepseek_v4.py
@@ -63,7 +63,6 @@ _MEGATRON_MODEL_TYPE = {
 _PRO_MODEL_NAMES = ("DeepSeek-V4-Pro-FP8",)
 _MXFP4_MODEL_NAMES = ("DeepSeek-V4-Flash-0731",)
 _FLASH_FULL_MODEL_NAMES = ("DeepSeek-V4-Flash-FP8", "DeepSeek-V4-Flash-0731")
-_BLACKWELL_HARDWARE = ("B200", "B300", "GB200", "GB300")
 
 _DSV4_TE_PRECISION_CONFIG = """
 configs:
@@ -191,16 +190,8 @@ class ScriptArgs(U.ExecuteTrainConfig):
         return self.bf16_name
 
 
-def _is_blackwell(args: ScriptArgs) -> bool:
-    if args.hardware != "auto":
-        return args.hardware in _BLACKWELL_HARDWARE
-
-    import torch
-
-    if not torch.cuda.is_available():
-        raise RuntimeError("Cannot auto-detect hardware because CUDA is not available. Pass --hardware explicitly.")
-    major, _minor = torch.cuda.get_device_capability()
-    return major >= 10
+def _hardware(args: ScriptArgs) -> str:
+    return U.detect_hardware() if args.hardware == "auto" else args.hardware
 
 
 def _download_dataset(args: ScriptArgs):
@@ -297,7 +288,7 @@ def _prepare_mxfp8(args: ScriptArgs):
     """
     if not args.rollout_mxfp8:
         return
-    assert _is_blackwell(args), "rollout_mxfp8 requires Blackwell (B200/B300/GB200/GB300)"
+    assert U.GENERATION_HARDWARE[_hardware(args)] == "Blackwell", "rollout_mxfp8 requires Blackwell"
     U.exec_command_gpu(
         f"python tools/convert_hf_to_mxfp8.py "
         f"--model-dir {args.model_dir}/{args.bf16_name} "
@@ -408,7 +399,6 @@ def _get_parallel_config(args: ScriptArgs) -> str:
             "--expert-tensor-parallel-size 1 "
         )
 
-    # GB300: 4 GPUs/node
     if actor_num_gpus_per_node == 4:
         if total_gpus == 32:  # 8 nodes x 4 GPUs
             return (
@@ -423,7 +413,6 @@ def _get_parallel_config(args: ScriptArgs) -> str:
                 "--expert-tensor-parallel-size 1 "
             )
 
-    # H200: 8 GPUs/node
     if actor_num_gpus_per_node == 8:
         if total_gpus == 64:  # 8 nodes x 8 GPUs
             return (
@@ -456,7 +445,7 @@ def _get_parallel_config(args: ScriptArgs) -> str:
 
 def _train(args: ScriptArgs):
     if args.train_mxfp8 or args.rollout_mxfp8:
-        assert _is_blackwell(args), "MXFP8 requires Blackwell (B200/B300/GB200/GB300)"
+        assert U.GENERATION_HARDWARE[_hardware(args)] == "Blackwell", "MXFP8 requires Blackwell"
     if not args.rollout_fp8 or args.hf_checkpoint is None or args.model_name in _MXFP4_MODEL_NAMES:
         rollout_checkpoint = f"{args.model_local_dir}/{args.rollout_name}"
         if args.hf_checkpoint != rollout_checkpoint:
@@ -560,15 +549,13 @@ def _train(args: ScriptArgs):
             "--optimizer-cpu-offload " "--use-precision-aware-optimizer " "--overlap-cpu-optimizer-d2h-h2d "
         )
 
-    is_4layer = args.model_name == "DeepSeek-V4-Flash-FP8-4layer"
-    is_gb300_profile = args.actor_num_gpus_per_node == 4 and not is_4layer
     if args.model_name == "DeepSeek-V4-Pro-FP8":
         sglang_world_size = 32
         sglang_tp_size = 32
         sglang_dp_size = 32
         sglang_ep_size = 32
-    elif is_gb300_profile:
-        # GB300, use tp=8. tp=4 causes CPU OOM when colocate
+    elif _hardware(args) in ("GB200", "GB300") and args.rollout_num_gpus >= 8:
+        # Grace, use tp=8. tp=4 causes CPU OOM when colocate
         sglang_world_size = 8
         sglang_tp_size = 8
         sglang_dp_size = 1
@@ -578,6 +565,9 @@ def _train(args: ScriptArgs):
         sglang_tp_size = 4
         sglang_dp_size = 1
         sglang_ep_size = 4
+    assert (
+        sglang_world_size <= args.rollout_num_gpus
+    ), f"a {sglang_world_size}-GPU engine cannot start on {args.rollout_num_gpus} rollout GPUs"
     # MXFP8 rollout dense GEMM uses the cutlass backend and routed MoE uses
     # FlashInfer's TRT-LLM kernel (mirrors the pre-rebase MXFP8 recipe).
     if args.rollout_mxfp8:

--- a/scripts/run_deepseek_v4.py
+++ b/scripts/run_deepseek_v4.py
@@ -454,6 +454,33 @@ def _get_parallel_config(args: ScriptArgs) -> str:
     )
 
 
+def _get_sglang_parallel_config(args: ScriptArgs) -> tuple[int, int, int, int]:
+    if args.model_name == "DeepSeek-V4-Pro-FP8":
+        config = (32, 32, 32, 32)
+    elif args.num_gpus_per_node == 4 and args.rollout_num_gpus >= 8:
+        # Span TP8 across GB300 nodes to avoid the colocated TP4 host-memory OOM.
+        config = (8, 8, 1, 8)
+    else:
+        config = (4, 4, 1, 4)
+
+    world_size, tp_size, dp_size, ep_size = config
+    if world_size > args.rollout_num_gpus:
+        raise ValueError(
+            f"SGLang rollout_num_gpus_per_engine={world_size} exceeds rollout_num_gpus={args.rollout_num_gpus}."
+        )
+    if args.rollout_num_gpus % world_size != 0:
+        raise ValueError(
+            f"rollout_num_gpus={args.rollout_num_gpus} must be divisible by "
+            f"SGLang rollout_num_gpus_per_engine={world_size}."
+        )
+    if tp_size > world_size or ep_size > world_size:
+        raise ValueError(
+            f"SGLang tp_size={tp_size} and ep_size={ep_size} must not exceed "
+            f"rollout_num_gpus_per_engine={world_size}."
+        )
+    return config
+
+
 def _train(args: ScriptArgs):
     if args.train_mxfp8 or args.rollout_mxfp8:
         assert _is_blackwell(args), "MXFP8 requires Blackwell (B200/B300/GB200/GB300)"
@@ -560,22 +587,7 @@ def _train(args: ScriptArgs):
             "--optimizer-cpu-offload " "--use-precision-aware-optimizer " "--overlap-cpu-optimizer-d2h-h2d "
         )
 
-    if args.model_name == "DeepSeek-V4-Pro-FP8":
-        sglang_world_size = 32
-        sglang_tp_size = 32
-        sglang_dp_size = 32
-        sglang_ep_size = 32
-    elif args.num_gpus_per_node == 4:
-        # GB300, use tp=8. tp=4 causes CPU OOM when colocate
-        sglang_world_size = 8
-        sglang_tp_size = 8
-        sglang_dp_size = 1
-        sglang_ep_size = 8
-    else:
-        sglang_world_size = 4
-        sglang_tp_size = 4
-        sglang_dp_size = 1
-        sglang_ep_size = 4
+    sglang_world_size, sglang_tp_size, sglang_dp_size, sglang_ep_size = _get_sglang_parallel_config(args)
     # MXFP8 rollout dense GEMM uses the cutlass backend and routed MoE uses
     # FlashInfer's TRT-LLM kernel (mirrors the pre-rebase MXFP8 recipe).
     if args.rollout_mxfp8:

--- a/scripts/run_deepseek_v4.py
+++ b/scripts/run_deepseek_v4.py
@@ -554,12 +554,10 @@ def _train(args: ScriptArgs):
         sglang_tp_size = 32
         sglang_dp_size = 32
         sglang_ep_size = 32
-    elif _hardware(args) in ("GB200", "GB300") and args.rollout_num_gpus >= 8:
-        # Grace, use tp=8. tp=4 causes CPU OOM when colocate
-        sglang_world_size = 8
-        sglang_tp_size = 8
+    elif _hardware(args) in ("GB200", "GB300"):
+        # Grace, prefer tp=8. tp=4 causes CPU OOM when colocate
+        sglang_world_size = sglang_tp_size = sglang_ep_size = min(args.rollout_num_gpus, 8)
         sglang_dp_size = 1
-        sglang_ep_size = 8
     else:
         sglang_world_size = 4
         sglang_tp_size = 4

--- a/scripts/run_gemma_4_26b_a4b.py
+++ b/scripts/run_gemma_4_26b_a4b.py
@@ -27,16 +27,18 @@ class ScriptArgs(U.ExecuteTrainConfig):
     model_org: str = "google"
     model_name: str = "gemma-4-26B-A4B-it"
     megatron_model_type: str = "gemma-4-26b-a4b-it"
-    num_gpus_per_node: int = 8
+    num_gpus_per_node: int | None = None
     enable_eval: bool = False
     num_rollout: int = 3000
     extra_args: str = ""
     data_dir: str = "/root/datasets"
     model_dir: str = "/root/models"
     megatron_path: str = "/root/Megatron-LM"
-    hardware: Literal["H200", "H100", "B200"] = "H200"
+    hardware: Literal["auto", "H200", "H100", "B200"] = "auto"
 
     def __post_init__(self):
+        self.hardware = U.resolve_hardware(self)
+        self.num_gpus_per_node = self.num_gpus_per_node or U.NUM_GPUS_OF_HARDWARE[self.hardware]
         if self.num_nodes == 1:
             self.mode = "debug_minimal"
 

--- a/scripts/run_gemma_4_31b.py
+++ b/scripts/run_gemma_4_31b.py
@@ -30,16 +30,18 @@ class ScriptArgs(U.ExecuteTrainConfig):
     model_org: str = "google"
     model_name: str = "gemma-4-31B-it"
     megatron_model_type: str = "gemma-4-31b-it"
-    num_gpus_per_node: int = 8
+    num_gpus_per_node: int | None = None
     enable_eval: bool = False
     num_rollout: int = 3000
     extra_args: str = ""
     data_dir: str = "/root/datasets"
     model_dir: str = "/root/models"
     megatron_path: str = "/root/Megatron-LM"
-    hardware: Literal["H200", "H100", "B200"] = "H200"
+    hardware: Literal["auto", "H200", "H100", "B200"] = "auto"
 
     def __post_init__(self):
+        self.hardware = U.resolve_hardware(self)
+        self.num_gpus_per_node = self.num_gpus_per_node or U.NUM_GPUS_OF_HARDWARE[self.hardware]
         if self.num_nodes == 1:
             self.mode = "debug_minimal"
 

--- a/scripts/run_glm45_355b_a32b.py
+++ b/scripts/run_glm45_355b_a32b.py
@@ -20,8 +20,8 @@ class ScriptArgs(U.ExecuteTrainConfig):
     model_org: str = "zai-org"
     model_name: str = "GLM-4.5"
     megatron_model_type: str = "glm4.5-355B-A32B"
-    num_gpus_per_node: int = 4
-    hardware: Literal["H100", "GB200", "GB300"] = "GB200"
+    num_gpus_per_node: int | None = None
+    hardware: Literal["auto", "H100", "GB200", "GB300"] = "auto"
     enable_eval: bool = True
     extra_args: str = ""
     data_dir: str = "/root/datasets"
@@ -37,6 +37,10 @@ class ScriptArgs(U.ExecuteTrainConfig):
     # TODO improve, should be able to override more easily
     tis_use_rs: bool = True
     task: Literal["dapo_aime", "gsm8k"] = "dapo_aime"
+
+    def __post_init__(self):
+        self.hardware = U.resolve_hardware(self)
+        self.num_gpus_per_node = self.num_gpus_per_node or U.NUM_GPUS_OF_HARDWARE[self.hardware]
 
 
 def _prepare_download(args: ScriptArgs):

--- a/scripts/run_glm47_flash.py
+++ b/scripts/run_glm47_flash.py
@@ -13,8 +13,8 @@ class ScriptArgs(U.ExecuteTrainConfig):
     model_org: str = "zai-org"
     model_name: str = "GLM-4.7-Flash"
     megatron_model_type: str = "glm4.7-flash"
-    num_gpus_per_node: int = 8
-    hardware: Literal["H200", "B200"] = "H200"
+    num_gpus_per_node: int | None = None
+    hardware: Literal["auto", "H200", "B200"] = "auto"
     rollout_num_gpus_per_engine: int | None = None  # None => derive from hardware
     sglang_attention_backend: str | None = None
     enable_eval: bool = True
@@ -22,6 +22,10 @@ class ScriptArgs(U.ExecuteTrainConfig):
     data_dir: str = "/root/datasets"
     model_dir: str = "/root/models"
     megatron_path: str = "/root/Megatron-LM"
+
+    def __post_init__(self):
+        self.hardware = U.resolve_hardware(self)
+        self.num_gpus_per_node = self.num_gpus_per_node or U.NUM_GPUS_OF_HARDWARE[self.hardware]
 
 
 def prepare(args: ScriptArgs):

--- a/scripts/run_glm5_2_744b_a40b.py
+++ b/scripts/run_glm5_2_744b_a40b.py
@@ -75,7 +75,7 @@ class ScriptArgs(U.ExecuteTrainConfig):
     model_org: str = "zai-org"
     model_name: str = "GLM-5.2"
     megatron_model_type: str = "glm5.2-744B-A40B"
-    num_gpus_per_node: int = 8
+    num_gpus_per_node: int | None = None
     fp8_rollout: bool = False
     use_deepep: bool = True
     megatron_use_deepep: bool = True
@@ -93,9 +93,11 @@ class ScriptArgs(U.ExecuteTrainConfig):
     model_dir: str = "/root/models"
     model_local_dir: str = "/root/models"
     megatron_path: str = "/root/Megatron-LM"
-    hardware: Literal["H200", "B200", "GB300"] = "H200"
+    hardware: Literal["auto", "H200", "B200", "GB300"] = "auto"
 
     def __post_init__(self):
+        self.hardware = U.resolve_hardware(self)
+        self.num_gpus_per_node = self.num_gpus_per_node or U.NUM_GPUS_OF_HARDWARE[self.hardware]
         if self.hardware == "GB300":
             assert not self.megatron_use_deepep, (
                 "Known issue: Megatron's DeepEP fail on GB300. " "Please specify --no-megatron-use-deepep."

--- a/scripts/run_glm5_744b_a40b.py
+++ b/scripts/run_glm5_744b_a40b.py
@@ -73,7 +73,7 @@ class ScriptArgs(U.ExecuteTrainConfig):
     model_org: str = "zai-org"
     model_name: str = "GLM-5"
     megatron_model_type: str = "glm5-744B-A40B"
-    num_gpus_per_node: int = 8
+    num_gpus_per_node: int | None = None
     fp8_rollout: bool = False
     use_deepep: bool = True
     megatron_use_deepep: bool = True
@@ -87,9 +87,11 @@ class ScriptArgs(U.ExecuteTrainConfig):
     model_dir: str = "/root/models"
     model_local_dir: str = "/root/models"
     megatron_path: str = "/root/Megatron-LM"
-    hardware: Literal["H200", "B200", "GB300"] = "H200"
+    hardware: Literal["auto", "H200", "B200", "GB300"] = "auto"
 
     def __post_init__(self):
+        self.hardware = U.resolve_hardware(self)
+        self.num_gpus_per_node = self.num_gpus_per_node or U.NUM_GPUS_OF_HARDWARE[self.hardware]
         if self.hardware == "GB300":
             assert not self.megatron_use_deepep, (
                 "Known issue: Megatron's DeepEP fail on GB300. " "Please specify --no-megatron-use-deepep."

--- a/scripts/run_joy_ai_llm_flash.py
+++ b/scripts/run_joy_ai_llm_flash.py
@@ -51,10 +51,10 @@ class ScriptArgs(U.ExecuteTrainConfig):
     model_org: str = "jdopensource"
     model_name: str = "JoyAI-LLM-Flash"
     megatron_model_type: str = "joyai-llm-flash"
-    num_gpus_per_node: int | None = 8
+    num_gpus_per_node: int | None = None
     actor_num_gpus_per_node: int | None = 4
     rollout_num_gpus: int | None = 4
-    hardware: Literal["B200", "B300", "GB200", "GB300"] = "B200"
+    hardware: Literal["auto", "B200", "B300", "GB200", "GB300"] = "auto"
     enable_eval: bool = False
     extra_args: str = ""
     data_dir: str = "/root/datasets"
@@ -74,6 +74,8 @@ class ScriptArgs(U.ExecuteTrainConfig):
     mxfp8_num_layers_at_end_in_bf16: int = 6
 
     def __post_init__(self):
+        self.hardware = U.resolve_hardware(self)
+        self.num_gpus_per_node = self.num_gpus_per_node or U.NUM_GPUS_OF_HARDWARE[self.hardware]
         if self.train_mxfp8:
             assert self.rollout_mxfp8, "train_mxfp8 requires rollout_mxfp8"
 

--- a/scripts/run_kimi_k25.py
+++ b/scripts/run_kimi_k25.py
@@ -58,16 +58,18 @@ class ScriptArgs(U.ExecuteTrainConfig):
     model_org: str = "moonshotai"
     model_name: str = "Kimi-K2.5"
     megatron_model_type: str = "kimi-k25"
-    num_gpus_per_node: int = 8
+    num_gpus_per_node: int | None = None
     enable_eval: bool = False
     num_rollout: int = 3000
     extra_args: str = ""
     data_dir: str = "/root/datasets"
     model_dir: str = "/root/models"
     megatron_path: str = "/root/Megatron-LM"
-    hardware: Literal["H200", "H100", "B200"] = "H200"
+    hardware: Literal["auto", "H200", "H100", "B200"] = "auto"
 
     def __post_init__(self):
+        self.hardware = U.resolve_hardware(self)
+        self.num_gpus_per_node = self.num_gpus_per_node or U.NUM_GPUS_OF_HARDWARE[self.hardware]
         if self.model_name == "Kimi-K2.5":
             self.model_org = "moonshotai"
             self.megatron_model_type = "kimi-k25"

--- a/scripts/run_mcore_fsdp.py
+++ b/scripts/run_mcore_fsdp.py
@@ -13,7 +13,7 @@ class ScriptArgs(U.ExecuteTrainConfig):
     colocate: bool = True
     model_name: str = "Qwen3-4B-Instruct-2507"
     num_gpus_per_node: int | None = None
-    hardware: Literal["H100", "GB300"] = "H100"
+    hardware: Literal["auto", "H100", "GB300"] = "auto"
     mode: Literal["normal", "debug_minimal"] = "normal"
     run_id: str = U.create_run_id()
     multi_eval: bool = False
@@ -27,14 +27,14 @@ class ScriptArgs(U.ExecuteTrainConfig):
     megatron_path: str = "/root/Megatron-LM"
 
     def __post_init__(self):
+        self.hardware = U.resolve_hardware(self)
+        self.num_gpus_per_node = self.num_gpus_per_node or U.NUM_GPUS_OF_HARDWARE[self.hardware]
         if self.train_backend == "megatron":
             self.megatron_model_type = {
                 "Qwen3-4B": "qwen3-4B",
                 "Qwen3-4B-Instruct-2507": "qwen3-4B-Instruct-2507",
                 "Qwen3-4B-Base": "qwen3-4B",
             }[self.model_name]
-
-        self.num_gpus_per_node = self.num_gpus_per_node or U.NUM_GPUS_OF_HARDWARE[self.hardware]
 
 
 def prepare(args: ScriptArgs):

--- a/scripts/run_nemotron_3_ultra_550b_a55b.py
+++ b/scripts/run_nemotron_3_ultra_550b_a55b.py
@@ -78,8 +78,8 @@ class ScriptArgs(U.ExecuteTrainConfig):
     model_org: str = "nvidia"
     model_name: str = FULL_MODEL_NAME
     megatron_model_type: str = "nemotron-3-ultra-550b-a55b"
-    num_gpus_per_node: int = 8
-    hardware: Literal["H200", "B200", "GB300"] = "H200"
+    num_gpus_per_node: int | None = None
+    hardware: Literal["auto", "H200", "B200", "GB300"] = "auto"
     enable_eval: bool = False
     enable_optimizer_offload: bool = True
     check_weight_update_equal: bool = False
@@ -96,6 +96,8 @@ class ScriptArgs(U.ExecuteTrainConfig):
     megatron_path: str = "/root/Megatron-LM"
 
     def __post_init__(self):
+        self.hardware = U.resolve_hardware(self)
+        self.num_gpus_per_node = self.num_gpus_per_node or U.NUM_GPUS_OF_HARDWARE[self.hardware]
         if (m := re.search(r"(\d+)layer", self.model_name)) is not None:
             self.megatron_model_type = f"nemotron-3-ultra-550b-a55b-{m.group(1)}layer"
         elif self.model_name != FULL_MODEL_NAME:

--- a/scripts/run_qwen3_30b_a3b.py
+++ b/scripts/run_qwen3_30b_a3b.py
@@ -17,7 +17,7 @@ class ScriptArgs(U.ExecuteTrainConfig):
     actor_num_gpus_per_node: int | None = None
     rollout_num_gpus: int | None = None
     no_colocate: bool = False
-    hardware: Literal["H100", "B200", "B300", "GB200", "GB300"] = "H100"
+    hardware: Literal["auto", "H100", "B200", "B300", "GB200", "GB300"] = "auto"
     enable_eval: bool = True
     extra_args: str = ""
     data_dir: str = "/root/datasets"
@@ -37,6 +37,7 @@ class ScriptArgs(U.ExecuteTrainConfig):
     tis_use_rs: bool = True
 
     def __post_init__(self):
+        self.hardware = U.resolve_hardware(self)
         self.num_gpus_per_node = self.num_gpus_per_node or U.NUM_GPUS_OF_HARDWARE[self.hardware]
         self.no_colocate = self.no_colocate or self.rollout_nvfp4
         if self.no_colocate:

--- a/scripts/run_qwen3_4b.py
+++ b/scripts/run_qwen3_4b.py
@@ -18,7 +18,7 @@ class ScriptArgs(U.ExecuteTrainConfig):
     model_name: str = "Qwen3-4B"
     megatron_model_type: str | None = None
     num_gpus_per_node: int | None = None
-    hardware: Literal["H100", "GB200", "GB300"] = "H100"
+    hardware: Literal["auto", "H100", "GB200", "GB300"] = "auto"
     extra_args: str = ""
     data_dir: str = "/root/datasets"
     model_dir: str = "/root/models"
@@ -38,10 +38,10 @@ class ScriptArgs(U.ExecuteTrainConfig):
     tis_use_rs: bool = True
 
     def __post_init__(self):
+        self.hardware = U.resolve_hardware(self)
+        self.num_gpus_per_node = self.num_gpus_per_node or U.NUM_GPUS_OF_HARDWARE[self.hardware]
         if self.train_backend == "megatron":
             self.megatron_model_type = get_megatron_model_type(self.model_name)
-
-        self.num_gpus_per_node = self.num_gpus_per_node or U.NUM_GPUS_OF_HARDWARE[self.hardware]
 
         # Derived parallelism defaults for Qwen3 dense models
         self.tensor_model_parallel_size = 1 if self.model_name == "Qwen3-0.6B" else 2

--- a/scripts/run_qwen3_5_35b_a3b_mtp.py
+++ b/scripts/run_qwen3_5_35b_a3b_mtp.py
@@ -12,8 +12,8 @@ class ScriptArgs(U.ExecuteTrainConfig):
     run_id: str = U.create_run_id()
     model_name: str = "Qwen3.5-35B-A3B"
     megatron_model_type: str = "qwen3.5-35B-A3B"
-    num_gpus_per_node: int = 8
-    hardware: Literal["H200", "B300"] = "H200"
+    num_gpus_per_node: int | None = None
+    hardware: Literal["auto", "H200", "B300"] = "auto"
     enable_eval: bool = False
     extra_args: str = ""
     data_dir: str = "/root/datasets"
@@ -28,6 +28,10 @@ class ScriptArgs(U.ExecuteTrainConfig):
     # sglang's own default (ep_size = engine tp size, max_running_requests from memory)
     sglang_ep_size: int | None = None
     sglang_max_running_requests: int | None = None
+
+    def __post_init__(self):
+        self.hardware = U.resolve_hardware(self)
+        self.num_gpus_per_node = self.num_gpus_per_node or U.NUM_GPUS_OF_HARDWARE[self.hardware]
 
 
 def prepare(args: ScriptArgs):

--- a/scripts/run_qwen3_6_35b_a3b_mtp.py
+++ b/scripts/run_qwen3_6_35b_a3b_mtp.py
@@ -18,8 +18,8 @@ class ScriptArgs(U.ExecuteTrainConfig):
     run_id: str = U.create_run_id()
     model_name: str = "Qwen3.6-35B-A3B"
     megatron_model_type: str = "qwen3.6-35B-A3B"
-    num_gpus_per_node: int = 8
-    hardware: Literal["H200"] = "H200"
+    num_gpus_per_node: int | None = None
+    hardware: Literal["auto", "H200"] = "auto"
     enable_eval: bool = False
     extra_args: str = ""
     data_dir: str = "/root/datasets"
@@ -45,6 +45,10 @@ class ScriptArgs(U.ExecuteTrainConfig):
     sglang_ep_size: int | None = None  # defaults to num_gpus_per_node
     recompute: bool = True
     skip_prepare: bool = False
+
+    def __post_init__(self):
+        self.hardware = U.resolve_hardware(self)
+        self.num_gpus_per_node = self.num_gpus_per_node or U.NUM_GPUS_OF_HARDWARE[self.hardware]
 
 
 def prepare(args: ScriptArgs):

--- a/tests/e2e/megatron/model_scripts/test_deepseek_v4_flash_4layer_ci.py
+++ b/tests/e2e/megatron/model_scripts/test_deepseek_v4_flash_4layer_ci.py
@@ -37,6 +37,7 @@ def _args() -> ScriptArgs:
         enable_eval=False,
         num_nodes=1,
         num_gpus_per_node=4,
+        hardware="H200",
         skip_saving=True,
         use_fault_tolerance=False,
         extra_args=(

--- a/tests/e2e/megatron/model_scripts/test_glm5_2_744b_a40b_5layer_ci.py
+++ b/tests/e2e/megatron/model_scripts/test_glm5_2_744b_a40b_5layer_ci.py
@@ -46,6 +46,7 @@ register_ci_gate(metric_key="rollout/raw_reward")
 
 def _args() -> ScriptArgs:
     return ScriptArgs(
+        hardware="H200",
         model_name="GLM-5.2_5layer",
         num_nodes=1,
         num_gpus_per_node=4,

--- a/tests/e2e/megatron/model_scripts/test_glm5_744b_a40b_4layer_ci.py
+++ b/tests/e2e/megatron/model_scripts/test_glm5_744b_a40b_4layer_ci.py
@@ -27,6 +27,7 @@ register_ci_gate(metric_key="rollout/raw_reward")
 
 def _args() -> ScriptArgs:
     return ScriptArgs(
+        hardware="H200",
         model_name="GLM-5_4layer",
         num_nodes=1,
         num_gpus_per_node=2,

--- a/tests/e2e/megatron/model_scripts/test_glm5_744b_a40b_4layer_r3.py
+++ b/tests/e2e/megatron/model_scripts/test_glm5_744b_a40b_4layer_r3.py
@@ -32,6 +32,7 @@ register_ci_gate(metric_key="rollout/raw_reward")
 
 def _args() -> ScriptArgs:
     return ScriptArgs(
+        hardware="H200",
         model_name="GLM-5_4layer",
         num_nodes=1,
         num_gpus_per_node=2,

--- a/tests/e2e/megatron/model_scripts/test_kimi_k25_2layer_ci.py
+++ b/tests/e2e/megatron/model_scripts/test_kimi_k25_2layer_ci.py
@@ -22,6 +22,7 @@ register_ci_gate(metric_key="rollout/raw_reward")
 
 def _args() -> ScriptArgs:
     return ScriptArgs(
+        hardware="H200",
         model_name="Kimi-K2.5-2layer",
         num_nodes=1,
         num_gpus_per_node=4,

--- a/tests/e2e/megatron/model_scripts/test_nemotron_3_ultra_4layer_ci.py
+++ b/tests/e2e/megatron/model_scripts/test_nemotron_3_ultra_4layer_ci.py
@@ -36,6 +36,7 @@ register_ci_gate(metric_key="rollout/raw_reward")
 
 def _args() -> ScriptArgs:
     return ScriptArgs(
+        hardware="H200",
         model_org="CharyZeng",
         model_name="NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16-4layer",
         mode="debug_minimal",

--- a/tests/e2e/megatron/test_joyai_llm_flash_mxfp8.py
+++ b/tests/e2e/megatron/test_joyai_llm_flash_mxfp8.py
@@ -6,6 +6,7 @@ from tests.ci.ci_register import register_cuda_ci
 register_cuda_ci(est_time=3600, suite="stage-c-8-gpu-b200", labels=["megatron"], disabled="Blackwell CI not supported")
 
 ARGS = ScriptArgs(
+    hardware="B200",
     rollout_mxfp8=True,
     train_mxfp8=True,
     ci_test=True,

--- a/tests/fast/launch_scripts/py_harness.py
+++ b/tests/fast/launch_scripts/py_harness.py
@@ -75,6 +75,19 @@ def iter_py_launch_scripts() -> list[PyLaunchScript]:
     return [PyLaunchScript(path=path, entrypoints=tuple(_entrypoint_names(path))) for path in paths]
 
 
+def launcher_hardware_literals() -> dict[str, tuple[str, ...]]:
+    """Every value each launcher's `--hardware` accepts, for the launchers that have the flag at all."""
+    literals = {}
+    for script in iter_py_launch_scripts():
+        for node in ast.walk(ast.parse(script.path.read_text())):
+            if isinstance(node, ast.AnnAssign) and getattr(node.target, "id", None) == "hardware":
+                values = node.annotation.slice
+                literals[script.rel] = tuple(
+                    e.value for e in (values.elts if isinstance(values, ast.Tuple) else [values])
+                )
+    return literals
+
+
 def iter_self_executing_launchers() -> list[Path]:
     """Launchers that reach the shell themselves rather than through command_utils."""
     roots = [REPO_ROOT / root for root in ("scripts", "examples", "tools")]
@@ -107,12 +120,12 @@ def install_shell_recorder(monkeypatch, sandbox: Path) -> Recording:
     return recording
 
 
-def freeze_environment(monkeypatch) -> None:
+def freeze_environment(monkeypatch, hardware: str = FROZEN_HARDWARE) -> None:
     for key, value in _FROZEN_ENV.items():
         monkeypatch.setenv(key, value)
     for key in CLEARED_ENV:
         monkeypatch.delenv(key, raising=False)
-    monkeypatch.setattr(command_utils, "detect_hardware", lambda: FROZEN_HARDWARE)
+    monkeypatch.setattr(command_utils, "detect_hardware", lambda: hardware)
 
 
 def install_command_recorder(monkeypatch) -> Recording:

--- a/tests/fast/launch_scripts/py_harness.py
+++ b/tests/fast/launch_scripts/py_harness.py
@@ -17,6 +17,7 @@ import miles.utils.external_utils.command_utils as command_utils
 from miles.utils.external_utils.model_args_utils import import_module_from_path
 
 FROZEN_RUN_ID = "260101-000000-000"
+FROZEN_HARDWARE = "H200"
 
 _GPU_COUNT_ANY_WAIT_LOOP_ACCEPTS = "1000000"
 _FROZEN_PID = 1000
@@ -111,6 +112,7 @@ def freeze_environment(monkeypatch) -> None:
         monkeypatch.setenv(key, value)
     for key in CLEARED_ENV:
         monkeypatch.delenv(key, raising=False)
+    monkeypatch.setattr(command_utils, "detect_hardware", lambda: FROZEN_HARDWARE)
 
 
 def install_command_recorder(monkeypatch) -> Recording:

--- a/tests/fast/launch_scripts/test_run_deepseek_v4.py
+++ b/tests/fast/launch_scripts/test_run_deepseek_v4.py
@@ -1,0 +1,54 @@
+import pytest
+
+from tests.fast.launch_scripts.py_harness import (
+    REPO_ROOT,
+    call_entrypoint,
+    freeze_environment,
+    import_launch_script,
+    install_command_recorder,
+)
+
+
+@pytest.mark.parametrize(
+    ("overrides", "expected_size"),
+    [
+        (
+            {"model_name": "DeepSeek-V4-Flash-FP8-4layer", "num_nodes": 1, "num_gpus_per_node": 4},
+            4,
+        ),
+        ({"model_name": "DeepSeek-V4-Flash-FP8", "num_nodes": 8, "num_gpus_per_node": 4}, 8),
+    ],
+)
+def test_four_gpu_node_rollout_topology_matches_available_resources(monkeypatch, tmp_path, overrides, expected_size):
+    freeze_environment(monkeypatch)
+    recording = install_command_recorder(monkeypatch)
+    module = import_launch_script(REPO_ROOT / "scripts/run_deepseek_v4.py")
+
+    call_entrypoint(module, "train", overrides, sandbox=tmp_path)
+
+    train_command = recording.commands[-1]
+    assert f"--rollout-num-gpus-per-engine {expected_size}" in train_command
+    assert f"--sglang-tp-size {expected_size}" in train_command
+    assert f"--sglang-ep-size {expected_size}" in train_command
+
+
+def test_rollout_topology_rejects_engine_larger_than_pool():
+    module = import_launch_script(REPO_ROOT / "scripts/run_deepseek_v4.py")
+    args = module.ScriptArgs(model_name="DeepSeek-V4-Pro-FP8", num_nodes=1, num_gpus_per_node=8)
+
+    with pytest.raises(
+        ValueError,
+        match="SGLang rollout_num_gpus_per_engine=32 exceeds rollout_num_gpus=8",
+    ):
+        module._get_sglang_parallel_config(args)
+
+
+def test_rollout_topology_rejects_partial_engine():
+    module = import_launch_script(REPO_ROOT / "scripts/run_deepseek_v4.py")
+    args = module.ScriptArgs(model_name="DeepSeek-V4-Flash-FP8", num_nodes=3, num_gpus_per_node=4)
+
+    with pytest.raises(
+        ValueError,
+        match="rollout_num_gpus=12 must be divisible by SGLang rollout_num_gpus_per_engine=8",
+    ):
+        module._get_sglang_parallel_config(args)

--- a/tests/fast/launch_scripts/test_run_deepseek_v4.py
+++ b/tests/fast/launch_scripts/test_run_deepseek_v4.py
@@ -12,16 +12,29 @@ from tests.fast.launch_scripts.py_harness import (
 @pytest.mark.parametrize(
     ("overrides", "expected_size"),
     [
+        ({"hardware": "H200", "num_nodes": 8, "num_gpus_per_node": 4}, 4),
+        ({"hardware": "GB300", "num_nodes": 8, "num_gpus_per_node": 4}, 8),
         (
-            {"model_name": "DeepSeek-V4-Flash-FP8-4layer", "num_nodes": 1, "num_gpus_per_node": 4},
+            {
+                "hardware": "H200",
+                "model_name": "DeepSeek-V4-Flash-FP8-4layer",
+                "num_nodes": 1,
+                "num_gpus_per_node": 4,
+            },
             4,
         ),
-        ({"model_name": "DeepSeek-V4-Flash-FP8", "num_nodes": 8, "num_gpus_per_node": 4}, 8),
+        (
+            {
+                "hardware": "GB300",
+                "model_name": "DeepSeek-V4-Flash-FP8-4layer",
+                "num_nodes": 1,
+                "num_gpus_per_node": 4,
+            },
+            4,
+        ),
     ],
 )
-def test_four_gpu_node_rollout_topology_distinguishes_4layer_from_gb300(
-    monkeypatch, tmp_path, overrides, expected_size
-):
+def test_the_rollout_profile_follows_the_hardware(monkeypatch, tmp_path, overrides, expected_size):
     freeze_environment(monkeypatch)
     recording = install_command_recorder(monkeypatch)
     module = import_launch_script(REPO_ROOT / "scripts/run_deepseek_v4.py")

--- a/tests/fast/launch_scripts/test_run_deepseek_v4.py
+++ b/tests/fast/launch_scripts/test_run_deepseek_v4.py
@@ -19,7 +19,9 @@ from tests.fast.launch_scripts.py_harness import (
         ({"model_name": "DeepSeek-V4-Flash-FP8", "num_nodes": 8, "num_gpus_per_node": 4}, 8),
     ],
 )
-def test_four_gpu_node_rollout_topology_matches_available_resources(monkeypatch, tmp_path, overrides, expected_size):
+def test_four_gpu_node_rollout_topology_distinguishes_4layer_from_gb300(
+    monkeypatch, tmp_path, overrides, expected_size
+):
     freeze_environment(monkeypatch)
     recording = install_command_recorder(monkeypatch)
     module = import_launch_script(REPO_ROOT / "scripts/run_deepseek_v4.py")
@@ -30,25 +32,3 @@ def test_four_gpu_node_rollout_topology_matches_available_resources(monkeypatch,
     assert f"--rollout-num-gpus-per-engine {expected_size}" in train_command
     assert f"--sglang-tp-size {expected_size}" in train_command
     assert f"--sglang-ep-size {expected_size}" in train_command
-
-
-def test_rollout_topology_rejects_engine_larger_than_pool():
-    module = import_launch_script(REPO_ROOT / "scripts/run_deepseek_v4.py")
-    args = module.ScriptArgs(model_name="DeepSeek-V4-Pro-FP8", num_nodes=1, num_gpus_per_node=8)
-
-    with pytest.raises(
-        ValueError,
-        match="SGLang rollout_num_gpus_per_engine=32 exceeds rollout_num_gpus=8",
-    ):
-        module._get_sglang_parallel_config(args)
-
-
-def test_rollout_topology_rejects_partial_engine():
-    module = import_launch_script(REPO_ROOT / "scripts/run_deepseek_v4.py")
-    args = module.ScriptArgs(model_name="DeepSeek-V4-Flash-FP8", num_nodes=3, num_gpus_per_node=4)
-
-    with pytest.raises(
-        ValueError,
-        match="rollout_num_gpus=12 must be divisible by SGLang rollout_num_gpus_per_engine=8",
-    ):
-        module._get_sglang_parallel_config(args)

--- a/tests/fast/true_on_policy/test_run_qwen3_4b.py
+++ b/tests/fast/true_on_policy/test_run_qwen3_4b.py
@@ -13,6 +13,7 @@ def test_qwen3_script_true_on_policy_single_knob_expands_to_megatron_contract(mo
     monkeypatch.setattr(run_qwen3_4b.U, "get_default_wandb_args", lambda *args, **kwargs: "")
 
     args = run_qwen3_4b.ScriptArgs(
+        hardware="H100",
         run_id="unit-test",
         model_name="Qwen3-4B",
         true_on_policy=True,
@@ -55,6 +56,7 @@ def test_qwen3_script_true_on_policy_tp2_cp4_normal_topology_contract(monkeypatc
     monkeypatch.setattr(run_qwen3_4b.U, "get_default_wandb_args", lambda *args, **kwargs: "")
 
     args = run_qwen3_4b.ScriptArgs(
+        hardware="H100",
         run_id="unit-test-tp2-cp4",
         model_name="Qwen3-4B",
         mode="normal",
@@ -108,6 +110,7 @@ def test_qwen3_script_off_policy_does_not_emit_true_on_policy_contract(monkeypat
     monkeypatch.setattr(run_qwen3_4b.U, "get_default_wandb_args", lambda *args, **kwargs: "")
 
     args = run_qwen3_4b.ScriptArgs(
+        hardware="H100",
         run_id="unit-test",
         model_name="Qwen3-4B",
         true_on_policy=False,

--- a/tests/fast/utils/test_command_utils.py
+++ b/tests/fast/utils/test_command_utils.py
@@ -1,4 +1,3 @@
-import ast
 import json
 import os
 import platform
@@ -7,7 +6,7 @@ import sys
 from types import SimpleNamespace
 
 import pytest
-from tests.fast.launch_scripts.py_harness import iter_py_launch_scripts
+from tests.fast.launch_scripts.py_harness import launcher_hardware_literals
 from tests.fast.utils.command_recorder import record_commands
 
 import miles.utils.external_utils.command_utils as command_utils
@@ -634,14 +633,8 @@ class TestEncodePseudoFile:
 
 
 def _hardware_launchers_accept() -> set[str]:
-    """Every value any launcher's `--hardware` takes, minus the sentinel run_deepseek_v4 resolves itself."""
-    values = set()
-    for script in iter_py_launch_scripts():
-        for node in ast.walk(ast.parse(script.path.read_text())):
-            if isinstance(node, ast.AnnAssign) and getattr(node.target, "id", None) == "hardware":
-                literal = node.annotation.slice
-                values.update(e.value for e in (literal.elts if isinstance(literal, ast.Tuple) else [literal]))
-    return values - {"auto"}
+    """Every value any launcher's `--hardware` takes, minus the sentinel that stands for "ask the node"."""
+    return set().union(*launcher_hardware_literals().values()) - {"auto"}
 
 
 class TestHardwareTables:

--- a/tests/fast/utils/test_command_utils.py
+++ b/tests/fast/utils/test_command_utils.py
@@ -1,8 +1,13 @@
+import ast
 import json
 import os
+import platform
 import shlex
+import sys
+from types import SimpleNamespace
 
 import pytest
+from tests.fast.launch_scripts.py_harness import iter_py_launch_scripts
 from tests.fast.utils.command_recorder import record_commands
 
 import miles.utils.external_utils.command_utils as command_utils
@@ -628,12 +633,84 @@ class TestEncodePseudoFile:
         assert shlex.split(f"--custom-config-path {encoded}")[1] == encoded
 
 
+def _hardware_launchers_accept() -> set[str]:
+    """Every value any launcher's `--hardware` takes, minus the sentinel run_deepseek_v4 resolves itself."""
+    values = set()
+    for script in iter_py_launch_scripts():
+        for node in ast.walk(ast.parse(script.path.read_text())):
+            if isinstance(node, ast.AnnAssign) and getattr(node.target, "id", None) == "hardware":
+                literal = node.annotation.slice
+                values.update(e.value for e in (literal.elts if isinstance(literal, ast.Tuple) else [literal]))
+    return values - {"auto"}
+
+
 class TestHardwareTables:
-    @pytest.mark.parametrize("hardware", ["H100", "GB200", "GB300", "MI350X", "MI355X"])
-    def test_every_supported_hardware_declares_its_gpus_per_node(self, hardware):
-        """A launcher whose default hardware is missing here raises KeyError before doing anything."""
-        assert command_utils.NUM_GPUS_OF_HARDWARE[hardware] > 0
+    def test_every_hardware_a_launcher_accepts_declares_its_gpus_per_node(self):
+        """A launcher whose hardware is missing here raises KeyError before doing anything."""
+        assert _hardware_launchers_accept() <= command_utils.NUM_GPUS_OF_HARDWARE.keys()
 
     def test_every_hardware_with_a_generation_also_has_a_gpu_count(self):
         """Every launcher reads the GPU count, while only some read the generation."""
         assert command_utils.GENERATION_HARDWARE.keys() <= command_utils.NUM_GPUS_OF_HARDWARE.keys()
+
+
+def _fake_torch(monkeypatch, *, capability, machine, total_memory=141 * 1024**3, name="fake", hip=None):
+    monkeypatch.setattr(platform, "machine", lambda: machine)
+    monkeypatch.setitem(
+        sys.modules,
+        "torch",
+        SimpleNamespace(
+            version=SimpleNamespace(hip=hip),
+            cuda=SimpleNamespace(
+                is_available=lambda: True,
+                get_device_name=lambda: name,
+                get_device_capability=lambda: capability,
+                get_device_properties=lambda device: SimpleNamespace(total_memory=total_memory),
+            ),
+        ),
+    )
+
+
+class TestDetectHardware:
+    @pytest.mark.parametrize(
+        ("capability", "machine", "expected"),
+        [
+            ((10, 0), "x86_64", "B200"),
+            ((10, 0), "aarch64", "GB200"),
+            ((10, 3), "x86_64", "B300"),
+            ((10, 3), "aarch64", "GB300"),
+        ],
+    )
+    def test_grace_is_what_separates_the_superchip_from_the_pcie_part(
+        self, monkeypatch, capability, machine, expected
+    ):
+        """GB200/GB300 carry the same die as B200/B300, so the host CPU is the only signal."""
+        _fake_torch(monkeypatch, capability=capability, machine=machine)
+
+        assert command_utils.detect_hardware() == expected
+
+    @pytest.mark.parametrize(("total_memory", "expected"), [(80 * 1024**3, "H100"), (141 * 1024**3, "H200")])
+    def test_hopper_is_split_by_memory(self, monkeypatch, total_memory, expected):
+        """H100 and H200 share sm90; only the HBM capacity tells them apart."""
+        _fake_torch(monkeypatch, capability=(9, 0), machine="x86_64", total_memory=total_memory)
+
+        assert command_utils.detect_hardware() == expected
+
+    def test_rocm_reads_the_device_name(self, monkeypatch):
+        _fake_torch(monkeypatch, capability=(9, 5), machine="x86_64", name="AMD Instinct MI355X", hip="6.4")
+
+        assert command_utils.detect_hardware() == "MI355X"
+
+    def test_an_unrecognized_device_asks_for_an_explicit_hardware(self, monkeypatch):
+        """Silently guessing the wrong profile costs a whole run; a launcher flag is one word."""
+        _fake_torch(monkeypatch, capability=(12, 0), machine="x86_64", name="NVIDIA GeForce RTX 5090")
+
+        with pytest.raises(AssertionError, match="pass --hardware"):
+            command_utils.detect_hardware()
+
+    def test_every_detectable_hardware_is_a_table_entry(self, monkeypatch):
+        """A detected name the tables do not carry is a KeyError at the first lookup."""
+        for capability in ((9, 0), (10, 0), (10, 3)):
+            for machine in ("x86_64", "aarch64"):
+                _fake_torch(monkeypatch, capability=capability, machine=machine)
+                assert command_utils.detect_hardware() in command_utils.NUM_GPUS_OF_HARDWARE

--- a/tests/manual/launch_scripts/test_py_launch_scripts.py
+++ b/tests/manual/launch_scripts/test_py_launch_scripts.py
@@ -7,6 +7,7 @@ import pytest
 
 from tests.fast.launch_scripts.py_harness import (
     CLEARED_ENV,
+    FROZEN_HARDWARE,
     call_entrypoint,
     format_recording,
     freeze_environment,
@@ -14,6 +15,7 @@ from tests.fast.launch_scripts.py_harness import (
     import_launch_script,
     install_command_recorder,
     iter_py_launch_scripts,
+    launcher_hardware_literals,
 )
 from tests.fast.launch_scripts.sh_harness import REPO_ROOT, assert_matches_snapshot
 
@@ -63,6 +65,19 @@ _SCRIPTS_WHOSE_DEFAULTS_ARE_UNSUPPORTED: dict[str, Callable[[Path], dict[str, ob
     },
 }
 
+# The machine each recording represents. Launchers default --hardware to whatever node they run on, so the
+# suite pins one; FROZEN_HARDWARE covers the rest.
+_HARDWARE_A_RECORDING_REPRESENTS = {
+    "scripts/amd/run_qwen3_30b_a3b.py": "MI355X",
+    "scripts/amd/run_qwen3_4b.py": "MI355X",
+    "scripts/run_deepseek_v32.py": "B200",
+    "scripts/run_glm45_355b_a32b.py": "GB200",
+    "scripts/run_joy_ai_llm_flash.py": "B200",
+    "scripts/run_mcore_fsdp.py": "H100",
+    "scripts/run_qwen3_30b_a3b.py": "H100",
+    "scripts/run_qwen3_4b.py": "H100",
+}
+
 _ENTRYPOINTS_DISABLED_BY_THEIR_OWN_DEFAULTS = {
     ("scripts/run_deepseek_v4.py", "prepare_mxfp8"),
     ("scripts/run_deepseek_v4.py", "prepare_fp8"),
@@ -77,7 +92,7 @@ _CASES = [(script.rel, entrypoint) for script in _SCRIPTS for entrypoint in scri
 @pytest.fixture(params=_CASES, ids=[f"{rel}::{entrypoint}" for rel, entrypoint in _CASES])
 def recorded(request, monkeypatch, tmp_path):
     rel, entrypoint = request.param
-    freeze_environment(monkeypatch)
+    freeze_environment(monkeypatch, hardware=_HARDWARE_A_RECORDING_REPRESENTS.get(rel, FROZEN_HARDWARE))
     recording = install_command_recorder(monkeypatch)
     module = import_launch_script(REPO_ROOT / rel)
     call_entrypoint(
@@ -150,6 +165,20 @@ class TestDiscovery:
         """Once the NPU patch is upstreamed this fails, forcing the exclusion out instead of letting it rot."""
         with pytest.raises(ImportError, match="execute_train_npu"):
             import_launch_script(REPO_ROOT / rel)
+
+    def test_every_pinned_recording_names_a_launcher_that_accepts_that_hardware(self):
+        """A pin the launcher does not accept records a profile nobody can run, and a stale key pins nothing."""
+        literals = launcher_hardware_literals()
+
+        assert _HARDWARE_A_RECORDING_REPRESENTS.keys() <= literals.keys()
+        for rel, hardware in _HARDWARE_A_RECORDING_REPRESENTS.items():
+            assert hardware in literals[rel], rel
+
+    def test_a_launcher_the_frozen_default_covers_is_not_pinned_as_well(self):
+        """Two ways to say the same thing drift apart; only the launchers FROZEN_HARDWARE cannot serve get a pin."""
+        redundant = {rel for rel, hardware in _HARDWARE_A_RECORDING_REPRESENTS.items() if hardware == FROZEN_HARDWARE}
+
+        assert not redundant
 
     def test_every_environment_knob_a_model_script_reads_is_frozen(self):
         """The snapshots now pin expanded model args, so a developer's exported override would fail them."""


### PR DESCRIPTION
## Summary

Make `--hardware` the single source for a launcher's machine profile: it defaults to detecting the node it runs on, and `num_gpus_per_node` follows from it.

Stacked on #2735 — the first three commits are that PR. Review from `ca4fcba01`.

## Problem

Every launcher hardcodes two things about the machine:

```python
num_gpus_per_node: int = 8
hardware: Literal["H200", "B200", "GB300"] = "H200"
```

Two ways to get a silently wrong profile out of that:

1. **Forget `--hardware`.** You get whichever machine the recipe was first written on. #2735 is one instance of the same class — a 4-GPU H200 smoke test took the Grace TP8 rollout profile and hung at `4/8 clients joined`.
2. **Pass `--hardware GB300` but not `--num-gpus-per-node 4`.** The topology is still sized for 8 GPUs per node.

## Fix

`--hardware` defaults to `"auto"`, resolved once in `__post_init__`:

```python
self.hardware = U.resolve_hardware(self)
self.num_gpus_per_node = self.num_gpus_per_node or U.NUM_GPUS_OF_HARDWARE[self.hardware]
```

`detect_hardware()` (added in #2735) maps the node to a `NUM_GPUS_OF_HARDWARE` key: compute capability picks the generation, the host CPU separates Grace from the x86 part carrying the same die, HBM capacity splits H100 from H200. `resolve_hardware()` additionally rejects a hardware the launcher declares no profile for, rather than letting a `match args.hardware` fall through it:

```
AssertionError: ScriptArgs has no verified profile for B200
```

An explicit `--hardware` still overrides, and an explicit `--num-gpus-per-node` still wins over the derivation — that is how a job takes four GPUs of an eight-GPU node.

## Scope

19 launchers declare `hardware`; all of them change. The 33 that do not keep their literal, because there `num_gpus_per_node` is often a deliberate partial node (`run_qwen3_0_6b_fsdp` takes 4, `examples/verifiers` takes 2) rather than the machine's shape.

## Verification

The replaced literals were all consistent — **every launcher that declares `hardware` hardcoded exactly `NUM_GPUS_OF_HARDWARE[its default hardware]`**, 13/13, so this is behavior-preserving at the default:

```
script                                     hw default  gpus  NUM[hw]
scripts/run_deepseek_v32.py                B200           8        8
scripts/run_glm45_355b_a32b.py             GB200          4        4
scripts/run_glm5_744b_a40b.py              H200           8        8
...                                        (13/13 match; 6 more already derived)
```

- `tests/manual/launch_scripts/test_py_launch_scripts.py`: **snapshots unchanged**, 182 passed (the 8 failures and 4 errors are the same set as on `main` in this checkout, all under `scripts/amd/**` and `run_kimi_k25`).
- `tests/fast/utils/test_command_utils.py` + `tests/fast/launch_scripts/test_run_deepseek_v4.py`: 80 passed.
- `pre-commit run --files <changed>`: passed.

Two new tests keep the recording pins honest: every pinned hardware must be one the launcher accepts, and a launcher the frozen default already covers may not be pinned twice.

## Review focus

- `resolve_hardware()` reads the supported set off the field's `Literal` — that is the one piece of reflection here.
- `_HARDWARE_A_RECORDING_REPRESENTS` in the snapshot suite: a launcher that reads the node cannot be recorded on a CPU runner, so the suite states which machine each recording is.
- `detect_hardware()`'s capability table is **not yet verified on real hardware** (sm_103 for B300/GB300, `aarch64` for Grace are derived from the architecture, not measured). Worth one run on a B300 / GB300 / H200 node before merge.
