### PR TITLE
Default fully-async recipes to retract weight-update pauses

### DIFF
--- a/docs/examples/infra-features/random-async.md
+++ b/docs/examples/infra-features/random-async.md
@@ -11,7 +11,7 @@ for bigger agentic workloads.
 ## Quick start
 
 ```bash
-# default (Qwen3.5-35B-A3B), in_place pause + broadcast weight transfer
+# default (Qwen3.5-35B-A3B), retract pause + broadcast weight transfer
 python run_random_async_3node.py
 
 # retract pause + p2p weight transfer

--- a/docs/user-guide/fully-async.md
+++ b/docs/user-guide/fully-async.md
@@ -91,7 +91,10 @@ the driver's step schedule:
    `--pause-generation-mode` flag decides how in-flight requests survive that pause: the
    default `retract` returns them to the waiting queue and recomputes their KV cache,
    while `in_place` freezes them and resumes on the existing cache. Passing `abort`
-   would kill them outright, which is why fully async rejects it.
+   would kill them outright, which is why fully async rejects it. Prefer `retract`:
+   because `in_place` keeps paused requests' KV, the engine cannot flush its prefix
+   cache on updates, so prefixes cached under pre-update weights keep serving later
+   requests and silently mix old-policy KV into new-policy rollouts.
 
 Because generation spans those weight updates, the samples in one group can carry
 different weight versions. The gap between a group's oldest weight version and the

--- a/examples/experimental/openenv/glm52_tbench2/run_glm5_2_744b_a40b_daytona.py
+++ b/examples/experimental/openenv/glm52_tbench2/run_glm5_2_744b_a40b_daytona.py
@@ -135,7 +135,7 @@ def _execute_train(args: ScriptArgs):
 
     rollout_args = (
         "--fully-async "
-        "--pause-generation-mode in_place "
+        "--pause-generation-mode retract "
         f"--async-max-concurrent-samples {args.async_max_concurrent_samples} "
         # Free a submission slot per finished sample, not per finished group:
         # with long-horizon agentic trials, waiting for each group's slowest

--- a/examples/infra_features/fully_async/run_qwen3_30b_a3b_fully_async.py
+++ b/examples/infra_features/fully_async/run_qwen3_30b_a3b_fully_async.py
@@ -5,7 +5,7 @@ import typer
 
 import miles.utils.external_utils.command_utils as U
 
-# in_place + broadcast
+# retract + broadcast
 # python run_qwen3_30b_a3b_fully_async.py
 
 # retract + p2p
@@ -25,7 +25,7 @@ class ScriptArgs(U.ExecuteTrainConfig):
     data_dir: str = "/root/datasets"
     model_dir: str = "/root/models"
     megatron_path: str = "/root/Megatron-LM"
-    pause_generation_mode: Literal["in_place", "retract"] = "in_place"
+    pause_generation_mode: Literal["in_place", "retract"] = "retract"
     update_weight_transfer_mode: Literal["broadcast", "p2p"] = "broadcast"
     extra_args: str = ""
 

--- a/examples/infra_features/fully_async/run_qwen3_5_4b_fully_async_eval.py
+++ b/examples/infra_features/fully_async/run_qwen3_5_4b_fully_async_eval.py
@@ -76,7 +76,7 @@ def execute(args: ScriptArgs):
         "--global-batch-size 256 "
         "--balance-data "
         # retract (default) can deadlock flush_cache in fully_async under load
-        "--pause-generation-mode in_place "
+        "--pause-generation-mode retract "
     )
 
     # Shared by both backends: snapshot staging on tmpfs + the eval datasets.

--- a/examples/infra_features/random_async/README.md
+++ b/examples/infra_features/random_async/README.md
@@ -8,7 +8,7 @@ for bigger agentic workloads.
 ## Quick start
 
 ```bash
-# default (Qwen3.5-35B-A3B), in_place pause + broadcast weight transfer
+# default (Qwen3.5-35B-A3B), retract pause + broadcast weight transfer
 python run_random_async_3node.py
 
 # retract pause + p2p weight transfer

--- a/examples/infra_features/random_async/run_random_async_3node.py
+++ b/examples/infra_features/random_async/run_random_async_3node.py
@@ -19,7 +19,7 @@ class ScriptArgs(U.ExecuteTrainConfig):
     num_rollout: int = 4
     model_dir: str = "/root/models"
     megatron_path: str = "/root/Megatron-LM"
-    pause_generation_mode: Literal["in_place", "retract"] = "in_place"
+    pause_generation_mode: Literal["in_place", "retract"] = "retract"
     update_weight_transfer_mode: Literal["broadcast", "p2p"] = "broadcast"
     skip_prepare: bool = False
     extra_args: str = ""

--- a/examples/swe-agent-harbor-docker/run-glm47-flash-agentic-async.py
+++ b/examples/swe-agent-harbor-docker/run-glm47-flash-agentic-async.py
@@ -83,7 +83,7 @@ class ScriptArgs(U.ExecuteTrainConfig):
 
     # Disaggregated fully-async settings
     train_num_nodes: int = 1
