### PR TITLE
fix(lora): Use in-place upsert for disaggregated single-LoRA sync

### DIFF
--- a/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/broadcast.py
+++ b/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/broadcast.py
@@ -147,6 +147,7 @@ class UpdateWeightFromDistributed(DistBucketedWeightUpdateMixin):
                 dtypes=dtypes,
                 shapes=shapes,
                 group_name=self._group_name,
+                upsert=True,
             )
             for engine in self.rollout_engines
         ]

--- a/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/mixin.py
+++ b/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/mixin.py
@@ -9,7 +9,6 @@ from tqdm import tqdm
 
 from miles.backends.training_utils.parallel import get_parallel_state
 from miles.utils.distributed_utils import get_gloo_group
-from miles.utils.lora import LORA_ADAPTER_NAME
 from miles.utils.timer import timer
 
 from ...lora_utils import _is_adapter_param_name, build_lora_sync_config, is_lora_weight_name
@@ -54,8 +53,7 @@ class DistBucketedWeightUpdateMixin:
             engines (via NCCL broadcast, p2p write, etc.).
         self._update_lora_weight_implementation(named_tensors) -> None
             Transfer the full LoRA adapter (HF-format ``(name, tensor)`` pairs) to
-            rollout engines. Only required when ``is_lora``; the
-            unload-before-reload is handled by ``_update_lora_weights``.
+            rollout engines, upserting it in place. Only required when ``is_lora``.
         self._update_multi_lora_weight_implementation(named_tensors, *, lora_name, lora_config) -> None
             Multi-LoRA variant: transfers one adapter under its per-slot engine
             name with the adapter's own config, upserting in place. Only
@@ -86,7 +84,6 @@ class DistBucketedWeightUpdateMixin:
                 f"--pipeline-model-parallel-size 1 (got {args.pipeline_model_parallel_size})."
             )
             self._lora_config = build_lora_sync_config(args)
