### PR TITLE
Add Qwen3.8-Flash-Next vision RL support

### DIFF
--- a/miles_plugins/mbridge/qwen3_8_next.py
+++ b/miles_plugins/mbridge/qwen3_8_next.py
@@ -144,59 +144,6 @@ class Qwen38NextBridge(Qwen3_5Bridge):
         # tensors along with it.
     }
 
-    # Vision tower. A standard ViT, so this is a plain name translation rather than
-    # anything structural: Megatron prefixes its vision params ``vision_model.``
-    # where HF uses ``model.visual.`` (megatron-bridge documents the same pair for
-    # Qwen3-VL). Declared here in mbridge because mbridge is the conversion path --
-    # tools/convert_hf_to_torch_dist.py goes through mbridge.AutoBridge -- so this is
-    # where the mapping has to live regardless of what the training-time model
-    # provider uses.
-    #
-    # A text-only RL run never instantiates the tower, and mbridge only resolves
-    # names for parameters the model actually creates, so declaring these costs
-    # nothing when they are unused; leaving them undeclared, on the other hand,
-    # means 333 checkpoint tensors silently absent from the converted checkpoint.
-    _VISION_DIRECT_MAPPING = {
-        "vision_model.patch_embed.proj.weight": "model.visual.patch_embed.proj.weight",
-        "vision_model.patch_embed.proj.bias": "model.visual.patch_embed.proj.bias",
-        "vision_model.pos_embed.weight": "model.visual.pos_embed.weight",
-        "vision_model.merger.linear_fc1.weight": "model.visual.merger.linear_fc1.weight",
-        "vision_model.merger.linear_fc1.bias": "model.visual.merger.linear_fc1.bias",
-        "vision_model.merger.linear_fc2.weight": "model.visual.merger.linear_fc2.weight",
-        "vision_model.merger.linear_fc2.bias": "model.visual.merger.linear_fc2.bias",
-        "vision_model.merger.norm.weight": "model.visual.merger.norm.weight",
-        "vision_model.merger.norm.bias": "model.visual.merger.norm.bias",
-    }
-
-    _VISION_LAYER_MAPPING = {
-        "attn.qkv.weight": ["model.visual.blocks.{layer_number}.attn.qkv.weight"],
-        "attn.qkv.bias": ["model.visual.blocks.{layer_number}.attn.qkv.bias"],
-        "attn.proj.weight": ["model.visual.blocks.{layer_number}.attn.proj.weight"],
-        "attn.proj.bias": ["model.visual.blocks.{layer_number}.attn.proj.bias"],
-        "mlp.linear_fc1.weight": ["model.visual.blocks.{layer_number}.mlp.linear_fc1.weight"],
-        "mlp.linear_fc1.bias": ["model.visual.blocks.{layer_number}.mlp.linear_fc1.bias"],
-        "mlp.linear_fc2.weight": ["model.visual.blocks.{layer_number}.mlp.linear_fc2.weight"],
-        "mlp.linear_fc2.bias": ["model.visual.blocks.{layer_number}.mlp.linear_fc2.bias"],
-        "norm1.weight": ["model.visual.blocks.{layer_number}.norm1.weight"],
-        "norm1.bias": ["model.visual.blocks.{layer_number}.norm1.bias"],
-        "norm2.weight": ["model.visual.blocks.{layer_number}.norm2.weight"],
-        "norm2.bias": ["model.visual.blocks.{layer_number}.norm2.bias"],
-    }
-
-    def _weight_name_mapping_vision(self, mcore_weights_name: str) -> list[str]:
-        """``vision_model.*`` -> ``model.visual.*``."""
-        if mcore_weights_name in self._VISION_DIRECT_MAPPING:
-            return [self._VISION_DIRECT_MAPPING[mcore_weights_name]]
-
-        prefix = "vision_model.blocks."
-        if mcore_weights_name.startswith(prefix):
-            rest = mcore_weights_name[len(prefix) :]
-            layer_number, _, tail = rest.partition(".")
-            if tail in self._VISION_LAYER_MAPPING:
-                return [t.format(layer_number=int(layer_number)) for t in self._VISION_LAYER_MAPPING[tail]]
-
-        raise NotImplementedError(f"Unsupported vision parameter name: {mcore_weights_name}")
-
     def _ple_layer_ids(self) -> list[int]:
         """0-based decoder layer indices carrying PLE.
 
@@ -253,8 +200,6 @@ class Qwen38NextBridge(Qwen3_5Bridge):
         raise NotImplementedError(f"Unsupported parameter name: {mcore_weights_name}")
 
     def _weight_name_mapping_mcore_to_hf(self, mcore_weights_name: str) -> list[str]:
-        if mcore_weights_name.startswith("vision_model."):
-            return self._weight_name_mapping_vision(mcore_weights_name)
         try:
             return super()._weight_name_mapping_mcore_to_hf(mcore_weights_name)
         except NotImplementedError:

--- a/miles_plugins/models/qwen3_8_next/model_provider.py
+++ b/miles_plugins/models/qwen3_8_next/model_provider.py
@@ -2,6 +2,7 @@
 n-gram side channel (input token ids never reach a transformer layer).
 """
 
+import copy
 import logging
 
 from megatron.core.models.gpt import GPTModel
