### PR TITLE
  fix(swe-agent): flush all session-server instances on abort

### DIFF
--- a/examples/swe-agent-harbor-docker/swe_agent_function.py
+++ b/examples/swe-agent-harbor-docker/swe_agent_function.py
@@ -144,8 +144,13 @@ async def abort(args) -> None:
     available.
     """
     agent_server_url = os.getenv("AGENT_SERVER_URL", os.getenv("SWE_AGENT_URL"))
-    instance_id = getattr(args, "session_server_instance_id", None)
-    if not agent_server_url or not instance_id:
+
+    instance_ids = set((getattr(args, "session_server_instance_ids", None) or {}).values())
+    singular = getattr(args, "session_server_instance_id", None)  # back-compat / child path
+    if singular:
+        instance_ids.add(singular)
+
+    if not agent_server_url or not instance_ids:
         return
 
     headers = None
@@ -153,13 +158,14 @@ async def abort(args) -> None:
     if admin_secret:
         headers = {"Authorization": f"Bearer {admin_secret}"}
 
-    try:
-        result = await post(
-            f"{agent_server_url.rstrip('/')}/flush",
-            {"session_server_instance_id": instance_id},
-            max_retries=3,
-            headers=headers,
-        )
-        logger.info(f"Flushed agent server {agent_server_url}: {result}")
-    except Exception as e:
-        logger.warning(f"Failed to flush agent server {agent_server_url}: {e}")
+    for instance_id in instance_ids:
+        try:
+            result = await post(
+                f"{agent_server_url.rstrip('/')}/flush",
+                {"session_server_instance_id": instance_id},
+                max_retries=3,
+                headers=headers,
+            )
+            logger.info(f"Flushed agent server {agent_server_url}: {result}")
+        except Exception as e:
+            logger.warning(f"Failed to flush agent server {agent_server_url}: {e}")


### PR DESCRIPTION
 ## Background:
In multi-turn agentic flows, the LLM interacts with the agent to complete the task. After the LLM-agent interaction process, the model is evaluated for its work and reward is scored. This happens on the CPU side. 

In miles, when using default oversampling with _GroupLevelScheduler_ during rollout, an entire batch of tasks are issued even if one task gets cancelled. This is so that issuing more tasks enables us to select the fastest completing tasks for our training batch and discard the others by sending and abort() signal.

 It is necessary that any in-flight aborts reach the task CPU process too. If not, rollout may be gated by the long running CPU processes making oversampling irrelavant. 
 
## Issue Description :
Currently the swe_agent_function.py defines abort() to kill in-flight harbor trials but the http FLUSH signal never reaches Harbor.
 This is because, the session server's instance ID is wrongly fetched. 
 
## Code fix summary: 
- Read the plural session_server_instance_ids map from the driver args and flush each one, keeping the singular attribute  as a backward-compatibility fallback.
 - Previously abort() read only the singular attribute, which was always _None_ on the driver, so the flush was silently skipped.
  
## Performance Impact: 
With this fix, multi-turn perf/rollout_time for Qwen3-Coder-30B on a subset of tasks from the SWE-Gym significantly improved with default oversampling. 
   
 Measured over one training run for one step and once with PR and without:
- perf/rollout_time: 1789.8s  to 1080.5s i.e. 39.6% faster 
- abort → drain tail: 877.9s to 21.4 s i.e. 97.6% faster (time spent waiting for trial's CPU verification to finish)
- train_wait: 1861.3s to 1143.5s i.e. 38.6%  faster

## Task subset to reproduce: 
dask__dask-7305, fake__nonexistent-task-0001, iterative__dvc-3527, conan-io__conan-13721, python__mypy-11434, getmoto__moto-7111, pandas-dev__pandas-53958, python__mypy-11857,
  facebookresearch__hydra-1824, getmoto__moto-7584, getmoto__moto-6226, getmoto__moto-6121, python__mypy-15413, getmoto__moto-5701, conan-io__conan-11560, python__mypy-15131
  
 Note the fake__nonexistent-task-0001 whose _TaskNotFound_ error will trigger oversampling but without this PR, rollout is gated by the longest running task _dask__dask-7305_