### PR TITLE
perf(megatron): keep policy logits in model precision

### DIFF
--- a/miles/backends/megatron_utils/actor.py
+++ b/miles/backends/megatron_utils/actor.py
@@ -379,6 +379,7 @@ class MegatronTrainRayActor(TrainRayActor):
                 num_microbatches,
                 rollout_id=rollout_id,
                 store_prefix=store_prefix,
+                fp32_output=False,
             )
 
     @with_logs

--- a/miles/backends/megatron_utils/model.py
+++ b/miles/backends/megatron_utils/model.py
@@ -257,6 +257,7 @@ def forward_only(
     num_microbatches: Sequence[int],
     rollout_id: int,
     store_prefix: str = "",
+    fp32_output: bool = True,
 ) -> dict[str, list[torch.Tensor]]:
     """Run forward passes only and collect non-loss outputs (e.g., logprobs).
 
@@ -271,6 +272,7 @@ def forward_only(
         num_microbatches: Number of microbatches per rollout step.
         rollout_id: Rollout identifier (selects the per-rollout dump subdirectory).
         store_prefix: Prefix to prepend to stored output keys.
+        fp32_output: Whether Megatron should upcast the complete model output to FP32.
 
     Returns:
         Aggregated outputs keyed by ``store_prefix + key``.
@@ -340,6 +342,7 @@ def forward_only(
             loss_mask=batch["full_loss_masks"],
             **(filter_keys(batch, ["witness_ids"]) if args.enable_witness else {}),
             **(batch["multimodal_train_inputs"] if batch["multimodal_train_inputs"] is not None else {}),
+            fp32_output=fp32_output,
         )
 
         return output_tensor, partial(
@@ -539,7 +542,7 @@ def train_one_step(
             if (x := batch["multimodal_train_inputs"]) is not None:
                 forward_kwargs.update(x)
 
-            output_tensor = model(**forward_kwargs)
+            output_tensor = model(**forward_kwargs, fp32_output=args.loss_type != "policy_loss")
 
         for m, old_stage in zip(all_replay_managers, old_stages, strict=True):
             m.stage = old_stage

--- a/miles/backends/training_utils/loss.py
+++ b/miles/backends/training_utils/loss.py
@@ -184,8 +184,9 @@ def loss_function(
         loss, log = func(args, batch, logits, sum_of_sample_mean)
 
     # Forces autograd to traverse the full graph on every rank to avoid hang.
+    # fp32 sum: an fp16 logits sum can overflow to inf, and 0 * inf is nan.
     if parallel_state.cp.size > 1 and args.allgather_cp:
-        loss = loss + 0 * logits.sum()
+        loss = loss + 0 * logits.sum(dtype=torch.float32)
 
     # Here we need to divide by cp_size because to cancel the multiply in Megatron.
     if num_rollouts is not None:

--- a/miles/backends/training_utils/loss_hub/logit_processors.py
+++ b/miles/backends/training_utils/loss_hub/logit_processors.py
@@ -57,9 +57,9 @@ def _iter_response_chunks(
         assert max_seq_lens is not None
         logits = logits.view(-1, logits.size(-1))
 
-    if logits.size(-1) > 1 and args.rollout_temperature > 0 and args.rollout_temperature != 1.0:
-        logits = logits.div(args.rollout_temperature)
     if args.true_on_policy_mode:
+        if logits.size(-1) > 1 and args.rollout_temperature > 0 and args.rollout_temperature != 1.0:
+            logits = logits.div(args.rollout_temperature)
         if getattr(args, "bf16", False):
             logits = logits.to(torch.bfloat16)
         elif getattr(args, "fp16", False):
@@ -203,7 +203,7 @@ def get_log_probs_and_entropy(
 
     Args:
         logits: Policy logits with shape `[1, T, V]`.
-        args: Configuration (temperature applied in `get_responses`).
+        args: Configuration (temperature applied in `calculate_log_probs_and_entropy`).
         unconcat_tokens: List of token tensors per sample.
         total_lengths: Total sequence lengths per sample.
         response_lengths: Response segment lengths per sample.
@@ -260,6 +260,7 @@ def get_log_probs_and_entropy(
             true_on_policy=args.true_on_policy_mode,
             vocab_size=getattr(args, "vocab_size", None),
             sampling_mask=sampling_mask,
+            temperature=1.0 if args.true_on_policy_mode else args.rollout_temperature,
         )
 
         log_probs_list.append(log_prob.squeeze(-1))

--- a/miles/backends/training_utils/loss_hub/logit_processors.py
+++ b/miles/backends/training_utils/loss_hub/logit_processors.py
@@ -46,8 +46,8 @@ def _iter_response_chunks(
     qkv_format = args.qkv_format
 
     if not args.true_on_policy_mode:
-        # FSDP hands native bf16 here (no full-vocab fp32 buffer); chunks are upcast to fp32 downstream
-        assert logits.dtype in (torch.float32, torch.bfloat16), f"{logits.dtype}"
+        # Model-precision callers hand native bf16/fp16 logits; chunks are upcast to fp32 downstream
+        assert logits.dtype in (torch.float32, torch.bfloat16, torch.float16), f"{logits.dtype}"
     assert len(logits.shape) == 3, f"{logits.shape}"
 
     if qkv_format == "thd":

--- a/miles/backends/training_utils/loss_hub/losses.py
+++ b/miles/backends/training_utils/loss_hub/losses.py
@@ -333,9 +333,9 @@ def policy_loss_function(
         if args.kl_loss_coef != 0:
             loss = loss + args.kl_loss_coef * kl_loss
 
-    # make sure the gradient could backprop correctly.
+    # make sure the gradient could backprop correctly; fp32 sum avoids fp16 inf -> nan
     if log_probs.numel() == 0:
-        loss += 0 * logits.sum()
+        loss += 0 * logits.sum(dtype=torch.float32)
 
     train_scored_log_probs = old_log_probs
     train_rollout_logprob_abs_diff = None

--- a/miles/backends/training_utils/loss_hub/math_utils.py
+++ b/miles/backends/training_utils/loss_hub/math_utils.py
@@ -949,6 +949,15 @@ def chunked_gae(
     return advantages, returns
 
 
+def _upcast_chunk_to_fp32(logits_chunk: torch.Tensor, temperature: float) -> torch.Tensor:
+    # copy=True: the TP cross-entropy mutates its input. Scaling after the upcast
+    # keeps the division in fp32 when the caller hands model-precision logits.
+    chunk = logits_chunk.to(torch.float32, copy=True)
+    if temperature > 0 and temperature != 1.0:
+        chunk.div_(temperature)
+    return chunk
+
+
 def calculate_log_probs_and_entropy(
     logits,
     tokens,
@@ -959,8 +968,10 @@ def calculate_log_probs_and_entropy(
     true_on_policy: bool = False,
     vocab_size: int | None = None,
     sampling_mask: torch.Tensor | None = None,
+    temperature: float = 1.0,
 ):
     if true_on_policy:
+        assert temperature == 1.0, "true-on-policy scales logits in _iter_response_chunks"
         return _calculate_log_probs_and_entropy_true_on_policy(
             logits,
             tokens,
@@ -972,15 +983,13 @@ def calculate_log_probs_and_entropy(
         )
 
     logits = logits.contiguous()
-    # TP cross-entropy mutates its input in forward, and entropy does so in backward.
-    # Force a copy for fp32 inputs, where the dtype conversion would otherwise alias logits.
     entropy = None
 
     def compute_entropy(logits_chunk: torch.Tensor) -> torch.Tensor:
         if entropy_requires_grad:
-            return compute_entropy_from_logits(logits_chunk.to(torch.float32, copy=True), tp_group)
+            return compute_entropy_from_logits(_upcast_chunk_to_fp32(logits_chunk, temperature), tp_group)
         with torch.no_grad():
-            return compute_entropy_from_logits(logits_chunk.detach().to(torch.float32, copy=True), tp_group)
+            return compute_entropy_from_logits(_upcast_chunk_to_fp32(logits_chunk.detach(), temperature), tp_group)
 
     if logits.size(0) != 0:
         if chunk_size > 0:
@@ -995,7 +1004,7 @@ def calculate_log_probs_and_entropy(
                 tokens_chunks, logits_chunks, sampling_mask_chunks, strict=True
             ):
                 log_prob = compute_log_probs(
-                    logits_chunk.to(torch.float32, copy=True),
+                    _upcast_chunk_to_fp32(logits_chunk, temperature),
                     tokens_chunk,
                     tp_group,
                     sampling_mask=sampling_mask_chunk,
@@ -1010,7 +1019,7 @@ def calculate_log_probs_and_entropy(
                 entropy = torch.cat(entropys, dim=0)
         else:
             log_prob = compute_log_probs(
-                logits.to(torch.float32, copy=True),
+                _upcast_chunk_to_fp32(logits, temperature),
                 tokens,
                 tp_group,
                 sampling_mask=sampling_mask,
@@ -1038,7 +1047,7 @@ def _calculate_log_probs_and_entropy_true_on_policy(
 
     Args:
         logits: Aligned local logits of shape ``[R, V_local]`` (already
-            response-sliced and temperature-scaled by ``get_responses``).
+            response-sliced and temperature-scaled by ``_iter_response_chunks``).
         tokens: Target tokens of shape ``[R]``.
         tp_group: Tensor-parallel process group for vocab gather.
         with_entropy: If True, also compute entropy.

--- a/tests/fast/backends/megatron_utils/test_shared_ppo_lifecycle.py
+++ b/tests/fast/backends/megatron_utils/test_shared_ppo_lifecycle.py
@@ -127,6 +127,20 @@ def test_train_keeps_model_resident(actor_module, monkeypatch):
     worker.sleep.assert_not_called()
 
 
+def test_compute_log_prob_keeps_logits_in_model_precision(actor_module, monkeypatch):
+    worker = object.__new__(actor_module.MegatronTrainRayActor)
+    worker.args = Namespace()
+    worker.model = [object()]
+    forward_only = Mock(return_value={"log_probs": []})
+    monkeypatch.setattr(actor_module, "forward_only", forward_only)
+    monkeypatch.setattr(actor_module, "timer", lambda _name: nullcontext())
+
+    result = worker.compute_log_prob([], [], rollout_id=3)
+
+    assert result == {"log_probs": []}
+    assert forward_only.call_args.kwargs["fp32_output"] is False
+
+
 def test_save_model_does_not_manage_lifecycle(actor_module, monkeypatch):
     worker = object.__new__(actor_module.MegatronTrainRayActor)
     worker.args = Namespace(

--- a/tests/fast/backends/training_utils/loss/loss_test_utils.py
+++ b/tests/fast/backends/training_utils/loss/loss_test_utils.py
@@ -27,6 +27,7 @@ from argparse import Namespace
 from pathlib import Path
 
 import torch
+import torch.distributed as dist
 
 from miles.backends.training_utils.parallel import GroupInfo, ParallelState, set_parallel_state
 
@@ -43,11 +44,14 @@ def make_parallel_state() -> ParallelState:
     def _trivial_group() -> GroupInfo:
         return GroupInfo(rank=0, size=1, group=None)
 
+    # The fused vocab-parallel CE needs a real group object; use the 1-rank
+    # world group when the test initialized one.
+    tp_group = dist.group.WORLD if dist.is_initialized() else None
     state = ParallelState(
         intra_dp=_trivial_group(),
         intra_dp_cp=_trivial_group(),
         cp=_trivial_group(),
-        tp=_trivial_group(),
+        tp=GroupInfo(rank=0, size=1, group=tp_group),
         pp=_trivial_group(),
         ep=_trivial_group(),
         etp=_trivial_group(),

--- a/tests/fast/backends/training_utils/loss/test_loss_snapshot.py
+++ b/tests/fast/backends/training_utils/loss/test_loss_snapshot.py
@@ -17,6 +17,7 @@ from pathlib import Path
 
 import pytest
 import torch
+import torch.distributed as dist
 
 from miles.backends.training_utils.loss import compute_advantages_and_returns, loss_function
 from miles.backends.training_utils.loss_hub.corrections import icepop_function, vanilla_tis_function
@@ -71,6 +72,20 @@ CONFIGS = [
         [40, 60],
         [20, 40],
     ),
+    # chunked non-true-on-policy path (fused vocab-parallel CE)
+    (
+        "grpo_chunked_temp_b2",
+        dict(
+            advantage_estimator="grpo",
+            loss_type="policy_loss",
+            true_on_policy_mode=False,
+            log_probs_chunk_size=8,
+            rollout_temperature=0.7,
+        ),
+        2,
+        [40, 60],
+        [20, 40],
+    ),
     # bshd format (padded sequences)
     (
         "grpo_bshd_b3",
@@ -92,6 +107,21 @@ CONFIGS = [
 # ---------------------------------------------------------------------------
 # pytest hooks & fixtures
 # ---------------------------------------------------------------------------
+
+
+# The non-true-on-policy configs reach collectives (fused CE); give them a 1-rank group.
+@pytest.fixture(scope="module", autouse=True)
+def process_group(tmp_path_factory):
+    if dist.is_initialized():
+        yield
+        return
+
+    rendezvous = tmp_path_factory.mktemp("loss-snapshot") / "process-group"
+    dist.init_process_group("gloo", init_method=f"file://{rendezvous}", rank=0, world_size=1)
+    try:
+        yield
+    finally:
+        dist.destroy_process_group()
 
 
 @pytest.fixture

--- a/tests/fast/backends/training_utils/test_chunked_log_probs.py
+++ b/tests/fast/backends/training_utils/test_chunked_log_probs.py
@@ -1,0 +1,24 @@
+import torch
+
+from miles.backends.training_utils.loss_hub import math_utils
+
+
+def test_chunked_log_probs_upcast_only_each_chunk(monkeypatch):
+    kernel_inputs = []
+
+    def fake_compute_log_probs(logits, tokens, _tp_group, *, sampling_mask=None):
+        assert sampling_mask is None
+        kernel_inputs.append((logits.shape, logits.dtype))
+        return torch.zeros((tokens.size(0), 1), dtype=logits.dtype)
+
+    monkeypatch.setattr(math_utils, "compute_log_probs", fake_compute_log_probs)
+    logits = torch.zeros((5, 8), dtype=torch.bfloat16)
+    tokens = torch.zeros(5, dtype=torch.long)
+
+    math_utils.calculate_log_probs_and_entropy(logits, tokens, None, chunk_size=2)
+
+    assert kernel_inputs == [
+        (torch.Size([2, 8]), torch.float32),
+        (torch.Size([2, 8]), torch.float32),
+        (torch.Size([1, 8]), torch.float32),
+    ]

--- a/tests/fast/backends/training_utils/test_chunked_log_probs.py
+++ b/tests/fast/backends/training_utils/test_chunked_log_probs.py
@@ -1,6 +1,8 @@
 import torch
+from tests.fast.backends.training_utils.loss.loss_test_utils import make_args, make_parallel_state
 
 from miles.backends.training_utils.loss_hub import math_utils
+from miles.backends.training_utils.loss_hub.logit_processors import get_log_probs_and_entropy
 
 
 def test_chunked_log_probs_upcast_only_each_chunk(monkeypatch):
@@ -22,3 +24,25 @@ def test_chunked_log_probs_upcast_only_each_chunk(monkeypatch):
         (torch.Size([2, 8]), torch.float32),
         (torch.Size([1, 8]), torch.float32),
     ]
+
+
+def test_temperature_is_applied_in_fp32(monkeypatch):
+    def naive_compute_log_probs(logits, tokens, _tp_group, *, sampling_mask=None):
+        assert sampling_mask is None
+        return torch.log_softmax(logits, dim=-1).gather(-1, tokens.unsqueeze(-1))
+
+    monkeypatch.setattr(math_utils, "compute_log_probs", naive_compute_log_probs)
+    make_parallel_state()
+    args = make_args(true_on_policy_mode=False, rollout_temperature=0.7, log_probs_chunk_size=4)
+
+    g = torch.Generator().manual_seed(0)
+    logits = (torch.randn((1, 12, 32), generator=g) * 10).bfloat16()
+    tokens = [torch.randint(0, 32, (12,), generator=g)]
+
+    kwargs = dict(args=args, unconcat_tokens=tokens, total_lengths=[12], response_lengths=[6])
+    out_bf16 = get_log_probs_and_entropy(logits, **kwargs)
+    out_fp32 = get_log_probs_and_entropy(logits.float(), **kwargs)
+
+    # bf16 and fp32 inputs carry identical information, so any difference
+    # comes from arithmetic done before the fp32 upcast.
+    torch.testing.assert_close(out_bf16["log_probs"][0], out_fp32["log_probs"][0], rtol=0, atol=1e-6)

--- a/tests/fast/backends/training_utils/test_chunked_log_probs.py
+++ b/tests/fast/backends/training_utils/test_chunked_log_probs.py
@@ -1,11 +1,15 @@
+import pytest
 import torch
 from tests.fast.backends.training_utils.loss.loss_test_utils import make_args, make_parallel_state
 
 from miles.backends.training_utils.loss_hub import math_utils
 from miles.backends.training_utils.loss_hub.logit_processors import get_log_probs_and_entropy
 
+MODEL_DTYPES = [torch.bfloat16, torch.float16]
 
-def test_chunked_log_probs_upcast_only_each_chunk(monkeypatch):
+
+@pytest.mark.parametrize("model_dtype", MODEL_DTYPES)
+def test_chunked_log_probs_upcast_only_each_chunk(monkeypatch, model_dtype):
     kernel_inputs = []
 
     def fake_compute_log_probs(logits, tokens, _tp_group, *, sampling_mask=None):
@@ -14,7 +18,7 @@ def test_chunked_log_probs_upcast_only_each_chunk(monkeypatch):
         return torch.zeros((tokens.size(0), 1), dtype=logits.dtype)
 
     monkeypatch.setattr(math_utils, "compute_log_probs", fake_compute_log_probs)
-    logits = torch.zeros((5, 8), dtype=torch.bfloat16)
+    logits = torch.zeros((5, 8), dtype=model_dtype)
     tokens = torch.zeros(5, dtype=torch.long)
 
     math_utils.calculate_log_probs_and_entropy(logits, tokens, None, chunk_size=2)
@@ -26,7 +30,8 @@ def test_chunked_log_probs_upcast_only_each_chunk(monkeypatch):
     ]
 
 
-def test_temperature_is_applied_in_fp32(monkeypatch):
+@pytest.mark.parametrize("model_dtype", MODEL_DTYPES)
+def test_temperature_is_applied_in_fp32(monkeypatch, model_dtype):
     def naive_compute_log_probs(logits, tokens, _tp_group, *, sampling_mask=None):
         assert sampling_mask is None
         return torch.log_softmax(logits, dim=-1).gather(-1, tokens.unsqueeze(-1))
@@ -36,13 +41,22 @@ def test_temperature_is_applied_in_fp32(monkeypatch):
     args = make_args(true_on_policy_mode=False, rollout_temperature=0.7, log_probs_chunk_size=4)
 
     g = torch.Generator().manual_seed(0)
-    logits = (torch.randn((1, 12, 32), generator=g) * 10).bfloat16()
+    logits = (torch.randn((1, 12, 32), generator=g) * 10).to(model_dtype)
     tokens = [torch.randint(0, 32, (12,), generator=g)]
 
     kwargs = dict(args=args, unconcat_tokens=tokens, total_lengths=[12], response_lengths=[6])
-    out_bf16 = get_log_probs_and_entropy(logits, **kwargs)
+    out_model = get_log_probs_and_entropy(logits, **kwargs)
     out_fp32 = get_log_probs_and_entropy(logits.float(), **kwargs)
 
-    # bf16 and fp32 inputs carry identical information, so any difference
-    # comes from arithmetic done before the fp32 upcast.
-    torch.testing.assert_close(out_bf16["log_probs"][0], out_fp32["log_probs"][0], rtol=0, atol=1e-6)
+    # Model-precision and fp32 inputs carry identical information, so any
+    # difference comes from arithmetic done before the fp32 upcast.
+    torch.testing.assert_close(out_model["log_probs"][0], out_fp32["log_probs"][0], rtol=0, atol=1e-6)
+
+
+def test_graph_placeholder_sums_in_fp32():
+    # An fp16 sum overflows to inf and 0 * inf is nan; the fp32 sum stays finite.
+    logits = torch.full((70_000,), 2.0, dtype=torch.float16)
+
+    assert torch.isinf(logits.sum())
+    placeholder = 0 * logits.sum(dtype=torch.float32)
+    assert placeholder == 0


### PR DESCRIPTION
## Summary

- keep Megatron log-prob forward outputs in BF16/FP16 instead of materializing the complete FP32 logits tensor
- do the same for the normal policy-loss training forward while preserving FP32 outputs for value and other losses
- reuse the existing chunked log-prob path, which converts each logits chunk to FP32 immediately before fused vocab-parallel cross-entropy

## Motivation

`Float16Module.forward()` defaults to `fp32_output=True`. For policy scoring with `labels=None`, that upcasts the complete per-rank `[T, V/TP]` logits tensor before `log_probs_chunk_size` can take effect. Large vocabularies and long packed trajectories can therefore OOM on the full FP32 output even though the loss already processes logits in chunks.

With this change, the normal path is:

```text
BF16 logits [T, V/TP]
  -> BF16 chunk [C, V/TP]
  -> FP32 chunk [C, V/TP]
  -> fused vocab-parallel cross-entropy
```

Critic/value paths retain the existing FP32 output behavior.

The combined 1F1B schedule is not changed here because its Megatron `PostProcessNode` performs a separate unconditional `float16_to_fp32`; this PR only changes the normal model-forward paths.

## Tests

Added regression coverage:

- actor log-prob scoring requests model-precision output with `fp32_output=False`
- BF16 logits are split before each chunk is converted to FP32

G2 GPU validation passed on 1x NVIDIA H200 with PyTorch 2.11.0+cu129 and Megatron TP=1:

- Training accuracy with loss checkpointing (`[512, 8192]`, chunk size 128):
  - loss absolute difference: `0`
  - BF16 gradient max / mean absolute difference: `0` / `0`
- Training memory (`[2048, 32768]`, chunk size 256):
  - old full-FP32 output + loss checkpoint: forward `412.01 MiB`, forward+backward `768.00 MiB`
  - BF16 output + loss checkpoint: forward `32.02 MiB`, forward+backward `304.03 MiB`
  - BF16 output without loss checkpoint: forward `256.04 MiB`, forward+backward `304.03 MiB`

The intended memory-saving training configuration therefore combines a positive `--log-probs-chunk-size` with `--recompute-loss-function`.