-    pause_generation_mode: Literal["in_place", "retract"] = "in_place"
+    pause_generation_mode: Literal["in_place", "retract"] = "retract"
     update_weight_transfer_mode: Literal["broadcast", "p2p"] = "broadcast"
     accumulate_allreduce_grads_in_fp32: bool = False
     max_tokens_per_gpu: int = 8192

--- a/scripts/run_inkling.py
+++ b/scripts/run_inkling.py
@@ -228,7 +228,7 @@ def _train(args: ScriptArgs):
 
     rollout_args = ""
     if args.fully_async:
-        rollout_args += "--fully-async " "--pause-generation-mode in_place "
+        rollout_args += "--fully-async " "--pause-generation-mode retract "
     rollout_args += (
         "--input-key prompt "
         "--label-key label "


### PR DESCRIPTION
TODO: show cache weight version, fix the unbounded issue

## Summary

`--pause-generation-mode in_place` leaves the SGLang radix (prefix) cache poisoned with pre-update KV after every weight update, so later rollouts silently generate on a mixture of new weights and old-policy KV. Every fully-async recipe on main currently defaults to or hardcodes `in_place`. This PR flips them to `retract`, which recomputes retracted requests' KV under the new weights and flushes the prefix cache on every update.

## Mechanism

- `pause_generation(mode="in_place")` freezes in-flight requests so their KV survives the update — that is the mode's purpose. Because those frozen requests hold KV, the engine-side cache flush cannot run: `scheduler.flush_cache` refuses while requests hold pages, and the engine's update paths `assert` on flush success. sglang's own `io_struct.py` documents it: *"In 'inplace' mode, flush_cache will fail if there are any requests"*.
- The miles update paths therefore skip the flush entirely under `in_place` (`update_weight_from_distributed/mixin.py:315-316`, same guard in `delta.py` and `update_weight_from_tensor.py`).
- Skipping the flush is forced, but its fallout is unhandled: **nothing ever invalidates the radix tree**. Prefixes cached under pre-update weights keep serving every later request that shares them, across arbitrarily many updates. A radix hit reuses the cached KV without recompute, and LRU keeps hot prefixes (shared system prompt, the per-prompt prefix under `--n-samples-per-prompt`, earlier turns of a multi-turn conversation) alive indefinitely — so the poisoning is unbounded in time and covers all subsequent traffic, not just the requests frozen across one update.

## Symptom

- Rollouts become a hybrid behavior policy: fresh weights on the un-cached suffix, stale KV on the cached prefix. The recorded `rollout_log_probs` describe that hybrid, while the trainer recomputes log probs under the current weights, so `train/train_rollout_logprob_abs_diff` grows with every update instead of sitting at cross-implementation numeric noise, and the effective behavior policy lags the trainer roughly in proportion to the cached-prefix token share.
- The existing `rollout/weight_version/mixed_version_ratio` metric stays near zero throughout: per-request weight-version events only track requests alive across an update, and radix reuse by *new* requests is invisible to them. The corruption is therefore silent on the dashboard.
- Severity scales with radix hit rate × per-update policy movement — worst for exactly the standard RL shape: shared system prompt, many samples per prompt, `--update-weights-interval 1`.

## Why retract is the right default now

- `retract` returns in-flight requests to the waiting queue, recomputes their KV under the new weights, and the update path flushes the prefix cache — both halves of the staleness problem disappear.
- Its historical blocker is gone: the flush-refused-under-load failure was fixed by #1750 plus sgl-project/sglang#31962, so `retract` works under high concurrency.
- `in_place` stays available for setups that need it, but until the engine invalidates version-stale prefixes on its own, it should be an explicit opt-in with known cost, not the default.

## Changes

| file | change |
| --- | --- |
| `examples/infra_features/fully_async/run_qwen3_30b_a3b_fully_async.py` | default `in_place` → `retract` |
| `examples/infra_features/fully_async/run_qwen3_5_4b_fully_async_eval.py` | hardcoded → `retract` |
| `examples/infra_features/random_async/run_random_async_3node.py` | default → `retract` |
| `examples/swe-agent-harbor-docker/run-glm47-flash-agentic-async.py` | default → `retract` |
| `examples/experimental/openenv/glm52_tbench2/run_glm5_2_744b_a40b_daytona.py` | hardcoded → `retract` |
| `scripts/run_inkling.py` | hardcoded → `retract` |
| `docs/user-guide/fully-async.md`, `docs/examples/infra-features/random-async.md`, `examples/infra_features/random_async/README.md` | document the default and the reason |

**Deliberate exception**: `examples/multi_lora/run_multi_lora.py` keeps `in_place` — its adapter upsert relies on it (an unload would deadlock behind paused in-flight requests), and its `--use-tis` corrects the training-side bias since the recorded log probs faithfully describe the (lagged) behavior policy.

## Follow-up

- Engine-side long-term fix, tracked separately: evict the evictable radix nodes when the weight version bumps. Frozen requests' nodes are lock-protected, so that would make `in_place` safe again (including for multi-turn workloads, which lose cross-turn prefix reuse under any flush-based scheme).

## Tests

- `pre-commit run --all-files` clean. The change is recipe defaults plus docs; behavior is covered by the existing fully-async paths that already run `retract`.