@@ -54,14 +55,24 @@ def get_qwen3_8_next_model_provider(pre_process: bool = True, post_process: bool
 
     from miles.backends.megatron_utils.model_provider import get_model_provider_func
 
-    args = get_args()
-    saved = args.custom_model_provider_path
+    args = copy.copy(get_args())
     args.custom_model_provider_path = None
-    try:
-        base_provider = get_model_provider_func(args)
-    finally:
-        args.custom_model_provider_path = saved
+    base_provider = get_model_provider_func(args)
 
     model = base_provider(pre_process=pre_process, post_process=post_process, vp_stage=vp_stage)
     _install_ple_context_hooks(model)
+    return model
+
+
+def get_qwen3_8_next_vlm_model_provider(pre_process: bool = True, post_process: bool = True, vp_stage=None):
+    from megatron.training import get_args
+
+    from miles_plugins.models.qwen3_8_next.vision import wire_qwen3_8_next_visual
+
+    model = get_qwen3_8_next_model_provider(
+        pre_process=pre_process,
+        post_process=post_process,
+        vp_stage=vp_stage,
+    )
+    wire_qwen3_8_next_visual(model, get_args().hf_checkpoint)
     return model

--- a/miles_plugins/models/qwen3_8_next/ops/attention.py
+++ b/miles_plugins/models/qwen3_8_next/ops/attention.py
@@ -13,9 +13,7 @@ from megatron.core.transformer.attention import SelfAttention
 from megatron.core.transformer.module import MegatronModule
 from torch import Tensor
 
-from miles_plugins.models.qwen3_8_next.ops.kernel.qsa_block_sparse_attn import (
-    qsa_block_sparse_attention_triton,
-)
+from miles_plugins.models.qwen3_8_next.ops.kernel.qsa_block_sparse_attn import qsa_block_sparse_attention_triton
 from miles_plugins.models.qwen3_8_next.ops.kernel.qsa_sparse_attn import qsa_sparse_attention_triton
 from miles_plugins.models.qwen3_8_next.ops.qsa_indexer import PackedBlockLayout, Qwen38NextQSAIndexer
 

--- a/miles_plugins/models/qwen3_8_next/ops/attention.py
+++ b/miles_plugins/models/qwen3_8_next/ops/attention.py
@@ -108,7 +108,14 @@ class Qwen38NextAttention(SelfAttention):
             self._qsa_cu_seqlens = None
             positions = torch.arange(seq, device=hidden_states.device)
         with torch.no_grad():
-            selection = self.indexer(indexer_states[:, 0], positions, cu_seqlens=self._qsa_cu_seqlens)
+            use_mrope = getattr(self.config, "position_embedding_type", None) == "mrope"
+            rotary_pos_emb = kwargs.get("rotary_pos_emb") if use_mrope else None
+            selection = self.indexer(
+                indexer_states[:, 0],
+                positions,
+                cu_seqlens=self._qsa_cu_seqlens,
+                rotary_pos_emb=rotary_pos_emb,
+            )
             seq_start = torch.arange(seq, device=positions.device) - positions
             r = self.compress_ratio
             tail_in_seq = (positions + 1) // r * r

--- a/miles_plugins/models/qwen3_8_next/ops/qsa_indexer.py
+++ b/miles_plugins/models/qwen3_8_next/ops/qsa_indexer.py
@@ -3,22 +3,22 @@
 Runs on the full-attention layers (12 of 48) and picks, per query token, which
 ``indexer_budget`` key tokens the sparse attention will actually look at.
 
-Reimplemented from sglang's ``QSAIndexer`` rather than imported -- miles takes no
+Reimplemented from sglang's ``QSAIndexer`` because Miles training does not depend
+on SGLang internals.
 """
 
 import math
 
 import torch
-
-
-def _indexer_acc_dtype(x):
-    return x.dtype if x.dtype in (torch.float32, torch.float64) else torch.float32
-
-
 from megatron.core.extensions.transformer_engine import TELinear
+from megatron.core.models.common.embeddings.rope_utils import apply_rotary_pos_emb
 from megatron.core.transformer.module import MegatronModule
 from megatron.core.transformer.transformer_config import TransformerConfig
 from torch import Tensor
+
+
+def _indexer_acc_dtype(x: Tensor) -> torch.dtype:
+    return x.dtype if x.dtype in (torch.float32, torch.float64) else torch.float32
 
 
 def gemma_rmsnorm_last_dim(x: Tensor, weight: Tensor, eps: float) -> Tensor:
@@ -83,6 +83,7 @@ class PackedBlockLayout:
         # per block
         self.block_seq = torch.repeat_interleave(torch.arange(blocks_per_seq.numel(), device=device), blocks_per_seq)
         self.block_local = torch.arange(self.num_blocks, device=device) - seq_block_start[self.block_seq]
+        self.block_token_start = seq_token_start[self.block_seq] + self.block_local * compress_ratio
 
 
 def compress_keys_by_mean_packed(token_k: Tensor, layout: PackedBlockLayout) -> Tensor:
@@ -112,7 +113,7 @@ def packed_block_causal_mask(query_positions: Tensor, layout: PackedBlockLayout,
 class Qwen38NextQSAIndexer(MegatronModule):
     """Selects the sparse-attention budget for one full-attention layer."""
 
-    def __init__(self, config: TransformerConfig, layer_number: int, rotary_emb=None):
+    def __init__(self, config: TransformerConfig, layer_number: int):
         super().__init__(config)
         self.layer_number = layer_number
         self.n_heads = config.qwen3_8_next_indexer_n_heads
@@ -122,8 +123,6 @@ class Qwen38NextQSAIndexer(MegatronModule):
         self.compress_ratio = config.qwen3_8_next_indexer_compress_ratio
         self.block_topk = self.token_topk // self.compress_ratio
         self.norm_eps = config.layernorm_epsilon
-        self.rotary_emb = rotary_emb
-
         self.index_qk_proj = TELinear(
             config.hidden_size,
             (self.n_heads + self.kv_heads) * self.head_dim,
@@ -140,7 +139,12 @@ class Qwen38NextQSAIndexer(MegatronModule):
         for p in (self.q_layernorm, self.k_layernorm):
             p.sequence_parallel = config.sequence_parallel
 
-    def project_qk(self, hidden_states: Tensor, positions: Tensor, layout: PackedBlockLayout | None = None):
+    def project_qk(
+        self,
+        hidden_states: Tensor,
+        rotary_pos_emb: Tensor | None = None,
+        layout: PackedBlockLayout | None = None,
+    ):
         """``[T, hidden] -> (q [T, n_heads, head_dim], block_k [B, head_dim])``."""
         qk, _ = self.index_qk_proj(hidden_states)
         split = self.n_heads * self.head_dim
@@ -157,24 +161,21 @@ class Qwen38NextQSAIndexer(MegatronModule):
             block_k = compress_keys_by_mean_packed(token_k, layout)
         block_k = gemma_rmsnorm_last_dim(block_k, self.k_layernorm, self.norm_eps)
 
-        if self.rotary_emb is not None:
+        if rotary_pos_emb is not None:
+            q = self._apply_rope(q, rotary_pos_emb[: q.shape[0]])
             if layout is None:
-                block_local = torch.arange(block_k.shape[0], device=positions.device)
+                block_freqs = rotary_pos_emb[:: self.compress_ratio][: block_k.shape[0]]
             else:
-                block_local = layout.block_local
-            block_positions = block_local * self.compress_ratio
-            q = self._apply_rope(positions, q)
-            block_k = self._apply_rope(block_positions, block_k.unsqueeze(1)).squeeze(1)
+                block_freqs = rotary_pos_emb[layout.block_token_start]
+            block_k = self._apply_rope(block_k.unsqueeze(1), block_freqs).squeeze(1)
         return q, block_k
 
-    def _apply_rope(self, positions: Tensor, x: Tensor) -> Tensor:
-        """Partial RoPE on the leading ``rotary_dim`` of each head."""
-        rotary_dim = getattr(self.rotary_emb, "rotary_dim", x.shape[-1])
-        if rotary_dim >= x.shape[-1]:
-            return self.rotary_emb(positions, x)
-        head = x[..., :rotary_dim]
-        rest = x[..., rotary_dim:]
-        return torch.cat([self.rotary_emb(positions, head), rest], dim=-1)
+    def _apply_rope(self, x: Tensor, rotary_pos_emb: Tensor) -> Tensor:
+        return apply_rotary_pos_emb(
+            x.unsqueeze(1),
+            rotary_pos_emb,
+            config=self.config,
+        ).squeeze(1)
 
     def score_blocks(
         self,
@@ -192,7 +193,13 @@ class Qwen38NextQSAIndexer(MegatronModule):
             valid = packed_block_causal_mask(query_positions, layout, self.compress_ratio)
         return logits.masked_fill(~valid, float("-inf"))
 
-    def forward(self, hidden_states: Tensor, positions: Tensor, cu_seqlens: Tensor | None = None) -> Tensor:
+    def forward(
+        self,
+        hidden_states: Tensor,
+        positions: Tensor,
+        cu_seqlens: Tensor | None = None,
+        rotary_pos_emb: Tensor | None = None,
+    ) -> Tensor:
         """``[T, hidden] -> [T, token_topk]`` int32 token indices, ``-1`` where unused.
 
         ``positions`` restart at 0 per sequence; the returned indices are absolute in
@@ -205,7 +212,7 @@ class Qwen38NextQSAIndexer(MegatronModule):
         if cu_seqlens is not None and cu_seqlens.numel() > 2:
             layout = PackedBlockLayout(cu_seqlens, positions, self.compress_ratio)
 
-        q, block_k = self.project_qk(hidden_states, positions, layout=layout)
+        q, block_k = self.project_qk(hidden_states, rotary_pos_emb=rotary_pos_emb, layout=layout)
         logits = self.score_blocks(q, block_k, positions, layout=layout)
 
         k = min(self.block_topk, logits.shape[-1])

--- a/miles_plugins/models/qwen3_8_next/vision.py
+++ b/miles_plugins/models/qwen3_8_next/vision.py
@@ -1,0 +1,175 @@
+"""Frozen Qwen3.8-Flash-Next visual tower and VLM forward wiring."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import torch
+from safetensors import safe_open
+from transformers.models.qwen3_5_moe.modeling_qwen3_5_moe import Qwen3_5MoeVisionModel
+
+from miles.utils.hf_config import load_hf_config
+
+if TYPE_CHECKING:
+    from megatron.core.models.gpt import GPTModel
+
+_VISUAL_PREFIX = "model.visual."
+
+
+def _load_visual_state_dict(hf_checkpoint: str) -> dict[str, torch.Tensor]:
+    with open(f"{hf_checkpoint}/model.safetensors.index.json", encoding="utf-8") as index_file:
+        weight_map = json.load(index_file)["weight_map"]
+
+    weights_by_file: dict[str, list[str]] = {}
+    for name, filename in weight_map.items():
+        if name.startswith(_VISUAL_PREFIX):
+            weights_by_file.setdefault(filename, []).append(name)
+    if not weights_by_file:
+        raise RuntimeError(f"No {_VISUAL_PREFIX} weights found in {hf_checkpoint}")
+
+    state_dict = {}
+    for filename, names in weights_by_file.items():
+        with safe_open(f"{hf_checkpoint}/{filename}", framework="pt") as shard:
+            for name in names:
+                state_dict[name.removeprefix(_VISUAL_PREFIX)] = shard.get_tensor(name)
+    return state_dict
+
+
+def build_qwen3_8_next_visual(
+    hf_checkpoint: str,
+    *,
+    device: torch.device,
+    dtype: torch.dtype,
+) -> Qwen3_5MoeVisionModel:
+    """Construct and strictly load the checkpoint's frozen visual tower."""
+    hf_config = load_hf_config(hf_checkpoint)
+    vision_config = hf_config.vision_config
+    vision_config._attn_implementation = "sdpa"
+    visual = Qwen3_5MoeVisionModel(vision_config)
+
+    visual.load_state_dict(_load_visual_state_dict(hf_checkpoint), strict=True)
+    visual.to(device=device, dtype=dtype)
+    visual.requires_grad_(False)
+    visual.eval()
+    return visual
+
+
+def _scatter_visual_embeddings(
+    model: GPTModel,
+    decoder_input: torch.Tensor,
+    input_ids: torch.Tensor,
+    token_id: int,
+    embeddings: torch.Tensor,
+) -> torch.Tensor:
+    from megatron.core import parallel_state
+
+    positions = torch.nonzero(input_ids.reshape(-1) == token_id, as_tuple=False).flatten()
+    if positions.numel() != embeddings.shape[0]:
+        raise ValueError(
+            f"Qwen3.8-Flash-Next visual token/feature mismatch: {positions.numel()} token(s), "
+            f"{embeddings.shape[0]} feature row(s)"
+        )
+
+    embeddings = embeddings.to(device=decoder_input.device, dtype=decoder_input.dtype)
+    if model.config.sequence_parallel and parallel_state.get_tensor_model_parallel_world_size() > 1:
+        sequence_length = decoder_input.shape[0]
+        rank = parallel_state.get_tensor_model_parallel_rank()
+        local_positions = positions.to(decoder_input.device) - rank * sequence_length
+        selected = (local_positions >= 0) & (local_positions < sequence_length)
+        local_positions = local_positions[selected]
+        embeddings = embeddings[selected]
+    else:
+        local_positions = positions.to(decoder_input.device)
+
+    decoder_input = decoder_input.clone()
+    if local_positions.numel():
+        decoder_input[local_positions, 0] = embeddings
+    return decoder_input
+
+
+def _position_ids(
+    hf_config,
+    input_ids: torch.Tensor,
+    packed_seq_params,
+    image_grid_thw: torch.Tensor | None,
+) -> torch.Tensor:
+    from miles_plugins.models.qwen3_vl import get_qwen3_vl_position_ids
+
+    return get_qwen3_vl_position_ids(
+        input_ids,
+        packed_seq_params=packed_seq_params,
+        image_grid_thw=image_grid_thw,
+        video_grid_thw=None,
+        spatial_merge_size=hf_config.vision_config.spatial_merge_size,
+        image_token_id=hf_config.image_token_id,
+        video_token_id=hf_config.video_token_id,
+        vision_start_token_id=hf_config.vision_start_token_id,
+    )
+
+
+def _wire_mrope(model: GPTModel, hf_config) -> None:
+    from megatron.bridge.models.qwen_vl.modelling_qwen3_vl.rope import Qwen3VLMultimodalRotaryEmbedding
+
+    if model.config.context_parallel_size != 1:
+        raise NotImplementedError("Qwen3.8-Flash-Next VLM training currently requires context parallel size 1")
+
+    rope_parameters = hf_config.text_config.rope_parameters
+    mrope_section = list(rope_parameters["mrope_section"])
+    model.config.position_embedding_type = "mrope"
+    model.config.mrope_section = mrope_section
+    model.config.apply_rope_fusion = False
+    model.position_embedding_type = "mrope"
+    model.mrope_section = mrope_section
+    model.rotary_pos_emb = Qwen3VLMultimodalRotaryEmbedding(
+        kv_channels=model.config.kv_channels,
+        rotary_percent=model.rotary_percent,
+        rotary_interleaved=model.config.rotary_interleaved,
+        rotary_base=model.rotary_base,
+        cp_group=model.pg_collection.cp,
+    )
+
+
+def wire_qwen3_8_next_visual(model: GPTModel, hf_checkpoint: str) -> None:
+    """Attach image handling without registering frozen tower parameters."""
+    hf_config = load_hf_config(hf_checkpoint)
+    _wire_mrope(model, hf_config)
+    original_forward = model.forward
+
+    if model.pre_process:
+        device = torch.device("cuda", torch.cuda.current_device())
+        visual = build_qwen3_8_next_visual(hf_checkpoint, device=device, dtype=model.config.params_dtype)
+        model.__dict__["_qwen3_8_next_visual"] = visual
+
+    def _multimodal_forward(*args, pixel_values=None, image_grid_thw=None, **kwargs):
+        input_ids = kwargs.get("input_ids", args[0] if args else None)
+        if input_ids is None or input_ids.ndim != 2 or input_ids.shape[0] != 1:
+            raise ValueError("Qwen3.8-Flash-Next VLM training expects packed input_ids with shape [1, sequence]")
+        kwargs["position_ids"] = _position_ids(
+            hf_config,
+            input_ids,
+            kwargs.get("packed_seq_params"),
+            image_grid_thw,
+        )
+
+        if not model.pre_process or pixel_values is None:
+            return original_forward(*args, **kwargs)
+
+        if image_grid_thw is None:
+            raise ValueError("pixel_values requires image_grid_thw")
+        decoder_input = model.embedding(input_ids=input_ids, position_ids=kwargs["position_ids"])
+        with torch.no_grad():
+            image_embeddings = model.__dict__["_qwen3_8_next_visual"](
+                pixel_values.to(device=decoder_input.device, dtype=model.config.params_dtype),
+                grid_thw=image_grid_thw.to(device=decoder_input.device),
+            ).pooler_output
+        kwargs["decoder_input"] = _scatter_visual_embeddings(
+            model,
+            decoder_input,
+            input_ids,
+            hf_config.image_token_id,
+            image_embeddings,
+        )
+        return original_forward(*args, **kwargs)
+
+    model.forward = _multimodal_forward

--- a/miles_plugins/models/qwen3_vl.py
+++ b/miles_plugins/models/qwen3_vl.py
@@ -256,28 +256,88 @@ def _reassemble_full_row(gathered, cu, cp_size):
     return full
 
 
-def _segment_positions(model, flat, cu, cu_t, kwargs, orig_get_rope_index):
+def get_qwen3_vl_position_ids(
+    input_ids,
+    *,
+    packed_seq_params,
+    image_grid_thw,
+    video_grid_thw,
+    spatial_merge_size,
+    image_token_id,
+    video_token_id,
+    vision_start_token_id,
+):
+    """Build Qwen3-VL-style position IDs, restarting each packed THD segment."""
+    from megatron.bridge.models.qwen_vl.modelling_qwen3_vl.rope import get_rope_index
+
+    parsed = _parse_packed_thd(
+        (),
+        {
+            "input_ids": input_ids,
+            "packed_seq_params": packed_seq_params,
+        },
+    )
+    if parsed is None:
+        position_ids, _ = get_rope_index(
+            spatial_merge_size,
+            image_token_id,
+            video_token_id,
+            vision_start_token_id,
+            input_ids,
+            image_grid_thw=image_grid_thw,
+            video_grid_thw=video_grid_thw,
+        )
+        return position_ids
+
+    if parsed.cp_size != 1:
+        raise NotImplementedError("get_qwen3_vl_position_ids does not support context parallelism")
+    if parsed.cu[0] != 0 or parsed.cu[-1] != parsed.local_len:
+        raise ValueError("cu_seqlens_q must cover the packed Qwen3-VL input")
+
+    segments = _segment_positions(
+        parsed.flat,
+        parsed.cu,
+        parsed.cu_t,
+        image_grid_thw=image_grid_thw,
+        video_grid_thw=video_grid_thw,
+        spatial_merge_size=spatial_merge_size,
+        image_token_id=image_token_id,
+        video_token_id=video_token_id,
+        vision_start_token_id=vision_start_token_id,
+        get_rope_index=get_rope_index,
+    )
+    return torch.cat(segments, dim=2).contiguous()
+
+
+def _segment_positions(
+    flat,
+    cu,
+    cu_t,
+    *,
+    image_grid_thw,
+    video_grid_thw,
+    spatial_merge_size,
+    image_token_id,
+    video_token_id,
+    vision_start_token_id,
+    get_rope_index,
+):
     """Per-segment MRoPE positions for a full (unsharded) packed row `flat` with boundaries `cu`.
 
     Returns a list of [3, 1, seg_len] tensors (one per non-empty segment), text segments get
     a linear 0..L range, media segments call get_rope_index with the matching grid slice.
     """
-    image_grid_thw = kwargs.get("image_grid_thw")
-    video_grid_thw = kwargs.get("video_grid_thw")
-    merge = model.config.spatial_merge_size
-    img_id, vid_id, vstart = model.image_token_id, model.video_token_id, model.vision_start_token_id
-
     # Vectorized media count per segment (one GPU->host copy total, no per-segment .item()).
     num_segments = len(cu) - 1
     img_counts = [0] * num_segments
     vid_counts = [0] * num_segments
-    starts = torch.nonzero(flat == vstart, as_tuple=False).flatten()
+    starts = torch.nonzero(flat == vision_start_token_id, as_tuple=False).flatten()
     starts = starts[starts + 1 < flat.numel()]
     if starts.numel() > 0:
         toks = flat[starts + 1]
         seg_idx = torch.bucketize(starts, cu_t, right=True) - 1  # [start,end) -> segment index
-        img_counts = torch.bincount(seg_idx[toks == img_id], minlength=num_segments).cpu().tolist()
-        vid_counts = torch.bincount(seg_idx[toks == vid_id], minlength=num_segments).cpu().tolist()
+        img_counts = torch.bincount(seg_idx[toks == image_token_id], minlength=num_segments).cpu().tolist()
+        vid_counts = torch.bincount(seg_idx[toks == video_token_id], minlength=num_segments).cpu().tolist()
 
     img_off = vid_off = 0
     segments = []
@@ -289,11 +349,11 @@ def _segment_positions(model, flat, cu, cu_t, kwargs, orig_get_rope_index):
         if ic == 0 and vc == 0:
             pos = torch.arange(seg.numel(), dtype=seg.dtype, device=seg.device).view(1, 1, -1).expand(3, 1, -1)
         else:
-            pos, _ = orig_get_rope_index(
-                merge,
-                img_id,
-                vid_id,
-                vstart,
+            pos, _ = get_rope_index(
+                spatial_merge_size,
+                image_token_id,
+                video_token_id,
+                vision_start_token_id,
                 seg.unsqueeze(0),
                 image_grid_thw=_slice(image_grid_thw, img_off, ic),
                 video_grid_thw=_slice(video_grid_thw, vid_off, vc),
@@ -312,10 +372,19 @@ def _build_packed_positions(model, parsed, kwargs, orig_get_rope_index):
         return None
     flat, cu, cu_t = parsed.flat, parsed.cu, parsed.cu_t
     local_len, cp_size, cp_rank = parsed.local_len, parsed.cp_size, parsed.cp_rank
+    position_kwargs = {
+        "image_grid_thw": kwargs.get("image_grid_thw"),
+        "video_grid_thw": kwargs.get("video_grid_thw"),
+        "spatial_merge_size": model.config.spatial_merge_size,
+        "image_token_id": model.image_token_id,
+        "video_token_id": model.video_token_id,
+        "vision_start_token_id": model.vision_start_token_id,
+        "get_rope_index": orig_get_rope_index,
+    }
 
     # Non-CP (or single chunk): cu_seqlens_q already describes this row exactly.
     if cu[-1] == local_len:
-        segments = _segment_positions(model, flat, cu, cu_t, kwargs, orig_get_rope_index)
+        segments = _segment_positions(flat, cu, cu_t, **position_kwargs)
         return torch.cat(segments, dim=2).contiguous() if segments else None
 
     # CP + THD packing: cu_seqlens_q gives the FULL padded per-segment boundaries (miles
@@ -328,7 +397,7 @@ def _build_packed_positions(model, parsed, kwargs, orig_get_rope_index):
         if full_flat is None:
             logger.debug("qwen3_vl packed mRoPE: CP segment not divisible by 2*cp; dense path")
             return None
-        segments = _segment_positions(model, full_flat, cu, cu_t, kwargs, orig_get_rope_index)
+        segments = _segment_positions(full_flat, cu, cu_t, **position_kwargs)
         if not segments:
             return None
         local_segments = [_natural_to_zigzag_slice(p, cp_size, cp_rank, dim=2) for p in segments]

--- a/scripts/run_qwen3_8_next.py
+++ b/scripts/run_qwen3_8_next.py
@@ -1,19 +1,22 @@
-"""Qwen3.8-Flash-Next (Qwen4Exp) DAPO training.
+"""Run Qwen3.8-Flash-Next text or image-conditioned GRPO training.
 
 Assumes an already-running ray cluster (MILES_SCRIPT_EXTERNAL_RAY=1) and a
-converted torch_dist reference checkpoint.
+converted torch_dist reference checkpoint. Geo3K additionally expects
+``geo3k_imgurl/train.parquet`` under ``data_dir``.
 
 Args:
+    task: ``dapo-math`` for the text baseline or ``geo3k`` for VLM training.
     model-name: "Qwen3.8-Flash-Next" (48-layer, 8 nodes x 4 GPUs, TP2 PP8 EP4)
-        or "Qwen3.8-Flash-Next-4layer" (smoke slice, 1 node x 4 GPUs,
-        TP2 PP2 EP2).
+        or "Qwen3.8-Flash-Next-4layer" (smoke slice, 1 node x 4/8 GPUs).
 
-Usage (inside the head-node container):
+Examples (inside the head-node container):
     python scripts/run_qwen3_8_next.py train --num-rollout 5
+    python scripts/run_qwen3_8_next.py train --task geo3k --model-name Qwen3.8-Flash-Next-4layer \
+        --num-nodes 1 --num-gpus-per-node 8
 """
 
 import os
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Literal
 
 import typer
@@ -31,9 +34,10 @@ _MODEL_REGISTRY = {
 @dataclass
 class ScriptArgs(U.ExecuteTrainConfig):
     model_name: Literal["Qwen3.8-Flash-Next", "Qwen3.8-Flash-Next-4layer"] = "Qwen3.8-Flash-Next"
+    task: Literal["dapo-math", "geo3k"] = "dapo-math"
     num_nodes: int = 8
     num_gpus_per_node: int = 4
-    run_id: str = "qwen38next-dapo"
+    run_id: str = field(default_factory=U.create_run_id)
     hf_checkpoint: str | None = None
     model_dir: str = "/root/models"
     ckpt_dir: str = "/root/ckpt"
@@ -41,6 +45,9 @@ class ScriptArgs(U.ExecuteTrainConfig):
     save_dir: str = "/root/shared_data"
     megatron_path: str = "/root/Megatron-LM"
     num_rollout: int = 5
+    rollout_batch_size: int = 4
+    n_samples_per_prompt: int = 8
+    global_batch_size: int | None = None
     rollout_max_response_len: int = 4096
     check_weight_update: bool = True
     enable_r3: bool = False
@@ -50,6 +57,37 @@ class ScriptArgs(U.ExecuteTrainConfig):
     def __post_init__(self):
         if self.hf_checkpoint is None:
             self.hf_checkpoint = f"{self.model_dir}/{self.model_name}"
+
+
+def _get_rollout_args(args: ScriptArgs) -> str:
+    if args.task == "geo3k":
+        label_key = "answer"
+        prompt_data = f"{args.data_dir}/geo3k_imgurl/train.parquet"
+        input_key = "problem"
+        multimodal_args = '--multimodal-keys \'{"image": "images"}\' '
+    else:
+        label_key = "label"
+        prompt_data = f"{args.data_dir}/dapo-math-17k/dapo-math-17k.jsonl"
+        input_key = "prompt"
+        multimodal_args = ""
+
+    return (
+        f"--label-key {label_key} "
+        "--apply-chat-template "
+        "--rollout-shuffle "
+        "--rm-type math "
+        f"--num-rollout {args.num_rollout} "
+        f"--rollout-batch-size {args.rollout_batch_size} "
+        f"--n-samples-per-prompt {args.n_samples_per_prompt} "
+        "--rollout-temperature 0.8 "
+        "--num-steps-per-rollout 1 "
+        "--balance-data "
+        f"--prompt-data {prompt_data} "
+        f"--input-key {input_key} "
+        f"{multimodal_args}"
+        f"--rollout-max-response-len {args.rollout_max_response_len} "
+        '--apply-chat-template-kwargs \'{"thinking_mode":"thinking"}\' '
+    )
 
 
 def _train(args: ScriptArgs):
@@ -72,22 +110,7 @@ def _train(args: ScriptArgs):
             "--no-save-optim --no-save-rng --no-load-optim --no-load-rng "
         )
 
-    rollout_args = (
-        "--label-key label "
-        "--apply-chat-template "
-        "--rollout-shuffle "
-        "--rm-type math "
-        f"--num-rollout {args.num_rollout} "
-        "--rollout-batch-size 4 "
-        "--n-samples-per-prompt 8 "
-        "--rollout-temperature 0.8 "
-        "--num-steps-per-rollout 1 "
-        "--balance-data "
-        f"--prompt-data {args.data_dir}/dapo-math-17k/dapo-math-17k.jsonl "
-        "--input-key prompt "
-        f"--rollout-max-response-len {args.rollout_max_response_len} "
-        '--apply-chat-template-kwargs \'{"thinking_mode":"thinking"}\' '
-    )
+    rollout_args = _get_rollout_args(args)
 
     if shape == (8, 4):
         parallel_args = (
@@ -118,6 +141,8 @@ def _train(args: ScriptArgs):
         "--micro-batch-size 1 "
         "--max-tokens-per-gpu 8192 "
     )
+    if args.global_batch_size is not None:
+        perf_args += f"--global-batch-size {args.global_batch_size} "
 
     grpo_args = (
         "--advantage-estimator grpo "
@@ -148,6 +173,12 @@ def _train(args: ScriptArgs):
         "--router-health-check-interval-secs 15 "
         "--router-health-failure-threshold 40 "
     )
+    if args.task == "geo3k":
+        sglang_args += "--sglang-mm-attention-backend sdpa "
+
+    model_provider = "miles_plugins.models.qwen3_8_next.model_provider.get_qwen3_8_next_model_provider"
+    if args.task == "geo3k":
+        model_provider = "miles_plugins.models.qwen3_8_next.model_provider.get_qwen3_8_next_vlm_model_provider"
 
     misc_args = (
         "--attention-dropout 0.0 "
@@ -166,8 +197,7 @@ def _train(args: ScriptArgs):
         "--model-name qwen4_exp "
         "--qkv-format thd "
         "--linear-attention-backend flashqla "
-        "--custom-model-provider-path "
-        "miles_plugins.models.qwen3_8_next.model_provider.get_qwen3_8_next_model_provider "
+        f"--custom-model-provider-path {model_provider} "
         "--rollout-health-check-interval 300 "
         "--distributed-timeout-minutes 60 "
         "--rollout-health-check-timeout 300 "

--- a/tests/e2e/megatron/model_scripts/test_qwen3_8_next_4layer_geo3k_ci.py
+++ b/tests/e2e/megatron/model_scripts/test_qwen3_8_next_4layer_geo3k_ci.py
@@ -1,0 +1,70 @@
+import os
+
+from scripts.run_qwen3_8_next import _MODEL_REGISTRY, ScriptArgs, _train
+
+from tests.ci.ci_register import register_cuda_ci
+from tests.ci.metric_history import register_ci_gate
+
+import miles.utils.external_utils.command_utils as U
+
+
+register_cuda_ci(
+    est_time=1800,
+    suite="stage-c-8-gpu-h200",
+    labels=["megatron", "model-scripts"],
+)
+
+register_ci_gate(metric_key="train/grad_norm")
+register_ci_gate(metric_key="train/ppo_kl")
+register_ci_gate(metric_key="train/train_rollout_logprob_abs_diff")
+register_ci_gate(metric_key="train/train_rollout_kl")
+register_ci_gate(metric_key="rollout/raw_reward")
+
+_MODEL_ORG = "CharyZeng"
+
+
+def _args() -> ScriptArgs:
+    return ScriptArgs(
+        model_name="Qwen3.8-Flash-Next-4layer",
+        task="geo3k",
+        num_nodes=1,
+        num_gpus_per_node=8,
+        num_rollout=2,
+        rollout_batch_size=2,
+        n_samples_per_prompt=2,
+        global_batch_size=4,
+        rollout_max_response_len=512,
+        skip_saving=True,
+        extra_args=(
+            "--ci-test " "--ci-disable-kl-checker " "--ci-disable-logprobs-checker " "--offload-train-target cpu "
+        ),
+    )
+
+
+def prepare(args: ScriptArgs):
+    os.environ["CONVERT_KEEP_PP1"] = "1"
+    os.environ["CUDA_DEVICE_MAX_CONNECTIONS"] = "1"
+    U.exec_command_cpu(f"mkdir -p {args.model_dir} {args.ckpt_dir} {args.data_dir}")
+    U.exec_command_cpu(f"hf download {_MODEL_ORG}/{args.model_name} --local-dir {args.hf_checkpoint}")
+    U.hf_download_dataset("chenhegu/geo3k_imgurl", data_dir=args.data_dir)
+    U.convert_checkpoint(
+        model_name=_MODEL_REGISTRY[args.model_name],
+        megatron_model_type=_MODEL_REGISTRY[args.model_name],
+        num_gpus_per_node=args.num_gpus_per_node,
+        dir_dst=args.ckpt_dir,
+        hf_checkpoint=args.hf_checkpoint,
+        megatron_path=args.megatron_path,
+        extra_args="--tensor-model-parallel-size 2 --pipeline-model-parallel-size 1",
+    )
+
+
+def execute(args: ScriptArgs):
+    _train(args)
+
+
+if __name__ == "__main__":
+    args = _args()
+    prepare(args)
+    for proxy_var in ("http_proxy", "https_proxy", "HTTP_PROXY", "HTTPS_PROXY"):
+        os.environ.pop(proxy_var, None)
+    execute(args)

--- a/tests/fast/launch_scripts/test_qwen3_8_next.py
+++ b/tests/fast/launch_scripts/test_qwen3_8_next.py
@@ -1,0 +1,48 @@
+from scripts.run_qwen3_8_next import ScriptArgs, _train
+
+import miles.utils.external_utils.command_utils as U
+
+
+def _capture_train_args(monkeypatch, *, task: str) -> str:
+    captured = {}
+    monkeypatch.setattr(U, "execute_train", lambda **kwargs: captured.update(kwargs))
+    _train(
+        ScriptArgs(
+            task=task,
+            num_nodes=1,
+            num_gpus_per_node=8,
+            rollout_batch_size=2,
+            n_samples_per_prompt=2,
+            global_batch_size=4,
+        )
+    )
+    return captured["train_args"]
+
+
+def test_geo3k_recipe_enables_qwen3_8_next_vision_path(monkeypatch):
+    train_args = _capture_train_args(monkeypatch, task="geo3k")
+
+    assert "--prompt-data /root/datasets/geo3k_imgurl/train.parquet" in train_args
+    assert "--input-key problem --multimodal-keys" in train_args
+    assert "--label-key answer" in train_args
+    assert "--rollout-batch-size 2" in train_args
+    assert "--n-samples-per-prompt 2" in train_args
+    assert "--global-batch-size 4" in train_args
+    assert "--sglang-mm-attention-backend sdpa" in train_args
+    assert (
+        "--custom-model-provider-path "
+        "miles_plugins.models.qwen3_8_next.model_provider.get_qwen3_8_next_vlm_model_provider" in train_args
+    )
+
+
+def test_text_recipe_keeps_qwen3_8_next_text_path(monkeypatch):
+    train_args = _capture_train_args(monkeypatch, task="dapo-math")
+
+    assert "--prompt-data /root/datasets/dapo-math-17k/dapo-math-17k.jsonl" in train_args
+    assert "--multimodal-keys" not in train_args
+    assert "--sglang-mm-attention-backend" not in train_args
+    assert "--offload-rollout-level kv_cache" not in train_args
+    assert (
+        "--custom-model-provider-path "
+        "miles_plugins.models.qwen3_8_next.model_provider.get_qwen3_8_next_model_provider" in train_args
+    )

--- a/tests/fast/models/test_qwen3_8_next_vision.py
+++ b/tests/fast/models/test_qwen3_8_next_vision.py
@@ -1,0 +1,53 @@
+from tests.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=30, suite="stage-a-cpu", labels=[])
+
+import json
+from types import SimpleNamespace
+
+import torch
+from safetensors.torch import save_file
+from transformers.models.qwen3_5_moe.configuration_qwen3_5_moe import Qwen3_5MoeVisionConfig
+from transformers.models.qwen3_5_moe.modeling_qwen3_5_moe import Qwen3_5MoeVisionModel
+
+import miles_plugins.models.qwen3_8_next.vision as vision
+
+
+def test_build_qwen3_8_next_visual_strictly_loads_and_freezes(tmp_path, monkeypatch):
+    config = Qwen3_5MoeVisionConfig(
+        depth=1,
+        hidden_size=32,
+        hidden_act="gelu_pytorch_tanh",
+        intermediate_size=64,
+        num_heads=4,
+        in_channels=3,
+        patch_size=2,
+        spatial_merge_size=2,
+        temporal_patch_size=2,
+        out_hidden_size=16,
+        num_position_embeddings=16,
+    )
+    reference = Qwen3_5MoeVisionModel(config)
+    filename = "model-00001-of-00001.safetensors"
+    prefixed_state = {
+        f"model.visual.{name}": tensor.detach().contiguous() for name, tensor in reference.state_dict().items()
+    }
+    save_file(prefixed_state, tmp_path / filename)
+    index = {"weight_map": {name: filename for name in prefixed_state}}
+    (tmp_path / "model.safetensors.index.json").write_text(json.dumps(index), encoding="utf-8")
+    monkeypatch.setattr(vision, "load_hf_config", lambda _: SimpleNamespace(vision_config=config))
+
+    actual = vision.build_qwen3_8_next_visual(
+        str(tmp_path),
+        device=torch.device("cpu"),
+        dtype=torch.float32,
+    )
+
+    assert not actual.training
+    assert not any(parameter.requires_grad for parameter in actual.parameters())
+    for name, expected in reference.state_dict().items():
+        assert torch.equal(actual.state_dict()[name], expected)
+
+    output = actual(torch.randn(16, 24), grid_thw=torch.tensor([[1, 4, 4]])).pooler_output
+    assert output.shape == (4, 16)
+    assert torch.isfinite(output).all()

--- a/tests/fast/test_qsa_block_sparse_attn.py
+++ b/tests/fast/test_qsa_block_sparse_attn.py
@@ -25,9 +25,7 @@ from miles_plugins.models.qwen3_8_next.ops.kernel.qsa_block_sparse_attn import (
     qsa_sparse_attention_from_indices,
     selection_to_block_bitmap,
 )
-from miles_plugins.models.qwen3_8_next.ops.kernel.qsa_sparse_attn import (  # noqa: E402
-    qsa_sparse_attention_triton,
-)
+from miles_plugins.models.qwen3_8_next.ops.kernel.qsa_sparse_attn import qsa_sparse_attention_triton  # noqa: E402
 
 BLK = 4
 HQ, HKV, D = 4, 1, 128
@@ -96,7 +94,9 @@ def test_gradients_match_gather_kernel():
         fn(qq, kk, vv, idx, SCALE).backward(gout)
         return qq.grad, kk.grad, vv.grad
 
-    for a, b, name in zip(run(qsa_sparse_attention_from_indices), run(qsa_sparse_attention_triton), "qkv"):
+    for a, b, name in zip(
+        run(qsa_sparse_attention_from_indices), run(qsa_sparse_attention_triton), "qkv", strict=True
+    ):
         rel = _rel(a, b)[1]
         assert rel < 1e-2, (name, rel)
 

--- a/tests/fast/test_qsa_indexer_packed.py
+++ b/tests/fast/test_qsa_indexer_packed.py
@@ -111,6 +111,10 @@ def test_layout_block_local_positions_restart_per_sequence():
 
     expected = torch.cat([torch.arange(-(-length // RATIO)) for length in LENS])
     torch.testing.assert_close(layout.block_local, expected)
+    expected_starts = torch.cat(
+        [int(cu[i]) + torch.arange(-(-length // RATIO)) * RATIO for i, length in enumerate(LENS)]
+    )
+    torch.testing.assert_close(layout.block_token_start, expected_starts)
     assert layout.num_blocks == sum(-(-length // RATIO) for length in LENS)
 
 

--- a/tests/fast/test_qwen3_vl_cp_mrope.py
+++ b/tests/fast/test_qwen3_vl_cp_mrope.py
@@ -7,10 +7,14 @@ test checks that reconstruction is the exact inverse of `slice_with_cp` (the fun
 uses to shard the tokens), and that re-slicing with `_natural_to_zigzag_slice` round-trips.
 """
 
+import sys
+from types import SimpleNamespace
+
 import pytest
 import torch
 import torch.nn.functional as F
 
+import miles_plugins.models.qwen3_vl as qwen3_vl
 from miles_plugins.models.qwen3_vl import _natural_to_zigzag_slice, _reassemble_full_row
 
 
@@ -78,3 +82,24 @@ def test_reassemble_bails_on_indivisible_segment():
     cu = [0, 6]  # 6 not divisible by 2*cp=4
     gathered = [torch.zeros(3, dtype=torch.long), torch.zeros(3, dtype=torch.long)]
     assert _reassemble_full_row(gathered, cu, cp_size=2) is None
+
+
+def test_position_ids_restart_for_each_packed_segment(monkeypatch):
+    rope_module = "megatron.bridge.models.qwen_vl.modelling_qwen3_vl.rope"
+    monkeypatch.setitem(sys.modules, rope_module, SimpleNamespace(get_rope_index=None))
+    monkeypatch.setattr(qwen3_vl, "_cp_size_rank", lambda: (1, 0))
+    packed = SimpleNamespace(qkv_format="thd", cu_seqlens_q=torch.tensor([0, 2, 5], dtype=torch.int32))
+
+    position_ids = qwen3_vl.get_qwen3_vl_position_ids(
+        torch.tensor([[11, 12, 21, 22, 23]]),
+        packed_seq_params=packed,
+        image_grid_thw=None,
+        video_grid_thw=None,
+        spatial_merge_size=2,
+        image_token_id=3,
+        video_token_id=4,
+        vision_start_token_id=2,
+    )
+
+    expected = torch.tensor([0, 1, 0, 1, 2]).view(1, 1, -1).expand(3, 1, -1)
+    assert torch.equal(position_ids, expected)

--- a/tests/snapshots/launch_scripts/py/scripts/run_qwen3_8_next.py/train.txt
+++ b/tests/snapshots/launch_scripts/py/scripts/run_qwen3_8_next.py/train.txt
@@ -1,0 +1,129 @@
+### 0
+pkill -9 sglang; sleep 3; ray stop
+  --force; pkill -9 ray; pkill -9 miles; sleep 3; pkill -9 ray; pkill -9 miles; pkill -9 redis; true; 
+
+### 1
+export PYTHONUNBUFFERED=1 && ray start
+  --head
+  --node-ip-address 127.0.0.1
+  --num-gpus 4
+  --disable-usage-stats
+
+### 2
+nvidia-smi topo -m 2>/dev/null | grep -o 'NV[0-9][0-9]*' | wc -l
+
+### 3
+export no_proxy=127.0.0.1 && export PYTHONUNBUFFERED=1 && ray job submit
+  --address="http://127.0.0.1:8265"
+  --runtime-env-json='{"env_vars": {"PYTHONUNBUFFERED": "1", "CUDA_DEVICE_MAX_CONNECTIONS": "1", "NCCL_NVLS_ENABLE": "0", "no_proxy": "127.0.0.1,127.0.0.1", "MASTER_ADDR": "127.0.0.1", "SGLANG_SKIP_CHECKPOINT_LOAD_CHECK": "1", "SGLANG_HEALTH_CHECK_TIMEOUT": "120", "SGLANG_DISABLE_MULTIMEM_AG": "1", "PYTHONPATH": "<REPO_ROOT>:/root/Megatron-LM:/frozen/pythonpath", "QSA_BACKEND": "triton", "PYTHONFAULTHANDLER": "1", "TORCHINDUCTOR_COMPILE_THREADS": "1", "TRITON_CACHE_DIR": "/tmp/triton_cache", "TORCHINDUCTOR_CACHE_DIR": "/tmp/inductor_cache"}}'
+  -- python3 <REPO_ROOT>/train.py
+  --spec miles_plugins.models.qwen3_8_next.qwen3_8_next get_qwen3_8_next_spec
+  --disable-bias-linear
+  --qk-layernorm
+  --group-query-attention
+  --num-attention-heads 24
+  --num-query-groups 2
+  --kv-channels 256
+  --num-layers 48
+  --hidden-size 2560
+  --ffn-hidden-size 640
+  --normalization RMSNorm
+  --apply-layernorm-1p
+  --position-embedding-type rope
+  --norm-epsilon 1e-6
+  --rotary-percent 0.25
+  --swiglu
+  --untie-embeddings-and-output-weights
+  --vocab-size 248320
+  --rotary-base 10000000
+  --moe-ffn-hidden-size 640
+  --moe-shared-expert-intermediate-size 640
+  --moe-router-score-function softmax
+  --moe-token-dispatcher-type alltoall
+  --moe-router-topk 10
+  --moe-layer-freq '[1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1]'
+  --num-experts 512
+  --moe-grouped-gemm
+  --moe-token-drop-policy probs
+  --moe-router-dtype fp32
+  --moe-permute-fusion
+  --moe-aux-loss-coeff 0
+  --attention-output-gate
+  --moe-shared-expert-gate
+  --hf-checkpoint /root/models/Qwen3.8-Flash-Next
+  --ref-load /root/ckpt/qwen3.8-flash-next_torch_dist 
+  --label-key label
+  --apply-chat-template
+  --rollout-shuffle
+  --rm-type math
+  --num-rollout 5
+  --rollout-batch-size 4
+  --n-samples-per-prompt 8
+  --rollout-temperature 0.8
+  --num-steps-per-rollout 1
+  --balance-data
+  --prompt-data /root/datasets/dapo-math-17k/dapo-math-17k.jsonl
+  --input-key prompt
+  --rollout-max-response-len 4096
+  --apply-chat-template-kwargs '{"thinking_mode":"thinking"}' 
+  --optimizer adam
+  --lr 1e-6
+  --lr-decay-style constant
+  --weight-decay 0.1
+  --adam-beta1 0.9
+  --adam-beta2 0.98 
+  --advantage-estimator grpo
+  --kl-loss-coef 0.00
+  --kl-loss-type low_var_kl
+  --entropy-coef 0.00
+  --eps-clip 0.2
+  --eps-clip-high 0.28 
+  --use-wandb
+  --wandb-project miles-run_qwen3_8_next
+  --wandb-group 260101-000000-000
+  --wandb-key 'frozen-wandb-api-key'
+  --disable-wandb-random-suffix 
+  --tensor-model-parallel-size 2
+  --sequence-parallel
+  --pipeline-model-parallel-size 8
+  --context-parallel-size 1
+  --expert-model-parallel-size 4
+  --expert-tensor-parallel-size 1
+  --recompute-granularity full
+  --recompute-method uniform
+  --recompute-num-layers 1
+  --micro-batch-size 1
+  --max-tokens-per-gpu 8192 
+  --rollout-num-gpus-per-engine 8
+  --sglang-tp-size 8
+  --sglang-ep-size 8
+  --sglang-dp-size 1
+  --sglang-linear-attn-prefill-backend flashinfer
+  --sglang-moe-runner-backend triton
+  --sglang-chunked-prefill-size 8192
+  --sglang-disable-radix-cache
+  --router-health-success-threshold 1
+  --router-health-check-interval-secs 15
+  --router-health-failure-threshold 40 
+  --attention-dropout 0.0
+  --hidden-dropout 0.0
+  --attention-softmax-in-fp32
+  --accumulate-allreduce-grads-in-fp32
+  --update-weight-buffer-size 1073741824
+  --actor-num-nodes 8
+  --actor-num-gpus-per-node 4
+  --num-gpus-per-node 4
+  --train-memory-margin-bytes 3221225472
+  --offload-train-target disk
+  --offload-train-disk-dir /tmp/train_offload
+  --sglang-mem-fraction-static 0.7
+  --colocate
+  --model-name qwen4_exp
+  --qkv-format thd
+  --linear-attention-backend flashqla
+  --custom-model-provider-path miles_plugins.models.qwen3_8_next.model_provider.get_qwen3_8_next_model_provider
+  --rollout-health-check-interval 300
+  --distributed-timeout-minutes 60
+  --rollout-health-check-timeout 300
+  --check-weight-update-equal
+  --check-weight-update-skip-list visual. ple_embedding.   


### PR DESCRIPTION
## Summary

Adds image-conditioned RL training for Qwen3.8-Flash-Next, stacked on #2777.

ci-megatron-pr: zhichen/hc-head-contraction-slot

- loads the checkpoint's official Qwen3.5-compatible visual tower directly from HF safetensors, freezes it, and wires its embeddings into the existing Megatron text model
- reuses Miles' existing frozen-tower convention and Qwen3-VL packed MRoPE logic rather than introducing a second processor or rollout path
- reuses Megatron's `apply_rotary_pos_emb` primitive so QSA receives the same three-axis MRoPE frequencies as the main attention path
- adds a Geo3K launcher recipe and an 8-GPU H200 E2E
- removes unused bridge vision mappings; the frozen tower is deliberately outside the registered Megatron module/checkpoint/weight-sync tree

Current scope is images with context parallel size 1. The visual tower stays frozen because Miles/SGLang visual-weight synchronization is not part of this change.

## SGLang

No SGLang patch is needed. The Miles SGLang branch at `599d740312f97cfdba91a818dfec43037ab42fe8` already contains the VLM portions of upstream sglang/sglang#36497: `Qwen4ExpForConditionalGeneration`, the Qwen3-VL processor registration, multimodal MRoPE, and official visual weight loading. The newer upstream-only changes are main-branch API/formatting work, PLE storage support, a layer-type alias, and SM120/121 sparse-decode routing; none is required for the SM103 B300 path tested here.

## Verification

- focused CPU tests: 4 packed-QSA + 7 packed-MRoPE + 1 visual-tower + 2 launcher tests passed
- all pre-commit hooks passed
- fresh checkpoint conversion from the official HF checkpoint passed with the pinned Megatron dependency
- real 4-layer Geo3K VLM smoke: 8 x NVIDIA B300, TP2/PP2/EP4, two rollout/train/weight-update cycles completed
  - B300 preflight verified the real processor, official-vs-Miles MRoPE equality, and visual output shape
  - the initial exact language-weight check and both 23/23 post-step weight updates passed
  - rollout 1 train/rollout absolute log-prob diff: `0.08226`; KL: `0.00754`
  - rollout 2 train/rollout absolute log-prob diff: `0.07708`; KL: `0.00681`

W&B: https://wandb.ai/nan-playground/miles-qwen38-vlm/runs/eg1dshjk
