### PR TITLE
Skip non-numeric rewards in the episode average

### DIFF
--- a/miles/ray/rollout/metrics.py
+++ b/miles/ray/rollout/metrics.py
@@ -1,4 +1,5 @@
 import logging
+from numbers import Number
 from typing import Any
 
 import numpy as np
@@ -155,7 +156,8 @@ def _compute_training_sample_metrics(args: Any, samples: list[Sample]) -> dict[s
             rollout_key = ("position", sample.group_index, position)
 
         raw_reward = sample.metadata["raw_reward"] if use_metadata_reward else sample.get_reward_value(args)
-        rewards_by_rollout.setdefault(rollout_key, []).append(raw_reward)
+        if isinstance(raw_reward, Number):
+            rewards_by_rollout.setdefault(rollout_key, []).append(raw_reward)
 
     rollout_rewards = [sum(rewards) / len(rewards) for rewards in rewards_by_rollout.values()]
     return {


### PR DESCRIPTION
`_compute_training_sample_metrics` (#2710) averages each rollout's raw reward. With
`--reward-key` unset, `Sample.get_reward_value` returns whatever the custom reward
function produced — on-policy distillation returns the teacher's scoring response —
so `sum(rewards)` raised `TypeError: unsupported operand type(s) for +: 'int' and 'dict'`
and took the whole rollout down.

Those rows still count towards `num_training_samples`; they are only left out of the
average.

Repro: `tests/e2e/short/test_qwen2.5_0.5B_opd_sglang.py`, which runs
`--custom-rm-path miles.rollout.on_policy_distillation.reward_func` without
`--reward-key`. Seen in [run 32803020540](https://github.com/radixark/miles/actions/runs/32803020540),
job `stage-c-8-gpu-h100 (0) / run`. #2710 landed after main's last CI run, so main has
not exercised this path yet.

There is nothing to read out of that dict: it holds the teacher's per-token log-probs,
which `post_process_rewards` turns into `teacher_log_probs` / `opd_reverse_kl`. OPD's
own scalar reward is defined as `0.0` ("the learning signal comes entirely from the OPD
KL penalty"), but that is OPD's private convention — a shared metric helper should not
assume it holds for every custom reward function that returns a mapping. The cleaner
convergence is for OPD to publish its scalar in `metadata["raw_reward"]`, which this
function already prefers, so it would never reach the check added here.

Note also that the metrics run before `post_process_rewards`, which returns rewards
rather than writing them back, so this function always sees the raw dict.
