### PR TITLE
test(dsv4): accept ValueError from reasoning-effort validation

### DIFF
--- a/tests/fast/utils/chat_template_utils/test_deepseek_v4.py
+++ b/tests/fast/utils/chat_template_utils/test_deepseek_v4.py
@@ -200,8 +200,10 @@ def test_reasoning_effort_high_accepted_and_matches_direct():
 
 
 def test_reasoning_effort_invalid_value_raises():
-    # Value-level validation is delegated to sglang (asserts the allowed set).
-    with pytest.raises(AssertionError):
+    # Value-level validation is delegated to sglang; depending on the sglang
+    # version it asserts the allowed set or raises ValueError. Both carry the
+    # same "Invalid reasoning effort" message.
+    with pytest.raises((AssertionError, ValueError), match="Invalid reasoning effort"):
         deepseek.V4.render_messages(_MSGS_BASIC, thinking_mode="thinking", reasoning_effort="ultra")
 
 


### PR DESCRIPTION
Every PR's stage-a-cpu run currently fails on test_reasoning_effort_invalid_value_raises: sglang changed its reasoning-effort validation from an assert to raising ValueError ('Invalid reasoning effort ... expected one of [high, max]'), and the test pins pytest.raises(AssertionError). Accept both exception types so the test tracks the delegated validation regardless of sglang version. Seen on radixark/miles#2777's run 33045107325; unrelated to that PR's diff.