### PR TITLE
fix(lora): exclude adapters when loading base checkpoint

### DIFF
--- a/miles/backends/megatron_utils/checkpoint.py
+++ b/miles/backends/megatron_utils/checkpoint.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import re
+from contextlib import contextmanager, nullcontext
 from pathlib import Path
 
 import torch.distributed as dist
@@ -97,6 +98,34 @@ logger = logging.getLogger(__name__)
 __all__ = ["save_checkpoint", "save_checkpoint_with_lora", "load_checkpoint"]
 
 
+@contextmanager
+def _hide_bridge_lora_adapters_from_dist_checkpoint():
+    """Expose only wrapped base modules to Megatron distributed checkpointing.
+
+    Megatron-Bridge applies LoRA before Miles loads the base checkpoint. Its
+    ``AdapterWrapper.sharded_state_dict`` normally includes the newly-created
+    adapter tensors, but a base-only checkpoint cannot contain those tensors.
+    This is especially invalid when loading with a different EP topology: the
+    fresh expert adapters look like checkpoint shards and fail integrity
+    validation before any base weight can be restored.
+
+    Temporarily delegating to ``to_wrap`` preserves the original checkpoint
+    keys and leaves the initialized adapter parameters attached to the model.
+    """
+    from megatron.bridge.peft.adapter_wrapper import AdapterWrapper
+
+    original = AdapterWrapper.sharded_state_dict
+
+    def base_sharded_state_dict(self, prefix="", sharded_offsets=(), metadata=None):
+        return self.to_wrap.sharded_state_dict(prefix, sharded_offsets, metadata)
+
+    AdapterWrapper.sharded_state_dict = base_sharded_state_dict
+    try:
+        yield
+    finally:
+        AdapterWrapper.sharded_state_dict = original
+
+
 def load_checkpoint(ddp_model, optimizer, opt_param_scheduler, checkpointing_context, skip_load_to_model_and_opt):
     # ref: how megatron `load_checkpoint` gets directory
     args = get_args()
@@ -112,13 +141,15 @@ def load_checkpoint(ddp_model, optimizer, opt_param_scheduler, checkpointing_con
         ), f"{args.load=} does not exist or is an empty directory. Did you specify the wrong folder?"
 
     if has_local_checkpoint_manager or _is_megatron_checkpoint(load_path):
