### PR TITLE
fix(replay): reject partially padded router rows

### DIFF
--- a/miles/utils/replay_base.py
+++ b/miles/utils/replay_base.py
@@ -57,10 +57,13 @@ class BaseReplayManager:
     # True when replayed indices are token/KV positions (indexer): rebase the
     # per-sample 0-based rollout indices onto the packed training sequence.
     replay_indices_are_token_positions = False
-    # MoE routing validates every replayed expert index before masking padded
-    # slots. Indexer replay has different partial-padding semantics, so only
-    # routing replay should opt into replacing every invalid slot.
-    sanitize_partial_invalid_indices = False
+    # Unlike all-invalid rows (whole padding tokens), partially invalid routing
+    # rows have no lossless representation in Megatron's top-k API: the API does
+    # not propagate a per-slot validity mask into probability normalization or
+    # routing-map construction. Routing replay therefore rejects them rather
+    # than inventing expert assignments. Indexer replay retains its existing
+    # partial-padding semantics.
+    reject_partial_invalid_indices = False
 
     def __init__(self):
         self.replays: list[Replay] = []
@@ -103,15 +106,16 @@ class BaseReplayManager:
             if self.enable_check_replay_result:
                 self.check_replay_result(old_topk_fn, scores, topk, top_indices, *args, **kwargs)
 
-            if self.sanitize_partial_invalid_indices:
+            if self.reject_partial_invalid_indices:
                 invalid = top_indices == -1
                 partial_invalid_rows = invalid.any(dim=-1) & ~invalid.all(dim=-1)
-                padding_mask = invalid & partial_invalid_rows.unsqueeze(-1)
-                if padding_mask.any():
-                    top_indices = top_indices.clone()
-                    top_indices[padding_mask] = (
-                        torch.arange(padding_mask.sum(), device=top_indices.device, dtype=top_indices.dtype)
-                        % scores.shape[1]
+                if partial_invalid_rows.any():
+                    invalid_slots = (invalid & partial_invalid_rows.unsqueeze(-1)).sum().item()
+                    raise RuntimeError(
+                        "Routing replay contains partially padded top-k rows "
+                        f"({partial_invalid_rows.sum().item()} rows, {invalid_slots} invalid slots). "
+                        "Megatron's routing API cannot preserve a per-slot padding mask; "
+                        "continuing would create extra expert routes."
                     )
 
             # fill padding tokens with arange to avoid invalid reading
@@ -128,7 +132,7 @@ class BaseReplayManager:
             # int64. A native torch.topk call also returns int64. Keep the
             # indexer-only, return-indices path unchanged because its kernels
             # consume the serialized int32 representation directly.
-            if return_probs or self.sanitize_partial_invalid_indices:
+            if return_probs:
                 top_indices = top_indices.long()
 
             if return_probs:
@@ -242,7 +246,7 @@ class RoutingReplayManager(BaseReplayManager):
     if_sp_region = True
     enable_check_replay_result = False
     replay_check_max_mismatch_fraction = 1e-2
-    sanitize_partial_invalid_indices = True
+    reject_partial_invalid_indices = True
 
 
 class IndexerReplayManager(BaseReplayManager):

--- a/miles/utils/replay_base.py
+++ b/miles/utils/replay_base.py
@@ -57,6 +57,10 @@ class BaseReplayManager:
     # True when replayed indices are token/KV positions (indexer): rebase the
     # per-sample 0-based rollout indices onto the packed training sequence.
     replay_indices_are_token_positions = False
+    # MoE routing validates every replayed expert index before masking padded
+    # slots. Indexer replay has different partial-padding semantics, so only
+    # routing replay should opt into replacing every invalid slot.
+    sanitize_partial_invalid_indices = False
 
     def __init__(self):
         self.replays: list[Replay] = []
@@ -99,6 +103,17 @@ class BaseReplayManager:
             if self.enable_check_replay_result:
                 self.check_replay_result(old_topk_fn, scores, topk, top_indices, *args, **kwargs)
 
+            if self.sanitize_partial_invalid_indices:
+                invalid = top_indices == -1
+                partial_invalid_rows = invalid.any(dim=-1) & ~invalid.all(dim=-1)
+                padding_mask = invalid & partial_invalid_rows.unsqueeze(-1)
+                if padding_mask.any():
+                    top_indices = top_indices.clone()
+                    top_indices[padding_mask] = (
+                        torch.arange(padding_mask.sum(), device=top_indices.device, dtype=top_indices.dtype)
+                        % scores.shape[1]
+                    )
+
             # fill padding tokens with arange to avoid invalid reading
             all_invalid = (top_indices == -1).all(dim=-1)
             if all_invalid.any():
@@ -107,6 +122,14 @@ class BaseReplayManager:
                     % scores.shape[1]
                 )
                 top_indices = torch.where(all_invalid.unsqueeze(-1), ar, top_indices)
