### PR TITLE
fix(session): aggregate v2 prefix cache metrics per session

### DIFF
--- a/miles/ray/rollout/metrics.py
+++ b/miles/ray/rollout/metrics.py
@@ -3,6 +3,7 @@ from typing import Any
 
 import numpy as np
 
+from miles.rollout.session.v2.metrics import collect_session_rollout_metrics
 from miles.utils.iter_utils import group_by
 from miles.utils.metric_utils import (
     compute_pass_rate,
@@ -207,11 +208,27 @@ def _compute_spec_metrics(args, all_samples: list[Sample]):
 
 
 def _compute_prefix_cache_metrics(args, all_samples: list[Sample]):
+    if args.use_session_server == "v2":
+        session_metrics, unavailable_session_ids = collect_session_rollout_metrics(all_samples)
+        if unavailable_session_ids:
+            logger.warning(
+                "Prefix-cache metrics unavailable for %d v2 sessions: %s",
+                len(unavailable_session_ids),
+                unavailable_session_ids,
+            )
+        cache_infos = [metrics["prefix_cache_info"] for metrics in session_metrics]
+        total_cached_tokens = sum(info["cached_tokens"] for info in cache_infos)
+        total_prompt_tokens = sum(info["total_prompt_tokens"] for info in cache_infos)
+        num_sessions = len(cache_infos)
+        return {
+            "prefix_cache_hit_rate": (total_cached_tokens / total_prompt_tokens if total_prompt_tokens > 0 else 0.0),
+            "avg_cached_tokens_per_sample": total_cached_tokens / num_sessions if num_sessions > 0 else 0.0,
+        }
+
     num_samples = len(all_samples)
     metrics = {}
     total_cached_tokens = sum(sample.prefix_cache_info.cached_tokens for sample in all_samples)
     total_prompt_tokens = sum(sample.prefix_cache_info.total_prompt_tokens for sample in all_samples)
-
     metrics["prefix_cache_hit_rate"] = total_cached_tokens / total_prompt_tokens if total_prompt_tokens > 0 else 0.0
     metrics["avg_cached_tokens_per_sample"] = total_cached_tokens / num_samples
     return metrics

--- a/miles/rollout/generate_hub/agentic_tool_call.py
+++ b/miles/rollout/generate_hub/agentic_tool_call.py
@@ -35,6 +35,7 @@ from sglang.srt.entrypoints.openai.protocol import ChatCompletionRequest
 
 from miles.rollout.base_types import GenerateFnInput, GenerateFnOutput
 from miles.rollout.generate_utils.openai_endpoint_utils import OpenAIEndpointTracer
+from miles.rollout.session.v2.metrics import assign_session_rollout_metrics, read_server_session_rollout_metrics
 from miles.utils.misc import load_function
 from miles.utils.types import Sample
 
@@ -102,6 +103,8 @@ async def generate(input: GenerateFnInput) -> GenerateFnOutput:
     if collect_timed_out:
         sample = deepcopy(input.sample)
         sample.status = Sample.Status.ABORTED
+        if use_v2:
+            assign_session_rollout_metrics([sample], session_id=tracer.session_id, available=False, metrics=None)
         return GenerateFnOutput(samples=[sample] if use_v2 else sample)
 
     if not result.samples:
@@ -111,9 +114,15 @@ async def generate(input: GenerateFnInput) -> GenerateFnOutput:
             logger.warning("No model calls recorded for sample")
         sample = deepcopy(input.sample)
         sample.status = Sample.Status.ABORTED
+        if use_v2:
+            metrics = read_server_session_rollout_metrics(result.session_metadata, tracer.session_id)
+            assign_session_rollout_metrics([sample], session_id=tracer.session_id, available=True, metrics=metrics)
         return GenerateFnOutput(samples=[sample] if use_v2 else sample)
 
     samples = result.samples
+    if use_v2:
+        metrics = read_server_session_rollout_metrics(result.session_metadata, tracer.session_id)
+        assign_session_rollout_metrics(samples, session_id=tracer.session_id, available=True, metrics=metrics)
     if not use_v2:
         # v1: the agent's metadata is applied driver-side. Under v2 it traveled
         # through collect_samples and came back applied by the server-side

--- a/miles/rollout/session/v2/core.py
+++ b/miles/rollout/session/v2/core.py
@@ -18,6 +18,7 @@ from miles.rollout.session.core import (
 from miles.rollout.session.errors import SessionNotFoundError, TokenizationError
 from miles.rollout.session.samples.codec import COMPUTED_FIELDS_V2, encode_samples
 from miles.rollout.session.types import GetSessionResponse, SessionRecord
+from miles.rollout.session.v2.metrics import SESSION_ROLLOUT_METRICS_KEY, build_session_rollout_metrics
 from miles.rollout.session.v2.session_state import (
     SessionRegistryV2,
     commit_generation,
@@ -80,10 +81,19 @@ class SessionCoreV2(SessionCore):
         metadata = self._session_metadata(session_id, session)
         if agent_metadata is not None:
             metadata["agent"] = agent_metadata
-        if not session.tree.nodes:
-            return _samples_response(
-                encode_samples([], metadata, empty_reason="no_records", fields=COMPUTED_FIELDS_V2)
+
+        def samples_response(samples, *, empty_reason=None):
+            # Hooks may inspect or mutate session metadata, so publish the
+            # authoritative server-owned value only at the wire boundary.
+            metadata[SESSION_ROLLOUT_METRICS_KEY] = build_session_rollout_metrics(
+                self.args, session_id, session.tree.nodes
             )
+            return _samples_response(
+                encode_samples(samples, metadata, empty_reason=empty_reason, fields=COMPUTED_FIELDS_V2)
+            )
+
+        if not session.tree.nodes:
+            return samples_response([], empty_reason="no_records")
 
         try:
             material = build_leaf_material(
@@ -92,9 +102,7 @@ class SessionCoreV2(SessionCore):
         except (AssertionError, ValueError) as exc:
             return Response(content=str(exc).encode(), status_code=422, media_type="text/plain")
         if not material:
-            return _samples_response(
-                encode_samples([], metadata, empty_reason="all_truncated", fields=COMPUTED_FIELDS_V2)
-            )
+            return samples_response([], empty_reason="all_truncated")
 
         # Hook lane: a policy bug is a deterministic 422 carrying the hook's
         # identity, never a masked 500 (server death stays loud).
@@ -114,10 +122,8 @@ class SessionCoreV2(SessionCore):
             )
             return Response(content=body.encode(), status_code=422, media_type="text/plain")
         if not samples:
-            return _samples_response(
-                encode_samples([], metadata, empty_reason="all_truncated", fields=COMPUTED_FIELDS_V2)
-            )
-        return _samples_response(encode_samples(samples, metadata, fields=COMPUTED_FIELDS_V2))
+            return samples_response([], empty_reason="all_truncated")
+        return samples_response(samples)
 
     async def chat_completions(
         self, session_id: str, *, method: str, query: str, headers: dict, body: bytes

--- a/miles/rollout/session/v2/metrics.py
+++ b/miles/rollout/session/v2/metrics.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+from argparse import Namespace
+from collections import defaultdict
+from typing import TYPE_CHECKING
+
+from miles.utils.types import Sample
+
+if TYPE_CHECKING:
+    from miles.rollout.session.v2.tree_trajectory import TrajectoryNode
+
+SESSION_ROLLOUT_METRICS_KEY = "session_rollout_metrics"
+
+_ENVELOPE_FIELDS = frozenset({"session_id", "available", "metrics"})
+_PREFIX_CACHE_INFO_FIELDS = frozenset({"cached_tokens", "total_prompt_tokens"})
+
+# Every revision has one explicit registry. The producer and validator require
+# the metrics object to match it exactly; a later metric extends this registry
+# and shares the same per-session carrier.
+SESSION_ROLLOUT_METRIC_SCHEMAS = {"prefix_cache_info": _PREFIX_CACHE_INFO_FIELDS}
+
+
+def build_session_rollout_metrics(args: Namespace, session_id: str, nodes: list[TrajectoryNode]) -> dict:
+    prefix_cache_info = Sample.PrefixCacheInfo()
+    for node in nodes:
+        prefix_cache_info.add(node.record.response["choices"][0]["meta_info"])
+    return {
+        "session_id": session_id,
+        "available": True,
+        "metrics": {"prefix_cache_info": prefix_cache_info.to_dict()},
+    }
+
+
+def _require_exact_object(value: object, name: str, expected_fields: frozenset[str] | set[str]) -> dict:
+    if type(value) is not dict:
+        raise ValueError(f"{name} must be an object")
+    if set(value) != set(expected_fields):
+        actual_fields = sorted(str(field) for field in value)
+        raise ValueError(f"{name} fields must be exactly {sorted(expected_fields)}, got {actual_fields}")
+    return value
+
+
+def _validate_metrics(metrics: object) -> dict:
+    expected_metrics = set(SESSION_ROLLOUT_METRIC_SCHEMAS)
+    metrics = _require_exact_object(metrics, "session_rollout_metrics.metrics", expected_metrics)
+    for metric_name, expected_fields in SESSION_ROLLOUT_METRIC_SCHEMAS.items():
+        payload_name = f"session_rollout_metrics.metrics.{metric_name}"
+        payload = _require_exact_object(metrics[metric_name], payload_name, expected_fields)
+        for field, value in payload.items():
+            if type(value) is not int or value < 0:
+                raise ValueError(f"{payload_name}.{field} must be a non-negative integer")
+    return metrics
+
+
+def _validate_envelope(envelope: object) -> dict:
+    envelope = _require_exact_object(envelope, "session_rollout_metrics", _ENVELOPE_FIELDS)
+    session_id = envelope["session_id"]
+    if type(session_id) is not str or not session_id:
+        raise ValueError("session_rollout_metrics.session_id must be a non-empty string")
+    if type(envelope["available"]) is not bool:
+        raise ValueError("session_rollout_metrics.available must be a boolean")
+    return envelope
+
+
+def read_server_session_rollout_metrics(session_metadata: dict, expected_session_id: str) -> dict:
+    if type(session_metadata) is not dict:
+        raise ValueError("session metadata must be an object")
+    if SESSION_ROLLOUT_METRICS_KEY not in session_metadata:
+        raise ValueError(f"session metadata is missing {SESSION_ROLLOUT_METRICS_KEY}")
+    envelope = _validate_envelope(session_metadata[SESSION_ROLLOUT_METRICS_KEY])
+    if envelope["session_id"] != expected_session_id:
+        raise ValueError(
+            "session_rollout_metrics.session_id does not match the collected session: "
+            f"{envelope['session_id']!r} != {expected_session_id!r}"
+        )
+    if not envelope["available"] or envelope["metrics"] is None:
+        raise ValueError("a successful session collect must carry available metrics")
+    return _validate_metrics(envelope["metrics"])
+
+
+def assign_session_rollout_metrics(
+    samples: list[Sample], *, session_id: str, available: bool, metrics: dict | None
+) -> None:
+    if type(session_id) is not str or not session_id:
+        raise ValueError("session_rollout_metrics.session_id must be a non-empty string")
+    if type(available) is not bool:
+        raise ValueError("session_rollout_metrics.available must be a boolean")
+    if available:
+        metrics = _validate_metrics(metrics)
+    elif metrics is not None:
+        raise ValueError("unavailable session_rollout_metrics must not carry metrics")
+
+    for sample in samples:
+        sample.metadata.pop(SESSION_ROLLOUT_METRICS_KEY, None)
+        sample.metadata[SESSION_ROLLOUT_METRICS_KEY] = {
+            "session_id": session_id,
+            "available": available,
+            "metrics": None,
+        }
+    if samples and available:
+        samples[0].metadata[SESSION_ROLLOUT_METRICS_KEY]["metrics"] = metrics
+
+
+def collect_session_rollout_metrics(samples: list[Sample]) -> tuple[list[dict], list[str]]:
+    by_session_id: dict[str, list[dict]] = defaultdict(list)
+    for sample in samples:
+        if SESSION_ROLLOUT_METRICS_KEY not in sample.metadata:
+            raise ValueError(f"v2 sample metadata is missing {SESSION_ROLLOUT_METRICS_KEY}")
+        envelope = _validate_envelope(sample.metadata[SESSION_ROLLOUT_METRICS_KEY])
+        by_session_id[envelope["session_id"]].append(envelope)
+
+    available_metrics: list[dict] = []
+    unavailable_session_ids: list[str] = []
+    for session_id, envelopes in by_session_id.items():
+        availability = {envelope["available"] for envelope in envelopes}
+        if len(availability) != 1:
+            raise ValueError(f"session {session_id!r} has inconsistent metrics availability")
+        carriers = [envelope for envelope in envelopes if envelope["metrics"] is not None]
+        if envelopes[0]["available"]:
+            if len(carriers) != 1:
+                raise ValueError(
+                    f"available session {session_id!r} must have exactly one metrics carrier, got {len(carriers)}"
+                )
+            available_metrics.append(_validate_metrics(carriers[0]["metrics"]))
+        else:
+            if carriers:
+                raise ValueError(f"unavailable session {session_id!r} must not have a metrics carrier")
+            unavailable_session_ids.append(session_id)
+    return available_metrics, unavailable_session_ids

--- a/tests/fast/dashboard/test_dump_reader_views.py
+++ b/tests/fast/dashboard/test_dump_reader_views.py
@@ -6,6 +6,8 @@ import pytest
 from tests.fast.dashboard.dummy_dump import dump_dummy_run
 
 from miles.dashboard.dump_reader import DumpReader
+from miles.rollout.session.v2.metrics import SESSION_ROLLOUT_METRICS_KEY
+from miles.utils.types import Sample
 
 REMOVED = (3,)  # within-step positions marked remove_sample=True by the fixture
 
@@ -45,6 +47,28 @@ def test_summary_matches_hand_computed(reader):
                 float((row.log_probs - row.rollout_log_probs).exp()[mask].mean()), rel=1e-5
             )
             assert entry["mean_entropy"] == pytest.approx(float(row.entropy[mask].mean()), rel=1e-5)
+
+
+def test_summary_uses_leaf_prefix_cache_info_not_session_carrier(reader):
+    sample = Sample(
+        prefix_cache_info=Sample.PrefixCacheInfo(cached_tokens=1, total_prompt_tokens=4),
+        metadata={
+            SESSION_ROLLOUT_METRICS_KEY: {
+                "session_id": "sid-1",
+                "available": True,
+                "metrics": {
+                    "prefix_cache_info": {
+                        "cached_tokens": 99,
+                        "total_prompt_tokens": 100,
+                    }
+                },
+            }
+        },
+    )
+
+    entry = reader._summary_row(sample, None, rollout_id=0)
+
+    assert entry["prefix_cache_hit_rate"] == 0.25
 
 
 def test_summary_removed_sample_has_no_masked_stats(reader):

--- a/tests/fast/ray/rollout/test_metrics.py
+++ b/tests/fast/ray/rollout/test_metrics.py
@@ -6,9 +6,12 @@ from tests.fast.ray.rollout.conftest import make_args, make_samples_grouped
 from miles.ray.rollout.metrics import (
     _compute_metrics_from_samples,
     _compute_passrate_from_samples,
+    _compute_prefix_cache_metrics,
     _compute_zero_std_metrics,
     log_rollout_data,
 )
+from miles.rollout.session.v2.metrics import SESSION_ROLLOUT_METRICS_KEY
+from miles.utils.types import Sample
 
 
 class TestComputeZeroStdMetrics:
@@ -52,6 +55,100 @@ class TestComputeZeroStdMetrics:
         # No groups → no all_zero/all_one keys (the function guards on total_groups>0).
         assert "zero_std/all_zero_percentage" not in out
         assert "zero_std/all_one_percentage" not in out
+
+
+class TestComputePrefixCacheMetrics:
+    @staticmethod
+    def _member(session_id, metrics, *, available=True):
+        sample = Sample()
+        sample.metadata[SESSION_ROLLOUT_METRICS_KEY] = {
+            "session_id": session_id,
+            "available": available,
+            "metrics": metrics,
+        }
+        return sample
+
+    @staticmethod
+    def _prefix_cache_info(cached_tokens, total_prompt_tokens):
+        return {
+            "prefix_cache_info": {
+                "cached_tokens": cached_tokens,
+                "total_prompt_tokens": total_prompt_tokens,
+            }
+        }
+
+    def test_v2_aggregates_once_per_session_and_uses_session_denominator(self):
+        args = make_args(use_session_server="v2")
+        samples = [
+            self._member("sid-1", self._prefix_cache_info(5, 10)),
+            self._member("sid-1", None),
+            self._member("sid-2", self._prefix_cache_info(7, 14)),
+        ]
+        for sample in samples:
+            sample.prefix_cache_info = Sample.PrefixCacheInfo(cached_tokens=100, total_prompt_tokens=100)
+
+        out = _compute_prefix_cache_metrics(args, samples)
+
+        assert out == {"prefix_cache_hit_rate": 0.5, "avg_cached_tokens_per_sample": 6.0}
+
+    @pytest.mark.parametrize("carriers", [0, 2])
+    def test_v2_rejects_missing_or_duplicate_carrier(self, carriers):
+        args = make_args(use_session_server="v2")
+        metrics = self._prefix_cache_info(1, 2)
+        samples = [self._member("sid-1", metrics if i < carriers else None) for i in range(2)]
+
+        with pytest.raises(ValueError, match="exactly one metrics carrier"):
+            _compute_prefix_cache_metrics(args, samples)
+
+    @pytest.mark.parametrize(
+        "metadata",
+        [
+            {},
+            {
+                SESSION_ROLLOUT_METRICS_KEY: {
+                    "session_id": "sid-1",
+                    "available": True,
+                    "metrics": {"prefix_cache_info": {"cached_tokens": 1}},
+                }
+            },
+            {
+                SESSION_ROLLOUT_METRICS_KEY: {
+                    "session_id": "sid-1",
+                    "available": True,
+                    "metrics": {
+                        "prefix_cache_info": {
+                            "cached_tokens": True,
+                            "total_prompt_tokens": 2,
+                        }
+                    },
+                }
+            },
+        ],
+    )
+    def test_v2_rejects_missing_or_bad_schema(self, metadata):
+        args = make_args(use_session_server="v2")
+
+        with pytest.raises(ValueError):
+            _compute_prefix_cache_metrics(args, [Sample(metadata=metadata)])
+
+    def test_v2_excludes_unavailable_session_from_totals_and_denominator(self, caplog):
+        args = make_args(use_session_server="v2")
+        samples = [
+            self._member("sid-1", self._prefix_cache_info(5, 10)),
+            self._member("sid-2", None, available=False),
+        ]
+
+        out = _compute_prefix_cache_metrics(args, samples)
+
+        assert out == {"prefix_cache_hit_rate": 0.5, "avg_cached_tokens_per_sample": 5.0}
+        assert "Prefix-cache metrics unavailable for 1 v2 sessions" in caplog.text
+
+    def test_v2_all_unavailable_sessions_return_zero_metrics(self):
+        args = make_args(use_session_server="v2")
+
+        out = _compute_prefix_cache_metrics(args, [self._member("sid-1", None, available=False)])
+
+        assert out == {"prefix_cache_hit_rate": 0.0, "avg_cached_tokens_per_sample": 0.0}
 
 
 class TestTitoMismatchMetrics:

--- a/tests/fast/rollout/generate_hub/test_agentic_v2.py
+++ b/tests/fast/rollout/generate_hub/test_agentic_v2.py
@@ -1,3 +1,4 @@
+import asyncio
 from types import SimpleNamespace
 
 import pytest
@@ -5,6 +6,7 @@ import pytest
 import miles.rollout.generate_hub.agentic_tool_call as agentic_tool_call
 from miles.rollout.base_types import GenerateFnInput
 from miles.rollout.session.samples.codec import SamplesReply
+from miles.rollout.session.v2.metrics import SESSION_ROLLOUT_METRICS_KEY
 from miles.utils.types import Sample
 
 
@@ -50,6 +52,16 @@ async def _fake_agent(**kwargs):
     return {"agent_result": "done"}
 
 
+def _session_metadata(prefix_cache_info=None):
+    return {
+        SESSION_ROLLOUT_METRICS_KEY: {
+            "session_id": "sid-1",
+            "available": True,
+            "metrics": {"prefix_cache_info": prefix_cache_info or Sample.PrefixCacheInfo().to_dict()},
+        }
+    }
+
+
 def _patch_agent(monkeypatch, tracer):
     async def fake_create(args):
         return tracer
@@ -61,19 +73,58 @@ def _patch_agent(monkeypatch, tracer):
 @pytest.mark.asyncio
 async def test_success_returns_list_and_forwards_agent_metadata(monkeypatch):
     sample = Sample(status=Sample.Status.COMPLETED, response="done", response_length=1, tokens=[1])
-    tracer = _Tracer(SamplesReply(samples=[sample], session_metadata={}, empty_reason=None))
+    tracer = _Tracer(SamplesReply(samples=[sample], session_metadata=_session_metadata(), empty_reason=None))
     _patch_agent(monkeypatch, tracer)
 
     output = await agentic_tool_call.generate(_generate_input())
 
     assert output.samples == [sample]
     assert tracer.agent_metadata == {"agent_result": "done"}
+    assert output.samples[0].metadata[SESSION_ROLLOUT_METRICS_KEY]["metrics"] == {
+        "prefix_cache_info": Sample.PrefixCacheInfo().to_dict()
+    }
+
+
+@pytest.mark.asyncio
+async def test_multi_leaf_success_assigns_one_session_metrics_carrier(monkeypatch):
+    stale = {"session_id": "stale", "available": True, "metrics": {"agent": "plant"}}
+    leaves = [
+        Sample(metadata={SESSION_ROLLOUT_METRICS_KEY: stale}),
+        Sample(metadata={SESSION_ROLLOUT_METRICS_KEY: stale}),
+    ]
+    prefix_cache_info = {"cached_tokens": 7, "total_prompt_tokens": 11}
+    tracer = _Tracer(
+        SamplesReply(
+            samples=leaves,
+            session_metadata=_session_metadata(prefix_cache_info),
+            empty_reason=None,
+        )
+    )
+    _patch_agent(monkeypatch, tracer)
+
+    output = await agentic_tool_call.generate(_generate_input())
+
+    assert [sample.metadata[SESSION_ROLLOUT_METRICS_KEY] for sample in output.samples] == [
+        {
+            "session_id": "sid-1",
+            "available": True,
+            "metrics": {"prefix_cache_info": prefix_cache_info},
+        },
+        {"session_id": "sid-1", "available": True, "metrics": None},
+    ]
 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("empty_reason", ["no_records", "all_truncated"])
 async def test_empty_reply_returns_aborted_list(monkeypatch, empty_reason):
-    tracer = _Tracer(SamplesReply(samples=[], session_metadata={}, empty_reason=empty_reason))
+    prefix_cache_info = {"cached_tokens": 7, "total_prompt_tokens": 11}
+    tracer = _Tracer(
+        SamplesReply(
+            samples=[],
+            session_metadata=_session_metadata(prefix_cache_info),
+            empty_reason=empty_reason,
+        )
+    )
     _patch_agent(monkeypatch, tracer)
     generate_input = _generate_input()
 
@@ -83,6 +134,34 @@ async def test_empty_reply_returns_aborted_list(monkeypatch, empty_reason):
     assert len(output.samples) == 1
     assert output.samples[0] is not generate_input.sample
     assert output.samples[0].status == Sample.Status.ABORTED
+    assert output.samples[0].metadata[SESSION_ROLLOUT_METRICS_KEY]["metrics"] == {
+        "prefix_cache_info": prefix_cache_info
+    }
+
+
+@pytest.mark.asyncio
+async def test_collection_timeout_marks_session_metrics_unavailable(monkeypatch):
+    tracer = _Tracer(error=asyncio.TimeoutError("samples unavailable"))
+    _patch_agent(monkeypatch, tracer)
+
+    output = await agentic_tool_call.generate(_generate_input())
+
+    (sample,) = output.samples
+    assert sample.status == Sample.Status.ABORTED
+    assert sample.metadata[SESSION_ROLLOUT_METRICS_KEY] == {
+        "session_id": "sid-1",
+        "available": False,
+        "metrics": None,
+    }
+
+
+@pytest.mark.asyncio
+async def test_v2_rejects_missing_server_session_metrics(monkeypatch):
+    tracer = _Tracer(SamplesReply(samples=[Sample()], session_metadata={}, empty_reason=None))
+    _patch_agent(monkeypatch, tracer)
+
+    with pytest.raises(ValueError, match="missing session_rollout_metrics"):
+        await agentic_tool_call.generate(_generate_input())
 
 
 @pytest.mark.asyncio

--- a/tests/fast/router/test_session_samples_op_v2.py
+++ b/tests/fast/router/test_session_samples_op_v2.py
@@ -31,6 +31,7 @@ from miles.rollout.session.errors import TokenizationError
 from miles.rollout.session.samples.codec import COMPUTED_FIELDS_V2, decode_samples_and_merge_input_sample
 from miles.rollout.session.sessions import setup_session_routes
 from miles.rollout.session.v2.core import SessionCoreV2
+from miles.rollout.session.v2.metrics import SESSION_ROLLOUT_METRICS_KEY
 from miles.rollout.session.v2.session_state import SessionRegistryV2
 from miles.utils.chat_template_utils import get_tito_tokenizer
 from miles.utils.misc import function_registry
@@ -237,8 +238,10 @@ async def test_session_metadata_matches_get_session(core):
 
     response = await core.get_session(sid)
     assert response.status_code == 200
+    rollout_metrics = reply.session_metadata.pop(SESSION_ROLLOUT_METRICS_KEY)
     assert reply.session_metadata == json.loads(response.body)["metadata"]
     assert reply.session_metadata["accumulated_token_ids"] == _ACCUMULATED
+    assert rollout_metrics["session_id"] == sid
 
 
 # ── empty_reason discriminator ──
@@ -250,6 +253,11 @@ async def test_no_records_reply(core):
     assert status == 200
     reply = decode_samples_and_merge_input_sample(payload, Sample(), fields=COMPUTED_FIELDS_V2)
     assert reply.samples == [] and reply.empty_reason == "no_records"
+    assert reply.session_metadata[SESSION_ROLLOUT_METRICS_KEY] == {
+        "session_id": sid,
+        "available": True,
+        "metrics": {"prefix_cache_info": Sample.PrefixCacheInfo().to_dict()},
+    }
 
 
 async def test_all_truncated_reply(core):
@@ -262,6 +270,10 @@ async def test_all_truncated_reply(core):
     assert status == 200
     reply = decode_samples_and_merge_input_sample(payload, Sample(), fields=COMPUTED_FIELDS_V2)
     assert reply.samples == [] and reply.empty_reason == "all_truncated"
+    assert reply.session_metadata[SESSION_ROLLOUT_METRICS_KEY]["metrics"]["prefix_cache_info"] == {
+        "cached_tokens": 5,
+        "total_prompt_tokens": 10,
+    }
 
 
 # ── the 422 lane ──
@@ -283,12 +295,12 @@ async def test_broken_chain_returns_422_and_server_survives(core):
 # ── the tree data plane: branches, trims, exactly-once, rewards ──
 
 
-def _single_turn_record(prompt_ids, output_ids, weight_version="w1"):
+def _single_turn_record(prompt_ids, output_ids, weight_version="w1", cached_tokens=0):
     return _make_record(
         prompt_token_ids=list(prompt_ids),
         output_token_ids=list(output_ids),
         output_log_probs=[-0.1] * len(output_ids),
-        cached_tokens=0,
+        cached_tokens=cached_tokens,
         prompt_tokens=len(prompt_ids),
         weight_version=weight_version,
         routed_experts=_r3_b64(len(prompt_ids) + len(output_ids) - 1, seed=0),
@@ -388,6 +400,79 @@ async def test_deep_abandoned_branch_survives_and_masks_shared_prefix(core, traj
     assert late_sample.loss_mask[-1] == 1  # its own completion still trains
     assert [sample.reward for sample in reply.samples] == [trajectory_reward, trajectory_reward]
     assert [sample.metadata["reward"] for sample in reply.samples] == [trajectory_reward, trajectory_reward]
+
+
+async def test_prefix_cache_metrics_count_every_tree_node_once(core):
+    sid, state = await _fresh_state(core)
+    root = _fabricate_node(
+        state,
+        None,
+        _single_turn_record([1, 2, 3], [10, 11], cached_tokens=2),
+        [1, 2, 3, 10, 11],
+        completion_span=(3, 5),
+    )
+    _fabricate_node(
+        state,
+        root,
+        _single_turn_record([1, 2, 3, 10, 11, 19], [29], cached_tokens=6),
+        [1, 2, 3, 10, 11, 19, 29],
+        completion_span=(6, 7),
+    )
+    early_mid = _fabricate_node(
+        state,
+        root,
+        _single_turn_record([1, 2, 3, 10, 11, 20], [30], cached_tokens=4),
+        [1, 2, 3, 10, 11, 20, 30],
+        completion_span=(6, 7),
+    )
+    early_leaf = _fabricate_node(
+        state,
+        early_mid,
+        _single_turn_record([1, 2, 3, 10, 11, 20, 30, 40], [50], cached_tokens=5),
+        [1, 2, 3, 10, 11, 20, 30, 40, 50],
+        completion_span=(8, 9),
+        response_id="early",
+    )
+    late_leaf = _fabricate_node(
+        state,
+        root,
+        _single_turn_record([1, 2, 3, 10, 11, 21], [31], cached_tokens=3),
+        [1, 2, 3, 10, 11, 21, 31],
+        completion_span=(6, 7),
+        response_id="late",
+    )
+    state.active_leaf = late_leaf
+
+    status, payload = await _collect_via_op(core, sid)
+    assert status == 200
+    reply = decode_samples_and_merge_input_sample(payload, Sample(), fields=COMPUTED_FIELDS_V2)
+    early_sample, late_sample = reply.samples
+
+    assert early_sample.tokens == early_leaf.token_ids
+    assert late_sample.tokens == late_leaf.token_ids
+    assert early_sample.prefix_cache_info.to_dict() == {"cached_tokens": 11, "total_prompt_tokens": 17}
+    assert late_sample.prefix_cache_info.to_dict() == {"cached_tokens": 5, "total_prompt_tokens": 9}
+    assert reply.session_metadata[SESSION_ROLLOUT_METRICS_KEY] == {
+        "session_id": sid,
+        "available": True,
+        "metrics": {"prefix_cache_info": {"cached_tokens": 20, "total_prompt_tokens": 29}},
+    }
+
+
+async def test_prefix_cache_metrics_include_node_excluded_by_max_seq_len(core):
+    sid = await _make_session(core, _two_turn_records(), _ACCUMULATED)
+
+    status, payload = await _collect_via_op(core, sid, max_seq_len=5)
+    assert status == 200
+    reply = decode_samples_and_merge_input_sample(payload, Sample(), fields=COMPUTED_FIELDS_V2)
+    (sample,) = reply.samples
+
+    assert sample.tokens == [1, 2, 3, 10, 11]
+    assert sample.prefix_cache_info.to_dict() == {"cached_tokens": 0, "total_prompt_tokens": 3}
+    assert reply.session_metadata[SESSION_ROLLOUT_METRICS_KEY]["metrics"]["prefix_cache_info"] == {
+        "cached_tokens": 5,
+        "total_prompt_tokens": 10,
+    }
 
 
 async def test_picker_warns_and_trims_longer_superseded_leaf(core, caplog):
@@ -528,6 +613,11 @@ def _reverse_picker(leaf_samples, session_metadata):
     return list(reversed(leaf_samples))
 
 
+def _pass_through_postprocessor(leaf_samples, session_metadata):
+    session_metadata[SESSION_ROLLOUT_METRICS_KEY] = {"agent": "plant"}
+    return leaf_samples
+
+
 def _duplicate_picker(leaf_samples, session_metadata):
     return [leaf_samples[0], leaf_samples[0]]
 
@@ -559,19 +649,23 @@ def _build_core_with_hooks(**hook_args) -> SessionCoreV2:
 async def _retry_shaped_session(core):
     sid, state = await _fresh_state(core)
     root = _fabricate_node(
-        state, None, _single_turn_record([1, 2, 3], [10, 11]), [1, 2, 3, 10, 11], completion_span=(3, 5)
+        state,
+        None,
+        _single_turn_record([1, 2, 3], [10, 11], cached_tokens=2),
+        [1, 2, 3, 10, 11],
+        completion_span=(3, 5),
     )
     _fabricate_node(
         state,
         root,
-        _single_turn_record([1, 2, 3, 10, 11, 20], [30]),
+        _single_turn_record([1, 2, 3, 10, 11, 20], [30], cached_tokens=4),
         [1, 2, 3, 10, 11, 20, 30],
         completion_span=(6, 7),
     )
     retry = _fabricate_node(
         state,
         root,
-        _single_turn_record([1, 2, 3, 10, 11, 21], [31]),
+        _single_turn_record([1, 2, 3, 10, 11, 21], [31], cached_tokens=3),
         [1, 2, 3, 10, 11, 21, 31],
         completion_span=(6, 7),
     )
@@ -595,6 +689,10 @@ async def test_custom_picker_keeps_abandoned_leaf(core):
         # owns the shared root completion; the retry masks it.
         assert abandoned.loss_mask[:2] == [1, 1]
         assert retry.loss_mask[:2] == [0, 0]
+        assert reply.session_metadata[SESSION_ROLLOUT_METRICS_KEY]["metrics"]["prefix_cache_info"] == {
+            "cached_tokens": 9,
+            "total_prompt_tokens": 15,
+        }
 
 
 async def test_custom_picker_reorder_keeps_earliest_leaf_as_owner(core):
@@ -607,6 +705,24 @@ async def test_custom_picker_reorder_keeps_earliest_leaf_as_owner(core):
         retry, abandoned = reply.samples
         assert retry.loss_mask[:2] == [0, 0]
         assert abandoned.loss_mask[:2] == [1, 1]
+        assert reply.session_metadata[SESSION_ROLLOUT_METRICS_KEY]["metrics"]["prefix_cache_info"] == {
+            "cached_tokens": 9,
+            "total_prompt_tokens": 15,
+        }
+
+
+async def test_custom_postprocessor_cannot_replace_session_rollout_metrics(core):
+    with function_registry.temporary("test_hooks.pass_through", _pass_through_postprocessor):
+        hooked = _build_core_with_hooks(session_sample_postprocessor_path="test_hooks.pass_through")
+        sid = await _retry_shaped_session(hooked)
+        response = await hooked.collect_samples(sid, max_seq_len=None)
+        assert response.status_code == 200
+        reply = decode_samples_and_merge_input_sample(bytes(response.body), Sample(), fields=COMPUTED_FIELDS_V2)
+        assert reply.session_metadata[SESSION_ROLLOUT_METRICS_KEY] == {
+            "session_id": sid,
+            "available": True,
+            "metrics": {"prefix_cache_info": {"cached_tokens": 9, "total_prompt_tokens": 15}},
+        }
 
 
 async def test_hook_exception_maps_to_422_with_identity(core):


### PR DESCRIPTION
<!-- lint: profile=normal -->
## Summary

Aggregate v2 prefix-cache counters once per session tree instead of once per retained leaf.

## Symptom & Reproduction

- **Symptom:** Branching v2 sessions duplicate shared-node cache counters and make `avg_cached_tokens_per_sample` depend on leaf count.
- **Reproduction:** One session with two leaves and one session with one leaf is currently divided by three flattened leaves rather than two source sessions.

## Root Cause

1. `build_leaf_material` correctly gives every leaf a path-local `Sample.prefix_cache_info`, including its shared ancestors.
2. `_compute_prefix_cache_metrics` sums flattened leaves and uses their count as the denominator, even though cache activity belongs to session generation calls.

## Fix

The v2 server aggregates each committed tree node once into a strict `session_rollout_metrics` envelope. The driver removes stale copies and assigns exactly one carrier per session. Ray validates session identity and carrier cardinality, then computes totals and the average over available source sessions. Unavailable collection is warned and excluded.

`Sample.prefix_cache_info` remains path-local for dashboard rows and other per-leaf consumers; non-v2 aggregation is unchanged.

## Verification

- Python 3.12 compilation and `git diff --check` passed for all eight changed files.
- Repository pre-commit hooks passed for all eight files, including Ruff, autoflake, isort, Black, and local policy hooks.
- Added driver tests for successful, empty, and unavailable collection.
- Added server tests for metadata collision, picker order, and max-sequence truncation.
- Added Ray tests for the session denominator and strict carrier validation.
- Added a dashboard test for leaf-row semantics.
- Runtime pytest was not executed because the explicitly bound `miles-default` devbox is released.

## Review Focus

- The revision-local metric registry contains exactly `prefix_cache_info` and every available session has one carrier.
- When combined with the speculative-metrics carrier, the revision-local registry, producer, validator, and combined tests must use one carrier with exact `{spec_info, prefix_cache_info}`.
- `avg_cached_tokens_per_sample` uses available session count under v2 and preserves the existing non-v2 behavior.
