### PR TITLE
Add Qwen 3.6 chess RL example

### DIFF
--- a/examples/experimental/chess/README.md
+++ b/examples/experimental/chess/README.md
@@ -1,0 +1,72 @@
+# Chess RL with TITO v2
+
+This experimental recipe trains `Qwen3.6-35B-A3B` with GRPO on games against
+Stockfish. Each game is one stateful Miles TITO v2 session. The chess harness
+owns the board, move validation, Stockfish opponent, compaction, replay journal,
+and reward; Miles owns policy serving, exact training samples, optimization,
+telemetry, and session cleanup.
+
+The recipe temporarily uses Miles' `qwen35` TITO family for Qwen 3.6. This is
+useful for testing because Qwen 3.5 and Qwen 3.6 share the relevant message
+boundaries and thinking format, but production Qwen 3.6 training should move to
+a dedicated, verified TITO family when one is available.
+
+## Default smoke configuration
+
+- One node with eight H200 GPUs.
+- Ten GRPO steps.
+- Eight prompts per step and eight trajectories per prompt: 64 games per step.
+- Four prompts assign the policy White and four assign it Black.
+- Stockfish Elo 1320.
+- Eight policy moves per game.
+- Training parallelism follows Miles' tested long-context Qwen layout:
+  TP2, CP2, EP8, PP1, and ETP1.
+- Qwen thinking is enabled and retained in subsequent turns.
+- TITO v2 keeps post-compaction trajectory segments trainable.
+- Full training and rollout entropy, Miles dashboard, Prometheus, W&B when
+  `WANDB_API_KEY` is present, full Miles traces, and chess replay journals.
+- W&B defaults to team `ch271828n-team`, project `miles-chess_run`, and a run
+  name equal to the reproducible run ID. Both team and project are configurable.
+- No checkpoint is saved by default. A full Qwen 3.6 checkpoint is roughly
+  464 GB; pass `--save-checkpoint` only when that artifact is wanted.
+
+The turn-cap reward is `1.0` when the final Stockfish score from the policy's
+perspective is positive and `0.0` otherwise. Games ending normally keep the
+harness rewards: win `1.0`, draw `0.0`, loss `-1.0`, infrastructure error `0.0`.
+Groups containing aborted or infrastructure-error games are rejected and
+resampled rather than trained as chess failures.
+
+## Launch
+
+Use a current Miles checkout and provide a reproducible run ID:
+
+```bash
+python examples/experimental/chess/run.py \
+    --run-id 260825-deadbeef \
+    --output-dir /scratch \
+    --num-rollout 10 \
+    --rollout-batch-size 8 \
+    --n-samples-per-prompt 8 \
+    --max-model-turns 8
+```
+
+Preparation downloads and converts `Qwen/Qwen3.6-35B-A3B`, installs Stockfish,
+checks out the pinned radix_raft chess harness, and installs its Python package.
+Use `--skip-prepare` only after those artifacts are present.
+
+When a verified Hugging Face checkpoint already exists on shared storage, pass
+it with `--hf-checkpoint-path` and put `--model-dir` on a filesystem large
+enough for the converted Megatron checkpoint. The source checkpoint is reused
+without downloading or modifying it.
+
+Run artifacts are grouped under `/scratch/<run-id>/`:
+
+- `chess_prompts.jsonl`: eight balanced prompt records.
+- `chess_games/`: complete chess replay journals and summaries.
+- `traces/`: Miles rollout and model traces.
+- `checkpoints/`: present only with `--save-checkpoint`.
+
+The default 65,536-token Miles limit, 8,192-token response allowance, and
+10,000-token reserve make the chess harness compact its active conversation at
+47,344 input tokens. Original generations remain in the replay journal, while
+TITO v2 returns the trainable trajectory segments created around compaction.

--- a/examples/experimental/chess/README.md
+++ b/examples/experimental/chess/README.md
@@ -62,6 +62,9 @@ without downloading or modifying it.
 Run artifacts are grouped under `/scratch/<run-id>/`:
 
 - `chess_prompts.jsonl`: eight balanced prompt records.
+- `run_manifest.json`: exact launcher arguments, configuration, source
+  revisions, container digest, and immutable snapshot references. Secret values
+  are never written.
 - `chess_games/`: complete chess replay journals and summaries.
 - `traces/`: Miles rollout and model traces.
 - `checkpoints/`: present only with `--save-checkpoint`.

--- a/examples/experimental/chess/README.md
+++ b/examples/experimental/chess/README.md
@@ -54,6 +54,10 @@ Preparation downloads and converts `Qwen/Qwen3.6-35B-A3B`, installs Stockfish,
 checks out the pinned radix_raft chess harness, and installs its Python package.
 Use `--skip-prepare` only after those artifacts are present.
 
+If the node cannot authenticate to the radix_raft remote, transfer a complete
+Git checkout to `--radix-raft-dir` before launching. Preparation reuses the
+pinned revision when it already exists locally and only fetches it when absent.
+
 When a verified Hugging Face checkpoint already exists on shared storage, pass
 it with `--hf-checkpoint-path` and put `--model-dir` on a filesystem large
 enough for the converted Megatron checkpoint. The source checkpoint is reused

--- a/examples/experimental/chess/README.md
+++ b/examples/experimental/chess/README.md
@@ -65,6 +65,19 @@ chess agent itself. This bounds the complete engine lifetime, not just the
 startup burst. Increase `--stockfish-max-concurrent-games` only after a real
 load probe succeeds on the target host.
 
+Run the same 64-game, two-engine-per-game load envelope without model inference:
+
+```bash
+PYTHONPATH=examples/experimental/chess python \
+    examples/experimental/chess/stockfish_load_probe.py \
+    --num_games 64 \
+    --max_concurrent_games 16 \
+    --stockfish_timeout_seconds 20
+```
+
+The probe starts, configures, and exercises both engines in every game, reports
+the peak number of live engines, and fails if any Stockfish process remains.
+
 If the node cannot authenticate to the radix_raft remote, transfer a complete
 Git checkout to `--radix-raft-dir` before launching. Preparation reuses the
 pinned revision when it already exists locally and only fetches it when absent.

