### PR TITLE
Partition the rollout radix cache by the session's initial weight version

### DIFF
--- a/docs/user-guide/fully-async.md
+++ b/docs/user-guide/fully-async.md
@@ -93,6 +93,15 @@ the driver's step schedule:
    while `in_place` freezes them and resumes on the existing cache. Passing `abort`
    would kill them outright, which is why fully async rejects it.
 
+   `retract` and `abort` also flush the engines' radix cache during the pause;
+   `in_place` cannot (frozen requests still hold their KV), so prefix KV computed
+   under the old weights stays cached. To keep that reuse bounded, every generation
+   request carries an `extra_key` locked to the weight version its sample first
+   posted under: the radix cache only matches entries with the same key, so new
+   samples never reuse KV from older weight versions, while a frozen multi-turn
+   sample keeps matching its own earlier KV — the same staleness `in_place` already
+   accepts for in-flight requests.
+
 Because generation spans those weight updates, the samples in one group can carry
 different weight versions. The gap between a group's oldest weight version and the
 engines' current one is its **staleness**, and it is the reason a group that finished

--- a/miles/rollout/generate_hub/multi_turn.py
+++ b/miles/rollout/generate_hub/multi_turn.py
@@ -48,6 +48,7 @@ async def generate(input: GenerateFnInput) -> GenerateFnOutput:
     prompt_tokens_ids = compute_prompt_ids_from_sample(input.state, sample, tools=tool_specs)
 
     sample.tokens = prompt_tokens_ids.copy()
+    lock_weight_version_extra_key(sample)
 
     for _turn in range(args.generate_max_turns):
         # ----------------------- Call inference endpoint -------------------------

--- a/miles/rollout/generate_hub/multi_turn.py
+++ b/miles/rollout/generate_hub/multi_turn.py
@@ -18,6 +18,7 @@ from miles.rollout.generate_utils.tool_call_utils import (
     execute_tool_calls,
     update_sample_with_tool_responses,
 )
+from miles.rollout.generate_utils.weight_version_partition import lock_weight_version_extra_key
 from miles.utils.http_utils import post
 from miles.utils.lifecycle import TrajectoryLifecycle
 from miles.utils.misc import load_function
@@ -55,6 +56,7 @@ async def generate(input: GenerateFnInput) -> GenerateFnOutput:
         if payload is None:
             sample.status = halt_status
             break
+        payload["extra_key"] = lock_weight_version_extra_key(sample)
 
         gen_t0 = time.time()
         output = await post(url, payload, headers=compute_routing_headers(args, sample))

--- a/miles/rollout/generate_hub/single_turn.py
+++ b/miles/rollout/generate_hub/single_turn.py
@@ -19,6 +19,7 @@ async def generate(input: GenerateFnInput) -> GenerateFnOutput:
     sample = input.sample
     sampling_params = input.sampling_params
     assert sample.status in {Sample.Status.PENDING, Sample.Status.ABORTED}, f"{sample.status=}"
+    lock_weight_version_extra_key(sample)
     url = f"http://{args.sglang_router_ip}:{args.sglang_router_port}/generate"
 
     prompt_ids = compute_prompt_ids_from_sample(input.state, sample)

--- a/miles/rollout/generate_hub/single_turn.py
+++ b/miles/rollout/generate_hub/single_turn.py
@@ -9,6 +9,7 @@ from miles.rollout.generate_utils.generate_endpoint_utils import (
     compute_routing_headers,
     update_sample_from_response,
 )
+from miles.rollout.generate_utils.weight_version_partition import lock_weight_version_extra_key
 from miles.utils.http_utils import post
 from miles.utils.types import Sample
 
@@ -40,6 +41,7 @@ async def generate(input: GenerateFnInput) -> GenerateFnOutput:
     if payload is None:
         sample.status = halt_status
         return GenerateFnOutput(samples=sample)
+    payload["extra_key"] = lock_weight_version_extra_key(sample)
 
     output = await post(url, payload, headers=compute_routing_headers(args, sample))
     await update_sample_from_response(args, sample, payload=payload, output=output)

--- a/miles/rollout/generate_utils/generate_endpoint_utils.py
+++ b/miles/rollout/generate_utils/generate_endpoint_utils.py
@@ -8,9 +8,9 @@ from typing import Any
 import numpy as np
 import pybase64
 
+from miles.rollout.generate_utils.weight_version_partition import observe_weight_version
 from miles.utils.lora import LORA_ADAPTER_NAME, lora_rollout_enabled
 from miles.utils.processing_utils import encode_image_for_rollout_engine, extract_multimodal_train_inputs
-from miles.rollout.generate_utils.weight_version_partition import observe_weight_version
 from miles.utils.types import Sample
 
 

--- a/miles/rollout/generate_utils/generate_endpoint_utils.py
+++ b/miles/rollout/generate_utils/generate_endpoint_utils.py
@@ -10,6 +10,7 @@ import pybase64
 
 from miles.utils.lora import LORA_ADAPTER_NAME, lora_rollout_enabled
 from miles.utils.processing_utils import encode_image_for_rollout_engine, extract_multimodal_train_inputs
+from miles.rollout.generate_utils.weight_version_partition import observe_weight_version
 from miles.utils.types import Sample
 
 