-        result = _load_checkpoint_megatron(
-            ddp_model=ddp_model,
-            optimizer=optimizer,
-            opt_param_scheduler=opt_param_scheduler,
-            checkpointing_context=checkpointing_context,
-            skip_load_to_model_and_opt=skip_load_to_model_and_opt,
-        )
+        load_context = _hide_bridge_lora_adapters_from_dist_checkpoint() if is_lora_model(ddp_model) else nullcontext()
+        with load_context:
+            result = _load_checkpoint_megatron(
+                ddp_model=ddp_model,
+                optimizer=optimizer,
+                opt_param_scheduler=opt_param_scheduler,
+                checkpointing_context=checkpointing_context,
+                skip_load_to_model_and_opt=skip_load_to_model_and_opt,
+            )
     else:
         result = _load_checkpoint_hf(
             ddp_model=ddp_model,

--- a/tests/fast/backends/megatron_utils/test_lora_checkpoint_helpers.py
+++ b/tests/fast/backends/megatron_utils/test_lora_checkpoint_helpers.py
@@ -6,11 +6,17 @@ GPU / distributed requirements.
 """
 
 from argparse import Namespace
+from types import ModuleType
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-from miles.backends.megatron_utils.checkpoint import _is_megatron_checkpoint, save_checkpoint_with_lora
+from miles.backends.megatron_utils.checkpoint import (
+    _hide_bridge_lora_adapters_from_dist_checkpoint,
+    _is_megatron_checkpoint,
+    load_checkpoint,
+    save_checkpoint_with_lora,
+)
 
 # ---------------------------------------------------------------------------
 # _is_megatron_checkpoint
@@ -92,3 +98,66 @@ class TestSaveCheckpointWithLoRA:
         save_checkpoint_with_lora(42, model, MagicMock(), MagicMock())
 
         mock_save_ckpt.assert_called_once()
+
+
+class TestLoadBaseCheckpointWithLoRA:
+    @staticmethod
+    def _adapter_module():
+        module = ModuleType("megatron.bridge.peft.adapter_wrapper")
+
+        class AdapterWrapper:
+            def sharded_state_dict(self, prefix="", sharded_offsets=(), metadata=None):
+                return {"adapter": prefix}
+
+        module.AdapterWrapper = AdapterWrapper
+        return module, AdapterWrapper
+
+    def test_adapter_wrapper_exposes_base_state_and_restores_method(self):
+        module, adapter_wrapper = self._adapter_module()
+        original = adapter_wrapper.sharded_state_dict
+        wrapper = adapter_wrapper()
+        wrapper.to_wrap = MagicMock()
+        wrapper.to_wrap.sharded_state_dict.return_value = {"base": "state"}
+
+        with patch.dict("sys.modules", {module.__name__: module}):
+            with _hide_bridge_lora_adapters_from_dist_checkpoint():
+                result = wrapper.sharded_state_dict("model.", ((0, 1, 2),), {"key": "value"})
+
+        assert result == {"base": "state"}
+        wrapper.to_wrap.sharded_state_dict.assert_called_once_with("model.", ((0, 1, 2),), {"key": "value"})
+        assert adapter_wrapper.sharded_state_dict is original
+
+    def test_adapter_wrapper_method_is_restored_after_error(self):
+        module, adapter_wrapper = self._adapter_module()
+        original = adapter_wrapper.sharded_state_dict
+
+        with patch.dict("sys.modules", {module.__name__: module}):
+            with pytest.raises(RuntimeError, match="checkpoint load failed"):
+                with _hide_bridge_lora_adapters_from_dist_checkpoint():
+                    raise RuntimeError("checkpoint load failed")
+
+        assert adapter_wrapper.sharded_state_dict is original
+
+    @pytest.mark.parametrize("is_lora", [True, False])
+    def test_megatron_load_hides_adapters_only_for_lora(self, tmp_path, is_lora):
+        (tmp_path / "latest_checkpointed_iteration.txt").write_text("1")
+        args = Namespace(load=str(tmp_path))
+        load_context = MagicMock()
+
+        with (
+            patch("miles.backends.megatron_utils.checkpoint.get_args", return_value=args),
+            patch("miles.backends.megatron_utils.checkpoint.is_lora_model", return_value=is_lora),
+            patch("miles.backends.megatron_utils.checkpoint.is_lora_enabled", return_value=False),
+            patch(
+                "miles.backends.megatron_utils.checkpoint._hide_bridge_lora_adapters_from_dist_checkpoint",
+                return_value=load_context,
+            ) as hide_adapters,
+            patch(
+                "miles.backends.megatron_utils.checkpoint._load_checkpoint_megatron", return_value=(1, 0)
+            ) as load_megatron,
+        ):
+            result = load_checkpoint(None, None, None, None, False)
+
+        assert result == (1, 0)
+        assert hide_adapters.call_count == int(is_lora)
+        load_megatron.assert_called_once()


### PR DESCRIPTION
## Summary

- hide freshly initialized Megatron-Bridge LoRA adapter tensors while loading a base-only distributed checkpoint
- delegate `AdapterWrapper.sharded_state_dict` to the wrapped base module only for the Megatron checkpoint load
- restore the original method on both success and failure
- add tests for state delegation, exception cleanup, and LoRA/non-LoRA load routing

## Why this is needed

Megatron-Bridge applies LoRA before Miles loads the base checkpoint. At that point, `AdapterWrapper.sharded_state_dict` includes fresh adapter tensors, but a base-only checkpoint has no matching adapter tensors.

Megatron distributed checkpointing treats those fresh tensors as checkpoint shards and can fail integrity validation before restoring any base weights. The failure is particularly visible when the checkpoint and training run use different expert-parallel topologies.

The temporary context keeps the original base checkpoint keyspace during the base load. The initialized adapters remain attached to the model, and a configured adapter checkpoint is still loaded afterward through the existing path.

## Validation

- checkpoint helper suite — 17 passed on CPU with Megatron imports stubbed
- Miles pre-commit hooks on the changed files — passed
- `git diff --check` — passed

Upstream CI should additionally exercise the test with the full Megatron/Triton environment.