### PR TITLE
rollout: let agent functions discard infra-aborted samples

### DIFF
--- a/docs/user-guide/agentic-rollout.md
+++ b/docs/user-guide/agentic-rollout.md
@@ -81,7 +81,33 @@ async def run_agent(base_url, prompt, request_kwargs, metadata, **kwargs):
 - `metadata` contains the sample metadata, session identifiers, and configured
   `max_seq_len`. Forward only the fields your environment needs.
 - Return a dictionary to merge rewards, reports, or metrics into each output
-  sample's metadata, or return `None` when there is nothing to add.
+  sample's metadata, or return `None` when there is nothing to add. Both keep
+  the sample: the recorded session becomes a training sample and the reward
+  model scores it (a missing `reward` scores 0).
+- Raise `miles.rollout.agent_function.InfraAbort(exit_status)` to discard the
+  sample.
+  Its group is dropped before any dynamic-sampling filter runs, and the drop is
+  counted in `rollout/aborted/drop_<exit_status>`.
+
+### Which outcomes to discard
+
+A discarded sample contributes no gradient, so the policy is never penalized
+for whatever led to it. That makes discarding safe only for failures the
+policy cannot bring about, and unsafe for everything it can:
+
+| Outcome | Can the policy cause it? | Do |
+|---|---|---|
+| Sandbox platform refuses to create a sandbox (quota, 429 after retries) | No | raise `InfraAbort` |
+| Environment or agent-server host process died; trainer lost its network path to the environment | No | raise `InfraAbort` |
+| Wall-clock timeout | Yes (stalling) | return `reward: 0` |
+| Sandbox lost mid-episode, verifier crashed or produced no result | Yes (the agent runs as root inside it) | return `reward: 0` |
+| Hit `max_seq_len` or a turn limit | Yes | return `reward: 0` |
+
+When a case is ambiguous — a WebSocket drop looks the same whether the
+platform was saturated or the agent killed the server — treat it as the
+policy's: a few false negatives cost less than an outcome the policy can
+learn to trigger. Record the cause in the returned metadata (`exit_status`)
+so its rate stays visible.
 
 For structured parsing, the payload may use SGLang's
 `ChatCompletionRequest`-compatible fields, which extend the OpenAI format.

--- a/docs/user-guide/fully-async.md
+++ b/docs/user-guide/fully-async.md
@@ -302,7 +302,14 @@ rollout/fully_async/stale_groups_filtered
 rollout/fully_async/avg_staleness, rollout/fully_async/max_staleness
 rollout/fully_async/buffer_avg_staleness, rollout/fully_async/buffer_max_staleness
 rollout/dynamic_filter/drop_<reason>
