### PR TITLE
fix(ci): exempt .claude skill tooling from the test-discovery rule

### DIFF
--- a/tests/ci/test/test_ci_discovery_coverage.py
+++ b/tests/ci/test/test_ci_discovery_coverage.py
@@ -56,8 +56,7 @@ def _test_files_outside_the_tests_tree() -> list[str]:
         if path
         # .claude/ holds agent-skill tooling whose test suites are run by the
         # skill's own workflow, not by the CI runners this rule guards.
-        and not path.startswith(("tests/", ".claude/"))
-        and PurePosixPath(path).name.startswith("test_")
+        and not path.startswith(("tests/", ".claude/")) and PurePosixPath(path).name.startswith("test_")
     )
 
 

--- a/tests/ci/test/test_ci_discovery_coverage.py
+++ b/tests/ci/test/test_ci_discovery_coverage.py
@@ -53,7 +53,11 @@ def _test_files_outside_the_tests_tree() -> list[str]:
     return sorted(
         path
         for path in listing.split("\0")
-        if path and not path.startswith("tests/") and PurePosixPath(path).name.startswith("test_")
+        if path
+        # .claude/ holds agent-skill tooling whose test suites are run by the
+        # skill's own workflow, not by the CI runners this rule guards.
+        and not path.startswith(("tests/", ".claude/"))
+        and PurePosixPath(path).name.startswith("test_")
     )
 
 


### PR DESCRIPTION
main is red since #1890: the mechanical-refactor-verify skill update added its internal test suites under `.claude/skills/.../scripts/tests/`, and `test_no_test_file_lives_outside_the_tests_tree` flags all 25 files on every PR's merge ref. These suites are exercised by the skill's own workflow, not by the CI runners this rule guards, so `.claude/` joins `tests/` in the path exemption.