### PR TITLE
fix(deepseek_v4): chunk indexer queries on demand

### DIFF
--- a/miles/backends/megatron_utils/arguments.py
+++ b/miles/backends/megatron_utils/arguments.py
@@ -52,5 +52,7 @@ def set_default_megatron_args(args):
 
     if not hasattr(args, "miles_dsa_topk_backend"):
         args.miles_dsa_topk_backend = "torch"
+    if not hasattr(args, "miles_dsa_indexer_query_chunk_size"):
+        args.miles_dsa_indexer_query_chunk_size = None
 
     return args

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -292,6 +292,15 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 help="Top-k backend for Miles DSA indexer.",
             )
             parser.add_argument(
+                "--miles-dsa-indexer-query-chunk-size",
+                type=int,
+                default=None,
+                help=(
+                    "Optional number of query rows per TileLang DeepSeek-V4 indexer call. "
+                    "Each chunk still scores every compressed key; unset preserves the full-query path."
+                ),
+            )
+            parser.add_argument(
                 "--true-on-policy-mode",
                 action="store_true",
                 default=False,
@@ -3495,6 +3504,14 @@ def miles_validate_args(args):
     if args.use_rollout_indexer_replay:
         args.use_indexer_replay = True
         assert args.context_parallel_size == 1, "indexer replay does not support context parallelism yet"
+
+    indexer_query_chunk_size = args.miles_dsa_indexer_query_chunk_size
+    if indexer_query_chunk_size is not None:
+        assert indexer_query_chunk_size > 0, "--miles-dsa-indexer-query-chunk-size must be positive"
+        assert not args.use_indexer_replay, (
+            "--miles-dsa-indexer-query-chunk-size does not support indexer replay because one layer forward "
+            "would produce multiple replay calls"
+        )
 
     if args.eval_max_context_len is None:
         logger.info(

--- a/miles_plugins/models/deepseek_v4/deepseek_v4.py
+++ b/miles_plugins/models/deepseek_v4/deepseek_v4.py
@@ -43,6 +43,21 @@ def _enable_deepseek_v4_tf32():
     torch.backends.cuda.matmul.allow_tf32 = True
 
 
+def _validate_v4_indexer_options(indexer_impl, topk_backend, query_chunk_size):
+    if indexer_impl == "tilelang":
+        return
+    if topk_backend != "torch":
+        raise ValueError(
+            "DeepSeek V4 miles DSA topk backend is only supported with V4_INDEXER_IMPL=tilelang; "
+            f"got {topk_backend=} with {indexer_impl=}."
+        )
+    if query_chunk_size is not None:
+        raise ValueError(
+            "DeepSeek V4 indexer query chunking is only supported with V4_INDEXER_IMPL=tilelang; "
+            f"got {query_chunk_size=} with {indexer_impl=}."
+        )
+
+
 class DeepSeekV4Attention(MegatronModule):
     def __init__(
         self,
@@ -171,14 +186,14 @@ class DeepSeekV4Attention(MegatronModule):
             if self.compress_ratio == 4:
                 indexer_impl = os.environ.get("V4_INDEXER_IMPL", "tilelang")
                 topk_backend = config.miles_dsa_topk_backend
+                _validate_v4_indexer_options(
+                    indexer_impl,
+                    topk_backend,
+                    getattr(config, "miles_dsa_indexer_query_chunk_size", None),
+                )
                 if indexer_impl == "tilelang":
                     self.indexer = V4Indexer(config=config, pg_collection=pg_collection)
                 else:
-                    if topk_backend != "torch":
-                        raise ValueError(
-                            "DeepSeek V4 miles DSA topk backend is only supported with V4_INDEXER_IMPL=tilelang; "
-                            f"got {topk_backend=} with {indexer_impl=}."
-                        )
                     indexer_submodules = DSAIndexerSubmodules(
                         linear_wq_b=TELinear,
                         linear_wk=TELinear,
@@ -344,6 +359,7 @@ def get_dsv4_spec(args, config, vp_stage):
     Usage: --spec miles_plugins.models.deepseek_v4.deepseek_v4 get_dsv4_spec
     """
     config.miles_dsa_topk_backend = args.miles_dsa_topk_backend
+    config.miles_dsa_indexer_query_chunk_size = args.miles_dsa_indexer_query_chunk_size
     _orig_get_spec = _eav_specs.get_experimental_attention_variant_module_spec
 
     def _patched_get_spec(config, backend=None):

--- a/miles_plugins/models/deepseek_v4/ops/kernel/tilelang_indexer_fwd.py
+++ b/miles_plugins/models/deepseek_v4/ops/kernel/tilelang_indexer_fwd.py
@@ -192,3 +192,58 @@ def batched_indexer_fwd(q, k, weights, cu_seqlen_ks, cu_seqlen_ke):
             cu_seqlen_ke,
         )
     return all_logits
+
+
+def batched_indexer_topk(
+    q,
+    k,
+    weights,
+    cu_seqlen_ks,
+    cu_seqlen_ke,
+    topk,
+    topk_fn,
+    query_chunk_size,
+):
+    """Select top-k indices while bounding the live query-by-key score matrix."""
+    if query_chunk_size <= 0:
+        raise ValueError(f"query_chunk_size must be positive, got {query_chunk_size}")
+
+    seqlen, batch, heads, _ = q.shape
+    seq_len_kv = k.shape[0]
+    block_q = 128 // heads
+    if block_q <= 0:
+        raise ValueError(f"indexer head count must not exceed 128, got {heads}")
+    topk_count = min(topk, seq_len_kv)
+    topk_indices = torch.empty((batch, seqlen, topk_count), device=q.device, dtype=torch.int32)
+
+    for batch_index in range(batch):
+        k_batch = k[:, batch_index, :].contiguous()
+        for start in range(0, seqlen, query_chunk_size):
+            end = min(start + query_chunk_size, seqlen)
+            valid_queries = end - start
+            q_chunk = q[start:end, batch_index, :, :].contiguous()
+            weights_chunk = weights[start:end, batch_index, :].contiguous()
+            cu_ks_chunk = cu_seqlen_ks[start:end]
+            cu_ke_chunk = cu_seqlen_ke[start:end]
+            padding = (-valid_queries) % block_q
+            if padding:
+                q_chunk = torch.cat(
+                    (q_chunk, q_chunk.new_zeros((padding, *q_chunk.shape[1:]))),
+                )
+                weights_chunk = torch.cat(
+                    (weights_chunk, weights_chunk.new_zeros((padding, *weights_chunk.shape[1:]))),
+                )
+                cu_ks_chunk = torch.cat((cu_ks_chunk, cu_ks_chunk.new_zeros(padding)))
+                cu_ke_chunk = torch.cat((cu_ke_chunk, cu_ke_chunk.new_zeros(padding)))
+            chunk_logits = indexer_fwd_interface(
+                q_chunk,
+                k_batch,
+                weights_chunk,
+                cu_ks_chunk,
+                cu_ke_chunk,
+            )
+            chunk_indices = topk_fn(chunk_logits, topk_count)
+            topk_indices[batch_index, start:end].copy_(chunk_indices[:valid_queries])
+            del chunk_logits, chunk_indices
+
+    return topk_indices

--- a/miles_plugins/models/deepseek_v4/ops/v4_indexer.py
+++ b/miles_plugins/models/deepseek_v4/ops/v4_indexer.py
@@ -12,6 +12,7 @@ from miles_plugins.models.deepseek_v4.ops.cp_utils import all_gather_cp, get_fre
 from miles_plugins.models.deepseek_v4.ops.kernel.tilelang_indexer_fwd import (
     _make_causal_cu_seqlens,
     batched_indexer_fwd,
+    batched_indexer_topk,
 )
 from miles_plugins.models.deepseek_v4.ops.qat import fp8_simulate_qat
 from miles_plugins.models.deepseek_v4.ops.rope import apply_rotary_emb, wrapped_precompute_freqs_cis
@@ -31,6 +32,7 @@ class V4Indexer(MegatronModule):
         self.index_head_dim = config.dsa_indexer_head_dim
         self.index_topk = config.dsa_indexer_topk
         self.topk_backend = config.miles_dsa_topk_backend
+        self.query_chunk_size = getattr(config, "miles_dsa_indexer_query_chunk_size", None)
         self.rope_head_dim = config.qk_pos_emb_head_dim
         self.compress_ratio = 4
         self.use_fp8_qat = config.fp8 is not None
@@ -128,9 +130,21 @@ class V4Indexer(MegatronModule):
             cp_rank = cp_group.rank()
             cu_ks = cu_ks[cp_rank * seqlen : (cp_rank + 1) * seqlen]
             cu_ke = cu_ke[cp_rank * seqlen : (cp_rank + 1) * seqlen]
-        index_scores = batched_indexer_fwd(q, k, weights.float(), cu_ks, cu_ke)
-
-        topk_count = min(self.index_topk, index_scores.size(-1))
-        topk_indices = get_dsa_topk_fn(self.topk_backend)(index_scores, topk_count)
+        topk_fn = get_dsa_topk_fn(self.topk_backend)
+        if self.query_chunk_size is None:
+            index_scores = batched_indexer_fwd(q, k, weights.float(), cu_ks, cu_ke)
+            topk_count = min(self.index_topk, index_scores.size(-1))
+            topk_indices = topk_fn(index_scores, topk_count)
+        else:
+            topk_indices = batched_indexer_topk(
+                q,
+                k,
+                weights.float(),
+                cu_ks,
+                cu_ke,
+                self.index_topk,
+                topk_fn,
+                self.query_chunk_size,
+            )
 
         return topk_indices

--- a/tests/fast/utils/test_arguments.py
+++ b/tests/fast/utils/test_arguments.py
@@ -263,6 +263,47 @@ def test_custom_megatron_post_save_hook_path_is_parsed():
     assert args.custom_megatron_post_save_hook_path == "pkg.module.hook"
 
 
+def test_dsa_indexer_query_chunk_size_is_optional_and_typed():
+    parser = argparse.ArgumentParser()
+    get_miles_extra_args_provider()(parser)
+
+    default_args = parser.parse_args(REQUIRED_ARGS)
+    chunked_args = parser.parse_args(["--miles-dsa-indexer-query-chunk-size", "4096"] + REQUIRED_ARGS)
+
+    assert default_args.miles_dsa_indexer_query_chunk_size is None
+    assert chunked_args.miles_dsa_indexer_query_chunk_size == 4096
+
+
+@pytest.mark.parametrize("chunk_size", ["0", "-1"])
+def test_dsa_indexer_query_chunk_size_must_be_positive(chunk_size):
+    parser = argparse.ArgumentParser()
+    get_miles_extra_args_provider()(parser)
+    args = parser.parse_args(
+        ["--miles-dsa-indexer-query-chunk-size", chunk_size, "--num-rollout", "1"] + REQUIRED_ARGS
+    )
+
+    with pytest.raises(AssertionError, match="query-chunk-size must be positive"):
+        miles_validate_args(args)
+
+
+def test_dsa_indexer_query_chunking_rejects_indexer_replay():
+    parser = argparse.ArgumentParser()
+    get_miles_extra_args_provider()(parser)
+    args = parser.parse_args(
+        [
+            "--miles-dsa-indexer-query-chunk-size",
+            "4096",
+            "--use-indexer-replay",
+            "--num-rollout",
+            "1",
+        ]
+        + REQUIRED_ARGS
+    )
+
+    with pytest.raises(AssertionError, match="does not support indexer replay"):
+        miles_validate_args(args)
+
+
 def test_custom_megatron_post_save_hook_path_requires_save():
     parser = argparse.ArgumentParser()
     get_miles_extra_args_provider()(parser)

--- a/tests/manual/models/deepseek_v4/test_v4_tilelang_indexer.py
+++ b/tests/manual/models/deepseek_v4/test_v4_tilelang_indexer.py
@@ -13,11 +13,16 @@ if tilelang is not None:
     from miles_plugins.models.deepseek_v4.ops.kernel.tilelang_indexer_fwd import (
         _make_causal_cu_seqlens,
         batched_indexer_fwd,
+        batched_indexer_topk,
     )
+    from miles_plugins.models.dsa_topk import get_dsa_topk_fn, torch_dsa_topk
 else:
     v4_lighting_indexer = None
     _make_causal_cu_seqlens = None
     batched_indexer_fwd = None
+    batched_indexer_topk = None
+    get_dsa_topk_fn = None
+    torch_dsa_topk = None
 
 
 # ---------------------------------------------------------------------------
@@ -273,6 +278,120 @@ def test_indexer_forward_topk(seqlen_q, batch, heads, dim, compress_ratio, topk)
         violation_rate = violations / total
         # Allow small violation rate due to kernel non-determinism on tied scores
         assert violation_rate < 0.05, f"topk violation rate too high: {violation_rate:.4f}"
+
+
+@requires_tilelang()
+def test_batched_indexer_topk_chunks_queries_in_order_with_full_keys(monkeypatch):
+    seen_shapes = []
+
+    def fake_indexer(q, kv, weights, cu_ks, cu_ke):
+        seen_shapes.append((q.shape[0], kv.shape[0]))
+        key_positions = torch.arange(kv.shape[0]).unsqueeze(0)
+        scores = key_positions.float().expand(q.shape[0], -1).clone()
+        valid = (key_positions >= cu_ks.unsqueeze(1)) & (key_positions < cu_ke.unsqueeze(1))
+        return scores.masked_fill(~valid, float("-inf"))
+
+    monkeypatch.setattr(
+        "miles_plugins.models.deepseek_v4.ops.kernel.tilelang_indexer_fwd.indexer_fwd_interface",
+        fake_indexer,
+    )
+    q = torch.zeros(5, 2, 64, 1, dtype=torch.bfloat16)
+    k = torch.zeros(7, 2, 1, dtype=torch.bfloat16)
+    weights = torch.ones(5, 2, 64, dtype=torch.float32)
+    cu_ks = torch.tensor([0, 1, 0, 2, 3], dtype=torch.int32)
+    cu_ke = torch.tensor([2, 4, 5, 7, 7], dtype=torch.int32)
+    full_logits = torch.stack(
+        [
+            fake_indexer(q[:, batch_index], k[:, batch_index], weights[:, batch_index], cu_ks, cu_ke)
+            for batch_index in range(2)
+        ]
+    )
+    expected = torch_dsa_topk(full_logits, 3)
+    seen_shapes.clear()
+
+    actual = batched_indexer_topk(
+        q,
+        k,
+        weights,
+        cu_ks,
+        cu_ke,
+        topk=3,
+        topk_fn=torch_dsa_topk,
+        query_chunk_size=2,
+    )
+
+    assert torch.equal(actual, expected)
+    assert seen_shapes == [(2, 7), (2, 7), (2, 7), (2, 7), (2, 7), (2, 7)]
+
+
+@requires_tilelang()
+def test_batched_indexer_topk_rejects_nonpositive_chunk_size():
+    q = torch.empty(0, 1, 1, 1, dtype=torch.bfloat16)
+    k = torch.empty(0, 1, 1, dtype=torch.bfloat16)
+    weights = torch.empty(0, 1, 1, dtype=torch.float32)
+    cu_seqlens = torch.empty(0, dtype=torch.int32)
+
+    with pytest.raises(ValueError, match="query_chunk_size must be positive"):
+        batched_indexer_topk(q, k, weights, cu_seqlens, cu_seqlens, 0, torch_dsa_topk, 0)
+
+
+@requires_cuda()
+@requires_tilelang()
+@pytest.mark.parametrize("topk_backend", ["torch", "flashinfer"])
+def test_batched_indexer_topk_gpu_matches_full_logits_with_remainder(topk_backend):
+    if topk_backend == "flashinfer":
+        pytest.importorskip("flashinfer")
+    seqlen_q, batch, heads, dim, compress_ratio, topk = 130, 1, 64, 128, 4, 16
+    q, k, weights = make_inputs(seqlen_q, batch, heads, dim, compress_ratio)
+    cu_ks, cu_ke = _make_causal_cu_seqlens(seqlen_q, k.shape[0], compress_ratio, q.device)
+    full_logits = batched_indexer_fwd(q, k, weights, cu_ks, cu_ke)
+    topk_fn = get_dsa_topk_fn(topk_backend)
+    expected = topk_fn(full_logits, topk)
+
+    actual = batched_indexer_topk(
+        q,
+        k,
+        weights,
+        cu_ks,
+        cu_ke,
+        topk=topk,
+        topk_fn=topk_fn,
+        query_chunk_size=31,
+    )
+
+    assert torch.equal(actual, expected)
+
+
+@requires_cuda()
+@requires_tilelang()
+def test_v4_query_chunking_rejects_non_tilelang_indexer():
+    from miles_plugins.models.deepseek_v4.deepseek_v4 import _validate_v4_indexer_options
+
+    with pytest.raises(ValueError, match="only supported with V4_INDEXER_IMPL=tilelang"):
+        _validate_v4_indexer_options("megatron", "torch", 4096)
+
+
+@requires_cuda()
+@requires_tilelang()
+def test_dsv4_spec_projects_query_chunk_size(monkeypatch):
+    from types import SimpleNamespace
+
+    from miles_plugins.models.deepseek_v4 import deepseek_v4
+
+    result = object()
+    monkeypatch.setattr(
+        deepseek_v4,
+        "get_transformer_block_with_experimental_attention_variant_spec",
+        lambda config, vp_stage: result,
+    )
+    args = SimpleNamespace(
+        miles_dsa_topk_backend="torch",
+        miles_dsa_indexer_query_chunk_size=4096,
+    )
+    config = SimpleNamespace()
+
+    assert deepseek_v4.get_dsv4_spec(args, config, vp_stage=0) is result
+    assert config.miles_dsa_indexer_query_chunk_size == 4096
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

The DeepSeek-V4 TileLang indexer currently materializes the complete fp32
`[batch, local_queries, global_compressed_keys]` score tensor before selecting
top-k keys. At 262,144 global tokens with CP8 and 4:1 KV compression, one rank
has 32,768 queries and 65,536 compressed keys: one score matrix is 8 GiB, and
the current batched wrapper transiently holds two copies.

## Change

- Add the opt-in `--miles-dsa-indexer-query-chunk-size` training argument.
- Chunk only the query dimension. Every chunk still scores the complete key
  set, uses its matching causal bounds, and writes top-k indices back in query
  order.
- Pad an incomplete query chunk only to TileLang's internal query block and
  discard those padded outputs, so every positive chunk size is kernel-safe.
- Keep the existing full-query path unchanged when the option is unset.
- Reject non-positive chunk sizes, indexer replay, and non-TileLang V4
  indexers. Replay currently assumes one indexer call per layer forward, while
  chunking intentionally makes several calls.

For chunk size `C`, the live logits allocation becomes proportional to
`C * global_compressed_keys` instead of
`local_queries * global_compressed_keys`. The returned top-k tensor is
unchanged in size.

## Verification

- Argument tests cover the default, a positive value, non-positive rejection,
  and replay rejection.
- A fake-kernel test verifies remainder chunks, query ordering, causal bounds,
  and that every chunk retains the full key set.
- The real TileLang H100 test compares a 130-query input with deliberately
  misaligned chunk size 31 against full logits and obtains exactly equal
  indices with both Torch and FlashInfer top-k.
- At the CP8 worst-rank 256k geometry above, four real H100 repeats were
  bit-identical to the full path. Incremental peak allocated memory fell from
  16.00 GiB to 1.098 GiB (14.57x). The chunked median was 0.157 seconds versus
  0.166 seconds for the full-path reference in this focused kernel run.