--- a/examples/experimental/chess/README.md
+++ b/examples/experimental/chess/README.md
@@ -16,6 +16,10 @@ a dedicated, verified TITO family when one is available.
 - One node with eight H200 GPUs.
 - Ten GRPO steps.
 - Eight prompts per step and eight trajectories per prompt: 64 games per step.
+- At most 16 games run simultaneously. The remaining trajectories queue, which
+  limits the node to 32 resident Stockfish processes because each active game
+  owns one opponent engine and one independent review engine.
+- Stockfish gets 20 seconds to start and complete its UCI handshake.
 - Four prompts assign the policy White and four assign it Black.
 - Stockfish Elo 1320.
 - Eight policy moves per game.
@@ -47,12 +51,19 @@ python examples/experimental/chess/run.py \
     --num-rollout 10 \
     --rollout-batch-size 8 \
     --n-samples-per-prompt 8 \
-    --max-model-turns 8
+    --max-model-turns 8 \
+    --stockfish-max-concurrent-games 16 \
+    --stockfish-startup-timeout-seconds 20
 ```
 
 Preparation downloads and converts `Qwen/Qwen3.6-35B-A3B`, installs Stockfish,
 checks out the pinned radix_raft chess harness, and installs its Python package.
 Use `--skip-prepare` only after those artifacts are present.
+
+The launcher applies the game limit both in Miles' rollout scheduler and in the
+chess agent itself. This bounds the complete engine lifetime, not just the
+startup burst. Increase `--stockfish-max-concurrent-games` only after a real
+load probe succeeds on the target host.
 
 If the node cannot authenticate to the radix_raft remote, transfer a complete
 Git checkout to `--radix-raft-dir` before launching. Preparation reuses the

--- a/examples/experimental/chess/chess_agent.py
+++ b/examples/experimental/chess/chess_agent.py
@@ -1,5 +1,7 @@
 """Qwen 3.5 TITO adapter for one chess rollout."""
 
+import asyncio
+import weakref
 from collections.abc import Mapping
 from typing import Any
 
@@ -9,6 +11,39 @@ _REQUIRED_CHAT_TEMPLATE_KWARGS: dict[str, bool] = {
     "clear_thinking": False,
     "enable_thinking": True,
 }
+_DEFAULT_STOCKFISH_MAX_CONCURRENT_GAMES = 16
+_GAME_LIMITERS: weakref.WeakKeyDictionary[
+    asyncio.AbstractEventLoop,
+    tuple[int, asyncio.Semaphore],
+] = weakref.WeakKeyDictionary()
+
+
+def _stockfish_max_concurrent_games(metadata: Mapping[str, Any] | None) -> int:
+    chess_options = (metadata or {}).get("chess", {})
+    if not isinstance(chess_options, Mapping):
+        raise TypeError("metadata.chess must be a mapping")
+    value = chess_options.get(
+        "stockfish_max_concurrent_games",
+        _DEFAULT_STOCKFISH_MAX_CONCURRENT_GAMES,
+    )
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TypeError("metadata.chess.stockfish_max_concurrent_games must be an integer")
+    if value < 1:
+        raise ValueError("metadata.chess.stockfish_max_concurrent_games must be at least 1")
+    return value
+
+
+def _game_limiter(limit: int) -> asyncio.Semaphore:
+    loop = asyncio.get_running_loop()
+    existing = _GAME_LIMITERS.get(loop)
+    if existing is None:
+        limiter = asyncio.Semaphore(limit)
+        _GAME_LIMITERS[loop] = (limit, limiter)
+        return limiter
+    configured_limit, limiter = existing
+    if configured_limit != limit:
+        raise ValueError("stockfish_max_concurrent_games must be consistent within one rollout loop")
+    return limiter
 
 
 def _request_with_thinking(request_kwargs: Mapping[str, Any] | None) -> dict[str, Any]:
@@ -35,10 +70,13 @@ async def run(
 ) -> dict[str, Any]:
     """Run one game while preserving Qwen thinking in the TITO conversation."""
 
-    return await run_chess(
-        base_url=base_url,
-        prompt=prompt,
-        request_kwargs=_request_with_thinking(request_kwargs),
-        metadata=dict(metadata or {}),
-        **kwargs,
-    )
+    metadata_values = dict(metadata or {})
+    limit = _stockfish_max_concurrent_games(metadata_values)
+    async with _game_limiter(limit):
+        return await run_chess(
+            base_url=base_url,
+            prompt=prompt,
+            request_kwargs=_request_with_thinking(request_kwargs),
+            metadata=metadata_values,
+            **kwargs,
+        )

--- a/examples/experimental/chess/chess_agent.py
+++ b/examples/experimental/chess/chess_agent.py
@@ -1,0 +1,44 @@
+"""Qwen 3.5 TITO adapter for one chess rollout."""
+
+from collections.abc import Mapping
+from typing import Any
+
+from chess_eval.tito_v2 import run as run_chess
+
+_REQUIRED_CHAT_TEMPLATE_KWARGS: dict[str, bool] = {
+    "clear_thinking": False,
+    "enable_thinking": True,
+}
+
+
+def _request_with_thinking(request_kwargs: Mapping[str, Any] | None) -> dict[str, Any]:
+    request = dict(request_kwargs or {})
+    existing = request.get("chat_template_kwargs", {})
+    if not isinstance(existing, Mapping):
+        raise TypeError("request_kwargs.chat_template_kwargs must be a mapping")
+
+    merged = dict(existing)
+    for key, required_value in _REQUIRED_CHAT_TEMPLATE_KWARGS.items():
+        if key in merged and merged[key] != required_value:
+            raise ValueError(f"chat_template_kwargs.{key} must be {required_value!r}")
+        merged[key] = required_value
+    request["chat_template_kwargs"] = merged
+    return request
+
+
+async def run(
+    base_url: str,
+    prompt: Any,
+    request_kwargs: dict[str, Any] | None = None,
+    metadata: dict[str, Any] | None = None,
+    **kwargs: Any,
+) -> dict[str, Any]:
+    """Run one game while preserving Qwen thinking in the TITO conversation."""
+
+    return await run_chess(
+        base_url=base_url,
+        prompt=prompt,
+        request_kwargs=_request_with_thinking(request_kwargs),
+        metadata=dict(metadata or {}),
+        **kwargs,
+    )

--- a/examples/experimental/chess/chess_filter.py
+++ b/examples/experimental/chess/chess_filter.py
@@ -1,0 +1,38 @@
+"""Dynamic-sampling filter for chess rollout groups."""
+
+from collections.abc import Iterable, Iterator, Mapping
+from typing import Any
+
+from miles.rollout.filter_hub.base_types import DynamicFilterOutput
+from miles.utils.types import Sample
+
+
+def _flatten_samples(samples: Iterable[Sample | list[Sample]]) -> Iterator[Sample]:
+    for item in samples:
+        if isinstance(item, list):
+            yield from item
+        else:
+            yield item
+
+
+def _chess_outcome(sample: Sample) -> object:
+    result = sample.metadata.get("chess_result")
+    return result.get("outcome") if isinstance(result, Mapping) else None
+
+
+def check_chess_group(
+    args: Any,
+    samples: list[Sample | list[Sample]],
+    **kwargs: Any,
+) -> DynamicFilterOutput:
+    """Reject groups containing aborted, unscored, or infrastructure-error games."""
+
+    del args, kwargs
+    flattened = list(_flatten_samples(samples))
+    if any(sample.status == Sample.Status.ABORTED for sample in flattened):
+        return DynamicFilterOutput(keep=False, reason="group_has_aborted")
+    if any(sample.reward is None for sample in flattened):
+        return DynamicFilterOutput(keep=False, reason="group_has_unscored_game")
+    if any(_chess_outcome(sample) == "error" for sample in flattened):
+        return DynamicFilterOutput(keep=False, reason="group_has_chess_infrastructure_error")
+    return DynamicFilterOutput(keep=True)

--- a/examples/experimental/chess/run.py
+++ b/examples/experimental/chess/run.py
@@ -85,7 +85,7 @@ class ScriptArgs(U.ExecuteTrainConfig):
     cp: int = 2
     pp: int = 1
     etp: int = 1
-    max_tokens_per_gpu: int = 32768
+    max_tokens_per_gpu: int = 8192
 
     sglang_mem_fraction_static: float = 0.7
     sglang_ep_size: int = 8

--- a/examples/experimental/chess/run.py
+++ b/examples/experimental/chess/run.py
@@ -41,7 +41,7 @@ import miles.utils.external_utils.command_utils as U
 
 _SCRIPT_DIR = Path(__file__).resolve().parent
 _RADIX_RAFT_REPOSITORY = "https://github.com/radixark/radix_raft.git"
-_RADIX_RAFT_REVISION = "6f1eb6d873d96ca5bf1f63bf9b1b102d833d9c71"
+_RADIX_RAFT_REVISION = "28a92796516e5192f8899466025f1de19c774c5f"
 
 
 @dataclass
@@ -73,6 +73,8 @@ class ScriptArgs(U.ExecuteTrainConfig):
     stockfish_elo: int = 1320
     max_model_turns: int = 8
     max_plies: int = 200
+    stockfish_startup_timeout_seconds: float = 20.0
+    stockfish_max_concurrent_games: int = 16
     stockfish_move_time_seconds: float = 0.2
     stockfish_review_time_seconds: float = 0.2
     compaction_trigger_tokens: int = 131072
@@ -103,6 +105,10 @@ class ScriptArgs(U.ExecuteTrainConfig):
     def __post_init__(self) -> None:
         self.hardware = U.resolve_hardware(self)
         self.num_gpus_per_node = self.num_gpus_per_node or U.NUM_GPUS_OF_HARDWARE[self.hardware]
+        if self.stockfish_startup_timeout_seconds <= 0:
+            raise ValueError("stockfish_startup_timeout_seconds must be positive")
+        if self.stockfish_max_concurrent_games < 1:
+            raise ValueError("stockfish_max_concurrent_games must be at least 1")
 
 
 def _run_dir(args: ScriptArgs) -> Path:
@@ -197,6 +203,8 @@ def _prompt_rows(args: ScriptArgs) -> list[dict[str, object]]:
                         "max_plies": args.max_plies,
                         "stockfish_elo": args.stockfish_elo,
                         "stockfish_path": args.stockfish_path,
+                        "stockfish_startup_timeout_seconds": args.stockfish_startup_timeout_seconds,
+                        "stockfish_max_concurrent_games": args.stockfish_max_concurrent_games,
                         "stockfish_move_time_seconds": args.stockfish_move_time_seconds,
                         "stockfish_review_time_seconds": args.stockfish_review_time_seconds,
                         "stockfish_threads": 1,
@@ -301,6 +309,7 @@ def _sglang_args(args: ScriptArgs) -> str:
         f"--sglang-mem-fraction-static {args.sglang_mem_fraction_static} "
         f"--sglang-ep-size {args.sglang_ep_size} "
         f"--sglang-max-running-requests {args.sglang_max_running_requests} "
+        f"--sglang-server-concurrency {args.stockfish_max_concurrent_games} "
         f"--sglang-router-port {args.sglang_router_port} "
         "--sglang-reasoning-parser qwen3 "
         "--sglang-tool-call-parser qwen3_coder "

--- a/examples/experimental/chess/run.py
+++ b/examples/experimental/chess/run.py
@@ -225,7 +225,7 @@ def _prepare_chess_environment(args: ScriptArgs) -> None:
     U.exec_command_cpu(f"git -C {args.radix_raft_dir} cat-file -e {args.radix_raft_revision}^{{commit}} || git -C {args.radix_raft_dir} fetch origin {args.radix_raft_revision}")
     U.exec_command_cpu(f"git -C {args.radix_raft_dir} checkout --detach {args.radix_raft_revision}")
     chess_package = Path(args.radix_raft_dir) / "experiments" / "shi" / "chess_eval"
-    U.exec_command_cpu(f"uv pip install --system -e {chess_package}")
+    U.exec_command_cpu(f"uv pip install --system --break-system-packages -e {chess_package}")
 
 
 def _prepare_model(args: ScriptArgs) -> None:

--- a/examples/experimental/chess/run.py
+++ b/examples/experimental/chess/run.py
@@ -222,7 +222,7 @@ def _prepare_chess_environment(args: ScriptArgs) -> None:
     U.exec_command_cpu("apt-get update")
     U.exec_command_cpu("DEBIAN_FRONTEND=noninteractive apt-get install -y stockfish")
     U.exec_command_cpu(f"test -d {args.radix_raft_dir}/.git || git clone {_RADIX_RAFT_REPOSITORY} {args.radix_raft_dir}")
-    U.exec_command_cpu(f"git -C {args.radix_raft_dir} fetch origin {args.radix_raft_revision}")
+    U.exec_command_cpu(f"git -C {args.radix_raft_dir} cat-file -e {args.radix_raft_revision}^{{commit}} || git -C {args.radix_raft_dir} fetch origin {args.radix_raft_revision}")
     U.exec_command_cpu(f"git -C {args.radix_raft_dir} checkout --detach {args.radix_raft_revision}")
     chess_package = Path(args.radix_raft_dir) / "experiments" / "shi" / "chess_eval"
     U.exec_command_cpu(f"uv pip install --system -e {chess_package}")

--- a/examples/experimental/chess/run.py
+++ b/examples/experimental/chess/run.py
@@ -26,7 +26,12 @@ Example:
 """
 
 import json
-from dataclasses import dataclass, field
+import os
+import platform
+import subprocess
+import sys
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Literal
 
@@ -92,6 +97,7 @@ class ScriptArgs(U.ExecuteTrainConfig):
     prometheus_port: int = 9090
     wandb_team: str = "ch271828n-team"
     wandb_project: str = "miles-chess_run"
+    container_image_digest: str = ""
     extra_args: str = ""
 
     def __post_init__(self) -> None:
@@ -123,6 +129,52 @@ def _hf_checkpoint(args: ScriptArgs) -> Path:
     if args.hf_checkpoint_path is not None:
         return Path(args.hf_checkpoint_path)
     return Path(args.model_dir) / args.model_name
+
+
+def _git_revision(path: Path) -> str | None:
+    result = subprocess.run(
+        ["git", "-C", str(path), "rev-parse", "HEAD"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip() if result.returncode == 0 else None
+
+
+def _write_run_manifest(args: ScriptArgs) -> None:
+    path = _run_dir(args) / "run_manifest.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    manifest = {
+        "run_id": args.run_id,
+        "created_at_utc": datetime.now(timezone.utc).isoformat(),
+        "host": platform.node(),
+        "configuration": asdict(args),
+        "launch_argv": sys.argv,
+        "train_args": _build_train_args(args),
+        "environment": {
+            **_extra_env_vars(args),
+            "WANDB_API_KEY": "present" if os.environ.get("WANDB_API_KEY") else "missing",
+        },
+        "versions": {
+            "miles": _git_revision(Path(U.repo_base_dir)),
+            "sglang": _git_revision(Path("/sgl-workspace/sglang")),
+            "megatron_lm": _git_revision(Path(args.megatron_path)),
+            "radix_raft": _git_revision(Path(args.radix_raft_dir)) or args.radix_raft_revision,
+            "container_image_digest": args.container_image_digest or None,
+        },
+        "snapshot_refs": {
+            "miles": f"refs/training-runs/{args.run_id}/miles",
+            "sglang": f"refs/training-runs/{args.run_id}/sglang",
+            "megatron_lm": f"refs/training-runs/{args.run_id}/megatron-lm",
+            "radix_raft": f"refs/training-runs/{args.run_id}/radix-raft",
+        },
+    }
+    temporary_path = path.with_suffix(".json.tmp")
+    temporary_path.write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    temporary_path.replace(path)
 
 
 def _prompt_rows(args: ScriptArgs) -> list[dict[str, object]]:
@@ -325,6 +377,7 @@ def _prepare(args: ScriptArgs) -> None:
     _write_prompt_data(args)
     _prepare_chess_environment(args)
     _prepare_model(args)
+    _write_run_manifest(args)
 
 
 def _execute(args: ScriptArgs) -> None:
@@ -342,6 +395,7 @@ def _execute(args: ScriptArgs) -> None:
 def main(args: ScriptArgs) -> None:
     if args.skip_prepare:
         _write_prompt_data(args)
+        _write_run_manifest(args)
     else:
         _prepare(args)
     _execute(args)

--- a/examples/experimental/chess/run.py
+++ b/examples/experimental/chess/run.py
@@ -1,0 +1,351 @@
+"""Train Qwen3.6-35B-A3B on chess games through Miles TITO v2.
+
+The launcher adapts Miles' full-parameter Qwen3.6 MTP/EAGLE recipe to the
+replayable chess harness in radix_raft. Each prompt owns one TITO v2 session and
+one chess game. The default smoke configuration performs ten GRPO steps with
+eight prompts and eight independent trajectories per prompt.
+
+Qwen 3.5 TITO is selected intentionally as a temporary compatibility surface
+for Qwen 3.6. The fixed template retains thinking and supports the user and
+assistant turns emitted by the chess harness.
+
+Args:
+    run_id: Reproducible identifier for outputs and telemetry.
+    max_model_turns: Maximum policy moves in each game.
+    save_checkpoint: Save the large full-parameter checkpoint at the final step.
+    skip_prepare: Reuse an already prepared model and chess environment.
+
+Example:
+    python examples/experimental/chess/run.py \
+        --run-id 260825-deadbeef \
+        --output-dir /scratch \
+        --num-rollout 10 \
+        --rollout-batch-size 8 \
+        --n-samples-per-prompt 8 \
+        --max-model-turns 8
+"""
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Literal
+
+import typer
+
+import miles.utils.external_utils.command_utils as U
+
+_SCRIPT_DIR = Path(__file__).resolve().parent
+_RADIX_RAFT_REPOSITORY = "https://github.com/radixark/radix_raft.git"
+_RADIX_RAFT_REVISION = "6f1eb6d873d96ca5bf1f63bf9b1b102d833d9c71"
+
+
+@dataclass
+class ScriptArgs(U.ExecuteTrainConfig):
+    run_id: str = field(default_factory=U.create_run_id)
+    model_name: str = "Qwen3.6-35B-A3B"
+    megatron_model_type: str = "qwen3.6-35B-A3B"
+    hardware: Literal["auto", "H200"] = "auto"
+    num_gpus_per_node: int | None = None
+    megatron_path: str = "/root/Megatron-LM"
+
+    skip_prepare: bool = False
+    model_dir: str = "/root/models"
+    hf_checkpoint_path: str | None = None
+    radix_raft_dir: str = "/root/radix_raft"
+    radix_raft_revision: str = _RADIX_RAFT_REVISION
+    output_dir: str = "/scratch"
+    stockfish_path: str = "/usr/games/stockfish"
+
+    num_rollout: int = 10
+    rollout_batch_size: int = 8
+    n_samples_per_prompt: int = 8
+    global_batch_size: int = 64
+    rollout_temperature: float = 0.8
+    rollout_top_p: float = 0.95
+    rollout_max_response_len: int = 8192
+    max_seq_len: int = 65536
+
+    stockfish_elo: int = 1320
+    max_model_turns: int = 8
+    max_plies: int = 200
+    stockfish_move_time_seconds: float = 0.2
+    stockfish_review_time_seconds: float = 0.2
+    compaction_trigger_tokens: int = 131072
+    compaction_reserve_tokens: int = 10000
+
+    tp: int = 2
+    ep: int = 8
+    cp: int = 2
+    pp: int = 1
+    etp: int = 1
+    max_tokens_per_gpu: int = 32768
+
+    sglang_mem_fraction_static: float = 0.7
+    sglang_ep_size: int = 8
+    sglang_max_running_requests: int = 256
+    session_server_port: int = 30000
+    sglang_router_port: int = 31000
+
+    save_checkpoint: bool = False
+    save_interval: int = 10
+    use_prometheus: bool = True
+    prometheus_port: int = 9090
+    wandb_team: str = "ch271828n-team"
+    wandb_project: str = "miles-chess_run"
+    extra_args: str = ""
+
+    def __post_init__(self) -> None:
+        self.hardware = U.resolve_hardware(self)
+        self.num_gpus_per_node = self.num_gpus_per_node or U.NUM_GPUS_OF_HARDWARE[self.hardware]
+
+
+def _run_dir(args: ScriptArgs) -> Path:
+    return Path(args.output_dir) / args.run_id
+
+
+def _prompt_data_path(args: ScriptArgs) -> Path:
+    return _run_dir(args) / "chess_prompts.jsonl"
+
+
+def _chess_output_dir(args: ScriptArgs) -> Path:
+    return _run_dir(args) / "chess_games"
+
+
+def _trace_dir(args: ScriptArgs) -> Path:
+    return _run_dir(args) / "traces"
+
+
+def _checkpoint_dir(args: ScriptArgs) -> Path:
+    return _run_dir(args) / "checkpoints"
+
+
+def _hf_checkpoint(args: ScriptArgs) -> Path:
+    if args.hf_checkpoint_path is not None:
+        return Path(args.hf_checkpoint_path)
+    return Path(args.model_dir) / args.model_name
+
+
+def _prompt_rows(args: ScriptArgs) -> list[dict[str, object]]:
+    rows: list[dict[str, object]] = []
+    for prompt_index in range(args.rollout_batch_size):
+        llm_side = "white" if prompt_index % 2 == 0 else "black"
+        rows.append(
+            {
+                "prompt": [
+                    {
+                        "role": "user",
+                        "content": "Play one complete chess rollout using the attached chess configuration.",
+                    }
+                ],
+                "metadata": {
+                    "chess_prompt_index": prompt_index,
+                    "chess": {
+                        "llm_side": llm_side,
+                        "max_model_turns": args.max_model_turns,
+                        "max_plies": args.max_plies,
+                        "stockfish_elo": args.stockfish_elo,
+                        "stockfish_path": args.stockfish_path,
+                        "stockfish_move_time_seconds": args.stockfish_move_time_seconds,
+                        "stockfish_review_time_seconds": args.stockfish_review_time_seconds,
+                        "stockfish_threads": 1,
+                        "stockfish_hash_mb": 64,
+                        "compaction_trigger_tokens": args.compaction_trigger_tokens,
+                        "compaction_reserve_tokens": args.compaction_reserve_tokens,
+                        "output_dir": str(_chess_output_dir(args)),
+                    },
+                },
+            }
+        )
+    return rows
+
+
+def _write_prompt_data(args: ScriptArgs) -> None:
+    path = _prompt_data_path(args)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    serialized = "\n".join(json.dumps(row, sort_keys=True) for row in _prompt_rows(args))
+    path.write_text(f"{serialized}\n", encoding="utf-8")
+
+
+def _prepare_chess_environment(args: ScriptArgs) -> None:
+    U.exec_command_cpu("apt-get update")
+    U.exec_command_cpu("DEBIAN_FRONTEND=noninteractive apt-get install -y stockfish")
+    U.exec_command_cpu(f"test -d {args.radix_raft_dir}/.git || git clone {_RADIX_RAFT_REPOSITORY} {args.radix_raft_dir}")
+    U.exec_command_cpu(f"git -C {args.radix_raft_dir} fetch origin {args.radix_raft_revision}")
+    U.exec_command_cpu(f"git -C {args.radix_raft_dir} checkout --detach {args.radix_raft_revision}")
+    chess_package = Path(args.radix_raft_dir) / "experiments" / "shi" / "chess_eval"
+    U.exec_command_cpu(f"uv pip install --system -e {chess_package}")
+
+
+def _prepare_model(args: ScriptArgs) -> None:
+    U.exec_command_cpu(f"mkdir -p {args.model_dir} {_run_dir(args)}")
+    hf_checkpoint = _hf_checkpoint(args)
+    if args.hf_checkpoint_path is None:
+        U.exec_command_cpu(f"test -e {hf_checkpoint} || hf download Qwen/{args.model_name} --local-dir {hf_checkpoint}")
+    else:
+        U.exec_command_cpu(f"test -d {hf_checkpoint}")
+    U.convert_checkpoint(
+        model_name=args.model_name,
+        megatron_model_type=args.megatron_model_type,
+        num_gpus_per_node=args.num_gpus_per_node,
+        dir_dst=args.model_dir,
+        hf_checkpoint=str(hf_checkpoint),
+        megatron_path=args.megatron_path,
+    )
+
+
+def _checkpoint_args(args: ScriptArgs) -> str:
+    result = f"--hf-checkpoint {_hf_checkpoint(args)} --ref-load {args.model_dir}/{args.model_name}_torch_dist "
+    if args.save_checkpoint:
+        result += f"--save {_checkpoint_dir(args)} --save-interval {args.save_interval} "
+    return result
+
+
+def _rollout_args(args: ScriptArgs) -> str:
+    return (
+        f"--prompt-data {_prompt_data_path(args)} "
+        "--input-key prompt "
+        "--metadata-key metadata "
+        "--rollout-shuffle "
+        f"--num-rollout {args.num_rollout} "
+        f"--rollout-batch-size {args.rollout_batch_size} "
+        f"--n-samples-per-prompt {args.n_samples_per_prompt} "
+        f"--rollout-temperature {args.rollout_temperature} "
+        f"--rollout-top-p {args.rollout_top_p} "
+        f"--rollout-max-response-len {args.rollout_max_response_len} "
+        f"--max-seq-len {args.max_seq_len} "
+        f"--global-batch-size {args.global_batch_size} "
+        "--balance-data "
+    )
+
+
+def _performance_args(args: ScriptArgs) -> str:
+    return (
+        f"--tensor-model-parallel-size {args.tp} "
+        "--sequence-parallel "
+        f"--pipeline-model-parallel-size {args.pp} "
+        f"--context-parallel-size {args.cp} "
+        f"--expert-model-parallel-size {args.ep} "
+        f"--expert-tensor-parallel-size {args.etp} "
+        "--recompute-granularity full "
+        "--recompute-method uniform "
+        "--recompute-num-layers 1 "
+        "--use-dynamic-batch-size "
+        f"--max-tokens-per-gpu {args.max_tokens_per_gpu} "
+        "--log-probs-chunk-size 4096 "
+    )
+
+
+def _grpo_args() -> str:
+    return "--advantage-estimator grpo --use-kl-loss --kl-loss-coef 0.00 --kl-loss-type low_var_kl --entropy-coef 0.00 --eps-clip 0.2 --eps-clip-high 0.28 "
+
+
+def _optimizer_args() -> str:
+    return "--optimizer adam --lr 1e-6 --lr-decay-style constant --weight-decay 0.1 --adam-beta1 0.9 --adam-beta2 0.98 --optimizer-cpu-offload --overlap-cpu-optimizer-d2h-h2d --use-precision-aware-optimizer "
+
+
+def _sglang_args(args: ScriptArgs) -> str:
+    return (
+        f"--rollout-num-gpus-per-engine {args.num_gpus_per_node} "
+        f"--sglang-mem-fraction-static {args.sglang_mem_fraction_static} "
+        f"--sglang-ep-size {args.sglang_ep_size} "
+        f"--sglang-max-running-requests {args.sglang_max_running_requests} "
+        f"--sglang-router-port {args.sglang_router_port} "
+        "--sglang-reasoning-parser qwen3 "
+        "--sglang-tool-call-parser qwen3_coder "
+        "--sglang-cuda-graph-bs 1 2 4 8 16 24 32 40 48 56 64 72 80 88 96 104 112 120 128 "
+        "--sglang-speculative-algorithm EAGLE "
+        "--sglang-speculative-num-steps 2 "
+        "--sglang-speculative-eagle-topk 1 "
+        "--sglang-speculative-num-draft-tokens 3 "
+        "--sglang-mamba-scheduler-strategy extra_buffer "
+    )
+
+
+def _agent_args(args: ScriptArgs) -> str:
+    return f"--custom-generate-function-path miles.rollout.generate_hub.agentic_tool_call.generate --custom-agent-function-path chess_agent.run --dynamic-sampling-filter-path chess_filter.check_chess_group --tito-model qwen35 --use-session-server v2 --session-server-port {args.session_server_port} "
+
+
+def _observability_args(args: ScriptArgs) -> str:
+    prometheus_args = ""
+    if args.use_prometheus:
+        prometheus_args = f"--use-prometheus --prometheus-port {args.prometheus_port} --prometheus-run-name {args.run_id} "
+    wandb_args = f"--use-wandb --wandb-team {args.wandb_team} --wandb-project {args.wandb_project} --wandb-group {args.run_id} --wandb-dir {_run_dir(args) / 'wandb'} --disable-wandb-random-suffix "
+    return f"--dump-details {_trace_dir(args)} --use-miles-dashboard --use-rollout-entropy {prometheus_args}{wandb_args}"
+
+
+def _misc_args(args: ScriptArgs) -> str:
+    return (
+        "--attention-dropout 0.0 "
+        "--hidden-dropout 0.0 "
+        "--accumulate-allreduce-grads-in-fp32 "
+        "--attention-softmax-in-fp32 "
+        "--attention-backend flash "
+        "--moe-token-dispatcher-type flex "
+        "--observe-training-entropy "
+        "--log-multi-turn "
+        "--colocate "
+        f"--actor-num-nodes {args.num_nodes} "
+        f"--actor-num-gpus-per-node {args.num_gpus_per_node} "
+        f"--num-gpus-per-node {args.num_gpus_per_node} "
+    )
+
+
+def _mtp_args() -> str:
+    return "--enable-mtp-training --mtp-num-layers 1 --mtp-loss-scaling-factor 0.2 "
+
+
+def _build_train_args(args: ScriptArgs) -> str:
+    return "".join(
+        (
+            _checkpoint_args(args),
+            _rollout_args(args),
+            _optimizer_args(),
+            _grpo_args(),
+            _observability_args(args),
+            _performance_args(args),
+            _sglang_args(args),
+            _agent_args(args),
+            _mtp_args(),
+            _misc_args(args),
+            args.extra_args,
+        )
+    )
+
+
+def _extra_env_vars(args: ScriptArgs) -> dict[str, str]:
+    chess_package = Path(args.radix_raft_dir) / "experiments" / "shi" / "chess_eval"
+    return {
+        "AGENT_MODEL_NAME": "model",
+        "PYTHONPATH": f"{_SCRIPT_DIR}:{chess_package}:{U.repo_base_dir}",
+        "SGLANG_ENABLE_SPEC_V2": "1",
+    }
+
+
+def _prepare(args: ScriptArgs) -> None:
+    _write_prompt_data(args)
+    _prepare_chess_environment(args)
+    _prepare_model(args)
+
+
+def _execute(args: ScriptArgs) -> None:
+    U.execute_train(
+        train_args=_build_train_args(args),
+        config=args,
+        num_gpus_per_node=args.num_gpus_per_node,
+        megatron_model_type=args.megatron_model_type,
+        megatron_path=args.megatron_path,
+        extra_env_vars=_extra_env_vars(args),
+    )
+
+
+@U.dataclass_cli
+def main(args: ScriptArgs) -> None:
+    if args.skip_prepare:
+        _write_prompt_data(args)
+    else:
+        _prepare(args)
+    _execute(args)
+
+
+if __name__ == "__main__":
+    typer.run(main)

--- a/examples/experimental/chess/run.py
+++ b/examples/experimental/chess/run.py
@@ -41,7 +41,7 @@ import miles.utils.external_utils.command_utils as U
 
 _SCRIPT_DIR = Path(__file__).resolve().parent
 _RADIX_RAFT_REPOSITORY = "https://github.com/radixark/radix_raft.git"
-_RADIX_RAFT_REVISION = "28a92796516e5192f8899466025f1de19c774c5f"
+_RADIX_RAFT_REVISION = "79cf2592e9daa2f738121b573c2d20f718890045"
 
 
 @dataclass

--- a/examples/experimental/chess/stockfish_load_probe.py
+++ b/examples/experimental/chess/stockfish_load_probe.py
@@ -1,0 +1,161 @@
+"""Exercise the chess recipe's real Stockfish load envelope."""
+
+import asyncio
+import json
+import subprocess
+import time
+from dataclasses import asdict, dataclass
+
+import chess
+import chess.engine
+from tap import Tap
+
+import chess_agent
+
+
+class Arguments(Tap):
+    """Load-test two real Stockfish processes per simulated chess game."""
+
+    stockfish_path: str = "/usr/games/stockfish"
+    stockfish_timeout_seconds: float = 20.0
+    num_games: int = 64
+    max_concurrent_games: int = 16
+    move_time_seconds: float = 0.02
+
+
+@dataclass(frozen=True)
+class ProbeResult:
+    num_games: int
+    max_concurrent_games: int
+    max_live_engines: int
+    failures: int
+    remaining_stockfish_processes: int
+    elapsed_seconds: float
+
+
+def _stockfish_process_count() -> int:
+    result = subprocess.run(
+        ["pgrep", "-cx", "stockfish"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode == 1:
+        return 0
+    if result.returncode != 0:
+        raise RuntimeError(f"pgrep failed with exit code {result.returncode}")
+    return int(result.stdout.strip())
+
+
+async def run_probe(arguments: Arguments) -> ProbeResult:
+    """Start, exercise, and clean up two engines for every simulated game."""
+
+    if arguments.stockfish_timeout_seconds <= 0:
+        raise ValueError("stockfish_timeout_seconds must be positive")
+    if arguments.num_games < 1:
+        raise ValueError("num_games must be at least 1")
+    if arguments.max_concurrent_games < 1:
+        raise ValueError("max_concurrent_games must be at least 1")
+    if arguments.move_time_seconds <= 0:
+        raise ValueError("move_time_seconds must be positive")
+    initial_processes = _stockfish_process_count()
+    if initial_processes:
+        raise RuntimeError(f"refusing to run while {initial_processes} Stockfish processes already exist")
+
+    live_engines = 0
+    max_live_engines = 0
+    state_lock = asyncio.Lock()
+    started_at = time.monotonic()
+    limiter = chess_agent._game_limiter(arguments.max_concurrent_games)
+
+    async def update_live(delta: int) -> None:
+        nonlocal live_engines, max_live_engines
+        async with state_lock:
+            live_engines += delta
+            max_live_engines = max(max_live_engines, live_engines)
+
+    async def one_game() -> None:
+        opponent: chess.engine.SimpleEngine | None = None
+        reviewer: chess.engine.SimpleEngine | None = None
+        async with limiter:
+            try:
+                opponent = await asyncio.to_thread(
+                    chess.engine.SimpleEngine.popen_uci,
+                    arguments.stockfish_path,
+                    timeout=arguments.stockfish_timeout_seconds,
+                )
+                await update_live(1)
+                reviewer = await asyncio.to_thread(
+                    chess.engine.SimpleEngine.popen_uci,
+                    arguments.stockfish_path,
+                    timeout=arguments.stockfish_timeout_seconds,
+                )
+                await update_live(1)
+                await asyncio.to_thread(
+                    opponent.configure,
+                    {
+                        "UCI_LimitStrength": True,
+                        "UCI_Elo": 1320,
+                        "Threads": 1,
+                        "Hash": 64,
+                    },
+                )
+                await asyncio.to_thread(
+                    reviewer.configure,
+                    {"Threads": 1, "Hash": 64},
+                )
+                board = chess.Board()
+                played = await asyncio.to_thread(
+                    opponent.play,
+                    board,
+                    chess.engine.Limit(time=arguments.move_time_seconds),
+                )
+                if played.move is None:
+                    raise RuntimeError("Stockfish returned no move")
+                board.push(played.move)
+                await asyncio.to_thread(
+                    reviewer.analyse,
+                    board,
+                    chess.engine.Limit(time=arguments.move_time_seconds),
+                )
+            finally:
+                engines = [engine for engine in (reviewer, opponent) if engine is not None]
+                cleanup_results = await asyncio.gather(
+                    *(asyncio.to_thread(engine.quit) for engine in engines),
+                    return_exceptions=True,
+                )
+                await update_live(-len(engines))
+                cleanup_failures = [result for result in cleanup_results if isinstance(result, BaseException)]
+                if cleanup_failures:
+                    raise RuntimeError(f"{len(cleanup_failures)} Stockfish processes failed to quit cleanly") from cleanup_failures[0]
+
+    outcomes = await asyncio.gather(
+        *(one_game() for _ in range(arguments.num_games)),
+        return_exceptions=True,
+    )
+    failures = sum(isinstance(outcome, BaseException) for outcome in outcomes)
+    elapsed_seconds = time.monotonic() - started_at
+    remaining_processes = _stockfish_process_count()
+    return ProbeResult(
+        num_games=arguments.num_games,
+        max_concurrent_games=arguments.max_concurrent_games,
+        max_live_engines=max_live_engines,
+        failures=failures,
+        remaining_stockfish_processes=remaining_processes,
+        elapsed_seconds=round(elapsed_seconds, 3),
+    )
+
+
+def main() -> None:
+    arguments = Arguments().parse_args()
+    result = asyncio.run(run_probe(arguments))
+    print(json.dumps(asdict(result), sort_keys=True))
+    if result.failures or result.remaining_stockfish_processes:
+        raise SystemExit(1)
+    expected_limit = 2 * arguments.max_concurrent_games
+    if result.max_live_engines > expected_limit:
+        raise RuntimeError(f"observed {result.max_live_engines} engines; expected at most {expected_limit}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/experimental/chess/stockfish_load_probe.py
+++ b/examples/experimental/chess/stockfish_load_probe.py
@@ -20,7 +20,7 @@ class Arguments(Tap):
     stockfish_timeout_seconds: float = 20.0
     num_games: int = 64
     max_concurrent_games: int = 16
-    move_time_seconds: float = 0.02
+    move_time_seconds: float = 0.2
 
 
 @dataclass(frozen=True)

--- a/examples/experimental/chess/test_chess_agent.py
+++ b/examples/experimental/chess/test_chess_agent.py
@@ -1,0 +1,53 @@
+"""Focused tests for the chess rollout adapter's load controls."""
+
+import asyncio
+from typing import Any
+
+import pytest
+
+import chess_agent
+
+
+def test_stockfish_game_limiter_caps_complete_rollouts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    active = 0
+    maximum_active = 0
+
+    async def fake_run_chess(**kwargs: Any) -> dict[str, Any]:
+        nonlocal active, maximum_active
+        del kwargs
+        active += 1
+        maximum_active = max(maximum_active, active)
+        await asyncio.sleep(0.01)
+        active -= 1
+        return {"ok": True}
+
+    async def exercise() -> list[dict[str, Any]]:
+        tasks = [
+            chess_agent.run(
+                base_url="http://session-server/sessions/test",
+                prompt="play",
+                metadata={"chess": {"stockfish_max_concurrent_games": 3}},
+            )
+            for _ in range(12)
+        ]
+        return await asyncio.gather(*tasks)
+
+    monkeypatch.setattr(chess_agent, "run_chess", fake_run_chess)
+    results = asyncio.run(exercise())
+
+    assert results == [{"ok": True}] * 12
+    assert maximum_active == 3
+
+
+@pytest.mark.parametrize("value", (0, -1))
+def test_stockfish_game_limiter_rejects_nonpositive_limits(value: int) -> None:
+    with pytest.raises(ValueError, match="must be at least 1"):
+        chess_agent._stockfish_max_concurrent_games({"chess": {"stockfish_max_concurrent_games": value}})
+
+
+@pytest.mark.parametrize("value", (True, 1.5, "16"))
+def test_stockfish_game_limiter_rejects_noninteger_limits(value: object) -> None:
+    with pytest.raises(TypeError, match="must be an integer"):
+        chess_agent._stockfish_max_concurrent_games({"chess": {"stockfish_max_concurrent_games": value}})


### PR DESCRIPTION
## Summary

- add an experimental Qwen3.6-35B-A3B GRPO recipe backed by the radix_raft chess harness and Miles TITO v2
- run 8 prompts with 8 trajectories each for 64 chess games per training step, balanced across White and Black
- preserve Qwen thinking, chess journals, Miles traces, dashboard telemetry, Prometheus metrics, and W&B metrics
- reject infrastructure-error groups instead of training them as chess losses
- bound the complete chess-game lifecycle to 16 concurrent games (32 Stockfish processes) and use a 20-second engine timeout
- add a real 64-game Stockfish load probe and focused concurrency tests

## Why

This provides a reproducible example for agentic RL where a policy plays chess through one stateful TITO v2 session per game. The explicit engine limit prevents a 64-trajectory batch from starting 128 Stockfish processes at once and exhausting the UCI startup deadline.

## Validation

- radix_raft chess harness: 112 tests passed locally; 109 passed and 3 skipped on the H200 devbox
- Miles chess adapter: 6 tests passed locally and on the H200 devbox
- Ruff formatting and lint checks passed
- launcher serialization probe passed after rebasing onto current `main`
- real H200-host load probe: 64/64 simulated games passed at 0.2-second move/review limits, peak 32 live Stockfish processes, zero leftovers

## Smoke run

- run ID: `260825-7c0797ba`
- one node with 8 H200 GPUs
- 10 GRPO steps, 8 prompts per step, 8 trajectories per prompt
- Stockfish Elo 1320; maximum 8 model turns per game
- complete source snapshots saved under `refs/training-runs/260825-7c0797ba/*`