+
+            # Rollout payloads are serialized as int32, while routing callers
+            # feed the result to PyTorch gather/scatter operators that require
+            # int64. A native torch.topk call also returns int64. Keep the
+            # indexer-only, return-indices path unchanged because its kernels
+            # consume the serialized int32 representation directly.
+            if return_probs or self.sanitize_partial_invalid_indices:
+                top_indices = top_indices.long()
 
             if return_probs:
                 return scores.gather(1, top_indices), top_indices
@@ -219,6 +242,7 @@ class RoutingReplayManager(BaseReplayManager):
     if_sp_region = True
     enable_check_replay_result = False
     replay_check_max_mismatch_fraction = 1e-2
+    sanitize_partial_invalid_indices = True
 
 
 class IndexerReplayManager(BaseReplayManager):

--- a/tests/fast/utils/test_replay_base.py
+++ b/tests/fast/utils/test_replay_base.py
@@ -4,7 +4,7 @@ register_cpu_ci(est_time=60, suite="stage-a-cpu", labels=[])
 
 import torch
 
-from miles.utils.replay_base import BaseReplayManager
+from miles.utils.replay_base import BaseReplayManager, RoutingReplayManager
 
 
 class _FakeReplay:
@@ -31,6 +31,14 @@ def _make_replay_manager(top_indices):
     return manager
 
 
+def _make_routing_replay_manager(top_indices):
+    manager = RoutingReplayManager()
+    manager.enabled = True
+    manager.stage = "replay_forward"
+    manager.set_current(_FakeReplay(top_indices))
+    return manager
+
+
 def test_get_topk_fn_fills_all_invalid_rows_with_arange():
     # an all-(-1) row is a masked/pad token; fill it with arange to avoid reading
     # invalid (-1) positions downstream
@@ -51,3 +59,31 @@ def test_get_topk_fn_preserves_partial_padding():
     topk_fn = manager.get_topk_fn(_topk, return_probs=False)
 
     torch.testing.assert_close(topk_fn(scores, 3), replayed_top_indices)
+
+
+def test_routing_get_topk_fn_fills_partial_padding():
+    # Megatron's MoE router validates every expert ID before applying the
+    # padding mask, so router replay must sanitize individual invalid slots.
+    scores = torch.arange(5, dtype=torch.float32).unsqueeze(0)
+    manager = _make_routing_replay_manager(torch.tensor([[2, -1, -1]], dtype=torch.int32))
+
+    topk_fn = manager.get_topk_fn(_topk, return_probs=False)
+
+    result = topk_fn(scores, 3)
+    torch.testing.assert_close(result, torch.tensor([[2, 0, 1]], dtype=torch.int64))
+    assert result.dtype == torch.long
+
+
+def test_routing_get_topk_fn_gathers_probs_after_sanitizing_without_mutating_replay():
+    scores = torch.tensor([[0.1, 0.2, 0.3, 0.4, 0.5]])
+    replayed_top_indices = torch.tensor([[2, -1, -1]], dtype=torch.int32)
+    manager = _make_routing_replay_manager(replayed_top_indices)
+
+    topk_fn = manager.get_topk_fn(_topk, return_probs=True)
+    probs, top_indices = topk_fn(scores, 3)
+
+    torch.testing.assert_close(top_indices, torch.tensor([[2, 0, 1]], dtype=torch.int64))
+    torch.testing.assert_close(probs, torch.tensor([[0.3, 0.1, 0.2]]))
+    # The replay tensor can be reused by the backward pass and must retain its
+    # sentinel padding rather than inheriting the forward pass's safe IDs.
+    torch.testing.assert_close(replayed_top_indices, torch.tensor([[2, -1, -1]], dtype=torch.int32))

