### PR TITLE
fix: align nightly CI schedule and OPD reward metrics

### DIFF
--- a/.github/workflows/pr-test-rocm.yml
+++ b/.github/workflows/pr-test-rocm.yml
@@ -29,8 +29,8 @@ on:
     types: [opened, synchronize, reopened, ready_for_review, labeled]
   schedule:
     # Same UTC nightly/weekly split as pr-test.yml; ci_policy.py maps each exact cron.
-    - cron: '0 15 * * 0-5'
-    - cron: '0 15 * * 6'
+    - cron: '0 14 * * 0-5'
+    - cron: '0 14 * * 6'
   workflow_dispatch:
     inputs:
       ci_megatron_pr:

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -7,8 +7,8 @@ on:
     types: [opened, synchronize, reopened, ready_for_review, labeled, closed]
   schedule:
     # All scheduled runs use UTC. Saturday's weekly full CI replaces nightly.
-    - cron: '0 15 * * 0-5'
-    - cron: '0 15 * * 6'
+    - cron: '0 14 * * 0-5'
+    - cron: '0 14 * * 6'
   workflow_dispatch:
     inputs:
       infinite_run:

--- a/docs/ci/00-stage.md
+++ b/docs/ci/00-stage.md
@@ -49,7 +49,7 @@ Distinct from image selection, the **`run-ci-image` label** selects the test sco
 - `pull_request`, `schedule`, and `workflow_dispatch` only say how the workflow started; none itself implies a cadence or domain scope.
 - Each Miles PR workflow passes trigger facts and, for PRs, the diff to `tests/ci/ci_policy.py`, which publishes the resolved policy and `skipped_stages` for `run_suite.py` and GPU job gates.
 - A PR `nightly` label maps to nightly cadence.
-- A scheduled run maps its exact UTC `github.event.schedule` cron: `0 15 * * 0-5` maps to nightly and `0 15 * * 6` maps to weekly; an unknown cron fails.
+- A scheduled run maps its exact UTC `github.event.schedule` cron: `0 14 * * 0-5` maps to nightly and `0 14 * * 6` maps to weekly; an unknown cron fails.
 - A manual dispatch keeps regular cadence and has no PR labels. Both GPU workflows add `--match-all-labels` so an explicit manual operation runs the full regular GPU suites; CPU selection remains unchanged.
 - A reusable `workflow_call` supplies an explicit cadence override because the called workflow inherits the caller's event name. Policy resolution deliberately runs the caller commit's `ci_policy.py`; only suite jobs check out the requested release ref.
 

--- a/docs/ci/01-label.md
+++ b/docs/ci/01-label.md
@@ -130,7 +130,7 @@ Release and weekly have the same selection and fast-fail policy. Release is sepa
 
 Rows are in precedence order: when scope signals overlap, the higher row wins (`run-ci-all` > weekly/release full scope > nightly > `run-ci-image`, the branch order of `resolve_policy`). `run-ci-all` widens only the domain scope; regular cadence still does not admit `nightly=True` registrations.
 
-The generic triggers carry no policy. All scheduled runs use UTC: nightly is identified by the exact cron `0 15 * * 0-5`, and weekly by `0 15 * * 6`. Saturday weekly replaces that day's nightly rather than starting alongside it. A manual dispatch uses regular cadence and no PR labels; the GPU workflow commands explicitly add `--match-all-labels` so that operation runs the full regular GPU suites without changing cadence. A called workflow instead supplies its cadence explicitly, which is how `release-branch-cut.yml` selects release.
+The generic triggers carry no policy. All scheduled runs use UTC: nightly is identified by the exact cron `0 14 * * 0-5`, and weekly by `0 14 * * 6`. Saturday weekly replaces that day's nightly rather than starting alongside it. A manual dispatch uses regular cadence and no PR labels; the GPU workflow commands explicitly add `--match-all-labels` so that operation runs the full regular GPU suites without changing cadence. A called workflow instead supplies its cadence explicitly, which is how `release-branch-cut.yml` selects release.
 
 A subtraction is not a per-test veto — it only stops that label from granting inclusion. A test carrying a subtracted label still runs when another of its labels is in the set, so a test that must stay outside the standard nightly scope must carry only labels that nightly subtracts.
 

--- a/miles/ray/rollout/metrics.py
+++ b/miles/ray/rollout/metrics.py
@@ -69,7 +69,7 @@ def log_eval_skip(rollout_id, args, reason: str):
     tracking.log(args, log_dict, step_key="eval/step")
 
 
