### PR TITLE
fix(replay): align BSHD data with Megatron token order

### DIFF
--- a/miles/backends/training_utils/replay_data.py
+++ b/miles/backends/training_utils/replay_data.py
@@ -27,6 +27,27 @@ def register_replay_list_sequential(replay_list, replay_data, **_kwargs):
         replay.record(replay_data[:, stream_idx])
 
 
+def _bshd_replay_to_megatron_order(
+    replay_data: torch.Tensor,
+    *,
+    sequence_parallel: bool,
+    tp_rank: int,
+    tp_size: int,
+) -> torch.Tensor:
+    """Convert rollout ``[B, S, ...]`` replay to Megatron ``[S, B, ...]`` order."""
+
+    assert replay_data.ndim == 4, replay_data.shape
+    replay_data = replay_data.transpose(0, 1).contiguous()
+    if sequence_parallel:
+        seqlen = replay_data.size(0)
+        assert seqlen % tp_size == 0
+        start = seqlen // tp_size * tp_rank
+        end = seqlen // tp_size * (tp_rank + 1)
+        replay_data = replay_data[start:end]
+    seqlen, batch_size, num_streams, topk = replay_data.shape
+    return replay_data.reshape(seqlen * batch_size, num_streams, topk)
+
+
 def fill_replay_data(
     *,
     args,
@@ -94,9 +115,12 @@ def fill_replay_data(
                 replay_data = [pad_func(r, max_seqlen - r.size(0))[start : start + local_len] for r in replay_data]
             else:
                 replay_data = [slice_with_cp(r, pad_func, qkv_format, max_seqlen) for r in replay_data]
-            replay_data = torch.stack(replay_data, dim=0)
-            batch_size, seqlen, num_layers, topk = replay_data.shape
-            replay_data = replay_data.reshape(batch_size * seqlen, num_layers, topk)
+            replay_data = _bshd_replay_to_megatron_order(
+                torch.stack(replay_data, dim=0),
+                sequence_parallel=getattr(args, "sequence_parallel", False) and if_sp_region,
+                tp_rank=tp_rank,
+                tp_size=tp_size,
+            )
         else:
             pad_size = parallel_state.tp.size * args.data_pad_size_multiplier
             if args.allgather_cp and cp_size > 1:
@@ -119,8 +143,9 @@ def fill_replay_data(
                 if pad != 0:
                     replay_data = pad_func(replay_data, pad)
 
-        # sequence_parallel is Megatron-only; FSDP has tp_size == 1 so the slice is a no-op there.
-        if getattr(args, "sequence_parallel", False) and if_sp_region:
+        # BSHD is already sequence-major and SP-sharded above. THD is token-major,
+        # so its existing flat SP slice remains correct.
+        if qkv_format != "bshd" and getattr(args, "sequence_parallel", False) and if_sp_region:
             seqlen = replay_data.size(0)
             assert seqlen % tp_size == 0
             start, end = seqlen // tp_size * tp_rank, seqlen // tp_size * (tp_rank + 1)

--- a/tests/fast/backends/training_utils/test_replay_data.py
+++ b/tests/fast/backends/training_utils/test_replay_data.py
@@ -5,7 +5,7 @@ register_cpu_ci(est_time=60, suite="stage-a-cpu", labels=[])
 import pytest
 import torch
 
-from miles.backends.training_utils.replay_data import register_replay_list_sequential
+from miles.backends.training_utils.replay_data import _bshd_replay_to_megatron_order, register_replay_list_sequential
 
 
 class _Replay:
@@ -45,3 +45,36 @@ def test_register_replay_list_sequential_rejects_out_of_range_stream_idx():
 
     with pytest.raises(AssertionError, match="out of range"):
         register_replay_list_sequential(replays, replay_data)
+
+
+def test_bshd_replay_uses_megatron_sequence_major_order():
+    replay_data = torch.arange(2 * 4).reshape(2, 4, 1, 1)
+
+    actual = _bshd_replay_to_megatron_order(
+        replay_data,
+        sequence_parallel=False,
+        tp_rank=0,
+        tp_size=2,
+    )
+
+    assert actual[:, 0, 0].tolist() == [0, 4, 1, 5, 2, 6, 3, 7]
+
+
+@pytest.mark.parametrize(
+    ("tp_rank", "expected"),
+    [
+        (0, [0, 4, 1, 5]),
+        (1, [2, 6, 3, 7]),
+    ],
+)
+def test_bshd_replay_sequence_parallel_slices_sequence_dimension(tp_rank, expected):
+    replay_data = torch.arange(2 * 4).reshape(2, 4, 1, 1)
+
+    actual = _bshd_replay_to_megatron_order(
+        replay_data,
+        sequence_parallel=True,
+        tp_rank=tp_rank,
+        tp_size=2,
+    )
+
+    assert actual[:, 0, 0].tolist() == expected


### PR DESCRIPTION
## Summary

- convert BSHD replay tensors from rollout `[B, S, ...]` order to Megatron `[S, B, ...]` order before flattening
- apply sequence-parallel sharding on the sequence dimension, before flattening sequence and batch
- add CPU regression coverage for multi-sample and TP=2 layouts

## Why this is needed

For `B=2, S=4`, a replay tensor containing:

```text
sample 0: 0 1 2 3
sample 1: 4 5 6 7
```

was flattened directly as `[0, 1, 2, 3, 4, 5, 6, 7]`. Megatron's BSHD hidden states are flattened from `[S, B, ...]`, so the corresponding route order is `[0, 4, 1, 5, 2, 6, 3, 7]`. With multiple samples, the old order can therefore replay a token's routing decision onto a different token.

For sequence parallelism with TP=2, slicing the already-flattened tensor also selected all of sample 0 on rank 0. The correct rank-local layouts are `[0, 4, 1, 5]` and `[2, 6, 3, 7]`.

## Validation

- `pytest tests/fast/backends/training_utils/test_replay_data.py -q` — 6 passed
- Miles pre-commit hooks on the changed files — passed
- `git diff --check` — passed

## Related work

#2698 changes per-sample BSHD padding in the same path. This PR is independent: it fixes token ordering after padding/CP slicing and adds focused ordering tests.