--- a/tests/fast/utils/test_replay_base.py
+++ b/tests/fast/utils/test_replay_base.py
@@ -2,6 +2,7 @@ from tests.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=60, suite="stage-a-cpu", labels=[])
 
+import pytest
 import torch
 
 from miles.utils.replay_base import BaseReplayManager, RoutingReplayManager
@@ -61,29 +62,28 @@ def test_get_topk_fn_preserves_partial_padding():
     torch.testing.assert_close(topk_fn(scores, 3), replayed_top_indices)
 
 
-def test_routing_get_topk_fn_fills_partial_padding():
-    # Megatron's MoE router validates every expert ID before applying the
-    # padding mask, so router replay must sanitize individual invalid slots.
+def test_routing_get_topk_fn_rejects_partial_padding():
+    # Megatron's MoE router has no per-slot padding mask after top-k selection.
+    # Filling these slots would create genuine routes, so routing replay must
+    # fail before returning indices to routing-map construction.
     scores = torch.arange(5, dtype=torch.float32).unsqueeze(0)
     manager = _make_routing_replay_manager(torch.tensor([[2, -1, -1]], dtype=torch.int32))
 
     topk_fn = manager.get_topk_fn(_topk, return_probs=False)
 
-    result = topk_fn(scores, 3)
-    torch.testing.assert_close(result, torch.tensor([[2, 0, 1]], dtype=torch.int64))
-    assert result.dtype == torch.long
+    with pytest.raises(RuntimeError, match="cannot preserve a per-slot padding mask"):
+        topk_fn(scores, 3)
 
 
-def test_routing_get_topk_fn_gathers_probs_after_sanitizing_without_mutating_replay():
+def test_routing_get_topk_fn_rejects_partial_padding_before_gathering_probs():
     scores = torch.tensor([[0.1, 0.2, 0.3, 0.4, 0.5]])
     replayed_top_indices = torch.tensor([[2, -1, -1]], dtype=torch.int32)
     manager = _make_routing_replay_manager(replayed_top_indices)
 
     topk_fn = manager.get_topk_fn(_topk, return_probs=True)
-    probs, top_indices = topk_fn(scores, 3)
 
-    torch.testing.assert_close(top_indices, torch.tensor([[2, 0, 1]], dtype=torch.int64))
-    torch.testing.assert_close(probs, torch.tensor([[0.3, 0.1, 0.2]]))
-    # The replay tensor can be reused by the backward pass and must retain its
-    # sentinel padding rather than inheriting the forward pass's safe IDs.
+    with pytest.raises(RuntimeError, match="continuing would create extra expert routes"):
+        topk_fn(scores, 3)
+
+    # The replay tensor can be reused by the backward pass and remains intact.
     torch.testing.assert_close(replayed_top_indices, torch.tensor([[2, -1, -1]], dtype=torch.int32))


### PR DESCRIPTION
## Problem

Routing replay can contain partially padded expert selections such as `[2, -1, -1]`. Fully invalid rows represent whole padding tokens, but a partially invalid row still contains an active route.

Megatron's current top-k API returns only scores and expert IDs. It does not carry a per-slot validity mask into score normalization or routing-map construction. Replacing the `-1` slots with arbitrary in-range IDs therefore invents expert work and changes the replayed policy.

Indexer replay has different partial-padding semantics and must retain its sentinels.

## Fix

- Opt only `RoutingReplayManager` into validation of partially invalid rows.
- Reject partial routing rows before score gathering or routing-map construction.
- Preserve the existing fully invalid-row behavior.
- Preserve partial padding for base/indexer replay.
- Keep routing indices in the int64 dtype expected by downstream gather/scatter paths when probabilities are returned.

This is intentionally fail closed. It does not claim to support partially padded routing rows. Lossless support requires extending the routing API to propagate a validity mask through probability normalization and every routing-map implementation, including indices-only routers.

This remains complementary to #2697, which handles fully padded rows.

## Validation

- Both routing return modes reject a partial row before scores or indices can become genuine routes.
- Base/indexer replay still preserves partial padding.
- Fully invalid rows retain their existing safe-ID behavior.
- `tests/fast/utils/test_replay_base.py`: 4 passed.
- Ruff and diff checks pass.

## Status

Held as draft while upstream decides whether partial rows should be rejected at the producer boundary or supported through an explicit validity-mask contract.