### PR TITLE
Bump flash-linear-attention to 0.5.2

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -84,7 +84,7 @@ RUN pip install /tmp/wheels/flash_attn_3-*.whl
 
 RUN pip install git+https://github.com/ISEEKYAN/mbridge.git@89eb10887887bc74853f89a4de258c0702932a1c --no-deps
 
-RUN pip install flash-linear-attention==0.4.2
+RUN pip install flash-linear-attention==0.5.2
 # required for DeepSeek V4
 RUN pip install tilelang==0.1.8 -f https://tile-ai.github.io/whl/nightly/cu128/
 RUN pip install --no-deps tile_kernels==1.0.0

--- a/docker/Dockerfile.rocm
+++ b/docker/Dockerfile.rocm
@@ -106,7 +106,7 @@ RUN pip install --no-deps --target=/tmp/mc "mooncake-transfer-engine-non-cuda==$
     cp -n /tmp/mc/mooncake/*.py "$(python3 -c 'import mooncake, os; print(os.path.dirname(mooncake.__file__))')" && \
     rm -rf /tmp/mc
 
-RUN pip install flash-linear-attention==0.4.2
+RUN pip install flash-linear-attention==0.5.2
 
 # Enable deepseek-ai/TileKernels on ROCm/gfx950 for mHC and FP8 QAT cast-back.
 # These temporary build-time patches make tile_kernels import lazy, remove CUDA/Hopper-only PDL from mhc_post,


### PR DESCRIPTION
## Summary

Bump flash-linear-attention 0.4.2 -> 0.5.2 in both docker images.

## Why

- fla 0.4.2's `chunk_intra_token_parallel` calls `triton.next_power_of_2` inside `@triton.jit`, which recent triton rejects ("Unsupported function referenced") — it kills the KDA training forward (glm5_next). 0.5.x moves it to host code.
- 0.4.2 is the last release with this bug; every KDA training deployment currently needs a hand-patched site-packages.

## Kernel A/B (0.4.2 vs 0.5.2, same inputs, GB300)

Covers every fla API miles uses: `chunk_kda` (+ `fused_kda_gate`, qk-l2norm, safe gate), `chunk_gated_delta_rule`, varlen `cu_seqlens`; forward outputs and input/gate gradients compared element-wise.

- KDA: forward bitwise-identical; gradients differ only at 1e-10 on ~1e-8-magnitude values (fp32 last bits).
- GDN: forward differs by a few bf16 ulps (max 9.8e-4; 0.5.2 reimplements the local cumsum with tilelang); gradients at 1e-10.

No API breaks: `fla.ops.cp.build_cp_context`, `cp_context` kwargs, `FusedRMSNormGated`/`ShortConvolution`, `lower_bound` all unchanged.

Note: on PyPI the 0.5.x `flash-linear-attention` wheel is a thin wrapper that depends on `fla-core`, which carries the actual code — `import fla` is unchanged.

## Risk

GDN forward is bf16-rounding-level different, so qwen3-next-family logprob metrics may shift within noise. The 4layer e2e CI on this PR is the gate.