@@ -80,6 +81,7 @@ def compute_request_payload(
 async def update_sample_from_response(
     args, sample: Sample, payload: dict, output: dict, update_loss_mask: bool = False
 ):
+    observe_weight_version(output["meta_info"])
     # Initialize sample.tokens for the first turn
     if (len(sample.response) == 0) and not sample.tokens:
         sample.tokens = payload["input_ids"]

--- a/miles/rollout/generate_utils/weight_version_partition.py
+++ b/miles/rollout/generate_utils/weight_version_partition.py
@@ -3,17 +3,33 @@
 # modes that skip engine-side cache flushes (in_place) would otherwise let KV
 # computed under old weights serve unrelated new requests indefinitely.
 
+from miles.utils.types import Sample
+
 WEIGHT_VERSION_EXTRA_KEY_METADATA_KEY: str = "weight_version_extra_key"
+
+_latest_weight_version: int | None = None
+
+
+def observe_weight_version(meta_info: dict) -> None:
+    global _latest_weight_version
+
+    try:
+        version = int(meta_info.get("weight_version"))
+    except (TypeError, ValueError):
+        return
+    _latest_weight_version = version if _latest_weight_version is None else max(_latest_weight_version, version)
+
+
+def latest_weight_version() -> int | None:
+    return _latest_weight_version
+
+
+def lock_weight_version_extra_key(sample: Sample) -> str:
+    if (extra_key := sample.metadata.get(WEIGHT_VERSION_EXTRA_KEY_METADATA_KEY)) is None:
+        extra_key = format_weight_version_extra_key(_latest_weight_version)
+        sample.metadata[WEIGHT_VERSION_EXTRA_KEY_METADATA_KEY] = extra_key
+    return extra_key
 
 
 def format_weight_version_extra_key(weight_version: int | None) -> str:
     return f"weight-version:{0 if weight_version is None else weight_version}"
-
-
-def observe_weight_version(current: int | None, meta_info: dict) -> int | None:
-    raw = meta_info.get("weight_version")
-    try:
-        version = int(raw)
-    except (TypeError, ValueError):
-        return current
-    return version if current is None else max(current, version)

--- a/miles/rollout/generate_utils/weight_version_partition.py
+++ b/miles/rollout/generate_utils/weight_version_partition.py
@@ -1,0 +1,19 @@
+# Namespacing generation requests by the weight version seen when a session
+# started keeps radix-cache prefix reuse within one weight generation: pause
+# modes that skip engine-side cache flushes (in_place) would otherwise let KV
+# computed under old weights serve unrelated new requests indefinitely.
+
+WEIGHT_VERSION_EXTRA_KEY_METADATA_KEY: str = "weight_version_extra_key"
+
+
+def format_weight_version_extra_key(weight_version: int | None) -> str:
+    return f"weight-version:{0 if weight_version is None else weight_version}"
+
+
+def observe_weight_version(current: int | None, meta_info: dict) -> int | None:
+    raw = meta_info.get("weight_version")
+    try:
+        version = int(raw)
+    except (TypeError, ValueError):
+        return current
+    return version if current is None else max(current, version)

--- a/miles/rollout/session/core.py
+++ b/miles/rollout/session/core.py
@@ -18,6 +18,7 @@ from starlette.responses import Response
 from miles.rollout.generate_utils.sample_utils import merge_samples
 from miles.rollout.generate_utils.weight_version_partition import (
     format_weight_version_extra_key,
+    latest_weight_version,
     observe_weight_version,
 )
 from miles.rollout.session.errors import (
@@ -418,9 +419,7 @@ class SessionCore:
             self._maybe_request_addition_r3(request_body, session.token_ids, prompt_token_ids)
             if "extra_key" not in request_body:
                 if session.weight_version_extra_key is None:
-                    session.weight_version_extra_key = format_weight_version_extra_key(
-                        self.registry.latest_weight_version
-                    )
+                    session.weight_version_extra_key = format_weight_version_extra_key(latest_weight_version())
                 request_body["extra_key"] = session.weight_version_extra_key
 
             proxy_body = json.dumps(request_body).encode()
@@ -439,9 +438,7 @@ class SessionCore:
             return proxy_result_to_response(result)
 
         response, choice, assistant_message, completion_token_ids = extract_completion(result)
-        self.registry.latest_weight_version = observe_weight_version(
-            self.registry.latest_weight_version, choice.get("meta_info") or {}
-        )
+        observe_weight_version(choice.get("meta_info") or {})
 
         # --- Phase 3: update state (lock held briefly) ---
         async with session.lock:

--- a/miles/rollout/session/core.py
+++ b/miles/rollout/session/core.py
@@ -9,10 +9,6 @@ HTTP-agnostic: the FastAPI adapter (``sessions.py`` + ``server.py``) turns each 
 """
 
 import json
-from miles.rollout.generate_utils.weight_version_partition import (
-    format_weight_version_extra_key,
-    observe_weight_version,
-)
 import logging
 import time
 from dataclasses import dataclass
@@ -20,6 +16,10 @@ from dataclasses import dataclass
 from starlette.responses import Response
 
 from miles.rollout.generate_utils.sample_utils import merge_samples
+from miles.rollout.generate_utils.weight_version_partition import (
+    format_weight_version_extra_key,
+    observe_weight_version,
+)
 from miles.rollout.session.errors import (
     MessageValidationError,
     SessionNotFoundError,

--- a/miles/rollout/session/core.py
+++ b/miles/rollout/session/core.py
@@ -9,6 +9,10 @@ HTTP-agnostic: the FastAPI adapter (``sessions.py`` + ``server.py``) turns each 
 """
 
 import json
+from miles.rollout.generate_utils.weight_version_partition import (
+    format_weight_version_extra_key,
+    observe_weight_version,
+)
 import logging
 import time
 from dataclasses import dataclass
@@ -412,6 +416,12 @@ class SessionCore:
             # prepare_pretokenized applied any retry rollback, so token_ids is
             # the checkpoint this request builds on.
             self._maybe_request_addition_r3(request_body, session.token_ids, prompt_token_ids)
+            if "extra_key" not in request_body:
+                if session.weight_version_extra_key is None:
+                    session.weight_version_extra_key = format_weight_version_extra_key(
+                        self.registry.latest_weight_version
+                    )
+                request_body["extra_key"] = session.weight_version_extra_key
 
             proxy_body = json.dumps(request_body).encode()
             expected_num_assistant = session.num_assistant
@@ -428,7 +438,10 @@ class SessionCore:
         if result["status_code"] != 200:
             return proxy_result_to_response(result)
 
-        response, _, assistant_message, completion_token_ids = extract_completion(result)
+        response, choice, assistant_message, completion_token_ids = extract_completion(result)
+        self.registry.latest_weight_version = observe_weight_version(
+            self.registry.latest_weight_version, choice.get("meta_info") or {}
+        )
 
         # --- Phase 3: update state (lock held briefly) ---
         async with session.lock:

--- a/miles/rollout/session/core.py
+++ b/miles/rollout/session/core.py
@@ -222,6 +222,7 @@ def log_weight_versions(session_id: str, record: SessionRecord, num_assistant: i
                 "session_id": session_id,
                 "num_assistant": num_assistant,
                 "rid": meta_info.get("id"),
+                "extra_key": record.request.get("extra_key"),
                 "weight_version": meta_info.get("weight_version"),
                 "weight_versions": meta_info.get("weight_versions"),
                 "prefill_weight_versions": meta_info.get("prefill_weight_versions"),

--- a/miles/rollout/session/linear_trajectory.py
+++ b/miles/rollout/session/linear_trajectory.py
@@ -311,7 +311,6 @@ class SessionRegistry:
         self.message_matcher: SessionMessageMatcher = (
             message_matcher if message_matcher is not None else strict_message_matches
         )
-        self.latest_weight_version: int | None = None
 
     def create_session(self) -> str:
         session_id = uuid.uuid4().hex

--- a/miles/rollout/session/linear_trajectory.py
+++ b/miles/rollout/session/linear_trajectory.py
@@ -77,6 +77,7 @@ class LinearTrajectory:
     trajectory_token_ids: list[list[int]] = field(default_factory=list)
     generated_checkpoint_message_ends: list[int] = field(default_factory=list)
     num_assistant: int = 0
+    weight_version_extra_key: str | None = None
 
     @property
     def token_ids(self) -> list[int]:
@@ -310,6 +311,7 @@ class SessionRegistry:
         self.message_matcher: SessionMessageMatcher = (
             message_matcher if message_matcher is not None else strict_message_matches
         )
+        self.latest_weight_version: int | None = None
 
     def create_session(self) -> str:
         session_id = uuid.uuid4().hex

--- a/miles/rollout/session/v2/core.py
+++ b/miles/rollout/session/v2/core.py
@@ -1,13 +1,13 @@
 import json
-from miles.rollout.generate_utils.weight_version_partition import (
-    format_weight_version_extra_key,
-    observe_weight_version,
-)
 import logging
 import time
 
 from starlette.responses import Response
 
+from miles.rollout.generate_utils.weight_version_partition import (
+    format_weight_version_extra_key,
+    observe_weight_version,
+)
 from miles.rollout.session.core import (
     JSON_MEDIA_TYPE,
     ProxyRequest,

--- a/miles/rollout/session/v2/core.py
+++ b/miles/rollout/session/v2/core.py
@@ -1,4 +1,8 @@
 import json
+from miles.rollout.generate_utils.weight_version_partition import (
+    format_weight_version_extra_key,
+    observe_weight_version,
+)
 import logging
 import time
 
@@ -163,6 +167,12 @@ class SessionCoreV2(SessionCore):
             logger.debug("Using TITO input_ids: %d tokens", len(prompt_token_ids))
 
             self._maybe_request_addition_r3(request_body, session.active_token_ids(), prompt_token_ids)
+            if "extra_key" not in request_body:
+                if session.weight_version_extra_key is None:
+                    session.weight_version_extra_key = format_weight_version_extra_key(
+                        self.registry.latest_weight_version
+                    )
+                request_body["extra_key"] = session.weight_version_extra_key
 
             proxy_body = json.dumps(request_body).encode()
             attach_parent = session.active_leaf
@@ -180,6 +190,9 @@ class SessionCoreV2(SessionCore):
             return proxy_result_to_response(result)
 
         response, choice, assistant_message, completion_token_ids = extract_completion(result)
+        self.registry.latest_weight_version = observe_weight_version(
+            self.registry.latest_weight_version, choice.get("meta_info") or {}
+        )
 
         # --- Phase 3: update state (lock held briefly) ---
         async with session.lock:

--- a/miles/rollout/session/v2/core.py
+++ b/miles/rollout/session/v2/core.py
@@ -6,6 +6,7 @@ from starlette.responses import Response
 
 from miles.rollout.generate_utils.weight_version_partition import (
     format_weight_version_extra_key,
+    latest_weight_version,
     observe_weight_version,
 )
 from miles.rollout.session.core import (
@@ -169,9 +170,7 @@ class SessionCoreV2(SessionCore):
             self._maybe_request_addition_r3(request_body, session.active_token_ids(), prompt_token_ids)
             if "extra_key" not in request_body:
                 if session.weight_version_extra_key is None:
-                    session.weight_version_extra_key = format_weight_version_extra_key(
-                        self.registry.latest_weight_version
-                    )
+                    session.weight_version_extra_key = format_weight_version_extra_key(latest_weight_version())
                 request_body["extra_key"] = session.weight_version_extra_key
 
             proxy_body = json.dumps(request_body).encode()
@@ -190,9 +189,7 @@ class SessionCoreV2(SessionCore):
             return proxy_result_to_response(result)
 
         response, choice, assistant_message, completion_token_ids = extract_completion(result)
-        self.registry.latest_weight_version = observe_weight_version(
-            self.registry.latest_weight_version, choice.get("meta_info") or {}
-        )
+        observe_weight_version(choice.get("meta_info") or {})
 
         # --- Phase 3: update state (lock held briefly) ---
         async with session.lock:

--- a/miles/rollout/session/v2/session_state.py
+++ b/miles/rollout/session/v2/session_state.py
@@ -41,6 +41,7 @@ class SessionStateV2:
     closing: bool = field(default=False, repr=False, compare=False)
     tree: SessionTree = field(default_factory=SessionTree)
     active_leaf: TrajectoryNode | None = None
+    weight_version_extra_key: str | None = None
 
     def active_path(self) -> list[TrajectoryNode]:
         return self.active_leaf.path_nodes() if self.active_leaf is not None else []

--- a/miles/rollout/sglang_rollout.py
+++ b/miles/rollout/sglang_rollout.py
@@ -15,6 +15,11 @@ from tqdm import tqdm
 
 from miles.rollout.base_types import GenerateFnInput, RolloutFnEvalOutput, RolloutFnTrainOutput
 from miles.rollout.filter_hub.base_types import MetricGatherer, call_dynamic_filter
+from miles.rollout.generate_utils.weight_version_partition import (
+    WEIGHT_VERSION_EXTRA_KEY_METADATA_KEY,
+    format_weight_version_extra_key,
+    observe_weight_version,
+)
 from miles.rollout.inference_rollout.compatibility import load_generate_function
 from miles.utils import dumper_utils
 from miles.utils.async_utils import run
@@ -31,11 +36,6 @@ from miles.utils.processing_utils import (
     extract_multimodal_train_inputs,
     load_processor,
     load_tokenizer,
-)
-from miles.rollout.generate_utils.weight_version_partition import (
-    WEIGHT_VERSION_EXTRA_KEY_METADATA_KEY,
-    format_weight_version_extra_key,
-    observe_weight_version,
 )
 from miles.utils.types import Sample
 

--- a/miles/rollout/sglang_rollout.py
+++ b/miles/rollout/sglang_rollout.py
@@ -15,10 +15,7 @@ from tqdm import tqdm
 
 from miles.rollout.base_types import GenerateFnInput, RolloutFnEvalOutput, RolloutFnTrainOutput
 from miles.rollout.filter_hub.base_types import MetricGatherer, call_dynamic_filter
-from miles.rollout.generate_utils.weight_version_partition import (
-    lock_weight_version_extra_key,
-    observe_weight_version,
-)
+from miles.rollout.generate_utils.weight_version_partition import lock_weight_version_extra_key, observe_weight_version
 from miles.rollout.inference_rollout.compatibility import load_generate_function
 from miles.utils import dumper_utils
 from miles.utils.async_utils import run

--- a/miles/rollout/sglang_rollout.py
+++ b/miles/rollout/sglang_rollout.py
@@ -32,6 +32,11 @@ from miles.utils.processing_utils import (
     load_processor,
     load_tokenizer,
 )
+from miles.rollout.generate_utils.weight_version_partition import (
+    WEIGHT_VERSION_EXTRA_KEY_METADATA_KEY,
+    format_weight_version_extra_key,
+    observe_weight_version,
+)
 from miles.utils.types import Sample
 
 from .generate_utils.generate_endpoint_utils import (
@@ -98,6 +103,8 @@ class GenerateState(metaclass=SingletonMeta):
         if getattr(args, "sglang_enable_deterministic_inference", False):
             sampling_seed_base = args.rollout_seed
             self.group_sampling_seeds = [sampling_seed_base + i for i in range(args.n_samples_per_prompt)]
+
+        self.latest_weight_version: int | None = None
 
         # dp rank balancing
         self.dp_counts = [0] * (args.sglang_dp_size or 1)
@@ -199,6 +206,12 @@ async def generate(args: Namespace, sample: Sample, sampling_params: dict[str, A
     elif lora_rollout_enabled(args):
         payload["lora_path"] = LORA_ADAPTER_NAME
 
+    if "extra_key" not in payload:
+        if (extra_key := sample.metadata.get(WEIGHT_VERSION_EXTRA_KEY_METADATA_KEY)) is None:
+            extra_key = format_weight_version_extra_key(state.latest_weight_version)
+            sample.metadata[WEIGHT_VERSION_EXTRA_KEY_METADATA_KEY] = extra_key
+        payload["extra_key"] = extra_key
+
     if args.use_rollout_routing_replay:
         payload["return_routed_experts"] = True
     if getattr(args, "use_rollout_indexer_replay", False):
@@ -226,6 +239,7 @@ async def generate(args: Namespace, sample: Sample, sampling_params: dict[str, A
     headers = compute_routing_headers(args, sample)
 
     output = await post(url, payload, headers=headers)
+    state.latest_weight_version = observe_weight_version(state.latest_weight_version, output["meta_info"])
     if getattr(args, "use_opd", False) and opd_top_k > 0 and opd_top_k_strategy != "only-teacher":
         output_top_logprobs = output.get("meta_info", {}).get("output_top_logprobs")
         if output_top_logprobs is not None:

--- a/miles/rollout/sglang_rollout.py
+++ b/miles/rollout/sglang_rollout.py
@@ -15,7 +15,11 @@ from tqdm import tqdm
 
 from miles.rollout.base_types import GenerateFnInput, RolloutFnEvalOutput, RolloutFnTrainOutput
 from miles.rollout.filter_hub.base_types import MetricGatherer, call_dynamic_filter
-from miles.rollout.generate_utils.weight_version_partition import lock_weight_version_extra_key, observe_weight_version
+from miles.rollout.generate_utils.weight_version_partition import (
+    WEIGHT_VERSION_EXTRA_KEY_METADATA_KEY,
+    lock_weight_version_extra_key,
+    observe_weight_version,
+)
 from miles.rollout.inference_rollout.compatibility import load_generate_function
 from miles.utils import dumper_utils
 from miles.utils.async_utils import run
@@ -150,6 +154,7 @@ async def generate(args: Namespace, sample: Sample, sampling_params: dict[str, A
     assert (
         sample.status == Sample.Status.PENDING or sample.status == Sample.Status.ABORTED
     ), f"Sample status is {sample.status}"
+    lock_weight_version_extra_key(sample)
 
     if state.processor and (
         isinstance(sample.prompt, (list, tuple))
@@ -201,7 +206,7 @@ async def generate(args: Namespace, sample: Sample, sampling_params: dict[str, A
         payload["lora_path"] = LORA_ADAPTER_NAME
 
     if "extra_key" not in payload:
-        payload["extra_key"] = lock_weight_version_extra_key(sample)
+        payload["extra_key"] = sample.metadata[WEIGHT_VERSION_EXTRA_KEY_METADATA_KEY]
 
     if args.use_rollout_routing_replay:
         payload["return_routed_experts"] = True

--- a/miles/rollout/sglang_rollout.py
+++ b/miles/rollout/sglang_rollout.py
@@ -16,8 +16,7 @@ from tqdm import tqdm
 from miles.rollout.base_types import GenerateFnInput, RolloutFnEvalOutput, RolloutFnTrainOutput
 from miles.rollout.filter_hub.base_types import MetricGatherer, call_dynamic_filter
 from miles.rollout.generate_utils.weight_version_partition import (
-    WEIGHT_VERSION_EXTRA_KEY_METADATA_KEY,
-    format_weight_version_extra_key,
+    lock_weight_version_extra_key,
     observe_weight_version,
 )
 from miles.rollout.inference_rollout.compatibility import load_generate_function
@@ -103,8 +102,6 @@ class GenerateState(metaclass=SingletonMeta):
         if getattr(args, "sglang_enable_deterministic_inference", False):
             sampling_seed_base = args.rollout_seed
             self.group_sampling_seeds = [sampling_seed_base + i for i in range(args.n_samples_per_prompt)]
-
-        self.latest_weight_version: int | None = None
 
         # dp rank balancing
         self.dp_counts = [0] * (args.sglang_dp_size or 1)
@@ -207,10 +204,7 @@ async def generate(args: Namespace, sample: Sample, sampling_params: dict[str, A
         payload["lora_path"] = LORA_ADAPTER_NAME
 
     if "extra_key" not in payload:
-        if (extra_key := sample.metadata.get(WEIGHT_VERSION_EXTRA_KEY_METADATA_KEY)) is None:
-            extra_key = format_weight_version_extra_key(state.latest_weight_version)
-            sample.metadata[WEIGHT_VERSION_EXTRA_KEY_METADATA_KEY] = extra_key
-        payload["extra_key"] = extra_key
+        payload["extra_key"] = lock_weight_version_extra_key(sample)
 
     if args.use_rollout_routing_replay:
         payload["return_routed_experts"] = True
@@ -239,7 +233,7 @@ async def generate(args: Namespace, sample: Sample, sampling_params: dict[str, A
     headers = compute_routing_headers(args, sample)
 
     output = await post(url, payload, headers=headers)
-    state.latest_weight_version = observe_weight_version(state.latest_weight_version, output["meta_info"])
+    observe_weight_version(output["meta_info"])
     if getattr(args, "use_opd", False) and opd_top_k > 0 and opd_top_k_strategy != "only-teacher":
         output_top_logprobs = output.get("meta_info", {}).get("output_top_logprobs")
         if output_top_logprobs is not None:

--- a/tests/fast/rollout/generate_hub/test_multi_turn.py
+++ b/tests/fast/rollout/generate_hub/test_multi_turn.py
@@ -16,6 +16,7 @@ from miles.utils.chat_template_utils import TITOTokenizerType, get_tito_tokenize
 from miles.utils.processing_utils import load_tokenizer
 from miles.utils.test_utils.mock_sglang_server import ProcessResult, ProcessResultMetaInfo
 from miles.utils.test_utils.mock_tools import SAMPLE_TOOLS, ThreeTurnStub, TwoTurnStub
+from miles.rollout.generate_utils.weight_version_partition import WEIGHT_VERSION_EXTRA_KEY_METADATA_KEY
 from miles.utils.types import Sample
 
 register_cpu_ci(est_time=130, suite="stage-b-cpu", labels=[])
@@ -126,7 +127,14 @@ def verify_samples(actual: Sample | list[Sample], expected: list[ExpectedSampleI
         # Session server populates diagnostic metadata (token IDs,
         # trim config, mismatch analysis, dashboard lifecycle timing) that
         # varies with mock setup. Strip these before comparing structure.
-        for key in ("tito_session_mismatch", "accumulated_token_ids", "max_trim_tokens", "lifecycle", "leaf"):
+        for key in (
+            "tito_session_mismatch",
+            "accumulated_token_ids",
+            "max_trim_tokens",
+            "lifecycle",
+            "leaf",
+            WEIGHT_VERSION_EXTRA_KEY_METADATA_KEY,
+        ):
             actual_partial.metadata.pop(key, None)
         assert actual_partial == expected_item.partial_sample
 
@@ -148,6 +156,7 @@ def expected_request(
         "input_ids": input_ids,
         "sampling_params": sampling_params or DEFAULT_SAMPLING_PARAMS,
         "return_logprob": True,
+        "extra_key": "weight-version:0",
         "return_routed_experts": return_routed_experts,
         "return_indexer_topk": return_indexer_topk,
     }
@@ -162,6 +171,7 @@ def expected_openai_request(messages: list[dict], **extra) -> dict:
         "logprobs": True,
         "return_meta_info": True,
         "no_stop_trim": False,
+        "extra_key": "weight-version:0",
         "chat_template_kwargs": {"clear_thinking": False},
         **extra,
     }

--- a/tests/fast/rollout/generate_hub/test_multi_turn.py
+++ b/tests/fast/rollout/generate_hub/test_multi_turn.py
@@ -12,11 +12,11 @@ import pytest
 from tests.ci.ci_register import register_cpu_ci
 from tests.fast.fixtures.generation_fixtures import GenerateEnv, generation_env, listify, make_sample, run_generate
 
+from miles.rollout.generate_utils.weight_version_partition import WEIGHT_VERSION_EXTRA_KEY_METADATA_KEY
 from miles.utils.chat_template_utils import TITOTokenizerType, get_tito_tokenizer
 from miles.utils.processing_utils import load_tokenizer
 from miles.utils.test_utils.mock_sglang_server import ProcessResult, ProcessResultMetaInfo
 from miles.utils.test_utils.mock_tools import SAMPLE_TOOLS, ThreeTurnStub, TwoTurnStub
-from miles.rollout.generate_utils.weight_version_partition import WEIGHT_VERSION_EXTRA_KEY_METADATA_KEY
 from miles.utils.types import Sample
 
 register_cpu_ci(est_time=130, suite="stage-b-cpu", labels=[])
@@ -734,6 +734,7 @@ class TestAgentNoRecords:
             make_args,
             with_session_server,
         )
+
         from miles.utils.http_utils import find_available_port
         from miles.utils.misc import SingletonMeta
         from miles.utils.test_utils.mock_sglang_server import with_mock_server

--- a/tests/fast/rollout/generate_hub/test_single_turn.py
+++ b/tests/fast/rollout/generate_hub/test_single_turn.py
@@ -12,6 +12,7 @@ from transformers import AutoProcessor
 
 from miles.utils.processing_utils import encode_image_for_rollout_engine
 from miles.utils.test_utils.mock_sglang_server import ProcessResult, ProcessResultMetaInfo
+from miles.rollout.generate_utils.weight_version_partition import WEIGHT_VERSION_EXTRA_KEY_METADATA_KEY
 from miles.utils.types import Sample
 
 _ = generation_env
@@ -48,6 +49,7 @@ def expected_request(
         "input_ids": input_ids or PROMPT_TOKENS,
         "sampling_params": sampling_params or SAMPLING_PARAMS,
         "return_logprob": True,
+        "extra_key": "weight-version:0",
     }
     if variant in ("single_turn", "multi_turn") or return_routed_experts:
         result["return_routed_experts"] = return_routed_experts
@@ -104,7 +106,7 @@ def expected_sample(
         rollout_routed_experts=rollout_routed_experts,
         remove_sample=False,
         status=status,
-        metadata={},
+        metadata={WEIGHT_VERSION_EXTRA_KEY_METADATA_KEY: "weight-version:0"},
         train_metadata=None,
         non_generation_time=0.0,
         spec_info=spec_info or Sample.SpecInfo(),

--- a/tests/fast/rollout/generate_hub/test_single_turn.py
+++ b/tests/fast/rollout/generate_hub/test_single_turn.py
@@ -10,9 +10,9 @@ from PIL import Image
 from tests.fast.fixtures.generation_fixtures import GenerateEnv, generation_env, listify, make_sample, run_generate
 from transformers import AutoProcessor
 
+from miles.rollout.generate_utils.weight_version_partition import WEIGHT_VERSION_EXTRA_KEY_METADATA_KEY
 from miles.utils.processing_utils import encode_image_for_rollout_engine
 from miles.utils.test_utils.mock_sglang_server import ProcessResult, ProcessResultMetaInfo
-from miles.rollout.generate_utils.weight_version_partition import WEIGHT_VERSION_EXTRA_KEY_METADATA_KEY
 from miles.utils.types import Sample
 
 _ = generation_env

--- a/tests/fast/rollout/generate_utils/test_weight_version_partition.py
+++ b/tests/fast/rollout/generate_utils/test_weight_version_partition.py
@@ -3,10 +3,12 @@ from types import SimpleNamespace
 
 import pytest
 
+import miles.rollout.generate_utils.weight_version_partition as weight_version_partition
 import miles.rollout.sglang_rollout as sglang_rollout
 from miles.rollout.generate_utils.weight_version_partition import (
     WEIGHT_VERSION_EXTRA_KEY_METADATA_KEY,
     format_weight_version_extra_key,
+    latest_weight_version,
     observe_weight_version,
 )
 from miles.utils.types import Sample
@@ -18,18 +20,26 @@ def test_format_maps_none_to_version_zero():
     assert format_weight_version_extra_key(7) == "weight-version:7"
 
 
-def test_observe_keeps_monotonic_max():
+def test_observe_keeps_monotonic_max(monkeypatch):
     """Belief only moves forward, even when a lagging engine reports an older version."""
-    assert observe_weight_version(None, {}) is None
-    assert observe_weight_version(None, {"weight_version": "3"}) == 3
-    assert observe_weight_version(3, {"weight_version": "2"}) == 3
-    assert observe_weight_version(3, {"weight_version": 5}) == 5
+    monkeypatch.setattr(weight_version_partition, "_latest_weight_version", None)
+    observe_weight_version({})
+    assert latest_weight_version() is None
+    observe_weight_version({"weight_version": "3"})
+    assert latest_weight_version() == 3
+    observe_weight_version({"weight_version": "2"})
+    assert latest_weight_version() == 3
+    observe_weight_version({"weight_version": 5})
+    assert latest_weight_version() == 5
 
 
-def test_observe_ignores_unparseable_versions():
+def test_observe_ignores_unparseable_versions(monkeypatch):
     """Non-numeric engine versions leave the belief untouched."""
-    assert observe_weight_version(4, {"weight_version": "default"}) == 4
-    assert observe_weight_version(4, {"weight_version": None}) == 4
+    monkeypatch.setattr(weight_version_partition, "_latest_weight_version", 4)
+    observe_weight_version({"weight_version": "default"})
+    assert latest_weight_version() == 4
+    observe_weight_version({"weight_version": None})
+    assert latest_weight_version() == 4
 
 
 class _FakeTokenizer:
@@ -55,7 +65,6 @@ def _make_state(args: Namespace) -> SimpleNamespace:
         args=args,
         tokenizer=_FakeTokenizer(),
         processor=None,
-        latest_weight_version=None,
     )
 
 
@@ -78,15 +87,15 @@ def _install_fake_post(monkeypatch: pytest.MonkeyPatch, payloads: list[dict], we
 async def test_generate_locks_extra_key_across_turns(monkeypatch):
     """A sample's first turn tags the current belief and later turns reuse it even after the belief advances."""
     args = _make_args()
-    state = _make_state(args)
-    monkeypatch.setattr(sglang_rollout, "GenerateState", lambda _args: state)
+    monkeypatch.setattr(sglang_rollout, "GenerateState", lambda _args: _make_state(args))
+    monkeypatch.setattr(weight_version_partition, "_latest_weight_version", None)
     payloads: list[dict] = []
     _install_fake_post(monkeypatch, payloads, weight_version="4")
 
     sample = Sample(prompt="q")
     await sglang_rollout.generate(args, sample, {"max_new_tokens": 8})
     assert payloads[0]["extra_key"] == "weight-version:0"
-    assert state.latest_weight_version == 4
+    assert latest_weight_version() == 4
 
     sample.status = Sample.Status.PENDING
     await sglang_rollout.generate(args, sample, {"max_new_tokens": 8})
@@ -98,9 +107,8 @@ async def test_generate_locks_extra_key_across_turns(monkeypatch):
 async def test_generate_tags_new_samples_with_latest_belief(monkeypatch):
     """A fresh sample starts in the namespace of the latest observed weight version."""
     args = _make_args()
-    state = _make_state(args)
-    state.latest_weight_version = 9
-    monkeypatch.setattr(sglang_rollout, "GenerateState", lambda _args: state)
+    monkeypatch.setattr(sglang_rollout, "GenerateState", lambda _args: _make_state(args))
+    monkeypatch.setattr(weight_version_partition, "_latest_weight_version", 9)
     payloads: list[dict] = []
     _install_fake_post(monkeypatch, payloads, weight_version="9")
 

--- a/tests/fast/rollout/generate_utils/test_weight_version_partition.py
+++ b/tests/fast/rollout/generate_utils/test_weight_version_partition.py
@@ -1,0 +1,108 @@
+from argparse import Namespace
+from types import SimpleNamespace
+
+import pytest
+
+import miles.rollout.sglang_rollout as sglang_rollout
+from miles.rollout.generate_utils.weight_version_partition import (
+    WEIGHT_VERSION_EXTRA_KEY_METADATA_KEY,
+    format_weight_version_extra_key,
+    observe_weight_version,
+)
+from miles.utils.types import Sample
+
+
+def test_format_maps_none_to_version_zero():
+    """A never-updated engine and version 0 share one namespace."""
+    assert format_weight_version_extra_key(None) == "weight-version:0"
+    assert format_weight_version_extra_key(7) == "weight-version:7"
+
+
+def test_observe_keeps_monotonic_max():
+    """Belief only moves forward, even when a lagging engine reports an older version."""
+    assert observe_weight_version(None, {}) is None
+    assert observe_weight_version(None, {"weight_version": "3"}) == 3
+    assert observe_weight_version(3, {"weight_version": "2"}) == 3
+    assert observe_weight_version(3, {"weight_version": 5}) == 5
+
+
+def test_observe_ignores_unparseable_versions():
+    """Non-numeric engine versions leave the belief untouched."""
+    assert observe_weight_version(4, {"weight_version": "default"}) == 4
+    assert observe_weight_version(4, {"weight_version": None}) == 4
+
+
+class _FakeTokenizer:
+    def encode(self, prompt: str, add_special_tokens: bool) -> list[int]:
+        return [1, 2, 3]
+
+
+def _make_args() -> Namespace:
+    return Namespace(
+        ci_test=False,
+        sglang_router_ip="127.0.0.1",
+        sglang_router_port=30000,
+        sglang_router_policy="round_robin",
+        sglang_speculative_algorithm=None,
+        use_rollout_routing_replay=False,
+        lora_rank=0,
+        lora_configs=None,
+    )
+
+
+def _make_state(args: Namespace) -> SimpleNamespace:
+    return SimpleNamespace(
+        args=args,
+        tokenizer=_FakeTokenizer(),
+        processor=None,
+        latest_weight_version=None,
+    )
+
+
+def _install_fake_post(monkeypatch: pytest.MonkeyPatch, payloads: list[dict], weight_version: str):
+    async def fake_post(url, payload, headers=None):
+        payloads.append(payload)
+        return {
+            "text": "ok",
+            "meta_info": {
+                "weight_version": weight_version,
+                "finish_reason": {"type": "stop"},
+                "output_token_logprobs": [(-0.1, 11)],
+            },
+        }
+
+    monkeypatch.setattr(sglang_rollout, "post", fake_post)
+
+
+@pytest.mark.asyncio
+async def test_generate_locks_extra_key_across_turns(monkeypatch):
+    """A sample's first turn tags the current belief and later turns reuse it even after the belief advances."""
+    args = _make_args()
+    state = _make_state(args)
+    monkeypatch.setattr(sglang_rollout, "GenerateState", lambda _args: state)
+    payloads: list[dict] = []
+    _install_fake_post(monkeypatch, payloads, weight_version="4")
+
+    sample = Sample(prompt="q")
+    await sglang_rollout.generate(args, sample, {"max_new_tokens": 8})
+    assert payloads[0]["extra_key"] == "weight-version:0"
+    assert state.latest_weight_version == 4
+
+    sample.status = Sample.Status.PENDING
+    await sglang_rollout.generate(args, sample, {"max_new_tokens": 8})
+    assert payloads[1]["extra_key"] == "weight-version:0"
+    assert sample.metadata[WEIGHT_VERSION_EXTRA_KEY_METADATA_KEY] == "weight-version:0"
+
+
+@pytest.mark.asyncio
+async def test_generate_tags_new_samples_with_latest_belief(monkeypatch):
+    """A fresh sample starts in the namespace of the latest observed weight version."""
+    args = _make_args()
+    state = _make_state(args)
+    state.latest_weight_version = 9
+    monkeypatch.setattr(sglang_rollout, "GenerateState", lambda _args: state)
+    payloads: list[dict] = []
+    _install_fake_post(monkeypatch, payloads, weight_version="9")
+
+    await sglang_rollout.generate(args, Sample(prompt="q"), {"max_new_tokens": 8})
+    assert payloads[0]["extra_key"] == "weight-version:9"

--- a/tests/fast/rollout/inference_rollout/integration/utils.py
+++ b/tests/fast/rollout/inference_rollout/integration/utils.py
@@ -9,6 +9,7 @@ from miles.rollout.base_types import (
 )
 from miles.rollout.filter_hub.base_types import DynamicFilterOutput
 from miles.rollout.inference_rollout.compatibility import call_rollout_function, load_rollout_function
+from miles.rollout.generate_utils.weight_version_partition import WEIGHT_VERSION_EXTRA_KEY_METADATA_KEY
 from miles.utils.types import Sample
 
 
@@ -30,7 +31,7 @@ def expected_sample(*, group_index: int | None) -> Sample:
         rollout_routed_experts=None,
         remove_sample=False,
         status=Sample.Status.COMPLETED,
-        metadata={},
+        metadata={WEIGHT_VERSION_EXTRA_KEY_METADATA_KEY: "weight-version:0"},
         train_metadata=None,
         non_generation_time=0.0,
         spec_info=Sample.SpecInfo(

--- a/tests/fast/rollout/inference_rollout/integration/utils.py
+++ b/tests/fast/rollout/inference_rollout/integration/utils.py
@@ -8,8 +8,8 @@ from miles.rollout.base_types import (
     RolloutFnTrainInput,
 )
 from miles.rollout.filter_hub.base_types import DynamicFilterOutput
-from miles.rollout.inference_rollout.compatibility import call_rollout_function, load_rollout_function
 from miles.rollout.generate_utils.weight_version_partition import WEIGHT_VERSION_EXTRA_KEY_METADATA_KEY
+from miles.rollout.inference_rollout.compatibility import call_rollout_function, load_rollout_function
 from miles.utils.types import Sample
 
 


### PR DESCRIPTION
## Problem

Weight-update pause modes that skip the engine-side cache flush (`in_place` — see `mixin.py` / `delta.py`: `if mode != "in_place": flush_cache()`) leave the radix cache holding KV computed under pre-update weights. Nothing ever invalidates those entries:

- A prefix cached before an update keeps serving **new** requests after the update; a hit refreshes its LRU position, so hot shared prefixes (system prompts, few-shot prefixes shared by a sampling group) survive indefinitely.
- Finished requests insert their full-sequence KV back into the tree, so hybrid entries (stale prefix + new-weight continuation) compound across updates.
- Rollouts then run on a mix of current weights and arbitrarily old cached KV, and the recorded `rollout_log_probs` describe that hybrid rather than any single policy version. `weight_version/mixed_version_ratio` only counts in-flight requests, so it stays near zero while this happens.

## Fix

Namespace every generation request's radix-cache key by the weight version its session started under, using sglang's existing `extra_key` request field (`RadixKey = (token_ids, extra_key)`; matching requires equality):

- `sglang_rollout.generate()` tags each request with `extra_key = "weight-version:<v>"`, locked into `sample.metadata` on the sample's first turn and reused verbatim on later turns. New samples always start in the current version's namespace and can never match KV from older weight generations; an in-flight multi-turn sample keeps reusing its **own** earlier KV across an update, which is exactly the bounded staleness `in_place` already accepts for frozen requests.
- The session server (v1 and v2 cores) locks the same tag per session on its first chat completion and injects it into the proxied body; a client-supplied `extra_key` is left untouched.
- The current version is tracked client-side as a monotonic max over `meta_info["weight_version"]` reported by responses, so no new plumbing from the trainer is needed. At an update boundary the belief can lag by one version, which is within the staleness `in_place` already tolerates for in-flight requests.

Under `retract` / `abort` (and the colocated / FSDP update paths, which flush unconditionally) the cache is emptied on every update, so all live entries share one tag and behavior is unchanged. The multi-LoRA adapter path already sends its own per-adapter-version `extra_key` and is untouched.

## Testing

- New unit tests cover the helper (monotonic belief, unparseable versions) and `generate()` tagging (first turn locks the tag, later turns reuse it after the belief advances, fresh samples pick up the latest belief).
- `tests/fast/rollout` passes.
