### PR TITLE
fix(args): require delay-split train data with --indep-dp

### DIFF
--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -2877,6 +2877,10 @@ def miles_validate_args(args):
         assert (
             args.train_backend == "megatron"
         ), f"indep_dp requires train_backend='megatron', got '{args.train_backend}'"
+        assert args.delay_split_train_data_by_dp, (
+            "--indep-dp requires --delay-split-train-data-by-dp: each cell trains on its own data-parallel "
+            "size, so the actor publishes no shared dp_size for the rollout manager to split train data by."
+        )
         per_replica_size = compute_megatron_world_size_except_dp(args)
         logger.info(f"indep_dp: adjusting args.world_size from {args.world_size} to {per_replica_size} (per-cell)")
         args.world_size = per_replica_size

--- a/tests/fast/utils/test_arguments.py
+++ b/tests/fast/utils/test_arguments.py
@@ -715,6 +715,43 @@ class TestResolveFtComponents:
         assert result is not components
 
 
+class TestIndepDpValidation:
+    def _parse(self, extra):
+        parser = argparse.ArgumentParser()
+        get_miles_extra_args_provider()(parser)
+        args = parser.parse_args(extra + ["--num-rollout", "1"] + REQUIRED_ARGS)
+        # Megatron owns these; the miles-only parser above never defines them.
+        vars(args).update(
+            tensor_model_parallel_size=1,
+            pipeline_model_parallel_size=1,
+            context_parallel_size=1,
+            world_size=1,
+        )
+        return args
+
+    def test_rejects_indep_dp_without_delay_split(self):
+        args = self._parse(["--indep-dp"])
+
+        with pytest.raises(AssertionError, match="--indep-dp requires --delay-split-train-data-by-dp"):
+            miles_validate_args(args)
+
+    def test_accepts_indep_dp_with_delay_split(self):
+        args = self._parse(["--indep-dp", "--delay-split-train-data-by-dp"])
+
+        miles_validate_args(args)
+
+        assert args.indep_dp is True
+        assert args.delay_split_train_data_by_dp is True
+
+    def test_ft_components_train_auto_sets_both_flags(self):
+        args = self._parse(["--use-fault-tolerance", "--ft-components", "train"])
+
+        miles_validate_args(args)
+
+        assert args.indep_dp is True
+        assert args.delay_split_train_data_by_dp is True
+
+
 @pytest.mark.parametrize(
     ("parallel_args", "expected"),
     [


### PR DESCRIPTION
## Summary

- `--indep-dp` without `--delay-split-train-data-by-dp` crashes at the first training handoff with a bare `KeyError: 'dp_size'`.
- Add one assertion in `miles_validate_args` so the run fails at argument validation with a message that names both flags and says why.
- Add three tests covering the rejected combination, the working combination, and the `--ft-components train` auto-set path.

## Context

`--indep-dp` and `--delay-split-train-data-by-dp` are independent flags. `miles_validate_args` sets both only when `train` is in `--ft-components` (`miles/utils/arguments.py:2859-2861`), so `--indep-dp` passed on its own leaves `delay_split_train_data_by_dp` at its `False` default.

Under `--indep-dp` the Megatron actor publishes an empty `train_parallel_config` (`miles/backends/megatron_utils/actor.py:150-158`): each cell trains with its own data-parallel size, so there is no shared `dp_size` to advertise. With `delay_split_train_data_by_dp` `False` the rollout manager takes the eager path (`miles/ray/rollout/rollout_manager.py:165-168`) and calls `split_train_data_by_dp`, which falls through to `train_parallel_config["dp_size"]` (`miles/ray/rollout/train_data_conversion.py:283`). The empty dict fails the `has_full_schedule_config` guard at `miles/utils/dp_schedule.py:20-25`, so the scheduled branch is skipped and the legacy branch raises.

`--delay-split-train-data-by-dp` is the configuration that works under `--indep-dp`: the split moves to the training side, where `process_rollout_data` takes `dp_size` from the cell's own parallel state (`miles/utils/data.py:302-307`, fed by `miles/backends/training_utils/data.py:42-48`) and never reads `train_parallel_config`.

The existing `if args.indep_dp:` block only asserted `train_backend == "megatron"`.

Review this change as one commit: c88cfd243eef9402f62eed3c7f1cd364e68cae82.

## Description

- `miles/utils/arguments.py`: assert `args.delay_split_train_data_by_dp` inside the existing `if args.indep_dp:` block in `miles_validate_args`, after the existing `train_backend` assertion.
- `tests/fast/utils/test_arguments.py`: add `TestIndepDpValidation` with three cases. `--indep-dp` alone raises the new assertion; `--indep-dp --delay-split-train-data-by-dp` passes validation; `--use-fault-tolerance --ft-components train` still auto-sets both flags and passes.
- The test helper fills in `tensor_model_parallel_size`, `pipeline_model_parallel_size`, `context_parallel_size`, and `world_size`, which Megatron owns and the miles-only parser does not define.

## Test plan

Head SHA: c88cfd243eef9402f62eed3c7f1cd364e68cae82

- [x] `pytest tests/fast/utils/test_arguments.py -q` at c88cfd243eef9402f62eed3c7f1cd364e68cae82: 142 passed, 2 failed. Both failures (`test_sglang_parallel_sizes_keep_server_args_destinations`, `TestEvalSglangOverrides::test_tp_size_is_not_exposed`) are environmental and reproduce on the parent commit.
- [x] Red before green: with the tests added and the assertion reverted, `test_rejects_indep_dp_without_delay_split` fails with `DID NOT RAISE`, and the other two pass.
- [x] `ruff 0.14.7 check`, `black 24.3.0 --check`, `isort 5.13.2 --check-only` on both changed files: clean.

## Risks and follow-ups

- This rejects a configuration that previously parsed. No launch script, example, or test in the repo passes `--indep-dp` without `--delay-split-train-data-by-dp`, so nothing in tree changes behavior. An out-of-tree run using that combination was already crashing at the first training handoff.
- `--use-dynamic-global-batch-size` reads the same missing key through a different path: `_compute_dynamic_global_batch_size` at `miles/ray/rollout/rollout_data_conversion.py:91`. That call runs from `postprocess_rollout_data` (`miles/ray/rollout/rollout_manager.py:260-262`) regardless of `delay_split_train_data_by_dp`, so this change does not cover it. `--indep-dp` with `--use-dynamic-global-batch-size` still raises `KeyError: 'dp_size'`. Left for a separate change, since the fix there is a behavior decision about what global batch size an indep-dp run should pick.

https://claude.ai/code/session_01EPSNDKV1Uzx5Acqg6TPxpg
