### PR TITLE
Fix Adam and Muon optimizer state resets

### DIFF
--- a/miles/backends/megatron_utils/model.py
+++ b/miles/backends/megatron_utils/model.py
@@ -28,6 +28,7 @@ from megatron.training.training import get_model
 from miles.backends.megatron_utils.ft.indep_dp import allreduce_grads_and_losses_across_replicas
 from miles.backends.megatron_utils.ft.types import TrainStepOutcome
 from miles.backends.megatron_utils.local_weight_checksum import dump_local_weight_checksums
+from miles.backends.megatron_utils.optimizer_state_reset import reset_optimizer_states
 from miles.utils.audit_utils.witness.allocator import WitnessInfo
 from miles.utils.audit_utils.witness.module import witness_dump_and_clear_stale
 from miles.utils.dumper_utils import DumperMegatronUtil, DumperPhase
@@ -736,16 +737,11 @@ def train(
 
     if args.reset_optimizer_states and not disable_optimizer:
         if is_first_replica_megatron_main_rank():
-            print("Reset optimizer states")
-        for chained_optimizer in optimizer.chained_optimizers:
-            for group in chained_optimizer.optimizer.param_groups:
-                if "step" in group:
-                    group["step"] = 0
-            for state in chained_optimizer.optimizer.state.values():
-                if "exp_avg" in state:
-                    state["exp_avg"].zero_()
-                if "exp_avg_sq" in state:
-                    state["exp_avg_sq"].zero_()
+            logger.info("Reset optimizer states")
+        reset_optimizer_states(
+            args.optimizer,
+            [chained_optimizer.optimizer for chained_optimizer in optimizer.chained_optimizers],
+        )
 
     if args.manual_gc:
         # Disable the default garbage collector and perform the collection manually.

--- a/miles/backends/megatron_utils/optimizer_state_reset.py
+++ b/miles/backends/megatron_utils/optimizer_state_reset.py
@@ -1,0 +1,97 @@
+"""Fail-closed optimizer-state reset helpers for Megatron training."""
+
+from collections.abc import MutableMapping, Sequence
+from typing import Any
+
+import torch
+from megatron.core.optimizer import Adam as MegatronAdam
+from megatron.core.optimizer import CPUAdam
+from megatron.core.optimizer.cpu_offloading.hybrid_optimizer import HybridDeviceOptimizer
+from megatron.core.optimizer.emerging_optimizers import TensorParallelMuon
+
+
+def _zero_step(container: MutableMapping[str, Any]) -> None:
+    if "step" not in container:
+        return
+
+    step = container["step"]
+    if isinstance(step, torch.Tensor):
+        step.zero_()
+    elif isinstance(step, (int, float)):
+        container["step"] = 0
+    else:
+        raise TypeError(f"Unsupported optimizer step type: {type(step).__name__}")
+
+
+def _zero_tensor(state: MutableMapping[str, Any], key: str) -> None:
+    value = state.get(key)
+    if not isinstance(value, torch.Tensor):
+        raise TypeError(f"Expected tensor optimizer state {key!r}, got {type(value).__name__}")
+    value.zero_()
+
+
+def _reset_adam_state(optimizer: torch.optim.Optimizer) -> None:
+    # Some Adam implementations store the step inside optimizer.param_groups.
+    for group in optimizer.param_groups:
+        _zero_step(group)
+
+    for state in optimizer.state.values():
+        unexpected_keys = set(state) - {"step", "exp_avg", "exp_avg_sq", "master_param"}
+        if unexpected_keys:
+            raise RuntimeError(f"Unsupported Adam optimizer state keys: {sorted(unexpected_keys)}")
+
+        has_exp_avg = "exp_avg" in state
+        has_exp_avg_sq = "exp_avg_sq" in state
+
+        # Both moments may be absent before a parameter's first optimizer step or for frozen parameters.
+        if has_exp_avg != has_exp_avg_sq:
+            raise RuntimeError(f"Incomplete Adam optimizer state: {sorted(state)}")
+
+        # This is a no-op for implementations that store the step only in param_groups.
+        _zero_step(state)
+
+        if has_exp_avg:
+            _zero_tensor(state, "exp_avg")
+            _zero_tensor(state, "exp_avg_sq")
+
+
+def _reset_muon_state(optimizer: TensorParallelMuon) -> None:
+    for state in optimizer.state.values():
+        unexpected_keys = set(state) - {"momentum_buffer"}
+        if unexpected_keys:
+            raise RuntimeError(f"Unsupported Muon optimizer state keys: {sorted(unexpected_keys)}")
+        if "momentum_buffer" in state:
+            _zero_tensor(state, "momentum_buffer")
+
+
+def _reset_supported_adam_state(optimizer: torch.optim.Optimizer) -> None:
+    if isinstance(optimizer, HybridDeviceOptimizer):
+        if optimizer.gpu_optimizer is not None:
+            raise TypeError("HybridDeviceOptimizer with a GPU child optimizer is not supported")
+        if not optimizer.cpu_optimizers:
+            raise TypeError("HybridDeviceOptimizer has no CPU child optimizers")
+        for child_optimizer in optimizer.cpu_optimizers:
+            if not isinstance(child_optimizer, CPUAdam):
+                raise TypeError(f"HybridDeviceOptimizer wraps unsupported CPU optimizer {type(child_optimizer).__name__}")
+    elif not isinstance(optimizer, (MegatronAdam, CPUAdam)):
+        raise TypeError(f"Unsupported Adam optimizer implementation: {type(optimizer).__name__}. When adding support for a new optimizer, update _reset_adam_state() for its state schema")
+
+    _reset_adam_state(optimizer)
+
+
+def reset_optimizer_states(optimizer_name: str, optimizers: Sequence[torch.optim.Optimizer]) -> None:
+    """Reset all history for a supported optimizer, failing on unknown implementations or state."""
+    if optimizer_name == "adam":
+        for optimizer in optimizers:
+            _reset_supported_adam_state(optimizer)
+        return
+
+    if optimizer_name == "dist_muon":
+        for optimizer in optimizers:
+            if isinstance(optimizer, TensorParallelMuon):
+                _reset_muon_state(optimizer)
+            else:
+                _reset_supported_adam_state(optimizer)
+        return
+
+    raise NotImplementedError(f"--reset-optimizer-states does not support optimizer {optimizer_name!r}")


### PR DESCRIPTION
The existing `reset_optimizer_states` implementation has two bugs:
1 - It does not reset state for muon
2 - it is incorrect for some adam implementations, e.g. CPUAdam, where the step parameter is stored in `optimizer.state` instead of `optimizer.param_groups`.

This PR supports these optimizers correctly, and fails loudly for other optimizers instead of silently not resetting state
