### PR TITLE
feat(session): configure session server workers explicitly

### DIFF
--- a/docs/examples/swe-agent-harbor-docker.md
+++ b/docs/examples/swe-agent-harbor-docker.md
@@ -117,12 +117,7 @@ For a smoke test, set `--num-rollout 1`. Expect roughly 10 minutes per step at
 this shape; because synchronous rollout waits for the slowest trajectory in the
 batch, a step that draws an unusually slow task can take several times that.
 
-`--router-external-host` is the address Harbor sandboxes use to call the Miles
-session server and SGLang router. It must resolve and route from the agent-server
-machine. `--miles-host-ip 0.0.0.0` is useful when those services must accept
-connections forwarded from another host. Ensure ports 30000 and 31000 are
-reachable end to end; Tailscale is one option when the machines are on different
-networks.
+`--router-external-host` is the address Harbor sandboxes use to call the Miles session server and SGLang router. It must resolve and route from the agent-server machine. `--miles-host-ip 0.0.0.0` is useful when those services must accept connections forwarded from another host. The launcher starts 32 session-server workers on ports 30000-30031 and the SGLang router on port 31000, so ensure that range and port are reachable end to end; Tailscale is one option when the machines are on different networks.
 
 ## 4. Verify progress
 

--- a/docs/user-guide/cli-reference.md
+++ b/docs/user-guide/cli-reference.md
@@ -316,7 +316,8 @@ contract, session behavior, and model-family selection.
 | `--tito-model` | enum | `default` | TITO model family. Named families load their registered fixed template; `default` is best-effort with a checkpoint-native or custom template. |
 | `--max-seq-len` | int | – | Total tokens per session, including prompts, completions, and environment responses. Registered with the agentic wrapper. |
 | `--session-server-ip` | str | router IP | Session-server bind address. |
-| `--session-server-port` | int or start/end | auto | One port, or a half-open port range `[start, end)` for multiple instances. |
+| `--session-server-port` | int | auto | Starting port for standalone session-server instances. |
+| `--session-server-workers` | int | `1` | Number of instances; Miles uses consecutive ports starting at `--session-server-port`. |
 | `--session-sample-picker-path` | `<module>.<fn>` | `drop_retries` | v2 only: selects leaf samples before post-processing. |
 | `--session-sample-postprocessor-path` | `<module>.<fn>` | `default_postprocess` | v2 only: finalizes loss masks and rewards. |
 

--- a/docs/user-guide/cli-reference.md
+++ b/docs/user-guide/cli-reference.md
@@ -317,7 +317,7 @@ contract, session behavior, and model-family selection.
 | `--max-seq-len` | int | – | Total tokens per session, including prompts, completions, and environment responses. Registered with the agentic wrapper. |
 | `--session-server-ip` | str | router IP | Session-server bind address. |
 | `--session-server-port` | int | auto | Starting port for standalone session-server instances. |
-| `--session-server-workers` | int | `1` | Number of instances; Miles uses consecutive ports starting at `--session-server-port`. |
+| `--session-server-workers` | int | `32` | Number of instances; Miles uses consecutive ports starting at `--session-server-port`. |
 | `--session-sample-picker-path` | `<module>.<fn>` | `drop_retries` | v2 only: selects leaf samples before post-processing. |
 | `--session-sample-postprocessor-path` | `<module>.<fn>` | `default_postprocess` | v2 only: finalizes loss masks and rewards. |
 

--- a/examples/experimental/nemo-gym/run.py
+++ b/examples/experimental/nemo-gym/run.py
@@ -150,6 +150,7 @@ def execute(args: ScriptArgs):
         # tailnet address); internal calls resolve it to localhost.
         "--session-server-ip 0.0.0.0 "
         "--session-server-port 30000 "
+        "--session-server-workers 32 "
         "--tito-model qwen3 "
     )
 

