### PR TITLE
[AMD][LoRA] Add a Qwen3-30B-A3B MoE LoRA launcher

### DIFF
--- a/docs/advanced/lora.md
+++ b/docs/advanced/lora.md
@@ -70,6 +70,7 @@ full-scale experiment evidence. It is not an exhaustive model whitelist.
 | Bridge | Qwen2.5 0.5B / 3B | Dense | [0.5B CUDA and ROCm E2E](https://github.com/radixark/miles/blob/main/tests/e2e/lora/test_lora_qwen2.5_0.5B.py), [3B disaggregated recipe](https://github.com/radixark/miles/blob/main/examples/lora/run-qwen2.5-3B-megatron-lora-disaggregated.sh) | The simplest starting point; `all-linear` works. |
 | Bridge | Qwen3 4B | Dense | [Single-LoRA recipe](https://github.com/radixark/miles/blob/main/examples/lora/run-qwen3-4B-megatron-lora.sh), [multi-LoRA recipe](https://github.com/radixark/miles/tree/main/examples/multi_lora) | Used by the current multi-adapter example. |
 | Bridge | GPT-OSS 20B | MoE | [Recipe](https://github.com/radixark/miles/blob/main/examples/lora/run-gpt-oss-20B-megatron-moe-lora.sh), [MoE LoRA E2E](https://github.com/radixark/miles/blob/main/tests/e2e/megatron/model_scripts/test_gpt_oss_20b_moe_lora_ci.py) | Uses the SGLang `triton` LoRA backend. |
+| Bridge | Qwen3-30B-A3B | MoE | [MI350X/MI355X launcher](https://github.com/radixark/miles/blob/main/scripts/amd/run_qwen3_30b_a3b_lora.py) | Per-expert adapters colocated with training, on the attention backend SGLang picks itself. |
 | Bridge | Kimi K2.5 | Multimodal MoE + MLA | [16-node recipe](https://github.com/radixark/miles/blob/main/examples/lora/run-kimi-k25-megatron-lora.sh) | Demonstrates shared-outer expert LoRA and an INT4 rollout / fake-QAT setup. |
 | Bridge | GLM-5 / 5.1 / 5.2 744B-A40B | MoE + MLA + DSA | [GLM-5.1 launcher](https://github.com/radixark/miles/blob/main/scripts/run_glm5_1_744b_a40b_lora.py), [GLM-5.2 launcher](https://github.com/radixark/miles/blob/main/scripts/run_glm5_2_744b_a40b_lora.py) | CI covers reduced 6-layer / 5-layer checkpoints; historical full-744B results are described below. |
 | Bridge | Qwen3.5 / Qwen3.6 35B-A3B | Hybrid GDN + MoE | [Launcher](https://github.com/radixark/miles/blob/main/scripts/run_qwen3_5_35b_a3b_lora.py), [Qwen3.5 E2E](https://github.com/radixark/miles/blob/main/tests/e2e/megatron/test_qwen3_5_35b_a3b_lora_ci.py) | Uses explicit wildcard targets to exclude MTP and vision modules. |
@@ -381,6 +382,12 @@ dataset-driven driver.
 - **Memory optimizations:** `--rematerialize-param-from-master-weight` and
   streamed optimizer state on NVMe reject LoRA. Ordinary actor disk offload is a
   different feature and is used by the draft agentic recipe.
+- **ROCm serving:** with a MoE adapter active, a heavily throttled rollout engine
+  has been seen to make SGLang's default ROCm attention backend raise an illegal
+  memory access inside its paged batch-prefill kernel, killing the engine's
+  scheduler process mid-rollout. An unthrottled engine ran the same recipe to
+  completion on that backend; `--sglang-attention-backend triton` also avoids it,
+  at roughly 20% more wall time.
 - **Multi-LoRA:** the current and proposed Tinker operation paths both require
   Bridge; native multi-LoRA remains roadmap work. Evaluation, colocate, PP,
   train offload, shared-outer experts, and FP8/FP4 MoE expert adapters are not

--- a/docs/models/qwen/qwen3-moe.md
+++ b/docs/models/qwen/qwen3-moe.md
@@ -132,6 +132,7 @@ Both `run_qwen3_30b_a3b.py` (H100, 1 node) and `run_qwen3_235b_a22b.py` enable C
 
 - **30 B launcher** supports FP8 / MXFP8 / INT4 rollout, Blackwell hardware, Megatron-bridge mode, and MIS via Typer flags.
 - **235 B defaults to the FP8 HF checkpoint** — pass `--no-rollout-fp8` to roll out from the BF16 directory instead.
+- **AMD ROCm LoRA**: `python scripts/amd/run_qwen3_30b_a3b_lora.py` trains a rank-32 per-expert MoE adapter colocated with the rollout engines on `MI350X` / `MI355X`.
 - **R3 not on by default**; opt-in via `run_qwen3_30b_a3b.py --enable-mis` (TIS / RS) for routing-stability experiments.
 
 ## 6. Pairs Well With

--- a/scripts/amd/run_qwen3_30b_a3b_lora.py
+++ b/scripts/amd/run_qwen3_30b_a3b_lora.py
@@ -1,0 +1,254 @@
+"""Qwen3-30B-A3B GRPO LoRA training on MI350X/MI355X, colocated.
+
+Trains a rank-32 adapter over attention and the routed experts through
+Megatron-Bridge (``--megatron-to-hf-mode bridge``) and republishes it to the
+colocated SGLang engines after every rollout.
+
+``--experts-shared-outer-loras`` picks the MoE-expert adapter layout. The two
+layouts are not checkpoint-compatible, and each is paired here with the serving
+path that carries it, the same pairing the MoE LoRA E2Es use: shared-outer with
+SGLang's virtual experts, per-expert with the fused_moe_lora alignment path.
+Both layouts train and serve; the hyperparameters below are tuned for the
+per-expert default, and shared-outer shortens responses far more aggressively
+under them.
+
+Requires ``prepare`` to have downloaded the HF checkpoint and the datasets; the
+bridge path reads the HF checkpoint directly, so no torch_dist conversion is
+needed.
+
+Args:
+    --model-name: HF repository name, also the directory under --model-dir.
+    --hardware: node type; "auto" resolves it from the visible GPU.
+    --num-rollout: total GRPO rollouts. This is a global endpoint, so keep it at
+        the final value when resuming rather than adding to it.
+    --lora-adapter-path: resume from a previously saved ``iter_N/adapter``,
+        which carries optimizer and scheduler state alongside the weights.
+    --experts-shared-outer-loras: train the shared-outer expert layout instead
+        of the per-expert one.
+    --sglang-attention-backend: off by default; overrides SGLang's own choice.
+
+Example:
+    python scripts/amd/run_qwen3_30b_a3b_lora.py --num-rollout 6
+"""
+
+from dataclasses import dataclass
+from typing import Literal
+
+import typer
+
+import miles.utils.external_utils.command_utils as U
+
+_TARGET_MODULES = "q_proj,k_proj,v_proj,o_proj,gate_proj,up_proj,down_proj"
+
+
+@dataclass
+class ScriptArgs(U.ExecuteTrainConfig):
+    run_id: str = U.create_run_id()
+    model_name: str = "Qwen3-30B-A3B"
+    megatron_model_type: str = "qwen3-30B-A3B"
+    hardware: Literal["auto", "MI350X", "MI355X"] = "auto"
+    num_gpus_per_node: int | None = None
+    data_dir: str = "/root/datasets"
+    model_dir: str = "/root/models"
+    megatron_path: str = "/root/Megatron-LM"
+
+    # LoRA
+    lora_rank: int = 32
+    lora_alpha: int = 32
+    lora_dropout: float = 0.0
+    target_modules: str = _TARGET_MODULES
+    lora_adapter_path: str = ""
+    # Host-RAM mirror of the frozen base, so it survives the colocate offload
+    # instead of being re-shipped from the trainer every step.
+    lora_base_cpu_backup: bool = True
+    # Shares gate_up lora_A and down lora_B across experts. Roughly a third of
+    # the per-expert parameter count, and a much larger step per parameter at a
+    # given learning rate.
+    experts_shared_outer_loras: bool = False
+
+    # rollout
+    num_rollout: int = 30
+    rollout_batch_size: int = 32
+    n_samples_per_prompt: int = 8
+    global_batch_size: int = 128
+    over_sampling_batch_size: int = 64
+    rollout_max_response_len: int = 8192
+
+    # rollout engine
+    sglang_attention_backend: str | None = None
+    sglang_lora_backend: str = "triton"
+    sglang_mem_fraction_static: float = 0.7
+    sglang_max_running_requests: int = 512
+    rollout_num_gpus_per_engine: int = 1
+
+    save_interval: int = 10
+    enable_eval: bool = True
+    extra_args: str = ""
+
+    def __post_init__(self):
+        self.hardware = U.resolve_hardware(self)
+        self.num_gpus_per_node = self.num_gpus_per_node or U.NUM_GPUS_OF_HARDWARE[self.hardware]
+
+
+def _get_parallel_config(args: ScriptArgs) -> str:
+    """Megatron parallel layout, for the topologies this recipe has been run on."""
+    match (args.hardware, args.num_nodes):
+        case ("MI350X" | "MI355X", 1):
+            return (
+                "--tensor-model-parallel-size 1 "
+                "--sequence-parallel "
+                "--pipeline-model-parallel-size 1 "
+                "--context-parallel-size 1 "
+                "--expert-model-parallel-size 4 "
+                "--expert-tensor-parallel-size 1 "
+                "--recompute-granularity full "
+                "--recompute-method uniform "
+                "--recompute-num-layers 1 "
+                "--use-dynamic-batch-size "
+                "--max-tokens-per-gpu 16384 "
+                "--micro-batch-size 1 "
+            )
+        case _:
+            raise NotImplementedError(f"no verified layout for {args.hardware} on {args.num_nodes} node(s)")
+
+
+def prepare(args: ScriptArgs):
+    """Download the HF checkpoint and the training and eval datasets."""
+    U.exec_command_cpu(f"mkdir -p {args.model_dir} {args.data_dir}")
+    U.exec_command_cpu(f"hf download Qwen/{args.model_name} --local-dir {args.model_dir}/{args.model_name}")
+    U.hf_download_dataset("zhuzilin/dapo-math-17k", data_dir=args.data_dir)
+    U.hf_download_dataset("zhuzilin/aime-2024", data_dir=args.data_dir)
+
+
+def execute(args: ScriptArgs):
+    """Run GRPO LoRA training (assumes ``prepare`` already ran)."""
+    save_path = f"{args.output_dir}/{args.run_id}/checkpoints"
+
+    ckpt_args = (
+        f"--hf-checkpoint {args.model_dir}/{args.model_name} "
+        "--megatron-to-hf-mode bridge "
+        f"--save {save_path} "
+        f"--save-interval {args.save_interval} "
+    )
+    if args.lora_adapter_path:
+        ckpt_args += f"--lora-adapter-path {args.lora_adapter_path} "
+
+    lora_args = (
+        f"--lora-rank {args.lora_rank} "
+        f"--lora-alpha {args.lora_alpha} "
+        f"--lora-dropout {args.lora_dropout} "
+        f'--target-modules "{args.target_modules}" '
+    )
+    if args.lora_base_cpu_backup:
+        lora_args += "--lora-base-cpu-backup "
+    if args.experts_shared_outer_loras:
+        lora_args += "--experts-shared-outer-loras "
+    else:
+        lora_args += "--no-sglang-lora-use-virtual-experts "
+
+    rollout_args = (
+        f"--prompt-data {args.data_dir}/dapo-math-17k/dapo-math-17k.jsonl "
+        "--input-key prompt "
+        "--label-key label "
+        "--rm-type deepscaler "
+        "--apply-chat-template "
+        "--rollout-shuffle "
+        "--balance-data "
+        f"--num-rollout {args.num_rollout} "
+        f"--rollout-batch-size {args.rollout_batch_size} "
+        f"--n-samples-per-prompt {args.n_samples_per_prompt} "
+        f"--rollout-max-response-len {args.rollout_max_response_len} "
+        "--rollout-temperature 1 "
+        f"--global-batch-size {args.global_batch_size} "
+        f"--over-sampling-batch-size {args.over_sampling_batch_size} "
+        "--dynamic-sampling-filter-path "
+        "miles.rollout.filter_hub.dynamic_sampling_filters.check_reward_nonzero_std "
+    )
+
+    eval_args = ""
+    if args.enable_eval:
+        eval_args = (
+            "--eval-interval 5 "
+            f"--eval-prompt-data aime {args.data_dir}/aime-2024/aime-2024.jsonl "
+            # AIME-2024 is 30 problems, so a single pass moves in steps of 3.3%;
+            # averaging 8 samples keeps the eval readable at this interval.
+            "--n-samples-per-eval-prompt 8 "
+            "--eval-max-response-len 16384 "
+            "--eval-top-p 1 "
+        )
+
+    perf_args = _get_parallel_config(args)
+
+    grpo_args = "--advantage-estimator grpo --entropy-coef 0.00 --eps-clip 0.2 --eps-clip-high 0.28 "
+
+    optimizer_args = (
+        "--optimizer adam "
+        # A rank-32 adapter over a sparse MoE needs a much larger step than a
+        # dense full-parameter run to move the policy at all.
+        "--lr 2e-4 "
+        "--lr-decay-style constant "
+        "--weight-decay 0.1 "
+        "--adam-beta1 0.9 "
+        "--adam-beta2 0.98 "
+    )
+
+    sglang_args = (
+        f"--rollout-num-gpus-per-engine {args.rollout_num_gpus_per_engine} "
+        f"--sglang-mem-fraction-static {args.sglang_mem_fraction_static} "
+        f"--sglang-max-running-requests {args.sglang_max_running_requests} "
+        f"--sglang-max-lora-rank {args.lora_rank} "
+        # Triton is the only SGLang LoRA backend that applies adapters to MoE layers.
+        f"--sglang-lora-backend {args.sglang_lora_backend} "
+        "--sglang-moe-runner-backend triton "
+        "--sglang-decode-log-interval 1000 "
+    )
+    if args.sglang_attention_backend not in (None, "default"):
+        # Escape hatch for the throttled-engine ROCm attention fault; see docs/advanced/lora.md.
+        # Off by default: the flags above do not throttle and the default backend runs this recipe.
+        sglang_args += f"--sglang-attention-backend {args.sglang_attention_backend} "
+
+    misc_args = (
+        "--attention-dropout 0.0 "
+        "--hidden-dropout 0.0 "
+        "--accumulate-allreduce-grads-in-fp32 "
+        "--attention-softmax-in-fp32 "
+        "--attention-backend flash "
+        "--calculate-per-token-loss "
+        f"--actor-num-nodes {args.num_nodes} "
+        f"--actor-num-gpus-per-node {args.num_gpus_per_node} "
+        f"--num-gpus-per-node {args.num_gpus_per_node} "
+        "--colocate "
+        f"--dump-details {args.output_dir}/{args.run_id}/dump_details "
+    )
+
+    train_args = (
+        f"{ckpt_args} "
+        f"{lora_args} "
+        f"{rollout_args} "
+        f"{eval_args} "
+        f"{perf_args} "
+        f"{grpo_args} "
+        f"{optimizer_args} "
+        f"{sglang_args} "
+        f"{misc_args} "
+        f"{U.get_default_wandb_args(__file__, run_id=args.run_id)} "
+        f"{args.extra_args} "
+    )
+
+    U.execute_train(
+        train_args=train_args,
+        config=args,
+        num_gpus_per_node=args.num_gpus_per_node,
+        megatron_model_type=args.megatron_model_type,
+        megatron_path=args.megatron_path,
+    )
+
+
+@U.dataclass_cli
+def main(args: ScriptArgs):
+    prepare(args)
+    execute(args)
+
+
+if __name__ == "__main__":
+    typer.run(main)

--- a/tests/manual/launch_scripts/test_py_launch_scripts.py
+++ b/tests/manual/launch_scripts/test_py_launch_scripts.py
@@ -69,6 +69,7 @@ _SCRIPTS_WHOSE_DEFAULTS_ARE_UNSUPPORTED: dict[str, Callable[[Path], dict[str, ob
 # suite pins one; FROZEN_HARDWARE covers the rest.
 _HARDWARE_A_RECORDING_REPRESENTS = {
     "scripts/amd/run_qwen3_30b_a3b.py": "MI355X",
+    "scripts/amd/run_qwen3_30b_a3b_lora.py": "MI355X",
     "scripts/amd/run_qwen3_4b.py": "MI355X",
     "scripts/run_deepseek_v32.py": "B200",
     "scripts/run_glm45_355b_a32b.py": "GB200",

--- a/tests/snapshots/launch_scripts/py/scripts/amd/run_qwen3_30b_a3b_lora.py/execute.txt
+++ b/tests/snapshots/launch_scripts/py/scripts/amd/run_qwen3_30b_a3b_lora.py/execute.txt
@@ -1,0 +1,122 @@
+### 0
+pkill -9 sglang; sleep 3; ray stop
+  --force; pkill -9 ray; pkill -9 miles; sleep 3; pkill -9 ray; pkill -9 miles; pkill -9 redis; true; 
+
+### 1
+export PYTHONUNBUFFERED=1 && ray start
+  --head
+  --node-ip-address 127.0.0.1
+  --num-gpus 8
+  --disable-usage-stats
+
+### 2
+nvidia-smi topo -m 2>/dev/null | grep -o 'NV[0-9][0-9]*' | wc -l
+
+### 3
+export no_proxy=127.0.0.1 && export PYTHONUNBUFFERED=1 && ray job submit
+  --address="http://127.0.0.1:8265"
+  --runtime-env-json='{"env_vars": {"PYTHONUNBUFFERED": "1", "CUDA_DEVICE_MAX_CONNECTIONS": "1", "NCCL_NVLS_ENABLE": "0", "no_proxy": "127.0.0.1,127.0.0.1", "MASTER_ADDR": "127.0.0.1", "PYTHONPATH": "<REPO_ROOT>:/root/Megatron-LM:/frozen/pythonpath"}}'
+  -- python3 <REPO_ROOT>/train.py
+  --disable-bias-linear
+  --qk-layernorm
+  --group-query-attention
+  --num-attention-heads 32
+  --num-query-groups 4
+  --kv-channels 128
+  --num-layers 48
+  --hidden-size 2048
+  --ffn-hidden-size 6144
+  --normalization RMSNorm
+  --position-embedding-type rope
+  --norm-epsilon 1e-6
+  --rotary-percent 1.0
+  --swiglu
+  --untie-embeddings-and-output-weights
+  --vocab-size 151936
+  --rotary-base 1000000
+  --moe-ffn-hidden-size 768
+  --moe-router-score-function softmax
+  --moe-token-dispatcher-type alltoall
+  --moe-router-topk 8
+  --moe-layer-freq '[1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1]'
+  --num-experts 128
+  --moe-grouped-gemm
+  --moe-token-drop-policy probs
+  --moe-router-dtype fp32
+  --moe-permute-fusion
+  --moe-aux-loss-coeff 0
+  --hf-checkpoint /root/models/Qwen3-30B-A3B
+  --megatron-to-hf-mode bridge
+  --save /root/shared_data/260101-000000-000/checkpoints
+  --save-interval 10 
+  --lora-rank 32
+  --lora-alpha 32
+  --lora-dropout 0.0
+  --target-modules "q_proj,k_proj,v_proj,o_proj,gate_proj,up_proj,down_proj"
+  --lora-base-cpu-backup
+  --no-sglang-lora-use-virtual-experts 
+  --prompt-data /root/datasets/dapo-math-17k/dapo-math-17k.jsonl
+  --input-key prompt
+  --label-key label
+  --rm-type deepscaler
+  --apply-chat-template
+  --rollout-shuffle
+  --balance-data
+  --num-rollout 30
+  --rollout-batch-size 32
+  --n-samples-per-prompt 8
+  --rollout-max-response-len 8192
+  --rollout-temperature 1
+  --global-batch-size 128
+  --over-sampling-batch-size 64
+  --dynamic-sampling-filter-path miles.rollout.filter_hub.dynamic_sampling_filters.check_reward_nonzero_std 
+  --eval-interval 5
+  --eval-prompt-data aime /root/datasets/aime-2024/aime-2024.jsonl
+  --n-samples-per-eval-prompt 8
+  --eval-max-response-len 16384
+  --eval-top-p 1 
+  --tensor-model-parallel-size 1
+  --sequence-parallel
+  --pipeline-model-parallel-size 1
+  --context-parallel-size 1
+  --expert-model-parallel-size 4
+  --expert-tensor-parallel-size 1
+  --recompute-granularity full
+  --recompute-method uniform
+  --recompute-num-layers 1
+  --use-dynamic-batch-size
+  --max-tokens-per-gpu 16384
+  --micro-batch-size 1 
+  --advantage-estimator grpo
+  --entropy-coef 0.00
+  --eps-clip 0.2
+  --eps-clip-high 0.28 
+  --optimizer adam
+  --lr 2e-4
+  --lr-decay-style constant
+  --weight-decay 0.1
+  --adam-beta1 0.9
+  --adam-beta2 0.98 
+  --rollout-num-gpus-per-engine 1
+  --sglang-mem-fraction-static 0.7
+  --sglang-max-running-requests 512
+  --sglang-max-lora-rank 32
+  --sglang-lora-backend triton
+  --sglang-moe-runner-backend triton
+  --sglang-decode-log-interval 1000 
+  --attention-dropout 0.0
+  --hidden-dropout 0.0
+  --accumulate-allreduce-grads-in-fp32
+  --attention-softmax-in-fp32
+  --attention-backend flash
+  --calculate-per-token-loss
+  --actor-num-nodes 1
+  --actor-num-gpus-per-node 8
+  --num-gpus-per-node 8
+  --colocate
+  --dump-details /root/shared_data/260101-000000-000/dump_details 
+  --use-wandb
+  --wandb-project miles-run_qwen3_30b_a3b_lora
+  --wandb-group 260101-000000-000
+  --wandb-key 'frozen-wandb-api-key'
+  --disable-wandb-random-suffix   

--- a/tests/snapshots/launch_scripts/py/scripts/amd/run_qwen3_30b_a3b_lora.py/prepare.txt
+++ b/tests/snapshots/launch_scripts/py/scripts/amd/run_qwen3_30b_a3b_lora.py/prepare.txt
@@ -1,0 +1,16 @@
+### 0
+mkdir -p /root/models /root/datasets
+
+### 1
+hf download Qwen/Qwen3-30B-A3B
+  --local-dir /root/models/Qwen3-30B-A3B
+
+### 2
+hf download
+  --repo-type dataset zhuzilin/dapo-math-17k
+  --local-dir /root/datasets/dapo-math-17k
+
+### 3
+hf download
+  --repo-type dataset zhuzilin/aime-2024
+  --local-dir /root/datasets/aime-2024


### PR DESCRIPTION
## Problem

There is no maintained Qwen3-30B-A3B MoE LoRA recipe for AMD.

## Change

Adds `scripts/amd/run_qwen3_30b_a3b_lora.py`: colocated GRPO over a rank-32 MoE adapter on `MI350X` / `MI355X`, plus its two snapshot recordings, the hardware pin the snapshot harness needs for an AMD-only launcher, and the two doc pages that index LoRA recipes.

`--experts-shared-outer-loras` selects the MoE-expert adapter layout, each paired with the serving path that carries it, matching the pairing in `tests/e2e/megatron/test_qwen3_5_35b_a3b_lora_ci.py`. Both layouts were run to completion; the hyperparameters are tuned for the per-expert default, and the docstring says so.

## Validation

One node, 8x MI350X (`gfx950`), `rocm/sgl-dev:miles-rocm720-mi35x`, with a Megatron-Bridge that supplies the ROCm TE grouped-linear contract fields and an SGLang that builds the MoE-LoRA align JIT kernel under HIP.

The launcher was run at its defaults, to completion, three times: per-expert (twice, once per attention backend) and shared-outer. Every run finished 30 rollouts, 30 training phases, 3 checkpoints and 7 evals with job `SUCCEEDED` and no engine lost.

Held-out accuracy is measured by re-scoring the saved checkpoints on a 128-problem DAPO-math split at 4 samples per problem — 512 samples per point, same problems for every point. AIME-2024 is 30 problems, so its in-run avg@8 carries a standard error near 3% and is reported only as a secondary signal.

Per-expert, on the backend SGLang picks itself (`aiter` on this node), which is what the recipe now ships:

| checkpoint | held-out accuracy | response len | truncated | AIME avg@8 |
|---|---|---|---|---|
| base | 0.793 | 9012 | 0.145 | 0.633 |
| `iter_0000009` | 0.820 | 7056 | 0.098 | 0.700 |
| `iter_0000019` | 0.815 | 5914 | 0.051 | 0.733 |
| `iter_0000029` | 0.824 | 5015 | 0.033 | 0.679 |

Accuracy rises 3.1 points while responses get 44% shorter and truncation drops 77%, so the adapter is learning rather than only trading length for reward.

The same recipe with `--sglang-attention-backend triton` reproduces that: `0.803` (base) `→ 0.820 → 0.820 → 0.828`, response length `9039 → 4796`, truncation `0.141 → 0.024`. It is 20% slower end to end — 8h11m against 6h34m for the same 30 rollouts, and 10m26s against 6m59s on a matched eval workload — so it is not the default. An earlier iteration of this recipe throttled the rollout engine hard (a forced `--sglang-max-total-tokens`, `--sglang-max-running-requests 8`, `--sglang-disable-overlap-schedule`); on that configuration the default backend lost engines to an illegal memory access in five runs out of five, which is why `--sglang-attention-backend` is exposed. The shipped configuration does not throttle and did not reproduce it.

Shared-outer, same defaults:

| checkpoint | held-out accuracy | response len | truncated | AIME avg@8 |
|---|---|---|---|---|
| base | 0.809 | 9015 | 0.131 | 0.650 |
| `iter_0000009` | 0.816 | 7644 | 0.068 | 0.650 |
| `iter_0000019` | 0.818 | 6176 | 0.002 | 0.392 |
| `iter_0000029` | 0.793 | 6194 | 0.000 | 0.379 |

It trains and serves correctly — adapter publishes verified `672/672` tensors, checkpoints and PEFT exports are complete — but at the per-expert learning rate it compresses far harder: truncation reaches zero by rollout 19, held-out accuracy peaks there and then falls below base, and AIME loses 27 points. Sharing `gate_up` `lora_A` and `down` `lora_B` across 128 experts makes each shared parameter absorb every expert's gradient, so the same learning rate is a much larger step. Tuning it is follow-up work; the recipe defaults to per-expert.

Resume is covered separately: a fresh-plus-resume pair verified `--lora-adapter-path` restart and 16 publishes at `37,248/37,248` tensors.

Checkpoint shape: each `iter_N/adapter` holds four EP shards, a complete PEFT pair, optimizer parameter state and training state. A rank-32 per-expert adapter over 128 experts and 48 layers is 1.34B trainable parameters, so a checkpoint is about 24GB; shared-outer is about 8.5GB. The recipe saves every 10 rollouts.

## Tests

- `pytest tests/fast/launch_scripts tests/manual/launch_scripts` — 490 passed against 486 on `main`, i.e. exactly the four new cases; the 14 pre-existing failures and 4 pre-existing errors are unchanged.
- `pre-commit run --all-files` clean.
