### PR TITLE
fix(metrics): scope episode rewards by adapter

### DIFF
--- a/miles/ray/rollout/metrics.py
+++ b/miles/ray/rollout/metrics.py
@@ -14,7 +14,7 @@ from miles.utils.metric_utils import (
 )
 from miles.utils.misc import load_function
 from miles.utils.tracking_utils import tracking
-from miles.utils.types import Sample
+from miles.utils.types import AdapterRef, Sample
 
 logger = logging.getLogger(__name__)
 
@@ -143,17 +143,18 @@ def _compute_training_sample_metrics(args: Any, samples: list[Sample]) -> dict[s
     Session compaction can turn one rollout into several training samples. The
     sample count includes every resulting row, while the reward first averages
     sibling rows that share a rollout ID so long rollouts do not receive more
-    metric weight merely because they produced more samples.
+    metric weight merely because they produced more samples. Adapter identity
+    scopes these IDs because each Multi-LoRA data source numbers them independently.
     """
-    rewards_by_rollout: dict[tuple[str, int | None, int], list[float]] = {}
+    rewards_by_rollout: dict[tuple[AdapterRef | None, str, int | None, int], list[float]] = {}
     use_metadata_reward = bool(samples and samples[0].metadata and "raw_reward" in samples[0].metadata)
     for position, sample in enumerate(samples):
         if sample.rollout_id is not None:
-            rollout_key = ("rollout", sample.group_index, sample.rollout_id)
+            rollout_key = (sample.adapter, "rollout", sample.group_index, sample.rollout_id)
         elif sample.index is not None:
-            rollout_key = ("sample", sample.group_index, sample.index)
+            rollout_key = (sample.adapter, "sample", sample.group_index, sample.index)
         else:
-            rollout_key = ("position", sample.group_index, position)
+            rollout_key = (sample.adapter, "position", sample.group_index, position)
 
         raw_reward = sample.metadata["raw_reward"] if use_metadata_reward else sample.get_reward_value(args)
         if isinstance(raw_reward, Number):

--- a/tests/fast/ray/rollout/test_metrics.py
+++ b/tests/fast/ray/rollout/test_metrics.py
@@ -10,6 +10,7 @@ from miles.ray.rollout.metrics import (
     _compute_zero_std_metrics,
     log_rollout_data,
 )
+from miles.utils.types import AdapterRef
 
 
 class TestTrainingSampleMetrics:
@@ -45,6 +46,21 @@ class TestTrainingSampleMetrics:
             make_sample(group_index=0, index=0, rollout_id=10, reward=1.0),
             make_sample(group_index=0, index=0, rollout_id=10, reward=1.0),
             make_sample(group_index=1, index=1, rollout_id=10, reward=0.0),
+        ]
+
+        out = _compute_training_sample_metrics(args, samples)
+
+        assert out["episode_raw_reward"] == pytest.approx(0.5)
+
+    def test_rollout_ids_are_scoped_by_adapter(self):
+        args = make_args(reward_key=None)
+        adapter_a = AdapterRef(name="adapter-a", slot=0)
+        adapter_b = AdapterRef(name="adapter-b", slot=1)
+        samples = [
+            make_sample(group_index=0, rollout_id=10, adapter=adapter_a, reward=1.0),
+            make_sample(group_index=0, rollout_id=10, adapter=adapter_a, reward=1.0),
+            make_sample(group_index=0, rollout_id=10, adapter=adapter_a, reward=1.0),
+            make_sample(group_index=0, rollout_id=10, adapter=adapter_b, reward=0.0),
         ]
 
         out = _compute_training_sample_metrics(args, samples)


### PR DESCRIPTION
## Summary

- scope rollout reward aggregation by `AdapterRef`
- prevent unrelated Multi-LoRA rollouts with reused local IDs from sharing one reward bucket
- add a regression test covering unequal compaction-fragment counts across adapters

## Why

Each Multi-LoRA adapter owns an independent rollout data source, so `(group_index, rollout_id)` is not globally unique. Without adapter identity in the key, `rollout/episode_raw_reward` can silently weight one adapter more heavily when its rollout produces more training samples.

This follows up on the pre-existing issue identified in [PR #2765](https://github.com/radixark/miles/pull/2765#discussion_r3869035608).

## Validation

- `24 passed` in `tests/fast/ray/rollout/test_metrics.py`
- Ruff check passed for both changed files
- direct real-code probe now reports the correct per-rollout mean (`0.5` instead of `0.75`)