--- a/examples/experimental/openenv/glm52_tbench2/run_glm5_2_744b_a40b_daytona.py
+++ b/examples/experimental/openenv/glm52_tbench2/run_glm5_2_744b_a40b_daytona.py
@@ -173,6 +173,7 @@ def _execute_train(args: ScriptArgs):
         "--tito-model glm47 "
         "--use-session-server "
         "--session-server-port 30000 "
+        "--session-server-workers 32 "
     )
 
     # 32-GPU training half. CP4 splits --max-seq-len across the CP ranks;

--- a/examples/experimental/openenv/openenv_launch_common.py
+++ b/examples/experimental/openenv/openenv_launch_common.py
@@ -150,6 +150,7 @@ def agent_args(tito_model: str, sandbox_backend: str = "") -> str:
         f"--tito-model {tito_model} "
         "--use-session-server "
         "--session-server-port 30000 "
+        "--session-server-workers 32 "
     )
 
 

--- a/examples/experimental/terminus-compaction/README.md
+++ b/examples/experimental/terminus-compaction/README.md
@@ -135,10 +135,7 @@ python examples/experimental/terminus-compaction/run.py \
     --router-external-host <trainer-address-reachable-from-agent-server>
 ```
 
-`--session-server-ip` is the local bind address. `--router-external-host` is the
-address Harbor uses to call back into the session server and SGLang router; it
-must resolve from the agent-server host. Allow inbound TCP connections to ports
-30000 and 31000 from that host.
+`--session-server-ip` is the local bind address. `--router-external-host` is the address Harbor uses to call back into the session server and SGLang router; it must resolve from the agent-server host. The launcher starts 32 session-server workers on ports 30000-30031 and the SGLang router on port 31000, so allow inbound TCP connections to that range and port from the agent-server host.
 
 For a local smoke test, run Harbor on the trainer, use
 `--agent-server-url http://127.0.0.1:11000`, and set both session addresses to a

--- a/examples/experimental/terminus-compaction/run.py
+++ b/examples/experimental/terminus-compaction/run.py
@@ -173,6 +173,7 @@ def _agent_args(args: ScriptArgs) -> str:
         "--use-session-server v2 "
         f"{bind_arg}"
         "--session-server-port 30000 "
+        "--session-server-workers 32 "
     )
 
 

--- a/examples/swe-agent-harbor-docker/README.md
+++ b/examples/swe-agent-harbor-docker/README.md
@@ -114,12 +114,7 @@ For a smoke test, set `--num-rollout 1`. Expect roughly 10 minutes per step at
 this shape; because synchronous rollout waits for the slowest trajectory in the
 batch, a step that draws an unusually slow task can take several times that.
 
-`--router-external-host` is the address Harbor sandboxes use to call the Miles
-session server and SGLang router. It must resolve and route from the agent-server
-machine. `--miles-host-ip 0.0.0.0` is useful when those services must accept
-connections forwarded from another host. Ensure ports 30000 and 31000 are
-reachable end to end; Tailscale is one option when the machines are on different
-networks.
+`--router-external-host` is the address Harbor sandboxes use to call the Miles session server and SGLang router. It must resolve and route from the agent-server machine. `--miles-host-ip 0.0.0.0` is useful when those services must accept connections forwarded from another host. The launcher starts 32 session-server workers on ports 30000-30031 and the SGLang router on port 31000, so ensure that range and port are reachable end to end; Tailscale is one option when the machines are on different networks.
 
 ## 4. Verify progress
 

--- a/examples/swe-agent-harbor-docker/run-glm47-flash-agentic-async.py
+++ b/examples/swe-agent-harbor-docker/run-glm47-flash-agentic-async.py
@@ -280,6 +280,7 @@ def execute(args: ScriptArgs):
         "--tito-model glm47 "
         "--use-session-server "
         "--session-server-port 30000 "
