### PR TITLE
fix(loss): exclude masked samples from token normalizer

### DIFF
--- a/miles/backends/training_utils/loss.py
+++ b/miles/backends/training_utils/loss.py
@@ -157,7 +157,10 @@ def loss_function(
           "values" (1D tensor: [count, metric1, metric2, ...]).
     """
     parallel_state = get_parallel_state()
-    num_tokens = sum([torch.clamp_min(loss_mask.sum(), 1) for loss_mask in batch["loss_masks"]])
+    # Fully masked samples must contribute neither numerator nor denominator.
+    # Clamping each sample to one silently shrinks per-token gradients as the
+    # masked-sample fraction grows.
+    num_tokens = sum(loss_mask.sum() for loss_mask in batch["loss_masks"])
     num_samples = len(batch["response_lengths"])
 
     sum_of_sample_mean = get_sum_of_sample_mean(

--- a/tests/fast/backends/training_utils/loss/test_training_logprob_reuse.py
+++ b/tests/fast/backends/training_utils/loss/test_training_logprob_reuse.py
@@ -289,6 +289,52 @@ def test_loss_dispatcher_uses_args_without_extra_policy_kwargs(monkeypatch, skip
     assert policy_loss.call_args.kwargs == {}
 
 
+def test_loss_dispatcher_excludes_fully_masked_samples_from_token_normalizer(monkeypatch):
+    make_parallel_state()
+    args = make_args(
+        calculate_per_token_loss=True,
+        observe_training_entropy=False,
+        true_on_policy_mode=False,
+    )
+    inputs = make_inputs(
+        seed=20,
+        batch_size=2,
+        prompt_lens=[3, 3],
+        response_lens=[3, 4],
+        vocab_size=8,
+        args=args,
+    )
+    batch = make_batch(inputs, "policy_loss")
+    batch["loss_masks"][0].zero_()
+    logits = deep_clone(inputs["policy_logits"])
+    policy_loss = Mock(return_value=(logits.sum() * 0, {"loss": logits.new_zeros(())}))
+    monkeypatch.setattr(loss_module, "get_loss_function", lambda _args: policy_loss)
+
+    _, normalizer, _ = loss_module.loss_function(args, batch, 1, logits)
+
+    assert normalizer.item() == batch["loss_masks"][1].sum().item() == 4
+
+
+def test_loss_dispatcher_allows_zero_active_tokens(monkeypatch):
+    make_parallel_state()
+    args = make_args(
+        calculate_per_token_loss=True,
+        observe_training_entropy=False,
+        true_on_policy_mode=False,
+    )
+    inputs = make_inputs(seed=21, batch_size=1, prompt_lens=[3], response_lens=[3], vocab_size=8, args=args)
+    batch = make_batch(inputs, "policy_loss")
+    batch["loss_masks"][0].zero_()
+    logits = deep_clone(inputs["policy_logits"])
+    policy_loss = Mock(return_value=(logits.sum() * 0, {"loss": logits.new_zeros(())}))
+    monkeypatch.setattr(loss_module, "get_loss_function", lambda _args: policy_loss)
+
+    loss, normalizer, _ = loss_module.loss_function(args, batch, 1, logits)
+
+    assert loss.item() == 0
+    assert normalizer.item() == 0
+
+
 def test_loss_dispatcher_does_not_apply_actor_skip_to_value_loss(monkeypatch):
     make_parallel_state()
     args = make_args(loss_type="value_loss", skip_actor_forward_only=True)


### PR DESCRIPTION
## Summary

- compute the per-token loss normalizer from active tokens only
- stop assigning one denominator token to every fully masked sample
- add regressions for mixed valid/masked batches and all-masked batches

## Why this is needed

The numerator already excludes fully masked samples, but the previous denominator used `clamp_min(1)` independently for every sample. A batch with one valid four-token response and one fully masked response was therefore normalized by 5 instead of 4, shrinking gradients by 20%.

More generally, with `T` active tokens and `M` fully masked samples, the old gradient scale was `T / (T + M)` relative to the intended per-token normalization. This makes optimization depend on how many skipped/padded samples happen to share the batch.

Returning zero for an all-masked local batch is safe: Megatron globally reduces the token count and clamps the final divisor to at least one.

## Validation

- focused masked-token regression tests — 2 passed
- Miles pre-commit hooks on the changed files — passed
- `git diff --check` — passed