### PR TITLE
fix(deepseek-v4): preserve grouped wo_a LoRA semantics

### DIFF
--- a/miles_plugins/models/deepseek_v4/deepseek_v4.py
+++ b/miles_plugins/models/deepseek_v4/deepseek_v4.py
@@ -24,6 +24,7 @@ from megatron.core.transformer.spec_utils import ModuleSpec
 from megatron.core.transformer.transformer_config import TransformerConfig
 from megatron.core.transformer.utils import make_sharded_tensors_for_checkpoint
 
+from miles_plugins.models.deepseek_v4.lora import apply_grouped_wo_a
 from miles_plugins.models.deepseek_v4.ops.compressor import DeepSeekV4Compressor
 from miles_plugins.models.deepseek_v4.ops.cp_utils import (
     all_gather_cp,
@@ -310,8 +311,12 @@ class DeepSeekV4Attention(MegatronModule):
         apply_rotary_emb(o[..., -rd:], freqs_cis, inverse=True)
 
         o = o.view(bsz, seqlen_local, self.n_local_groups, -1)
-        wo_a = self.wo_a.weight.view(self.n_local_groups, self.o_lora_rank, -1)
-        o = torch.einsum("bsgd,grd->bsgr", o, wo_a)
+        o = apply_grouped_wo_a(
+            self.wo_a,
+            o,
+            num_groups=self.n_local_groups,
+            group_output_dim=self.o_lora_rank,
+        )
         x, _ = self.wo_b(o.flatten(2))
 
         output = einops.rearrange(x, "b s d -> s b d")

--- a/miles_plugins/models/deepseek_v4/lora.py
+++ b/miles_plugins/models/deepseek_v4/lora.py
@@ -1,0 +1,51 @@
+"""LoRA helpers for DeepSeek-V4's grouped output projection."""
+
+import torch
+
+
+def apply_grouped_wo_a(
+    module,
+    input_: torch.Tensor,
+    *,
+    num_groups: int,
+    group_output_dim: int,
+) -> torch.Tensor:
+    """Apply ``wo_a`` as independent projections for each output group.
+
+    DeepSeek-V4 stores the group weights in one flattened column-parallel
+    matrix, while the forward pass consumes only the matching input/output
+    group. A standard LoRA wrapper broadcasts that flattened projection across
+    every input group, so its delta must be reduced to the same group diagonal.
+    """
+
+    base_module = getattr(module, "to_wrap", module)
+    weight = base_module.weight
+    expected_output_dim = num_groups * group_output_dim
+    if weight.ndim != 2 or weight.shape[0] != expected_output_dim:
+        raise RuntimeError(
+            "DeepSeek-V4 grouped wo_a weight mismatch: "
+            f"got {tuple(weight.shape)}, expected [{expected_output_dim}, input_dim]"
+        )
+    if input_.shape[-2:] != (num_groups, weight.shape[1]):
+        raise RuntimeError(
+            "DeepSeek-V4 grouped wo_a input mismatch: "
+            f"got {tuple(input_.shape)}, expected [..., {num_groups}, {weight.shape[1]}]"
+        )
+
+    grouped_weight = weight.view(num_groups, group_output_dim, weight.shape[1])
+    output = torch.einsum("...gd,grd->...gr", input_, grouped_weight)
+
+    adapter = getattr(module, "adapter", None)
+    if adapter is None or not getattr(module, "_adapter_enabled", True):
+        return output
+
+    adapter_output = module.adapter_forward(adapter, input_.contiguous())
+    expected_shape = (*input_.shape[:-1], expected_output_dim)
+    if tuple(adapter_output.shape) != expected_shape:
+        raise RuntimeError(
+            "DeepSeek-V4 grouped wo_a LoRA output mismatch: "
+            f"got {tuple(adapter_output.shape)}, expected {expected_shape}"
+        )
+    adapter_output = adapter_output.view(*input_.shape[:-2], num_groups, num_groups, group_output_dim)
+    adapter_output = torch.diagonal(adapter_output, dim1=-3, dim2=-2).movedim(-1, -2)
+    return output + adapter_output

--- a/tests/fast/plugins/test_deepseek_v4_lora.py
+++ b/tests/fast/plugins/test_deepseek_v4_lora.py
@@ -1,0 +1,98 @@
+from tests.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=10, suite="stage-a-cpu", labels=[])
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from miles_plugins.models.deepseek_v4.lora import apply_grouped_wo_a
+
+
+class _GroupedLoRA:
+    _adapter_enabled = True
+    adapter = object()
+
+    def __init__(self, base_weight, lora_a, lora_b):
+        self.to_wrap = SimpleNamespace(weight=base_weight)
+        self.lora_a = lora_a
+        self.lora_b = lora_b
+
+    def adapter_forward(self, adapter, input_):
+        assert adapter is self.adapter
+        return (input_ @ self.lora_a.T) @ self.lora_b.T
+
+
+def test_grouped_wo_a_uses_only_matching_lora_group():
+    torch.manual_seed(0)
+    batch, sequence, groups = 2, 3, 4
+    input_dim, output_dim, adapter_rank = 5, 2, 3
+    input_ = torch.randn(batch, sequence, groups, input_dim)
+    base_weight = torch.randn(groups * output_dim, input_dim)
+    lora_a = torch.randn(adapter_rank, input_dim, requires_grad=True)
+    lora_b = torch.randn(groups * output_dim, adapter_rank, requires_grad=True)
+    module = _GroupedLoRA(base_weight, lora_a, lora_b)
+
+    output = apply_grouped_wo_a(
+        module,
+        input_,
+        num_groups=groups,
+        group_output_dim=output_dim,
+    )
+
+    effective_weight = base_weight.view(groups, output_dim, input_dim) + (lora_b @ lora_a).view(
+        groups, output_dim, input_dim
+    )
+    expected = torch.einsum("...gd,grd->...gr", input_, effective_weight)
+    torch.testing.assert_close(output, expected)
+
+    output.square().sum().backward()
+    assert lora_a.grad is not None
+    assert lora_b.grad is not None
+
+
+def test_grouped_wo_a_uses_base_projection_when_adapter_is_disabled():
+    groups, input_dim, output_dim = 2, 3, 4
+    input_ = torch.randn(5, groups, input_dim)
+    base_weight = torch.randn(groups * output_dim, input_dim)
+    module = _GroupedLoRA(
+        base_weight,
+        torch.randn(2, input_dim),
+        torch.randn(groups * output_dim, 2),
+    )
+    module._adapter_enabled = False
+
+    output = apply_grouped_wo_a(
+        module,
+        input_,
+        num_groups=groups,
+        group_output_dim=output_dim,
+    )
+
+    expected = torch.einsum(
+        "...gd,grd->...gr",
+        input_,
+        base_weight.view(groups, output_dim, input_dim),
+    )
+    torch.testing.assert_close(output, expected)
+
+
+def test_grouped_wo_a_rejects_incompatible_adapter_output():
+    groups, input_dim, output_dim = 2, 3, 4
+    input_ = torch.randn(5, groups, input_dim)
+    module = _GroupedLoRA(
+        torch.randn(groups * output_dim, input_dim),
+        torch.randn(2, input_dim),
+        # One output row short: a standard projection could silently broadcast
+        # this, but the grouped diagonal would no longer describe wo_a.
+        torch.randn(groups * output_dim - 1, 2),
+    )
+
+    with pytest.raises(RuntimeError, match="LoRA output mismatch"):
+        apply_grouped_wo_a(
+            module,
+            input_,
+            num_groups=groups,
+            group_output_dim=output_dim,
+        )