+        "--session-server-workers 32 "
     )
 
     misc_args = (

--- a/examples/swe-agent-harbor-docker/run.py
+++ b/examples/swe-agent-harbor-docker/run.py
@@ -174,6 +174,7 @@ def execute(args: ScriptArgs):
         "--tito-model glm47 "
         "--use-session-server "
         "--session-server-port 30000 "
+        "--session-server-workers 32 "
     )
 
     misc_args = (

--- a/examples/swe-agent-harbor-docker/run_glm52_lora_tb2_daytona.py
+++ b/examples/swe-agent-harbor-docker/run_glm52_lora_tb2_daytona.py
@@ -319,6 +319,7 @@ def execute(args: ScriptArgs):
         "--tito-model glm47 "
         "--use-session-server "
         "--session-server-port 30001 "
+        "--session-server-workers 32 "
     )
 
     misc_args = (

--- a/miles/ray/rollout/router_manager.py
+++ b/miles/ray/rollout/router_manager.py
@@ -82,22 +82,13 @@ def start_router(args, *, has_pd_disaggregation: bool = False, force_new: bool =
     return router_ip, router_port
 
 
-def _resolve_session_server_ports(raw: list[int] | None) -> list[int]:
-    """Resolve the ``--session-server-port`` value into the ports to serve on.
-
-    None: one auto-allocated port. One value: a single server on that port.
-    Two values: the half-open range [start, end), one server per port.
-    """
-    if raw is None:
-        return [find_available_port(random.randint(5000, 6000))]
-    if len(raw) == 1:
-        return raw
-    if len(raw) == 2:
-        start, end = raw
-        if start >= end:
-            raise ValueError(f"--session-server-port range [{start}, {end}) is empty.")
-        return list(range(start, end))
-    raise ValueError(f"--session-server-port takes one port or a start/end range, got {len(raw)} values: {raw}")
+def _resolve_session_server_ports(start: int | None, workers: int) -> list[int]:
+    """Return the requested number of consecutive ports from the configured or auto-selected start."""
+    if workers < 1:
+        raise ValueError("--session-server-workers must be at least 1.")
+    if start is None:
+        start = find_available_port(random.randint(5000, 6000))
+    return list(range(start, start + workers))
 
 
 def start_session_server(args):
@@ -119,7 +110,7 @@ def start_session_server(args):
         args.session_server_ip = args.sglang_router_ip
 
     ip = args.session_server_ip
-    ports = _resolve_session_server_ports(getattr(args, "session_server_port", None))
+    ports = _resolve_session_server_ports(args.session_server_port, args.session_server_workers)
     for port in ports:
         if not is_port_available(port):
             raise RuntimeError(

--- a/miles/ray/rollout/router_manager.py
+++ b/miles/ray/rollout/router_manager.py
@@ -86,6 +86,7 @@ def _resolve_session_server_ports(start: int | None, workers: int) -> list[int]:
     """Return the requested number of consecutive ports from the configured or auto-selected start."""
     if workers < 1:
         raise ValueError("--session-server-workers must be at least 1.")
+    # TODO(#1837): Refactor IP/port allocation; keep this naive for now.
     if start is None:
         start = find_available_port(random.randint(5000, 6000))
     return list(range(start, start + workers))

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -2546,7 +2546,7 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
             parser.add_argument(
                 "--session-server-workers",
                 type=int,
-                default=1,
+                default=32,
                 help="Number of standalone session servers to launch on consecutive ports.",
             )
             parser.add_argument(

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -2540,11 +2540,14 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
             parser.add_argument(
                 "--session-server-port",
                 type=int,
-                nargs="+",
                 default=None,
-                help="Port(s) of the standalone session servers. One value: a single server on "
-                "that port. Two values: a half-open range [start, end), one server per port. "
-                "Auto-allocates a single port if not set.",
+                help="Starting port for standalone session servers. Auto-allocated if not set.",
+            )
+            parser.add_argument(
+                "--session-server-workers",
+                type=int,
+                default=1,
+                help="Number of standalone session servers to launch on consecutive ports.",
             )
             parser.add_argument(
                 "--tito-model",

--- a/tests/fast/ray/rollout/conftest.py
+++ b/tests/fast/ray/rollout/conftest.py
@@ -87,7 +87,7 @@ def make_args(**overrides: Any) -> Namespace:
         use_session_server=False,
         session_server_ip=None,
         session_server_port=None,
-        session_server_workers=1,
+        session_server_workers=32,
         # external rollout
         rollout_external=False,
         rollout_external_engine_addrs=None,

--- a/tests/fast/ray/rollout/conftest.py
+++ b/tests/fast/ray/rollout/conftest.py
@@ -87,6 +87,7 @@ def make_args(**overrides: Any) -> Namespace:
         use_session_server=False,
         session_server_ip=None,
         session_server_port=None,
+        session_server_workers=1,
         # external rollout
         rollout_external=False,
         rollout_external_engine_addrs=None,

--- a/tests/fast/ray/rollout/test_router_manager.py
+++ b/tests/fast/ray/rollout/test_router_manager.py
@@ -60,7 +60,7 @@ class TestStartSessionServer:
             sglang_router_ip="127.0.0.1",
             sglang_router_port=20000,
             session_server_ip="127.0.0.1",
-            session_server_port=[20001],
+            session_server_port=20001,
         )
         with patch("miles.ray.rollout.router_manager.is_port_available", return_value=False):
             with pytest.raises(RuntimeError, match="already in use"):
@@ -70,18 +70,15 @@ class TestStartSessionServer:
 class TestResolveSessionServerPorts:
     def test_none_auto_allocates_one_port(self):
         with patch("miles.ray.rollout.router_manager.find_available_port", return_value=20002):
-            assert _resolve_session_server_ports(None) == [20002]
+            assert _resolve_session_server_ports(None, 1) == [20002]
 
-    def test_single_value_is_a_single_server(self):
-        assert _resolve_session_server_ports([30000]) == [30000]
+    def test_one_worker_uses_the_starting_port(self):
+        assert _resolve_session_server_ports(30000, 1) == [30000]
 
-    def test_two_values_expand_to_half_open_range(self):
-        assert _resolve_session_server_ports([30000, 30004]) == [30000, 30001, 30002, 30003]
+    def test_workers_expand_from_the_starting_port(self):
+        assert _resolve_session_server_ports(30000, 4) == [30000, 30001, 30002, 30003]
 
-    def test_empty_range_raises(self):
-        with pytest.raises(ValueError, match="empty"):
-            _resolve_session_server_ports([30004, 30000])
-
-    def test_more_than_two_values_raises(self):
-        with pytest.raises(ValueError, match="one port or a start/end range"):
-            _resolve_session_server_ports([30000, 30001, 30002])
+    @pytest.mark.parametrize("workers", [0, -1])
+    def test_non_positive_workers_raise(self, workers):
+        with pytest.raises(ValueError, match="at least 1"):
+            _resolve_session_server_ports(30000, workers)

--- a/tests/fast/utils/test_arguments.py
+++ b/tests/fast/utils/test_arguments.py
@@ -376,6 +376,29 @@ class TestSessionServerV2Validation:
         assert str(exc_info.value) == (f"--use-session-server v2 does not support {flag}; v2 returns list[Sample]")
 
 
+class TestSessionServerScalingArguments:
+    def _parse(self, extra):
+        parser = argparse.ArgumentParser()
+        get_miles_extra_args_provider()(parser)
+        return parser.parse_args(extra + ["--num-rollout", "1"] + REQUIRED_ARGS)
+
+    def test_defaults_to_one_worker_and_an_auto_port(self):
+        args = self._parse([])
+
+        assert args.session_server_port is None
+        assert args.session_server_workers == 1
+
+    def test_parses_starting_port_and_worker_count(self):
+        args = self._parse(["--session-server-port", "30000", "--session-server-workers", "4"])
+
+        assert args.session_server_port == 30000
+        assert args.session_server_workers == 4
+
+    def test_rejects_the_removed_end_port_form(self):
+        with pytest.raises(SystemExit):
+            self._parse(["--session-server-port", "30000", "30004"])
+
+
 class TestSessionMessageMatcherArgument:
     def _parse(self, extra):
         parser = argparse.ArgumentParser()

--- a/tests/fast/utils/test_arguments.py
+++ b/tests/fast/utils/test_arguments.py
@@ -382,11 +382,11 @@ class TestSessionServerScalingArguments:
         get_miles_extra_args_provider()(parser)
         return parser.parse_args(extra + ["--num-rollout", "1"] + REQUIRED_ARGS)
 
-    def test_defaults_to_one_worker_and_an_auto_port(self):
+    def test_defaults_to_32_workers_and_an_auto_port(self):
         args = self._parse([])
 
         assert args.session_server_port is None
-        assert args.session_server_workers == 1
+        assert args.session_server_workers == 32
 
     def test_parses_starting_port_and_worker_count(self):
         args = self._parse(["--session-server-port", "30000", "--session-server-workers", "4"])

--- a/tests/manual/session/bench_session_server_overhead.py
+++ b/tests/manual/session/bench_session_server_overhead.py
@@ -574,8 +574,8 @@ def run_http_bench(args) -> dict[str, Any]:
     try:
         from miles.rollout.session.server import run_session_server
 
-        # Consecutive ports from one free base, mirroring the production
-        # `--session-server-port start end` range deployment.
+        # Consecutive ports from one free base, mirroring production's
+        # `--session-server-port START --session-server-workers N` deployment.
         base_port = find_available_port(33000)
         ports = list(range(base_port, base_port + instances))
         for port in ports[1:]:


### PR DESCRIPTION
## Summary

Add `--session-server-workers` so the starting port and instance count are configured independently.

## Motivation

Encoding the instance count as the end of `--session-server-port START END` overloads one flag with two independent settings. Separate starting-port and worker-count inputs let operators change concurrency without recomputing an endpoint.

## Usage

```bash
--use-session-server \
--session-server-port 5000 \
--session-server-workers 16
```

This launches 16 independent session-server processes on ports 5000 through 5015. Omitting `--session-server-workers` selects the 32-worker default; an explicit value overrides it.

## Design Notes

- **Mental model:** `--session-server-port` and `--session-server-workers` flow through `_resolve_session_server_ports` to launch one independent server on each consecutive port with the existing per-session affinity.
- The old two-value port form is rejected instead of retained as a compatibility path, so the starting port and instance count each have one owner.
- In-repo example launchers explicitly request 32 workers so their migration does not silently depend on the new default.
- Generated example docs mirror the source READMEs' session ports 30000-30031 and router port 31000.
- Non-positive worker counts fail before any session-server process is spawned.

## Verification

- Session-worker production checks on the unchanged Python candidate at `97498d439`: exact argparse and resolver source harnesses passed.
- `uvx ruff check` across every changed Python file at `97498d439`: passed.
- README source comparison at `97498d439`: both network guides match the launchers' session ports 30000-30031 and router port 31000.
- `uvx --from pre-commit pre-commit run sync-example-docs --all-files`: passed on `97498d439`.
- `uvx pytest --confcutdir=tests/fast/doc tests/fast/doc/test_sync_example_docs.py::test_docs_examples_matches_the_readmes -q`: passed on `97498d439`.
- Full local pytest and real session-server startup remain unverified because the local environment lacks project runtime dependencies; remote CI remains required.

## Review Focus

- `_resolve_session_server_ports` in `miles/ray/rollout/router_manager.py`: consecutive-port expansion and the intentional removal of the old end-port form.
- Example source and generated network guides: required port reachability stays synchronized with launcher configuration.
- Automatic start selection probes only the starting port before deriving the remaining consecutive ports; review conflict behavior for that derived block.
