### PR TITLE
feat(deepseek-v4): add native LoRA construction and conversion bridge

### DIFF
--- a/miles/backends/megatron_utils/bridge_lora_helpers.py
+++ b/miles/backends/megatron_utils/bridge_lora_helpers.py
@@ -6,6 +6,7 @@ forward / backward / optimizer logic.
 
 from __future__ import annotations
 
+import copy
 import logging
 from argparse import Namespace
 from dataclasses import dataclass
@@ -18,6 +19,21 @@ from miles.utils.multi_lora import is_multi_lora_enabled, targets_expert_leaves
 from .lora_utils import convert_target_modules_to_hf, patch_param_grad_buffer_for_colocate_mode_lora
 
 logger = logging.getLogger(__name__)
+
+_DEEPSEEK_V4_MAIN_ATTENTION_TARGETS = frozenset({"wq_a", "wq_b", "wkv", "wo_a", "wo_b"})
+
+
+def _qualify_deepseek_v4_lora_targets(target_modules):
+    """Disambiguate V4's main attention leaves from nested DSA modules."""
+
+    if not target_modules:
+        return target_modules
+    is_string = isinstance(target_modules, str)
+    modules = [target_modules] if is_string else list(target_modules)
+    qualified = [
+        f"*.self_attention.{module}" if module in _DEEPSEEK_V4_MAIN_ATTENTION_TARGETS else module for module in modules
+    ]
+    return qualified[0] if is_string else qualified
 
 
 @dataclass
@@ -128,6 +144,11 @@ def _setup_lora_model_via_bridge(args: Namespace) -> list:
     from megatron.bridge.training.config import DistributedDataParallelConfig
 
     hf_config = load_hf_config(args.hf_checkpoint)
+    from miles_plugins.megatron_bridge.deepseek_v4 import is_deepseek_v4_config
+
+    if is_deepseek_v4_config(hf_config):
+        return _setup_deepseek_v4_lora_model(args)
+
     bridge = AutoBridge.from_hf_pretrained(args.hf_checkpoint, trust_remote_code=True)
     provider = bridge.to_megatron_provider(load_weights=False)
 
@@ -207,3 +228,70 @@ def _setup_lora_model_via_bridge(args: Namespace) -> list:
 
     model = provider.provide_distributed_model(wrap_with_ddp=True, ddp_config=ddp_config)
     return model
+
+
+def _setup_deepseek_v4_lora_model(args: Namespace) -> list:
+    """Build native DeepSeek-V4, applying PEFT before DDP wrapping."""
+
+    if is_multi_lora_enabled(args):
+        raise NotImplementedError("DeepSeek-V4 native construction does not yet support Multi-LoRA")
+
+    from megatron.bridge.models.model_provider import ModelProviderMixin, get_model as get_bridge_model
+    from megatron.bridge.training.config import DistributedDataParallelConfig
+    from megatron.core.enums import ModelType
+    from megatron.core.process_groups_config import ProcessGroupCollection
+
+    from .lora_utils import create_lora_instance
+    from .model_provider import get_model_provider_func
+
+    native_provider_func = get_model_provider_func(
+        args,
+        role="actor",
+        use_bridge_provider=False,
+    )
+
+    class _MilesDeepSeekV4Provider(ModelProviderMixin):
+        virtual_pipeline_model_parallel_size = args.virtual_pipeline_model_parallel_size
+        fp16 = args.fp16
+        bf16 = args.bf16
+
+        def provide(self, pre_process=None, post_process=None, vp_stage=None):
+            return native_provider_func(
+                pre_process=pre_process,
+                post_process=post_process,
+                vp_stage=vp_stage,
+            )
+
+    # The generic MLA aliases map bare ``wq_b`` to the DSA indexer's
+    # ``linear_wq_b``. V4 owns both that nested module and a main-attention
+    # ``wq_b``, so qualify the five main projections before PEFT's suffix
+    # matcher sees them. Explicit indexer targets remain unchanged.
+    lora_args = copy.copy(args)
+    lora_args.target_modules = _qualify_deepseek_v4_lora_targets(args.target_modules)
+    lora_args.exclude_modules = _qualify_deepseek_v4_lora_targets(getattr(args, "exclude_modules", None))
+    lora = create_lora_instance(lora_args)
+
+    def apply_lora_hook(model_chunks):
+        transformed = lora(model_chunks, training=True)
+        lora.set_params_to_save(transformed)
+        return transformed
+
+    use_distributed_optimizer = "muon" not in (args.optimizer or "").lower()
+    ddp_config = DistributedDataParallelConfig(
+        use_distributed_optimizer=use_distributed_optimizer,
+        grad_reduce_in_fp32=args.accumulate_allreduce_grads_in_fp32,
+    )
+    ddp_config.finalize()
+
+    if args.offload_train:
+        patch_param_grad_buffer_for_colocate_mode_lora()
+
+    return get_bridge_model(
+        _MilesDeepSeekV4Provider(),
+        ddp_config=ddp_config,
+        model_type=ModelType.encoder_or_decoder,
+        bf16=args.bf16,
+        fp16=args.fp16,
+        pre_wrap_hook=apply_lora_hook,
+        pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
+    )