+rollout/aborted/drop_<exit_status>
 ```
+
+`aborted_groups_filtered` counts every group dropped for containing an aborted
+sample; `rollout/aborted/drop_<exit_status>` splits the same count by the cause
+the aborted sample recorded (`NoModelCalls`, `CollectFailed`, or the
+`exit_status` of the agent function's `InfraAbort`). The sync rollout reports
+the latter too.
 
 The `avg_staleness` and `max_staleness` pair covers the groups training actually
 consumed, while the `buffer_` pair covers the groups still sitting in the buffer when

--- a/examples/experimental/nemo-gym/README.md
+++ b/examples/experimental/nemo-gym/README.md
@@ -183,7 +183,7 @@ SWE-bench eval report in `metadata` → `sample.metadata["eval_report"]`) and
 enters training through `sample.metadata["reward"]`.
 
 Episodes that fail before the first model call produce no session records; the
-sample is marked aborted and `check_no_aborted` drops its group from training.
+sample is marked aborted and its group is dropped from training.
 
 ## Validating without a GPU
 

--- a/miles/rollout/agent_function.py
+++ b/miles/rollout/agent_function.py
@@ -1,0 +1,31 @@
+"""The agent-function contract for ``agentic_tool_call.generate``.
+
+An agent function (``--custom-agent-function-path``) drives one episode against
+the session-scoped policy URL and returns a dict to merge into the sample's
+metadata, or None when there is nothing to add. Either way the recorded session
+becomes a training sample. The one way to discard the sample is to raise
+:class:`InfraAbort`.
+
+This module must stay free of heavy imports: agent functions import it on
+CPU-only hosts and in offline tests where torch is not available.
+"""
+
+
+class InfraAbort(Exception):
+    """Raised by an agent function to discard the sample it is producing.
+
+    Reserve it for failures the policy cannot have caused: the sandbox platform
+    refusing to create a sandbox, an environment host process that died, the
+    trainer losing its network path to the environment. A discarded sample
+    contributes no gradient, so any outcome the policy CAN bring about -- a
+    timeout, a sandbox the agent broke, a verifier the agent starved -- must be
+    returned as reward 0 instead; discarding those teaches the policy to trigger
+    them to escape the penalty.
+
+    ``exit_status`` names the cause. It is recorded on the aborted sample's
+    metadata and counted in the ``rollout/aborted/drop_<exit_status>`` metric.
+    """
+
+    def __init__(self, exit_status: str, message: str | None = None):
+        super().__init__(message or exit_status)
+        self.exit_status = exit_status

--- a/miles/rollout/filter_hub/base_types.py
+++ b/miles/rollout/filter_hub/base_types.py
@@ -1,6 +1,8 @@
 from collections import defaultdict
 from dataclasses import dataclass
 
+from miles.utils.types import Sample
+
 
 @dataclass
 class DynamicFilterOutput:
@@ -21,17 +23,40 @@ def call_dynamic_filter(fn, *args, **kwargs):
     return output
 
 
+def _flatten_samples(group) -> list[Sample]:
+    return [s for item in group for s in (item if isinstance(item, list) else [item])]
+
+
+def group_has_aborted(group) -> bool:
+    return any(s.status == Sample.Status.ABORTED for s in _flatten_samples(group))
+
+
+def aborted_exit_status(group) -> str:
+    """The cause the first aborted sample recorded (agentic_tool_call sets it), else "unknown"."""
+    for s in _flatten_samples(group):
+        if s.status == Sample.Status.ABORTED:
+            return str(s.metadata.get("exit_status") or "unknown")
+    return "unknown"
+
+
 class MetricGatherer:
     def __init__(self):
         self._dynamic_filter_drop_reason_count = defaultdict(lambda: 0)
+        self._aborted_drop_reason_count = defaultdict(lambda: 0)
 
     def on_dynamic_filter_drop(self, reason: str | None):
         if not reason:
             return
         self._dynamic_filter_drop_reason_count[reason] += 1
 
+    def on_aborted_group_drop(self, group):
+        self._aborted_drop_reason_count[aborted_exit_status(group)] += 1
+
     def collect(self):
         return {
-            f"rollout/dynamic_filter/drop_{reason}": count
-            for reason, count in self._dynamic_filter_drop_reason_count.items()
+            **{
+                f"rollout/dynamic_filter/drop_{reason}": count
+                for reason, count in self._dynamic_filter_drop_reason_count.items()
+            },
+            **{f"rollout/aborted/drop_{reason}": count for reason, count in self._aborted_drop_reason_count.items()},
         }

--- a/miles/rollout/fully_async_data_buffer.py
+++ b/miles/rollout/fully_async_data_buffer.py
@@ -126,6 +126,7 @@ class DefaultDataBuffer(DataBuffer):
         # filters at receiving sample: abort filter, dynamic filter
         if any(s.status == Sample.Status.ABORTED for s in iter_samples(input.group)):
             self._metric_aborted_groups += 1
+            self._metric_gatherer.on_aborted_group_drop(input.group)
             self._unused_handler_fn(input.prompt_group)
             return
         filter_output = call_dynamic_filter(self._dynamic_filter, self._args, input.group)

--- a/miles/rollout/generate_hub/agentic_tool_call.py
+++ b/miles/rollout/generate_hub/agentic_tool_call.py
@@ -21,6 +21,10 @@ Agent function contract:
   Returning None means no extra metadata to attach.
   Returning a dict merges it into every sample's metadata, so downstream
   reward models (--custom-rm-path) can read whatever the agent left there.
+  Raising miles.rollout.agent_function.InfraAbort discards the sample (Sample.Status.ABORTED,
+  metadata["exit_status"] = the abort's exit_status). Neither returning None nor
+  raising any other exception discards anything: the recorded session still
+  becomes a sample, scored by the reward model as usual.
 """
 
 import argparse
@@ -33,6 +37,7 @@ from typing import Any
 import httpx
 from sglang.srt.entrypoints.openai.protocol import ChatCompletionRequest
 
+from miles.rollout.agent_function import InfraAbort
 from miles.rollout.base_types import GenerateFnInput, GenerateFnOutput
 from miles.rollout.generate_utils.openai_endpoint_utils import OpenAIEndpointTracer
 from miles.utils.misc import load_function
@@ -68,6 +73,7 @@ async def generate(input: GenerateFnInput) -> GenerateFnOutput:
     metadata = {**metadata, "session_server_id": tracer.session_server_id}
 
     agent_metadata = None
+    infra_abort: InfraAbort | None = None
     collect_failed = False
     t_start = time.monotonic()
     try:
@@ -79,6 +85,9 @@ async def generate(input: GenerateFnInput) -> GenerateFnOutput:
             metadata=metadata,
         )
         logger.debug(f"{log_prefix} Agent function returned in {time.monotonic()-t_start:.1f}s")
+    except InfraAbort as e:
+        infra_abort = e
+        logger.warning(f"{log_prefix} Agent function discarded the sample ({e.exit_status}): {e}")
     except Exception as e:
         logger.warning(f"{log_prefix} Agent function failed: {e}", exc_info=True)
 
@@ -101,18 +110,17 @@ async def generate(input: GenerateFnInput) -> GenerateFnOutput:
             )
 
     if collect_failed:
-        sample = deepcopy(input.sample)
-        sample.status = Sample.Status.ABORTED
-        return GenerateFnOutput(samples=[sample] if use_v2 else sample)
+        return _aborted_output(input.sample, "CollectFailed", use_v2)
+
+    if infra_abort is not None:
+        return _aborted_output(input.sample, infra_abort.exit_status, use_v2)
 
     if not result.samples:
         if result.empty_reason == "all_truncated":
             logger.warning("All samples truncated (prompt already exceeds max_seq_len)")
-        else:
-            logger.warning("No model calls recorded for sample")
-        sample = deepcopy(input.sample)
-        sample.status = Sample.Status.ABORTED
-        return GenerateFnOutput(samples=[sample] if use_v2 else sample)
+            return _aborted_output(input.sample, "AllTruncated", use_v2)
+        logger.warning("No model calls recorded for sample")
+        return _aborted_output(input.sample, "NoModelCalls", use_v2)
 
     samples = result.samples
     if use_v2 and len(samples) > 1:
@@ -142,6 +150,14 @@ async def generate(input: GenerateFnInput) -> GenerateFnOutput:
     (sample,) = samples
     sample.metadata.update(result.session_metadata)
     return GenerateFnOutput(samples=sample)
+
+
+def _aborted_output(input_sample: Sample, exit_status: str, use_v2: bool) -> GenerateFnOutput:
+    """The input sample marked ABORTED, with the cause on its metadata for the drop metric."""
+    sample = deepcopy(input_sample)
+    sample.status = Sample.Status.ABORTED
+    sample.metadata = {**sample.metadata, "exit_status": exit_status}
+    return GenerateFnOutput(samples=[sample] if use_v2 else sample)
 
 
 def _add_arguments(parser: argparse.ArgumentParser):

--- a/miles/rollout/inference_rollout/inference_rollout_train.py
+++ b/miles/rollout/inference_rollout/inference_rollout_train.py
@@ -8,7 +8,7 @@ from packaging.version import parse
 from tqdm import tqdm
 
 from miles.rollout.base_types import RolloutFnTrainOutput
-from miles.rollout.filter_hub.base_types import MetricGatherer, call_dynamic_filter
+from miles.rollout.filter_hub.base_types import MetricGatherer, call_dynamic_filter, group_has_aborted
 from miles.rollout.generate_utils.prefill_logprobs import recompute_samples_rollout_logprobs_via_prefill
 from miles.rollout.generate_utils.sample_utils import reward_log_summary, sample_text_preview
 from miles.rollout.inference_rollout.inference_rollout_common import GenerateState, generate_and_rm_group
@@ -137,6 +137,11 @@ async def generate_rollout_async(
 
             assert len(group) == args.n_samples_per_prompt
             all_data.append(group)
+            # An aborted sample has no reward, so its group cannot be trained on. Drop it here,
+            # before the dynamic filter, so no filter configuration can let it through.
+            if group_has_aborted(group):
+                metric_gatherer.on_aborted_group_drop(group)
+                continue
             dynamic_filter_output = call_dynamic_filter(dynamic_filter, args, group)
             if not dynamic_filter_output.keep:
                 metric_gatherer.on_dynamic_filter_drop(reason=dynamic_filter_output.reason)

--- a/miles/rollout/sglang_rollout.py
+++ b/miles/rollout/sglang_rollout.py
@@ -14,7 +14,7 @@ from packaging.version import parse
 from tqdm import tqdm
 
 from miles.rollout.base_types import GenerateFnInput, RolloutFnEvalOutput, RolloutFnTrainOutput
-from miles.rollout.filter_hub.base_types import MetricGatherer, call_dynamic_filter
+from miles.rollout.filter_hub.base_types import MetricGatherer, call_dynamic_filter, group_has_aborted
 from miles.rollout.inference_rollout.compatibility import load_generate_function
 from miles.utils import dumper_utils
 from miles.utils.async_utils import run
@@ -496,6 +496,12 @@ async def generate_rollout_async(
 
             assert len(group) == args.n_samples_per_prompt
             all_data.append(group)
+            # An aborted sample has no reward, so its group cannot be trained on. Drop it here,
+            # before the dynamic filter, so no filter configuration can let it through.
+            if group_has_aborted(group):
+                metric_gatherer.on_aborted_group_drop(group)
+                state.remaining_batch_size -= 1
+                continue
             dynamic_filter_output = call_dynamic_filter(dynamic_filter, args, group)
             if not dynamic_filter_output.keep:
                 metric_gatherer.on_dynamic_filter_drop(reason=dynamic_filter_output.reason)

--- a/tests/fast/rollout/generate_hub/test_agentic_v2.py
+++ b/tests/fast/rollout/generate_hub/test_agentic_v2.py
@@ -1,9 +1,11 @@
 from types import SimpleNamespace
 
+import httpx
 import pytest
 
 import miles.rollout.generate_hub.agentic_tool_call as agentic_tool_call
 from miles.ray.rollout.rollout_data_conversion import validate_compact_rollout_ids
+from miles.rollout.agent_function import InfraAbort
 from miles.rollout.base_types import GenerateFnInput
 from miles.rollout.session.samples.codec import SamplesReply
 from miles.utils.types import Sample
@@ -29,12 +31,14 @@ class _Tracer:
 
 def _generate_input(**args_kwargs) -> GenerateFnInput:
     args = SimpleNamespace(
-        session_server_ip="127.0.0.1",
-        session_server_ports=[12345],
-        custom_agent_function_path="test.fake_agent",
-        max_seq_len=None,
-        use_session_server="v2",
-        **args_kwargs,
+        **{
+            "session_server_ip": "127.0.0.1",
+            "session_server_ports": [12345],
+            "custom_agent_function_path": "test.fake_agent",
+            "max_seq_len": None,
+            "use_session_server": "v2",
+            **args_kwargs,
+        }
     )
     state = SimpleNamespace(args=args)
     sample = Sample(
@@ -51,12 +55,12 @@ async def _fake_agent(**kwargs):
     return {"agent_result": "done"}
 
 
-def _patch_agent(monkeypatch, tracer):
+def _patch_agent(monkeypatch, tracer, agent=_fake_agent):
     async def fake_create(args):
         return tracer
 
     monkeypatch.setattr(agentic_tool_call.OpenAIEndpointTracer, "create", fake_create)
-    monkeypatch.setattr(agentic_tool_call, "load_function", lambda path: _fake_agent)
+    monkeypatch.setattr(agentic_tool_call, "load_function", lambda path: agent)
 
 
 @pytest.mark.asyncio
@@ -107,8 +111,10 @@ async def test_v2_requires_input_rollout_identity(monkeypatch):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("empty_reason", ["no_records", "all_truncated"])
-async def test_empty_reply_returns_aborted_list(monkeypatch, empty_reason):
+@pytest.mark.parametrize(
+    ("empty_reason", "exit_status"), [("no_records", "NoModelCalls"), ("all_truncated", "AllTruncated")]
+)
+async def test_empty_reply_returns_aborted_list(monkeypatch, empty_reason, exit_status):
     tracer = _Tracer(SamplesReply(samples=[], session_metadata={}, empty_reason=empty_reason))
     _patch_agent(monkeypatch, tracer)
     generate_input = _generate_input()
@@ -119,6 +125,59 @@ async def test_empty_reply_returns_aborted_list(monkeypatch, empty_reason):
     assert len(output.samples) == 1
     assert output.samples[0] is not generate_input.sample
     assert output.samples[0].status == Sample.Status.ABORTED
+    assert output.samples[0].metadata["exit_status"] == exit_status
+    assert output.samples[0].metadata["source"] == "test"  # the input metadata is kept
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("use_v2", [True, False])
+async def test_infra_abort_discards_the_sample(monkeypatch, use_v2):
+    """InfraAbort from the agent function -> ABORTED sample carrying the exit_status; the session is still collected."""
+    recorded = Sample(status=Sample.Status.COMPLETED, response="partial", response_length=1, tokens=[1])
+    tracer = _Tracer(SamplesReply(samples=[recorded], session_metadata={}, empty_reason=None))
+
+    async def aborting_agent(**kwargs):
+        raise InfraAbort("SandboxUnavailable", "daytona: quota exhausted after 8 retries")
+
+    _patch_agent(monkeypatch, tracer, agent=aborting_agent)
+    generate_input = _generate_input(use_session_server="v2" if use_v2 else "v1")
+
+    output = await agentic_tool_call.generate(generate_input)
+
+    samples = output.samples if use_v2 else [output.samples]
+    assert len(samples) == 1
+    assert samples[0].status == Sample.Status.ABORTED
+    assert samples[0].metadata["exit_status"] == "SandboxUnavailable"
+    assert samples[0] is not recorded  # the recorded turns are not trained on
+    assert tracer.agent_metadata is None  # v2: nothing forwarded to the server merge
+
+
+@pytest.mark.asyncio
+async def test_other_exceptions_keep_the_recorded_sample(monkeypatch):
+    """Any exception other than InfraAbort is a failure the policy may have caused: the sample stays."""
+    recorded = Sample(status=Sample.Status.COMPLETED, response="partial", response_length=1, tokens=[1])
+    tracer = _Tracer(SamplesReply(samples=[recorded], session_metadata={}, empty_reason=None))
+
+    async def failing_agent(**kwargs):
+        raise RuntimeError("verifier crashed")
+
+    _patch_agent(monkeypatch, tracer, agent=failing_agent)
+
+    output = await agentic_tool_call.generate(_generate_input())
+
+    assert output.samples == [recorded]
+    assert recorded.status == Sample.Status.COMPLETED
+
+
+@pytest.mark.asyncio
+async def test_collection_transport_error_aborts_with_exit_status(monkeypatch):
+    tracer = _Tracer(error=httpx.ConnectError("session server unreachable"))
+    _patch_agent(monkeypatch, tracer)
+
+    output = await agentic_tool_call.generate(_generate_input())
+
+    assert output.samples[0].status == Sample.Status.ABORTED
+    assert output.samples[0].metadata["exit_status"] == "CollectFailed"
 
 
 @pytest.mark.asyncio

--- a/tests/fast/rollout/test_aborted_group_drop.py
+++ b/tests/fast/rollout/test_aborted_group_drop.py
@@ -1,0 +1,95 @@
+from tests.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=30, suite="stage-a-cpu", labels=[])
+
+import asyncio
+import subprocess
+import sys
+
+import pytest
+from tests.fast.rollout.inference_rollout.test_sample_completion_backfill import (
+    GROUP_SIZE,
+    Harness,
+    make_args,
+    make_group,
+)
+
+import miles.rollout.inference_rollout.inference_rollout_train as train
+from miles.rollout.filter_hub.base_types import (
+    MetricGatherer,
+    aborted_exit_status,
+    group_has_aborted,
+)
+from miles.utils.types import Sample
+
+
+def _aborted_group(group_index: int, exit_status: str | None) -> list[Sample]:
+    group = make_group(group_index)
+    group[0].status = Sample.Status.ABORTED
+    group[0].reward = None
+    if exit_status is not None:
+        group[0].metadata["exit_status"] = exit_status
+    return group
+
+
+def test_group_has_aborted_handles_flat_and_nested_groups():
+    assert not group_has_aborted(make_group(1))
+    assert group_has_aborted(_aborted_group(1, "InfraError"))
+    # v2 groups nest a list of leaves per prompt
+    assert group_has_aborted([make_group(1), _aborted_group(2, None)])
+
+
+def test_aborted_exit_status_reads_the_first_aborted_sample():
+    assert aborted_exit_status(_aborted_group(1, "SandboxUnavailable")) == "SandboxUnavailable"
+    assert aborted_exit_status(_aborted_group(1, None)) == "unknown"
+    assert aborted_exit_status(make_group(1)) == "unknown"
+
+
+def test_metric_gatherer_counts_aborted_drops_by_exit_status():
+    gatherer = MetricGatherer()
+    gatherer.on_aborted_group_drop(_aborted_group(1, "SandboxUnavailable"))
+    gatherer.on_aborted_group_drop(_aborted_group(2, "SandboxUnavailable"))
+    gatherer.on_aborted_group_drop(_aborted_group(3, None))
+    gatherer.on_dynamic_filter_drop("zero_std")
+
+    assert gatherer.collect() == {
+        "rollout/aborted/drop_SandboxUnavailable": 2,
+        "rollout/aborted/drop_unknown": 1,
+        "rollout/dynamic_filter/drop_zero_std": 1,
+    }
+
+
+@pytest.mark.asyncio
+async def test_sync_rollout_drops_aborted_group_without_a_dynamic_filter(monkeypatch):
+    """An aborted group never reaches the training batch, even with no dynamic filter configured."""
+    harness = Harness(monkeypatch, make_args(rollout_batch_size=2, dynamic_sampling_filter_path=None))
+    aborted = _aborted_group(999, "SandboxUnavailable")
+    normal_data_source = harness.data_source
+
+    def data_source(num_groups):
+        # the first group the loop draws is the aborted one; every later draw is a normal group
+        if not data_source.served_aborted:
+            data_source.served_aborted = True
+            return [aborted]
+        return normal_data_source(num_groups)
+
+    data_source.served_aborted = False
+    task = asyncio.create_task(train.generate_rollout_async(harness.state, 0, data_source))
+
+    # finish every submitted group as it appears until the loop has its batch
+    while not task.done():
+        for blocker in harness._blockers:
+            blocker.set()
+        await asyncio.sleep(0)
+
+    output, _ = task.result()
+    assert len(output.samples) == 2
+    assert all(len(group) == GROUP_SIZE for group in output.samples)
+    assert not any(group_has_aborted(group) for group in output.samples)
+    assert output.metrics["rollout/aborted/drop_SandboxUnavailable"] == 1
+
+
+def test_agent_function_contract_module_is_torch_free():
+    """Agent functions import the contract on CPU-only hosts and in offline tests (see nemogym_agent_function)."""
+    code = "import sys; import miles.rollout.agent_function; sys.exit(1 if 'torch' in sys.modules else 0)"
+    assert subprocess.run([sys.executable, "-c", code], check=False).returncode == 0

--- a/tests/fast/rollout/test_aborted_group_drop.py
+++ b/tests/fast/rollout/test_aborted_group_drop.py
@@ -15,11 +15,7 @@ from tests.fast.rollout.inference_rollout.test_sample_completion_backfill import
 )
 
 import miles.rollout.inference_rollout.inference_rollout_train as train
-from miles.rollout.filter_hub.base_types import (
-    MetricGatherer,
-    aborted_exit_status,
-    group_has_aborted,
-)
+from miles.rollout.filter_hub.base_types import MetricGatherer, aborted_exit_status, group_has_aborted
 from miles.utils.types import Sample
 
 

--- a/tests/fast/rollout/test_fully_async_rollout.py
+++ b/tests/fast/rollout/test_fully_async_rollout.py
@@ -199,6 +199,8 @@ async def test_aborted_group_recycled(monkeypatch):
     output = await fn(RolloutFnTrainInput(rollout_id=0))
 
     assert data_source.recycled == [aborted]
+    assert output.metrics["rollout/fully_async/aborted_groups_filtered"] == 1
+    assert output.metrics["rollout/aborted/drop_unknown"] == 1
     # reset_for_retry cleared generated outputs so the prompt can be re-sampled
     assert all(sample.response == "" and sample.weight_versions == [] for sample in aborted)
     assert output.samples[0][0].group_index != 1


### PR DESCRIPTION
## Purpose

Give agent functions a way to discard a sample whose failure the policy could not have caused (the sandbox platform refused to create a sandbox, an environment host died). Today every such episode is trained on as `reward = 0` — a false negative — because returning `None` means "no metadata to merge" and exceptions are swallowed.

## What

- `miles.rollout.agentic.InfraAbort(exit_status)` (torch-free module): raising it from an agent function marks the sample `ABORTED` with `metadata["exit_status"]`. Reserved for failures the policy cannot cause; anything it can cause (a timeout, a sandbox it broke) must stay `reward 0`, or the policy learns to trigger it to escape the penalty. The rule and a who-can-cause-what table are in the agentic-rollout guide.
- Both sync rollout loops now drop a group containing an `ABORTED` sample regardless of the dynamic filter (the fully-async buffer already did); `check_no_aborted` keeps working but is no longer load-bearing.
- `rollout/aborted/drop_<exit_status>` counts dropped groups by cause on all three paths — dropping costs rollout compute, and this metric is what says whether the rate is affordable.

## Behaviour change

`None` and exceptions keep today's meaning; no leg raises `InfraAbort` yet (that is #2802). The one change to existing runs: a sync run **without** `check_no_aborted` no longer lets an aborted group (reward `None`) into the training batch.

Related: #2800 (per-sample dropping, parked until the metric shows real rates).
