### PR TITLE
test(tito): use FP8 Qwen3.6 checkpoint

### DIFF
--- a/tests/e2e/sglang/test_session_server_multi_role/test_qwen36.py
+++ b/tests/e2e/sglang/test_session_server_multi_role/test_qwen36.py
@@ -9,7 +9,7 @@ register_ci_gate(metric_key="rollout/tito_session_mismatch_rate/v2/assistant_tex
 
 
 CONFIG = ModelConfig(
-    model_name="Qwen/Qwen3.6-35B-A3B",
+    model_name="Qwen/Qwen3.6-35B-A3B-FP8",
     reasoning_parser="qwen3",
     tool_call_parser="qwen3_coder",
     tito_model="qwen36",


### PR DESCRIPTION
## Summary

Run the Qwen3.6 TITO session verifier with the FP8 checkpoint.

## Motivation

The Qwen3.6 session verifier currently loads the full-precision 35B checkpoint even though this CI surface validates TITO chat serialization and session reuse. The matching FP8 checkpoint keeps that validation target while avoiding the full-precision model artifact.

## Before / After

- **Before / After:** `test_qwen36.py` changes `Qwen/Qwen3.6-35B-A3B` to `Qwen/Qwen3.6-35B-A3B-FP8`.
- **What moved where:** only `ModelConfig.model_name` changes.

## Behavior Preservation

- `CONFIG` keeps the same topology, speculative decoding, parsers, cycles, and append-tool behavior.
- CUDA and ROCm registrations plus both session-mismatch metric gates remain unchanged.

## Verification

- `uvx pre-commit run --files tests/e2e/sglang/test_session_server_multi_role/test_qwen36.py`: passed.
- `tests.ci.file_run`: resolved the file to CUDA suite `stage-c-4-gpu-h200`, runner labels `h200,4gpu`, and a 1,800-second timeout.
- `test_qwen36.py` GPU execution: pending; only this file will be dispatched after PR creation.

## Review Focus

- `ModelConfig.model_name`: the FP8 checkpoint must preserve the tokenizer and chat-template behavior exercised by TITO.
- Unchanged verifier settings: the checkpoint substitution must not weaken v1/v2 session or tool-call coverage.