--- a/miles/backends/megatron_utils/hf_export.py
+++ b/miles/backends/megatron_utils/hf_export.py
@@ -102,6 +102,15 @@ def _get_hf_bridge(hf_checkpoint: str):
     return AutoBridge.from_hf_pretrained(hf_checkpoint, trust_remote_code=True)
 
 
+def _uses_adapter_only_export(args, model: Sequence[DDP]) -> bool:
+    if not is_lora_model(model):
+        return False
+
+    from miles_plugins.megatron_bridge.deepseek_v4 import is_deepseek_v4_config
+
+    return is_deepseek_v4_config(load_hf_config(args.hf_checkpoint))
+
+
 def save_hf_model(
     args,
     rollout_id: int,
@@ -112,11 +121,16 @@ def save_hf_model(
 ) -> None:
     """Save Megatron model in HuggingFace format.
 
-    For LoRA models this saves both:
+    For most LoRA models this saves both:
     - A **merged** HF model (adapter weights folded into base) at ``{path}/``
       so it can be loaded directly with ``AutoModelForCausalLM.from_pretrained``.
     - An **adapter-only** HF PEFT checkpoint at ``{path}/adapter/``
       so it can be loaded with ``PeftModel.from_pretrained``.
+
+    DeepSeek-V4 uses an adapter-only portable layout. Its model is constructed
+    natively and the Bridge integration is conversion-only, so the complete
+    reload contract is the pinned base checkpoint plus ``{path}/adapter/``
+    rather than a partially merged base.
 
     This function is collective — all ranks must call it. On success, global rank 0
     writes a ``.complete`` marker file.
@@ -130,12 +144,22 @@ def save_hf_model(
     """
     should_log = get_parallel_state().effective_dp_cp.rank == 0 and get_parallel_state().tp.rank == 0
     path = Path(path if path is not None else args.save_hf.format(rollout_id=rollout_id))
+    adapter_only = _uses_adapter_only_export(args, model)
 
     try:
         if should_log:
             logger.info(f"Saving model in HuggingFace format to {path}")
 
-        if args.megatron_to_hf_mode == "raw" and not is_lora_model(model):
+        if adapter_only:
+            path.mkdir(parents=True, exist_ok=True)
+            if torch.distributed.get_rank() == 0:
+                (path / HF_EXPORT_COMPLETE_MARKER).unlink(missing_ok=True)
+            if should_log:
+                logger.info(
+                    "DeepSeek-V4 portable export is adapter-only; "
+                    "the frozen base remains the pinned native checkpoint"
+                )
+        elif args.megatron_to_hf_mode == "raw" and not is_lora_model(model):
             # LoRA keeps the bridge (adapter merging).
             hf_config = load_hf_config(args.hf_checkpoint)
             export_hf_model_direct(
@@ -164,7 +188,7 @@ def save_hf_model(
                         f"bridge likely has no mapping for this model architecture."
                     )
 
-        if should_log:
+        if should_log and not adapter_only:
             logger.info(f"Successfully saved merged HuggingFace model to {path}")
     except Exception as e:
         if raise_on_error:
@@ -179,7 +203,12 @@ def save_hf_model(
             adapter_path = path / "adapter"
             if should_log:
                 logger.info(f"Saving LoRA adapter (HF PEFT format) to {adapter_path}")
-            save_lora_checkpoint(model, args, str(adapter_path))
+            save_lora_checkpoint(
+                model,
+                args,
+                str(adapter_path),
+                require_hf_export=adapter_only,
+            )
             if should_log:
                 logger.info(f"Successfully saved LoRA adapter to {adapter_path}")
         except Exception as e:

--- a/miles/backends/megatron_utils/lora_utils.py
+++ b/miles/backends/megatron_utils/lora_utils.py
@@ -190,6 +190,16 @@ def _is_adapter_param_name(name: str) -> bool:
     return "lora_" in name or (".adapter." in name and ("linear_in" in name or "linear_out" in name))
 
 
+def _collective_export_errors(local_error: str | None) -> list[str]:
+    """Return HF export failures from every rank in a consistent order."""
+    if not dist.is_initialized():
+        return [local_error] if local_error is not None else []
+
+    gathered_errors: list[str | None] = [None] * dist.get_world_size()
+    dist.all_gather_object(gathered_errors, local_error)
+    return [error for error in gathered_errors if error is not None]
+
+
 _param_grad_buffer_patched = False
 
 
@@ -463,6 +473,8 @@ def save_lora_checkpoint(
     # ---- HF PEFT format (uses bridge for correct name/weight conversion) ----
     # Bridge export is collective: all TP ranks participate in the all-gather,
     # so every rank must call export_adapter_weights.
+    hf_export_exception: Exception | None = None
+    local_hf_export_error: str | None = None
     try:
         bridge = AutoBridge.from_hf_pretrained(args.hf_checkpoint, trust_remote_code=True)
 
@@ -501,10 +513,16 @@ def save_lora_checkpoint(
             os.sync()
             logger.info(f"Saved HF PEFT adapter to {save_path} with {len(lora_state_dict)} tensors")
     except Exception as hf_export_err:
+        hf_export_exception = hf_export_err
+        local_hf_export_error = f"rank {global_rank}: {type(hf_export_err).__name__}: {hf_export_err}"
+
+    hf_export_errors = _collective_export_errors(local_hf_export_error)
+    if hf_export_errors:
+        error_summary = "; ".join(hf_export_errors)
         if require_hf_export:
-            raise RuntimeError("Required HF PEFT adapter export failed") from hf_export_err
+            raise RuntimeError(f"Required HF PEFT adapter export failed: {error_summary}") from hf_export_exception
         logger.warning(
-            f"HF PEFT adapter export skipped ({hf_export_err}); the per-rank native "
+            f"HF PEFT adapter export skipped ({error_summary}); the per-rank native "
             f"shards + training state are sufficient for training resume."
         )
 

--- a/miles/backends/megatron_utils/lora_utils.py
+++ b/miles/backends/megatron_utils/lora_utils.py
@@ -414,6 +414,7 @@ def save_lora_checkpoint(
     optimizer: Any | None = None,
     opt_param_scheduler: Any | None = None,
     iteration: int | None = None,
+    require_hf_export: bool = False,
 ) -> str:
     """Save LoRA adapter checkpoint to disk.
 
@@ -474,6 +475,9 @@ def save_lora_checkpoint(
             ):
                 lora_state_dict[hf_name] = weight
 
+        if not lora_state_dict:
+            raise RuntimeError("Megatron-Bridge exported no HF PEFT adapter tensors")
+
         if is_dp_cp_rank_0 and tp_rank == 0 and pp_rank == 0:
             torch.save(lora_state_dict, save_path / "adapter_model.bin")
 
@@ -497,6 +501,8 @@ def save_lora_checkpoint(
             os.sync()
             logger.info(f"Saved HF PEFT adapter to {save_path} with {len(lora_state_dict)} tensors")
     except Exception as hf_export_err:
+        if require_hf_export:
+            raise RuntimeError("Required HF PEFT adapter export failed") from hf_export_err
         logger.warning(
             f"HF PEFT adapter export skipped ({hf_export_err}); the per-rank native "
             f"shards + training state are sufficient for training resume."

--- a/miles/backends/megatron_utils/model_provider.py
+++ b/miles/backends/megatron_utils/model_provider.py
@@ -132,6 +132,8 @@ class LinearForLastLayer(torch.nn.Linear):
 def get_model_provider_func(
     args: argparse.Namespace,
     role: Literal["actor", "critic"] = "actor",
+    *,
+    use_bridge_provider: bool = True,
 ):
     # Support custom model provider path (similar to --custom-rm-path for reward models)
     if getattr(args, "custom_model_provider_path", None):
@@ -161,7 +163,7 @@ def get_model_provider_func(
 
         return wrapped_model_provider
 
-    if args.megatron_to_hf_mode == "bridge":
+    if use_bridge_provider and args.megatron_to_hf_mode == "bridge":
         from megatron.bridge import AutoBridge
 
         bridge = AutoBridge.from_hf_pretrained(args.hf_checkpoint, trust_remote_code=True)

--- a/miles_plugins/megatron_bridge/__init__.py
+++ b/miles_plugins/megatron_bridge/__init__.py
@@ -75,3 +75,8 @@ try:
     from . import nemotron_h  # noqa: F401
 except Exception as _e:  # pragma: no cover - defensive
     logger.warning("miles nemotron_h plugin failed to load: %s", _e)
+
+try:
+    from . import deepseek_v4  # noqa: F401
+except Exception as _e:  # pragma: no cover - defensive
+    logger.warning("miles deepseek_v4 plugin failed to load: %s", _e)

--- a/miles_plugins/megatron_bridge/deepseek_v4.py
+++ b/miles_plugins/megatron_bridge/deepseek_v4.py
@@ -1,0 +1,112 @@
+"""Conversion-only Megatron-Bridge support for Miles' native DeepSeek-V4."""
+
+from megatron.bridge.models.conversion.mapping_registry import MegatronMappingRegistry
+from megatron.bridge.models.conversion.model_bridge import MegatronModelBridge
+from megatron.bridge.models.conversion.param_mapping import (
+    AutoMapping,
+    ColumnParallelMapping,
+    ReplicatedMapping,
+)
+from megatron.bridge.models.deepseek.common import get_common_mapping_list
+from megatron.bridge.models.deepseek.deepseek_v3_bridge import DeepSeekV3Bridge
+from megatron.bridge.models.mla_provider import MLAModelProvider
+from megatron.core.models.gpt.gpt_model import GPTModel
+
+
+_DSV4_ATTENTION_MAPPINGS = {
+    "decoder.layers.*.self_attention.wq_a.weight": "model.layers.*.self_attn.wq_a.weight",
+    "decoder.layers.*.self_attention.q_norm.weight": "model.layers.*.self_attn.q_norm.weight",
+    "decoder.layers.*.self_attention.wq_b.weight": "model.layers.*.self_attn.wq_b.weight",
+    "decoder.layers.*.self_attention.wkv.weight": "model.layers.*.self_attn.wkv.weight",
+    "decoder.layers.*.self_attention.kv_norm.weight": "model.layers.*.self_attn.kv_norm.weight",
+    "decoder.layers.*.self_attention.wo_a.weight": "model.layers.*.self_attn.wo_a.weight",
+    "decoder.layers.*.self_attention.wo_b.weight": "model.layers.*.self_attn.wo_b.weight",
+}
+
+_DSV4_REPLICATED_MAPPINGS = {
+    "decoder.layers.*.hc_attn_fn": "model.layers.*.hc_attn_fn",
+    "decoder.layers.*.hc_attn_base": "model.layers.*.hc_attn_base",
+    "decoder.layers.*.hc_attn_scale": "model.layers.*.hc_attn_scale",
+    "decoder.layers.*.hc_ffn_fn": "model.layers.*.hc_ffn_fn",
+    "decoder.layers.*.hc_ffn_base": "model.layers.*.hc_ffn_base",
+    "decoder.layers.*.hc_ffn_scale": "model.layers.*.hc_ffn_scale",
+    "decoder.layers.*.self_attention.compressor.ape": "model.layers.*.self_attn.compressor.ape",
+    "decoder.layers.*.self_attention.compressor.wkv.weight": "model.layers.*.self_attn.compressor.wkv.weight",
+    "decoder.layers.*.self_attention.compressor.wgate.weight": "model.layers.*.self_attn.compressor.wgate.weight",
+    "decoder.layers.*.self_attention.compressor.norm.weight": "model.layers.*.self_attn.compressor.norm.weight",
+    "decoder.layers.*.self_attention.indexer.compressor.ape": "model.layers.*.self_attn.indexer.compressor.ape",
+    "decoder.layers.*.self_attention.indexer.compressor.wkv.weight": (
+        "model.layers.*.self_attn.indexer.compressor.wkv.weight"
+    ),
+    "decoder.layers.*.self_attention.indexer.compressor.wgate.weight": (
+        "model.layers.*.self_attn.indexer.compressor.wgate.weight"
+    ),
+    "decoder.layers.*.self_attention.indexer.compressor.norm.weight": (
+        "model.layers.*.self_attn.indexer.compressor.norm.weight"
+    ),
+    "decoder.layers.*.mlp.router.tid2eid": "model.layers.*.mlp.topk.tid2eid",
+    "decoder.layers.*.mlp.router.expert_bias": "model.layers.*.mlp.gate.e_score_correction_bias",
+    "decoder.hc_head_params.hc_head_fn": "model.hc_head_fn",
+    "decoder.hc_head_params.hc_head_base": "model.hc_head_base",
+    "decoder.hc_head_params.hc_head_scale": "model.hc_head_scale",
+}
+
+_DSV4_COLUMN_PARALLEL_MAPPINGS = {
+    "decoder.layers.*.self_attention.attn_sink": "model.layers.*.self_attn.attn_sink",
+}
+
+_DSV4_AUTO_MAPPINGS = {
+    "decoder.layers.*.self_attention.indexer.linear_wq_b.weight": "model.layers.*.self_attn.indexer.wq_b.weight",
+    "decoder.layers.*.self_attention.indexer.linear_weights_proj.weight": (
+        "model.layers.*.self_attn.indexer.weights_proj.weight"
+    ),
+}
+
+
+def is_deepseek_v4_config(hf_config) -> bool:
+    architectures = getattr(hf_config, "architectures", None) or []
+    return bool(architectures and architectures[0] == "DeepseekV4ForCausalLM")
+
+
+def _get_dsv4_explicit_mappings():
+    mappings = [
+        AutoMapping(megatron_param=megatron_param, hf_param=hf_param)
+        for megatron_param, hf_param in _DSV4_ATTENTION_MAPPINGS.items()
+    ]
+    mappings.extend(
+        ReplicatedMapping(megatron_param=megatron_param, hf_param=hf_param)
+        for megatron_param, hf_param in _DSV4_REPLICATED_MAPPINGS.items()
+    )
+    mappings.extend(
+        ColumnParallelMapping(megatron_param=megatron_param, hf_param=hf_param)
+        for megatron_param, hf_param in _DSV4_COLUMN_PARALLEL_MAPPINGS.items()
+    )
+    mappings.extend(
+        AutoMapping(megatron_param=megatron_param, hf_param=hf_param)
+        for megatron_param, hf_param in _DSV4_AUTO_MAPPINGS.items()
+    )
+    return mappings
+
+
+@MegatronModelBridge.register_bridge(
+    source="DeepseekV4ForCausalLM",
+    target=GPTModel,
+    provider=MLAModelProvider,
+    model_type="deepseek_v4",
+)
+class MilesDeepSeekV4Bridge(DeepSeekV3Bridge):
+    """Map the native V4 graph for adapter publication and export only."""
+
+    def provider_bridge(self, hf_pretrained):
+        raise RuntimeError(
+            "DeepSeek-V4 model construction must use Miles' native dsv4 provider; "
+            "this bridge is conversion-only"
+        )
+
+    def mapping_registry(self) -> MegatronMappingRegistry:
+        mappings = get_common_mapping_list(hf_config=self.hf_config)
+        mappings.extend(_get_dsv4_explicit_mappings())
+        return MegatronMappingRegistry(*mappings)
+
+
+__all__ = ["MilesDeepSeekV4Bridge", "is_deepseek_v4_config"]

--- a/tests/fast/plugins/test_deepseek_v4_bridge.py
+++ b/tests/fast/plugins/test_deepseek_v4_bridge.py
@@ -1,0 +1,163 @@
+from tests.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=10, suite="stage-a-cpu", labels=[])
+
+from argparse import Namespace
+from contextlib import nullcontext
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+import torch
+from megatron.bridge.models.conversion.param_mapping import (
+    AutoMapping,
+    ColumnParallelMapping,
+    ReplicatedMapping,
+)
+
+from miles.backends.megatron_utils import hf_export
+from miles.backends.megatron_utils.bridge_lora_helpers import (
+    _qualify_deepseek_v4_lora_targets,
+    _setup_lora_model_via_bridge,
+)
+from miles.backends.megatron_utils.lora_utils import save_lora_checkpoint
+from miles_plugins.megatron_bridge.deepseek_v4 import (
+    _get_dsv4_explicit_mappings,
+    is_deepseek_v4_config,
+)
+
+
+def test_dsv4_explicit_mapping_semantics():
+    mappings = {mapping.megatron_param: mapping for mapping in _get_dsv4_explicit_mappings()}
+    assert len(mappings) == len(_get_dsv4_explicit_mappings())
+
+    for suffix in ("fn", "base", "scale"):
+        assert isinstance(mappings[f"decoder.layers.*.hc_attn_{suffix}"], ReplicatedMapping)
+        assert isinstance(mappings[f"decoder.layers.*.hc_ffn_{suffix}"], ReplicatedMapping)
+        assert isinstance(mappings[f"decoder.hc_head_params.hc_head_{suffix}"], ReplicatedMapping)
+
+    assert isinstance(mappings["decoder.layers.*.self_attention.attn_sink"], ColumnParallelMapping)
+    for prefix in (
+        "decoder.layers.*.self_attention.compressor",
+        "decoder.layers.*.self_attention.indexer.compressor",
+    ):
+        for suffix in ("ape", "wkv.weight", "wgate.weight", "norm.weight"):
+            assert isinstance(mappings[f"{prefix}.{suffix}"], ReplicatedMapping)
+
+    assert isinstance(mappings["decoder.layers.*.self_attention.wq_b.weight"], AutoMapping)
+    assert isinstance(
+        mappings["decoder.layers.*.self_attention.indexer.linear_wq_b.weight"],
+        AutoMapping,
+    )
+    assert isinstance(mappings["decoder.layers.*.mlp.router.tid2eid"], ReplicatedMapping)
+    assert isinstance(mappings["decoder.layers.*.mlp.router.expert_bias"], ReplicatedMapping)
+
+
+def test_dsv4_lora_construction_selects_native_provider():
+    args = Namespace(hf_checkpoint="checkpoint")
+    config = SimpleNamespace(architectures=["DeepseekV4ForCausalLM"])
+    sentinel = object()
+
+    with (
+        patch(
+            "miles.backends.megatron_utils.bridge_lora_helpers.load_hf_config",
+            return_value=config,
+        ),
+        patch(
+            "miles.backends.megatron_utils.bridge_lora_helpers._setup_deepseek_v4_lora_model",
+            return_value=sentinel,
+        ) as setup_native,
+    ):
+        assert _setup_lora_model_via_bridge(args) is sentinel
+
+    setup_native.assert_called_once_with(args)
+
+
+def test_dsv4_main_attention_targets_are_disambiguated_from_indexer():
+    assert _qualify_deepseek_v4_lora_targets(
+        ["wq_a", "wq_b", "wkv", "wo_a", "wo_b", "indexer.wq_b", "linear_fc1"]
+    ) == [
+        "*.self_attention.wq_a",
+        "*.self_attention.wq_b",
+        "*.self_attention.wkv",
+        "*.self_attention.wo_a",
+        "*.self_attention.wo_b",
+        "indexer.wq_b",
+        "linear_fc1",
+    ]
+
+
+def test_dsv4_lora_portable_export_is_adapter_only():
+    config = SimpleNamespace(architectures=["DeepseekV4ForCausalLM"])
+    args = Namespace(hf_checkpoint="checkpoint")
+    model = [object()]
+
+    with (
+        patch.object(hf_export, "is_lora_model", return_value=True),
+        patch.object(hf_export, "load_hf_config", return_value=config),
+    ):
+        assert hf_export._uses_adapter_only_export(args, model)
+
+
+def test_dsv4_architecture_match_is_exact():
+    assert is_deepseek_v4_config(SimpleNamespace(architectures=["DeepseekV4ForCausalLM"]))
+    assert not is_deepseek_v4_config(SimpleNamespace(architectures=["DeepseekV3ForCausalLM"]))
+
+
+def test_dsv4_adapter_only_export_is_fail_closed(tmp_path):
+    config = SimpleNamespace(architectures=["DeepseekV4ForCausalLM"])
+    args = Namespace(
+        hf_checkpoint="checkpoint",
+        save_hf=str(tmp_path / "rollout-{rollout_id}"),
+    )
+    model = [object()]
+
+    with (
+        patch.object(hf_export, "is_lora_model", return_value=True),
+        patch.object(hf_export, "load_hf_config", return_value=config),
+        patch.object(hf_export, "get_parallel_state") as parallel_state,
+        patch.object(hf_export.torch.distributed, "get_rank", return_value=0),
+        patch.object(hf_export, "save_lora_checkpoint", side_effect=RuntimeError("no mapping")) as save_adapter,
+    ):
+        parallel_state.return_value.effective_dp_cp.rank = 0
+        parallel_state.return_value.tp.rank = 0
+        with pytest.raises(RuntimeError, match="no mapping"):
+            hf_export.save_hf_model(args, 0, model, raise_on_error=True)
+
+    save_adapter.assert_called_once()
+    assert save_adapter.call_args.kwargs["require_hf_export"] is True
+    assert not (tmp_path / "rollout-0" / ".complete").exists()
+
+
+def test_required_adapter_export_rejects_empty_bridge_result(tmp_path):
+    model = SimpleNamespace(
+        named_parameters=lambda: [("layer.adapter.linear_in.weight", torch.nn.Parameter(torch.ones(1)))]
+    )
+    parallel_state = SimpleNamespace(
+        effective_dp=SimpleNamespace(rank=0),
+        cp=SimpleNamespace(rank=0),
+        tp=SimpleNamespace(rank=0),
+        pp=SimpleNamespace(rank=0),
+    )
+    bridge = SimpleNamespace(export_adapter_weights=lambda *_args, **_kwargs: iter(()))
+
+    with (
+        patch(
+            "miles.backends.megatron_utils.lora_utils.get_parallel_state",
+            return_value=parallel_state,
+        ),
+        patch("megatron.bridge.AutoBridge.from_hf_pretrained", return_value=bridge),
+        patch(
+            "miles.utils.megatron_bridge_utils.patch_megatron_model",
+            side_effect=lambda _model: nullcontext(),
+        ),
+    ):
+        with pytest.raises(RuntimeError, match="Required HF PEFT adapter export failed"):
+            save_lora_checkpoint(
+                [model],
+                Namespace(hf_checkpoint="checkpoint"),
+                str(tmp_path),
+                require_hf_export=True,
+            )
+
+    assert not (tmp_path / "adapter_model.bin").exists()

--- a/tests/fast/plugins/test_deepseek_v4_bridge.py
+++ b/tests/fast/plugins/test_deepseek_v4_bridge.py
@@ -2,18 +2,22 @@ from tests.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=10, suite="stage-a-cpu", labels=[])
 
+import os
 from argparse import Namespace
 from contextlib import nullcontext
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
 import torch
+import torch.distributed as dist
 from megatron.bridge.models.conversion.param_mapping import (
     AutoMapping,
     ColumnParallelMapping,
     ReplicatedMapping,
 )
+from tests.fast.dist_utils import init_gloo, run_multiprocess
 
 from miles.backends.megatron_utils import hf_export
 from miles.backends.megatron_utils.bridge_lora_helpers import (
@@ -25,6 +29,62 @@ from miles_plugins.megatron_bridge.deepseek_v4 import (
     _get_dsv4_explicit_mappings,
     is_deepseek_v4_config,
 )
+
+
+def _run_required_export_writer_failure(rank: int, world_size: int, port: int) -> None:
+    init_gloo(rank, world_size, port=port)
+    save_dir = Path(os.environ["MILES_TEST_DSV4_EXPORT_DIR"])
+    model = SimpleNamespace(
+        named_parameters=lambda: [("layer.adapter.linear_in.weight", torch.nn.Parameter(torch.ones(1)))]
+    )
+    parallel_state = SimpleNamespace(
+        effective_dp=SimpleNamespace(rank=0),
+        cp=SimpleNamespace(rank=0),
+        tp=SimpleNamespace(rank=rank),
+        pp=SimpleNamespace(rank=0),
+    )
+    bridge = SimpleNamespace(
+        export_adapter_weights=lambda *_args, **_kwargs: iter(
+            [("model.layer.lora_A.weight", torch.ones(1), "decoder.layer.adapter.linear_in.weight")]
+        )
+    )
+    args = Namespace(
+        hf_checkpoint="checkpoint",
+        target_modules=[],
+        lora_rank=1,
+        lora_alpha=1,
+        lora_dropout=0.0,
+    )
+    original_torch_save = torch.save
+
+    def fail_writer_only(state, path, *args, **kwargs):
+        if rank == 0 and Path(path).name == "adapter_model.bin":
+            raise OSError("writer failed")
+        return original_torch_save(state, path, *args, **kwargs)
+
+    try:
+        with (
+            patch(
+                "miles.backends.megatron_utils.lora_utils.get_parallel_state",
+                return_value=parallel_state,
+            ),
+            patch("megatron.bridge.AutoBridge.from_hf_pretrained", return_value=bridge),
+            patch(
+                "miles.utils.megatron_bridge_utils.patch_megatron_model",
+                side_effect=lambda _model: nullcontext(),
+            ),
+            patch("miles.backends.megatron_utils.lora_utils.torch.save", side_effect=fail_writer_only),
+        ):
+            with pytest.raises(RuntimeError, match="rank 0: OSError: writer failed") as error:
+                save_lora_checkpoint(
+                    [model],
+                    args,
+                    str(save_dir),
+                    require_hf_export=True,
+                )
+        (save_dir / f"error-rank-{rank}.txt").write_text(str(error.value))
+    finally:
+        dist.destroy_process_group()
 
 
 def test_dsv4_explicit_mapping_semantics():
@@ -161,3 +221,15 @@ def test_required_adapter_export_rejects_empty_bridge_result(tmp_path):
             )
 
     assert not (tmp_path / "adapter_model.bin").exists()
+
+
+def test_required_adapter_export_propagates_writer_failure_to_every_rank(tmp_path):
+    os.environ["MILES_TEST_DSV4_EXPORT_DIR"] = str(tmp_path)
+    try:
+        run_multiprocess(_run_required_export_writer_failure, world_size=2)
+    finally:
+        os.environ.pop("MILES_TEST_DSV4_EXPORT_DIR", None)
+
+    errors = [(tmp_path / f"error-rank-{rank}.txt").read_text() for rank in range(2)]
+    assert errors[0] == errors[1]
+    assert "rank 0: OSError: writer failed" in errors[0]


### PR DESCRIPTION
> **Depends on #2771.** The grouped `wo_a` execution path must land before this PR enables and wraps that target.

## Problem

Current Miles pins Megatron-Bridge at `7f0fb345`, which does not register `DeepseekV4ForCausalLM`. Letting Bridge select a provider therefore cannot construct the current native V4 graph. Treating it as V3 or using incomplete inferred mappings is worse: a strict current-main load exposed thousands of unmapped or missing checkpoint parameters.

V4 also owns both a main-attention `wq_b` and a nested DSA indexer `linear_wq_b`. The generic MLA alias maps bare `wq_b` to the indexer, so an unqualified V4 treatment can wrap the wrong module.

Finally, a V4 portable export is valid only as an adapter against the pinned native base. The conversion-only bridge cannot safely claim to emit a complete merged base, and a failed adapter conversion must not leave a success marker or strand peer ranks in a barrier.

## Fix

- Detect the exact V4 architecture and construct it through the Miles native provider/spec.
- Apply PEFT in a pre-wrap hook, before DDP construction.
- Qualify the five main V4 attention targets so `wq_b` cannot also match the nested indexer.
- Register a conversion-only Bridge for the current native graph, with explicit attention mappings and explicit replicated/column/automatic semantics for hyper-connections, compressors, routing tables, attention sink, and indexer weights.
- Keep portable V4 output adapter-only against the pinned base.
- Make required adapter export fail closed on empty or failed Bridge conversion.
- Collect writer/export failures across all ranks before raising, so rank-local I/O failure cannot leave peers at the trailing barrier.
- Write `.complete` only after a valid adapter is present.
- Reject unsupported native V4 Multi-LoRA instead of silently falling back.

This does not duplicate the MXFP4 ingestion work in #2717. It is scoped to current main and its pinned Bridge/native V4 graph. If the large Megatron bump in #2706 lands first, the mapping layer will need a focused rebase because that PR intentionally renames and relayouts the V4 graph. The general PEFT-export work in #2580 is related; this PR adds the V4 requirement that portable export cannot remain best-effort.

## Validation

- 8 focused tests cover mapping ownership, native-provider dispatch, main/indexer target qualification, adapter-only layout, exact architecture selection, empty export, completion-marker failure, and two-rank writer-failure propagation.
- The writer-failure case confirms both ranks receive the same rank-0 I/O error instead of deadlocking.
- Tests run against the exact pinned Megatron-Bridge and Miles Megatron sources; unavailable GPU-only packages were stubbed only for import.
- Ruff and diff checks pass.
- The underlying current-main graph and explicit mappings were exercised on a 32-rank V4 LoRA run: strict base load reached zero unmapped/missing warnings, then completed finite updates and trainer-to-rollout publications.

## Remaining qualification

A successful adapter-only artifact still needs to be loaded back against the pinned base before portable export is called complete. This PR remains draft until that round trip is recorded and #2771 lands.