### PR TITLE
fix(megatron): use public vocab padding API

### DIFF
--- a/miles/backends/megatron_utils/arguments.py
+++ b/miles/backends/megatron_utils/arguments.py
@@ -2,7 +2,7 @@ import logging
 import os
 
 from megatron.training.arguments import parse_args, validate_args
-from megatron.training.tokenizer.tokenizer import _vocab_size_with_padding
+from megatron.training.vocab_utils import calculate_padded_vocab_size
 
 __all__ = ["validate_args", "parse_args", "set_default_megatron_args"]
 
@@ -32,7 +32,12 @@ def set_default_megatron_args(args):
         args.rope_type = "yarn" if args.multi_latent_attention else "rope"
 
     if args.vocab_size and not args.padded_vocab_size:
-        args.padded_vocab_size = _vocab_size_with_padding(args.vocab_size, args)
+        args.padded_vocab_size = calculate_padded_vocab_size(
+            args.vocab_size,
+            args.make_vocab_size_divisible_by,
+            args.tensor_model_parallel_size,
+            logging_enabled=args.rank == 0,
+        )
 
     if not args.tokenizer_model and not args.tokenizer_type:
         logger.info("--tokenizer-model not set, use --hf-checkpoint as tokenizer model.")


### PR DESCRIPTION
<!-- lint: profile=normal -->
## Summary

Use Megatron's public vocabulary-padding API when Miles fills `padded_vocab_size`.

## Symptom & Reproduction

- **Symptom:** Importing `miles.backends.megatron_utils.arguments` fails in current CPU CI with `ModuleNotFoundError`.
- **Reproduction:** Run `tests/fast/test_megatron_cli_flags.py::test_post_layernorm_flags_propagate_to_megatron` against `radixark/Megatron-LM:miles-main`.

## Root Cause

1. Miles imports the private `megatron.training.tokenizer.tokenizer._vocab_size_with_padding` helper.
2. Current `radixark/Megatron-LM:miles-main` removed that module and exposes `calculate_padded_vocab_size` from `megatron.training.vocab_utils` instead.

## Fix

Call `calculate_padded_vocab_size` with the existing vocabulary size, divisibility, tensor-parallel size, and rank-zero logging policy.

## Verification

- The current Megatron dependency at `235952df607b3820716e5e67728a5ab470ca33ae` contains the public helper with the required signature and no legacy tokenizer module.
- Python 3.12 compilation, `git diff --check`, and every applicable repository pre-commit hook passed for `miles/backends/megatron_utils/arguments.py`.
- Focused CPU pytest was not executed because the explicitly bound `miles-default` devbox is released.

## Review Focus

- The public helper receives the same divisibility inputs as the removed private API.
- Logging remains rank-zero only.