-def log_rollout_data(rollout_id, args, samples, rollout_extra_metrics, rollout_time):
+def log_rollout_data(rollout_id, args, samples, rollout_extra_metrics, rollout_time, raw_rewards=None):
     if (x := args.custom_rollout_log_function_path) is not None:
         custom_log_func = load_function(x)
         if custom_log_func(rollout_id, args, samples, rollout_extra_metrics, rollout_time):
@@ -79,7 +79,7 @@ def log_rollout_data(rollout_id, args, samples, rollout_extra_metrics, rollout_t
         return
 
     log_dict = {**(rollout_extra_metrics or {})}
-    log_dict |= dict_add_prefix(_compute_metrics_from_samples(args, samples), "rollout/")
+    log_dict |= dict_add_prefix(_compute_metrics_from_samples(args, samples, raw_rewards=raw_rewards), "rollout/")
     log_dict |= dict_add_prefix(_compute_perf_metrics_from_samples(args, samples, rollout_time), "perf/")
     if args.log_passrate:
         log_dict |= dict_add_prefix(
@@ -92,11 +92,11 @@ def log_rollout_data(rollout_id, args, samples, rollout_extra_metrics, rollout_t
     tracking.log(args, log_dict, step_key="rollout/step")
 
 
-def _compute_metrics_from_samples(args, samples):
+def _compute_metrics_from_samples(args, samples, raw_rewards=None):
     response_lengths = [sample.effective_response_length for sample in samples]
 
     log_dict = {}
-    log_dict |= _compute_training_sample_metrics(args, samples)
+    log_dict |= _compute_training_sample_metrics(args, samples, raw_rewards=raw_rewards)
     log_dict |= dict_add_prefix(compute_statistics(response_lengths), "response_len/")
     log_dict |= _compute_zero_std_metrics(args, samples)
     log_dict |= _compute_spec_metrics(args, samples)
@@ -136,7 +136,9 @@ def _compute_metrics_from_samples(args, samples):
     return log_dict
 
 
-def _compute_training_sample_metrics(args: Any, samples: list[Sample]) -> dict[str, float | int]:
+def _compute_training_sample_metrics(
+    args: Any, samples: list[Sample], raw_rewards: list[float] | None = None
+) -> dict[str, float | int]:
     """Count training rows and average raw reward with equal weight per rollout.
 
     Session compaction can turn one rollout into several training samples. The
@@ -145,8 +147,15 @@ def _compute_training_sample_metrics(args: Any, samples: list[Sample]) -> dict[s
     metric weight merely because they produced more samples.
     """
     rewards_by_rollout: dict[tuple[str, int | None, int], list[float]] = {}
-    use_metadata_reward = bool(samples and samples[0].metadata and "raw_reward" in samples[0].metadata)
-    for position, sample in enumerate(samples):
+    if raw_rewards is not None:
+        assert len(raw_rewards) == len(samples)
+    else:
+        use_metadata_reward = bool(samples and samples[0].metadata and "raw_reward" in samples[0].metadata)
+        raw_rewards = [
+            sample.metadata["raw_reward"] if use_metadata_reward else sample.get_reward_value(args)
+            for sample in samples
+        ]
+    for position, (sample, raw_reward) in enumerate(zip(samples, raw_rewards, strict=True)):
         if sample.rollout_id is not None:
             rollout_key = ("rollout", sample.group_index, sample.rollout_id)
         elif sample.index is not None:
@@ -154,7 +163,6 @@ def _compute_training_sample_metrics(args: Any, samples: list[Sample]) -> dict[s
         else:
             rollout_key = ("position", sample.group_index, position)
 
-        raw_reward = sample.metadata["raw_reward"] if use_metadata_reward else sample.get_reward_value(args)
         rewards_by_rollout.setdefault(rollout_key, []).append(raw_reward)
 
     rollout_rewards = [sum(rewards) / len(rewards) for rewards in rewards_by_rollout.values()]

--- a/miles/ray/rollout/rollout_manager.py
+++ b/miles/ray/rollout/rollout_manager.py
@@ -151,15 +151,23 @@ class RolloutManager:
         if (get_buffer_length := getattr(self.data_source, "get_buffer_length", None)) is not None:
             dashboard_hooks.report_data_buffer(get_buffer_length())
         with timer("rollout"):
-            data, metadata, metrics = await self._get_rollout_data(rollout_id=rollout_id)
-        save_debug_rollout_data(self.args, data, rollout_id=rollout_id, evaluation=False, metadata=metadata)
-        log_rollout_data(rollout_id, self.args, data, metrics, time.time() - start_time)
+            samples, metadata, metrics = await self._get_rollout_data(rollout_id=rollout_id)
+        rollout_time = time.time() - start_time
+        save_debug_rollout_data(self.args, samples, rollout_id=rollout_id, evaluation=False, metadata=metadata)
         data = convert_samples_to_train_data(
             self.args,
-            data,
+            samples,
             metadata=metadata,
             custom_convert_samples_to_train_data_func=self.custom_convert_samples_to_train_data_func,
             custom_reward_post_process_func=self.custom_reward_post_process_func,
+        )
+        log_rollout_data(
+            rollout_id,
+            self.args,
+            samples=samples,
+            rollout_extra_metrics=metrics,
+            rollout_time=rollout_time,
+            raw_rewards=data.get("raw_reward"),
         )
         sample_indices = data.get("sample_indices")
         if self.args.delay_split_train_data_by_dp:

--- a/tests/ci/ci_policy.py
+++ b/tests/ci/ci_policy.py
@@ -26,8 +26,8 @@ CI_CADENCES = frozenset({REGULAR_CADENCE, NIGHTLY_CADENCE, WEEKLY_CADENCE, RELEA
 # A scheduled trigger has no policy by itself. Each configured cron must map
 # explicitly so a future cadence cannot silently inherit nightly behavior.
 SCHEDULE_POLICIES: dict[str, tuple[str, tuple[str, ...]]] = {
-    "0 15 * * 0-5": (NIGHTLY_CADENCE, ()),
-    "0 15 * * 6": (WEEKLY_CADENCE, ()),
+    "0 14 * * 0-5": (NIGHTLY_CADENCE, ()),
+    "0 14 * * 6": (WEEKLY_CADENCE, ()),
 }
 
 

--- a/tests/ci/test/test_ci_policy.py
+++ b/tests/ci/test/test_ci_policy.py
@@ -48,8 +48,8 @@ register_cpu_ci(est_time=1, suite="stage-a-cpu", labels=[])
             ("run-ci-megatron", "nightly", "run-ci-megatron", "run-ci-a_B.c-d"),
             True,
         ),
-        ("schedule", "0 15 * * 0-5", "not JSON", NIGHTLY_CADENCE, (), True),
-        ("schedule", "0 15 * * 6", "not JSON", WEEKLY_CADENCE, (), True),
+        ("schedule", "0 14 * * 0-5", "not JSON", NIGHTLY_CADENCE, (), True),
+        ("schedule", "0 14 * * 6", "not JSON", WEEKLY_CADENCE, (), True),
         ("workflow_dispatch", "", "not JSON", REGULAR_CADENCE, (), False),
     ],
 )
@@ -87,7 +87,7 @@ def test_unknown_trigger_is_rejected():
 
 def test_nightly_label_and_nightly_schedule_share_the_same_run_policy():
     labeled = resolve_workflow_inputs("pull_request", "", '["nightly"]')
-    scheduled = resolve_workflow_inputs("schedule", "0 15 * * 0-5", "not JSON")
+    scheduled = resolve_workflow_inputs("schedule", "0 14 * * 0-5", "not JSON")
 
     assert resolve_policy(labeled.cadence, set(labeled.raw_labels)) == resolve_policy(
         scheduled.cadence, set(scheduled.raw_labels)
@@ -95,7 +95,7 @@ def test_nightly_label_and_nightly_schedule_share_the_same_run_policy():
 
 
 def test_weekly_schedule_resolves_to_independent_full_policy():
-    scheduled = resolve_workflow_inputs("schedule", "0 15 * * 6", "not JSON")
+    scheduled = resolve_workflow_inputs("schedule", "0 14 * * 6", "not JSON")
     policy = resolve_policy(scheduled.cadence, set(scheduled.raw_labels))
 
     assert policy.cadence == WEEKLY_CADENCE

--- a/tests/ci/test/test_run_suite.py
+++ b/tests/ci/test/test_run_suite.py
@@ -387,10 +387,10 @@ class TestWorkflowScopeSeam:
         configured = set(re.findall(r"^\s+- cron: ['\"]([^'\"]+)['\"]\s*$", workflow, flags=re.MULTILINE))
         assert configured == set(SCHEDULE_POLICIES)
 
-    def test_scheduled_runs_use_utc_1500(self):
+    def test_scheduled_runs_use_utc_1400(self):
         workflow = self._workflow()
-        assert "    - cron: '0 15 * * 0-5'" in workflow
-        assert "    - cron: '0 15 * * 6'" in workflow
+        assert "    - cron: '0 14 * * 0-5'" in workflow
+        assert "    - cron: '0 14 * * 6'" in workflow
         assert "timezone:" not in workflow
 
     def test_weekly_serializes_each_gpu_matrix(self):
@@ -473,8 +473,8 @@ class TestRocmWorkflowScopeSeam:
         assert "pull_request_target:" not in workflow
         configured = set(re.findall(r"^\s+- cron: ['\"]([^'\"]+)['\"]\s*$", workflow, flags=re.MULTILINE))
         assert configured == set(SCHEDULE_POLICIES)
-        assert "    - cron: '0 15 * * 0-5'" in workflow
-        assert "    - cron: '0 15 * * 6'" in workflow
+        assert "    - cron: '0 14 * * 0-5'" in workflow
+        assert "    - cron: '0 14 * * 6'" in workflow
         assert "timezone:" not in workflow
 
         policy_block = workflow.split("resolve-ci-policy:", 1)[1].split("resolve-ci-image:", 1)[0]

--- a/tests/fast/ray/rollout/test_metrics.py
+++ b/tests/fast/ray/rollout/test_metrics.py
@@ -64,6 +64,17 @@ class TestTrainingSampleMetrics:
 
         assert out == {"num_training_samples": 2, "episode_raw_reward": pytest.approx(0.5)}
 
+    def test_post_processed_rewards_override_structured_sample_rewards(self):
+        args = make_args(reward_key=None)
+        samples = [
+            make_sample(index=0, reward={"teacher": {"meta_info": {}}}),
+            make_sample(index=1, reward={"teacher": {"meta_info": {}}}),
+        ]
+
+        out = _compute_training_sample_metrics(args, samples, raw_rewards=[0.0, 0.0])
+
+        assert out == {"num_training_samples": 2, "episode_raw_reward": 0.0}
+
     def test_empty_samples(self):
         assert _compute_training_sample_metrics(make_args(), []) == {
             "num_training_samples": 0,


### PR DESCRIPTION
## Summary
Move nightly CI to 14:00 UTC and prevent OPD metrics from summing structured rewards.

## Symptom & Reproduction
- **Symptom:** Scheduled CUDA job [`stage-c-8-gpu-h100 (0) / run`](https://github.com/radixark/miles/actions/runs/32864895802/job/97860709994) failed at `f2b7c79298a53c53861514d099f7def73bd29f4a` in `test_qwen2.5_0.5B_opd_sglang.py` with `TypeError: unsupported operand type(s) for +: 'int' and 'dict'`.
- **Schedule:** CUDA and ROCm nightly workflows still started at 15:00 UTC instead of 14:00 UTC.
- **Reproduction:** `_compute_training_sample_metrics` received OPD teacher-response dictionaries before `post_process_rewards`; it attempted to average them as numbers instead of using the expected scalar `0.0` rewards.

## Root Cause
1. `RolloutManager.generate` logged samples before reward post-processing.
2. `_compute_training_sample_metrics` summed OPD teacher payloads as floats.
3. `pr-test*.yml` and `SCHEDULE_POLICIES` still encoded 15:00 UTC.

## Fix
Convert samples before standard rollout logging and pass the conversion-owned scalar `raw_reward` into training-sample metrics while preserving structured OPD payloads and rollout timing. Update both GPU workflow crons, their exact policy mapping, tests, and governing CI documentation to 14:00 UTC.

## Verification
- `python3 -m pytest -q tests/fast/ray/rollout/test_metrics.py tests/ci/test/test_ci_policy.py tests/ci/test/test_run_suite.py`: 130 passed on `miles-h200-dev-2` against the final combined snapshot.
- `tests/e2e/short/test_qwen2.5_0.5B_opd_sglang.py`: Ray job `raysubmit_SXzs8T7xEKxU9N9H` succeeded with two `rollout/episode_raw_reward: 0.0` emissions and no original `TypeError`; the OPD files are byte-identical in the final branch.
- `pre-commit run --files <10 changed paths>` and `git diff --check`: all applicable checks passed.

## Review Focus
- `_compute_training_sample_metrics`: scalar reward ownership without interpreting structured OPD payloads.
- `RolloutManager.generate`: reward conversion ordering while preserving the rollout timing boundary.
- `.github/workflows/pr-test*.yml` / `SCHEDULE_POLICIES`: exact CUDA and ROCm cron-policy agreement.