-            self._lora_loaded = False
             self._hf_weight_iterator = HfWeightIteratorBase.create(
                 args=args,
                 model=model,
@@ -229,10 +226,9 @@ class DistBucketedWeightUpdateMixin:
         """Orchestrate the LoRA adapter update; delegate transmit to the subclass.
 
         Mirrors the base path's split: this method owns the transport-agnostic
-        steps (bridge iteration, validation, source gating, and the
-        unload-before-reload), and hands the gathered adapter to
-        ``self._update_lora_weight_implementation`` — broadcast (NCCL) or p2p
-        provide their own.
+        steps (bridge iteration, validation, and source gating), and hands the
+        gathered adapter to ``self._update_lora_weight_implementation`` —
+        broadcast (NCCL) or p2p provide their own.
 
         All TP ranks iterate the bridge (required for internal TP collectives),
         but only the source rank transmits.
@@ -258,12 +254,7 @@ class DistBucketedWeightUpdateMixin:
                 "(no lora_A/lora_B names found). Check weight iterator."
             )
 
-        if self._lora_loaded:
-            ray.get(
-                [engine.unload_lora_adapter.remote(lora_name=LORA_ADAPTER_NAME) for engine in self.rollout_engines]
-            )
         self._update_lora_weight_implementation(accumulated_named_tensors)
-        self._lora_loaded = True
 
     def _update_multi_lora_weights(self) -> None:
         """Upsert the actor-selected adapters; the push set is identical on every rank so TP collectives align."""

--- a/tests/fast/backends/megatron_utils/test_lora_weight_sync_validation.py
+++ b/tests/fast/backends/megatron_utils/test_lora_weight_sync_validation.py
@@ -353,7 +353,7 @@ class TestFlattenedTensorBucketRoundTrip:
 # ---------------------------------------------------------------------------
 # Distributed (disaggregate) LoRA sync. The base-weight split is mirrored:
 #   - DistBucketedWeightUpdateMixin._update_lora_weights  → shared orchestration
-#       (bridge iteration, guards, source gating, engine lock, unload-on-reload)
+#       (bridge iteration, guards, source gating, in-place refresh)
 #   - <subclass>._update_lora_weight_implementation       → transport (NCCL / p2p)
 # ---------------------------------------------------------------------------
 
@@ -378,18 +378,17 @@ class TestDistLoraUpdateOrchestration:
     """Shared ``_update_lora_weights``: transport-agnostic orchestration.
 
     It must enforce the silent-failure guards (zero chunks, no LoRA names), gate
-    on the source rank, unload a stale adapter before reload, and delegate the
-    actual transmit to ``_update_lora_weight_implementation`` (mocked here).
+    on the source rank, and delegate the actual transmit to
+    ``_update_lora_weight_implementation`` (mocked here).
     """
 
     @staticmethod
-    def _make_self(*, engines, chunks=None, is_source=True, lora_loaded=False):
+    def _make_self(*, engines, chunks=None, is_source=True):
         if chunks is None:
             chunks = [SAMPLE_LORA_WEIGHTS]
         return SimpleNamespace(
             _hf_weight_iterator=SimpleNamespace(get_hf_weight_chunks=lambda *a, **k: iter(chunks)),
             _is_lora_source=is_source,
-            _lora_loaded=lora_loaded,
             rollout_engines=engines,
             _update_lora_weight_implementation=MagicMock(name="impl"),
         )
@@ -407,7 +406,6 @@ class TestDistLoraUpdateOrchestration:
         fake_self._update_lora_weight_implementation.assert_called_once()
         (sent,) = fake_self._update_lora_weight_implementation.call_args.args
         assert sent == SAMPLE_LORA_WEIGHTS
-        assert fake_self._lora_loaded is True
 
     def test_non_source_rank_does_not_transmit(self):
         # Non-source ranks still iterate the bridge (TP collectives) but must not
@@ -432,27 +430,11 @@ class TestDistLoraUpdateOrchestration:
             self._run(fake_self)
         fake_self._update_lora_weight_implementation.assert_not_called()
 
-    def test_reload_unloads_existing_adapter_first(self):
-        # When an adapter is already loaded, the stale one must be unloaded before
-        # the new weights are pushed, else SGLang rejects the duplicate name.
+    def test_update_does_not_unload_adapter(self):
         engines = [_FakeEngine()]
-        fake_self = self._make_self(engines=engines, lora_loaded=True)
-        self._run(fake_self)
-        assert engines[0].unload_lora_adapter.calls == [{"lora_name": LORA_ADAPTER_NAME}]
-        fake_self._update_lora_weight_implementation.assert_called_once()
-
-    def test_first_load_does_not_unload(self):
-        engines = [_FakeEngine()]
-        fake_self = self._make_self(engines=engines, lora_loaded=False)
+        fake_self = self._make_self(engines=engines)
         self._run(fake_self)
         assert engines[0].unload_lora_adapter.calls == []
-
-    def test_lora_loaded_stays_false_when_implementation_raises(self):
-        fake_self = self._make_self(engines=[_FakeEngine()])
-        fake_self._update_lora_weight_implementation.side_effect = RuntimeError("boom")
-        with pytest.raises(RuntimeError, match="boom"):
-            self._run(fake_self)
-        assert fake_self._lora_loaded is False
 
 
 class TestBroadcastLoraImplementation:
@@ -495,6 +477,7 @@ class TestBroadcastLoraImplementation:
         assert kwargs["names"] == [n for n, _ in SAMPLE_LORA_WEIGHTS]
         assert kwargs["dtypes"] == [t.dtype for _, t in SAMPLE_LORA_WEIGHTS]
         assert kwargs["shapes"] == [list(t.shape) for _, t in SAMPLE_LORA_WEIGHTS]
+        assert kwargs["upsert"] is True
         # One NCCL broadcast (src=0, shared base group) per tensor.
         assert dist_mock.broadcast.call_count == len(SAMPLE_LORA_WEIGHTS)
         for call in dist_mock.broadcast.call_args_list:


### PR DESCRIPTION
Use SGLang’s `upsert=True` path for disaggregated single-LoRA weight synchronization instead of unloading and reloading the adapter.

During fully async rollouts, paused or retracted requests may retain references to the loaded LoRA adapter. The existing refresh flow waits for those references during `unload_lora_adapter`, while generation cannot resume until weight synchronization finishes. This can deadlock a weight update.