### PR DESCRIPTION
## Problem

DeepSeek-V4 `wo_a` is not a single dense projection. It stores `G` independent group weights in a flattened column-parallel matrix, and each input group must use only the matching output group.

A generic `LoRALinear` wrapper creates two problems:

1. native forward reads `self.wo_a.weight`, but the wrapper owns the base module under `to_wrap`;
2. applying the flattened LoRA projection to every input group produces a `G × G` cross-group result, while the base operator uses only the group diagonal.

## Fix

Add a V4-specific grouped projection helper that:

- unwraps the base weight from the adapter wrapper;
- computes the native grouped base projection;
- evaluates the Bridge adapter through its public `adapter_forward` contract;
- reshapes the flattened delta and selects only matching input/output groups;
- preserves the base-only path when the adapter is disabled; and
- fails closed on incompatible base, input, or adapter-output layouts.

The helper is used only by V4 `wo_a`; other LoRA projections retain their generic wrappers.

## Validation

- Model-free numerical test compares against the exact effective grouped weight.
- Gradients reach both LoRA factors.
- Disabled-adapter and incompatible-layout cases are covered.
- `tests/fast/plugins/test_deepseek_v4_lora.py`: 3 passed.
- Ruff and diff checks pass.

## Ordering

This PR should merge before #2772. That PR enables and wraps `wo_a`, and therefore depends on this grouped execution path.

Related rollout-engine execution PR: sgl-project/sglang#36579. V4 target registration and dimensions: sgl-project/sglang#36578.