### PR TITLE
dashboard: scroll the token strip instead of paging through it

### DIFF
--- a/miles/dashboard/README.md
+++ b/miles/dashboard/README.md
@@ -55,8 +55,9 @@ Views:
   (`zero_std`), average weight-version staleness, eval tab.
 - **sample view** — a `conversation` tab (role-tagged turns with thinking /
   tool calls, from the trajectory sidecar) and a lazily-loaded `tokens` tab
-  (per-token metric strips + a selectable metric-vs-position chart,
-  loss-masked regions dimmed).
+  (the whole sequence in one scrollable metric-colored strip, opened at the
+  first generated token, + a selectable metric-vs-position chart, loss-masked
+  regions dimmed).
 
 ## Develop
 

--- a/miles/dashboard/static/style.css
+++ b/miles/dashboard/static/style.css
@@ -81,7 +81,12 @@ table.data tr.flagged td { color: var(--bad); }
 .tablewrap { max-height: 480px; overflow: auto; }
 
 .tabs { display: flex; gap: 4px; margin-bottom: 10px; }
-.tokens { line-height: 1.9; font-family: ui-monospace, monospace; font-size: 13px; word-break: break-all; }
+/* position: relative makes the box the offsetParent of its tokens, so a token's
+   offsetTop is the scroll offset that brings it to the top of the box */
+.tokens {
+  line-height: 1.9; font-family: ui-monospace, monospace; font-size: 13px; word-break: break-all;
+  max-height: 480px; overflow-y: auto; position: relative;
+}
 .tok { border-radius: 2px; padding: 1px 0; position: relative; }
 .tok.prompt { color: var(--muted); }
 .tok.masked { opacity: 0.35; }

--- a/miles/dashboard/static/views_tokens.js
+++ b/miles/dashboard/static/views_tokens.js
@@ -110,7 +110,11 @@ export async function renderTokens(view, meta, route) {
 
   const conversationPane = renderConversation(conversationRow);
   const tabs = el("div", { class: "tabs" });
-  const body = el("div");
+  // both panes stay mounted and are toggled with `hidden`, because detaching a
+  // pane destroys its layout and the browser resets the token strip's scroll
+  // offset to 0 on re-attach — one glance at the conversation would otherwise
+  // send the reader back to token 0 of a several-thousand-token prompt
+  const body = el("div", {}, [conversationPane, tokensPane]);
   const select = (name) => {
     tabs.replaceChildren(
       ...["conversation", "tokens"].map((tab) =>
@@ -119,8 +123,12 @@ export async function renderTokens(view, meta, route) {
         ]),
       ),
     );
-    body.replaceChildren(name === "conversation" ? conversationPane : tokensPane);
-    if (name === "tokens") startTokens();
+    conversationPane.hidden = name !== "conversation";
+    tokensPane.hidden = name !== "tokens";
+    if (name === "tokens") {
+      startTokens();
+      tokensPane._onShown?.(); // work the load deferred because the pane was hidden
+    }
   };
   // chips sit above the tab bar, not inside either pane, so status/reward stay
   // on screen while reading tokens
@@ -262,9 +270,21 @@ async function loadTokensPane(root, rolloutId, sampleIndex, evaluation) {
   paintStrip();
 
   root.replaceChildren(controls, strip, chartPanel);
-  renderChart();
-  // open on the first generated token: an agentic prompt runs to thousands of
-  // tokens of chat history, and none of the per-token metrics are defined over it
+
+  // Sizing the chart canvas and reading a token's offsetTop both need a layout
+  // box, and this load is slow enough to carry its own "several minutes" notice
+  // — long enough for the reader to have switched back to the Conversation tab
+  // before it lands. Rendering into a hidden pane would silently produce a 0x0
+  // canvas and a scrollTop of 0, so the layout-bound work waits to be replayed
+  // by whoever shows the pane next.
   const firstResponse = spans[payload.response_offset];
-  if (firstResponse) box.scrollTop = firstResponse.offsetTop;
+  root._onShown = () => {
+    if (!root.getClientRects().length) return; // still no layout box
+    renderChart();
+    // open on the first generated token: an agentic prompt runs to thousands of
+    // tokens of chat history, and none of the per-token metrics are defined over it
+    if (firstResponse) box.scrollTop = firstResponse.offsetTop;
+    root._onShown = null; // one-shot, so later tab switches never yank the reader's scroll
+  };
+  root._onShown();
 }

--- a/miles/dashboard/static/views_tokens.js
+++ b/miles/dashboard/static/views_tokens.js
@@ -4,8 +4,6 @@ import { el, fmtNum } from "./app.js";
 import { divergingColor, drawChart, hideTooltip, sequentialColor, showTooltip } from "./charts.js";
 import { renderConversation, renderSampleChips } from "./conversation.js";
 
-const WINDOW_SIZES = [256, 1024, 4096];
-
 // stat -> how to color a value: diverging stats define center/scale via values
 const STATS = {
   imp_ratio: { color: (v) => divergingColor(Math.log(Math.max(v, 1e-6))) },
@@ -131,18 +129,15 @@ export async function renderTokens(view, meta, route) {
 }
 
 async function loadTokensPane(root, rolloutId, sampleIndex, evaluation) {
-  const probe = await api(`/api/rollout/${rolloutId}/sample/${sampleIndex}/tokens`, {
-    start: 0,
-    end: 1,
-    eval: evaluation,
-  });
-  const total = probe.total_len;
+  // one full-range read feeds both panes. The chart always spanned the whole
+  // response, so the windowed strip fetch this replaces was re-requesting a
+  // slice of bytes the server was already sending.
+  const payload = await api(`/api/rollout/${rolloutId}/sample/${sampleIndex}/tokens`, { eval: evaluation });
+  const available = Object.keys(STATS).filter((s) => payload[s] !== null && payload[s] !== undefined);
 
-  let windowSize = total <= 4096 ? total : 1024;
-  let start = 0;
   let stat = "imp_ratio";
+  if (!available.includes(stat)) stat = available[0];
   let chartMetric = "imp_ratio";
-  let chartData = null; // full-range payload: the chart spans the whole response
 
   const controls = el("div", { class: "controls" });
   const strip = el("div", { class: "panel" });
@@ -150,7 +145,6 @@ async function loadTokensPane(root, rolloutId, sampleIndex, evaluation) {
   const chartCanvas = el("canvas", { class: "chart" }); // persistent: zoom survives metric switches
 
   function renderChart() {
-    const available = Object.keys(STATS).filter((s) => chartData[s] !== null && chartData[s] !== undefined);
     if (!available.length) {
       chartPanel.replaceChildren();
       return;
@@ -178,7 +172,7 @@ async function loadTokensPane(root, rolloutId, sampleIndex, evaluation) {
       ]),
       chartCanvas,
     );
-    const values = chartData[chartMetric];
+    const values = payload[chartMetric];
     const points = [];
     let afterGap = false;
     values.forEach((v, i) => {
@@ -186,111 +180,91 @@ async function loadTokensPane(root, rolloutId, sampleIndex, evaluation) {
         afterGap = true;
         return;
       }
-      const pos = chartData.prompt_len + i;
+      const pos = payload.prompt_len + i;
       points.push({ x: pos, y: v, gap: afterGap, label: `pos ${pos}\n${chartMetric} = ${fmtNum(v)}` });
       afterGap = false;
     });
     // shade the prompt and mask=0 runs: regions the policy did not generate
-    const bands = [{ x0: 0, x1: chartData.prompt_len, strong: true, label: "prompt" }];
-    const mask = chartData.loss_mask;
+    const bands = [{ x0: 0, x1: payload.prompt_len, strong: true, label: "prompt" }];
+    const mask = payload.loss_mask;
     if (mask) {
       let runStart = null;
       mask.forEach((m, i) => {
         if (m === 0 && runStart === null) runStart = i;
         if (m !== 0 && runStart !== null) {
-          bands.push({ x0: chartData.prompt_len + runStart, x1: chartData.prompt_len + i });
+          bands.push({ x0: payload.prompt_len + runStart, x1: payload.prompt_len + i });
           runStart = null;
         }
       });
-      if (runStart !== null) bands.push({ x0: chartData.prompt_len + runStart, x1: chartData.prompt_len + mask.length });
+      if (runStart !== null) bands.push({ x0: payload.prompt_len + runStart, x1: payload.prompt_len + mask.length });
     }
     queueMicrotask(() => drawChart(chartCanvas, points, { bands }));
   }
 
-  async function loadChart() {
-    chartData = await api(`/api/rollout/${rolloutId}/sample/${sampleIndex}/tokens`, {
-      start: 0,
-      end: total,
-      eval: evaluation,
-    });
-    renderChart();
-  }
-
-  async function load() {
-    const payload = await api(`/api/rollout/${rolloutId}/sample/${sampleIndex}/tokens`, {
-      start,
-      end: Math.min(start + windowSize, total),
-      eval: evaluation,
-    });
-    const available = Object.keys(STATS).filter((s) => payload[s] !== null && payload[s] !== undefined);
-    if (!available.includes(stat)) stat = available[0];
-
-    // ---- controls ----
-    const statSelect = el("select", {}, available.map((s) =>
-      Object.assign(el("option", { value: s }, [s]), { selected: s === stat }),
-    ));
-    statSelect.onchange = () => {
-      stat = statSelect.value;
-      load();
+  // ---- token strip ----
+  // the loss ignores masked positions, so they are dimmed and never tinted: a
+  // color there would read as signal that does not exist
+  const isMasked = (respPos) =>
+    payload.loss_mask !== null && respPos >= 0 && respPos < payload.loss_mask.length && payload.loss_mask[respPos] === 0;
+  const responseLen = (payload.train_log_probs ?? payload.rollout_log_probs ?? []).length;
+  const heading = el("h3", {});
+  // built once, then only recolored when "color by" changes: a rebuild would
+  // throw away wherever in the sequence the reader had scrolled to
+  const spans = payload.token_ids.map((tokenId, i) => {
+    const respPos = i - payload.response_offset; // index into stat arrays
+    const inResponse = respPos >= 0 && respPos < responseLen;
+    const text = payload.token_text ? payload.token_text[i] : `·${tokenId}`;
+    const masked = inResponse && isMasked(respPos);
+    const span = el("span", { class: `tok ${inResponse ? "" : "prompt"} ${masked ? "masked" : ""}` }, [
+      text.replaceAll("\n", "⏎\n"),
+    ]);
+    span.onmousemove = (ev) => {
+      const lines = [`#${payload.start + i} id=${tokenId} ${JSON.stringify(text)}`];
+      if (!inResponse) lines.push("(prompt)");
+      else {
+        for (const s of available) lines.push(`${s} = ${fmtNum(payload[s][respPos])}`);
+        if (masked) lines.push("loss_mask = 0");
+      }
+      showTooltip(ev.clientX, ev.clientY, lines.join("\n"));
     };
-    const sizeSelect = el("select", {}, WINDOW_SIZES.filter((w) => w < total).concat([total]).map((w) =>
-      Object.assign(el("option", { value: w }, [w === total ? `all ${total}` : String(w)]), {
-        selected: w === windowSize,
-      }),
-    ));
-    sizeSelect.onchange = () => {
-      windowSize = Number(sizeSelect.value);
-      load();
-    };
-    const startInput = el("input", { type: "number", value: start, min: 0, max: total - 1 });
-    startInput.onchange = () => {
-      start = Math.max(0, Math.min(Number(startInput.value), total - 1));
-      load();
-    };
-    controls.replaceChildren(
-      el("button", { onclick: () => ((start = Math.max(0, start - windowSize)), load()) }, ["◀"]),
-      el("span", {}, [`tokens ${payload.start}–${payload.end} of ${total} (prompt ${payload.prompt_len})`]),
-      el("button", { onclick: () => ((start = Math.min(total - 1, start + windowSize)), load()) }, ["▶"]),
-      el("span", { class: "muted" }, [" window"]),
-      sizeSelect,
-      el("span", { class: "muted" }, [" start"]),
-      startInput,
-      el("span", { class: "muted" }, [" color by"]),
-      statSelect,
-    );
+    span.onmouseleave = hideTooltip;
+    return span;
+  });
+  const box = el("div", { class: "tokens" }, spans);
 
-    // ---- token strip ----
+  // the color scale spans the whole response, so a given value keeps one color
+  // no matter where in the sequence it sits
+  function paintStrip() {
     const values = payload[stat] ?? [];
     const color = values.length ? colorFor(stat, values) : () => "transparent";
-    const spans = payload.token_ids.map((tokenId, i) => {
-      const respPos = i - payload.response_offset; // index into stat arrays
-      const inResponse = respPos >= 0 && respPos < (payload.train_log_probs ?? payload.rollout_log_probs ?? []).length;
-      const text = payload.token_text ? payload.token_text[i] : `·${tokenId}`;
-      const masked = inResponse && payload.loss_mask !== null && payload.loss_mask[respPos] === 0;
-      const value = inResponse && values.length ? values[respPos] : null;
-      const span = el("span", { class: `tok ${inResponse ? "" : "prompt"} ${masked ? "masked" : ""}` }, [
-        text.replaceAll("\n", "⏎\n"),
-      ]);
-      if (value !== null && value !== undefined && !masked) span.style.background = color(value);
-      span.onmousemove = (ev) => {
-        const lines = [`#${payload.start + i} id=${tokenId} ${JSON.stringify(text)}`];
-        if (!inResponse) lines.push("(prompt)");
-        else {
-          for (const s of available) lines.push(`${s} = ${fmtNum(payload[s][respPos])}`);
-          if (masked) lines.push("loss_mask = 0");
-        }
-        showTooltip(ev.clientX, ev.clientY, lines.join("\n"));
-      };
-      span.onmouseleave = hideTooltip;
-      return span;
+    spans.forEach((span, i) => {
+      const respPos = i - payload.response_offset;
+      const value = respPos >= 0 && respPos < values.length ? values[respPos] : null;
+      const tinted = value !== null && value !== undefined && !isMasked(respPos);
+      span.style.background = tinted ? color(value) : "";
     });
-    strip.replaceChildren(
-      el("h3", {}, [`Tokens — colored by ${stat}${payload.token_text ? "" : " (no tokenizer: ids shown)"}`]),
-      el("div", { class: "tokens" }, spans),
-    );
-
+    heading.textContent = `Tokens — colored by ${stat}${payload.token_text ? "" : " (no tokenizer: ids shown)"}`;
   }
 
+  const statSelect = el("select", {}, available.map((s) =>
+    Object.assign(el("option", { value: s }, [s]), { selected: s === stat }),
+  ));
+  statSelect.onchange = () => {
+    stat = statSelect.value;
+    paintStrip();
+  };
+  controls.replaceChildren(
+    el("span", {}, [`${payload.total_len} tokens (prompt ${payload.prompt_len})`]),
+    el("span", { class: "muted" }, [" color by"]),
+    statSelect,
+  );
+  strip.replaceChildren(heading, box);
+  paintStrip();
+
   root.replaceChildren(controls, strip, chartPanel);
-  await Promise.all([load(), loadChart()]);
+  renderChart();
+  // open on the first generated token: an agentic prompt runs to thousands of
+  // tokens of chat history, and none of the per-token metrics are defined over it
+  const firstResponse = spans[payload.response_offset];
+  if (firstResponse) box.scrollTop = firstResponse.offsetTop;
 }


### PR DESCRIPTION
## Summary

The token strip in the sample view showed a 1024-token window at a time. Reading a long response meant clicking `◀` / `▶` through it page by page, and the `window` / `start` inputs were the only way to reach a position in the middle. The strip now renders the whole sequence into a scroll box, so it is one continuous scroll and the scrollbar reaches any position directly.

| before | after |
| --- | --- |
| <a href="https://raw.githubusercontent.com/radixark/miles/f99090f48b337ec2b085a895fa6fce456de39635/token-scroll/before.png"><img src="https://raw.githubusercontent.com/radixark/miles/f99090f48b337ec2b085a895fa6fce456de39635/token-scroll/before.png" width="420"></a> | <a href="https://raw.githubusercontent.com/radixark/miles/f99090f48b337ec2b085a895fa6fce456de39635/token-scroll/after.png"><img src="https://raw.githubusercontent.com/radixark/miles/f99090f48b337ec2b085a895fa6fce456de39635/token-scroll/after.png" width="420"></a> |

Same 25,257-token sample. On the left, `tokens 0–1024 of 25257` with the paging widgets; reaching the end takes 24 clicks. On the right the paging widgets are gone, and the strip is scrolled deep into the sequence.

## Why rendering everything is free

The metric chart under the strip already fetched the full range (`start=0, end=total`). The windowed strip request was therefore asking the server for a slice of bytes it was already sending. Measured on a 64,006-token sample:

| | cost |
| --- | --- |
| full-range `/tokens` fetch | ~920 ms — already paid today, by the chart |
| DOM build, all 64,006 spans | 66 ms |
| heap for the built strip | ~29 MB |

So the windowing was never buying render time; the strip was cheap all along. Folding the strip onto the chart's payload takes the pane from three `/tokens` calls (probe + window + full range) down to one, and the whole pane now renders 1.9 s after the tab is clicked on that 64k sample.

I also measured a delegated single-container `mousemove` against the current per-span handlers: 60 ms vs 66 ms at 64k spans. That is not worth the regression risk, so the tooltip code is untouched.

## What changed

- `style.css` — `.tokens` becomes `max-height: 480px; overflow-y: auto`, matching the `.tablewrap` scroll box the tables already use. `position: relative` makes the box the offsetParent of its tokens, so a token's `offsetTop` is directly the scroll offset that brings it to the top.
- `views_tokens.js` — one full-range read replaces the probe and the windowed read; `◀` / `▶` / `window` / `start` are deleted, leaving `N tokens (prompt P)` and `color by`.

Two things follow from having the whole sequence in hand, and both are improvements the paging design could not offer:

- **The color scale is computed once over the full response** instead of per window. Previously the scale was rebuilt from whatever slice was on screen, so the same value drew a different color depending on which page you were on.
- **Spans are built once and only recolored** when `color by` changes, so switching the metric no longer discards where you had scrolled to.

The box opens at the first generated token. An agentic prompt runs to thousands of tokens of chat history, none of it carrying a per-token metric, and landing at position 0 would put the reader that far from anything worth reading. The prompt is one scroll up.

## Verification

No JS test harness exists in the repo (no `package.json`; the Python tests under `tests/fast/dashboard/` never load the static files), so this was verified by driving real Chrome via Playwright against dumps built by `tests/fast/dashboard/dummy_dump.py` through the real dump pipeline.

Behavior, on a 64,006-token sample:

| check | result |
| --- | --- |
| `/tokens` requests for the pane | **1** (was 3) |
| spans rendered | 64,006 — the whole sequence |
| box geometry | `clientHeight` 480, `scrollHeight` 29,378, `overflow-y: auto` |
| scrolling the box | box moves, `window.scrollY` unchanged |
| tooltip after scrolling | shows all 9 stats for the hovered token |
| `color by` switch | recolors, `scrollTop` 315 → 315, span count unchanged |
| chart below the box | still drawn and reachable |
| page errors | none |

Cases, each opened in a fresh browser context:

| case | result |
| --- | --- |
| 5,000-token prompt + 800-token response | opens at `scrollTop` 2186 (clamped from the response start at 2299 — the response is on screen), paging buttons `[]`, number inputs `0` |
| eval view (`?eval=1`) | only `rollout_log_probs` offered, 800 tinted, no masked spans — no train-side columns exist |
| sample with no conversation sidecar | tokens-only layout, strip scrolls the same |
| removed sample (all-zero loss mask) | 10 masked spans, **0 tinted** — masked positions stay dim and uncolored |
| 10-token sample | `scrollHeight == clientHeight`, no scrollbar — short samples look exactly as before |

The masked case is the one that matters for review: this PR replaces the inline mask check with an `isMasked` helper called from both the build and the repaint, and that case confirms both callers agree.

## Test plan

`pre-commit` covers Python only and no Python file is touched. The dashboard's Python tests are unaffected — this is static frontend only, and no API, schema, or reader behavior changes.
