### PR TITLE
openenv e2b backend: send the template name under the field the server reads (AgentENV interim)

### DIFF
--- a/examples/experimental/agentenv/README.md
+++ b/examples/experimental/agentenv/README.md
@@ -59,6 +59,9 @@ export E2B_API_URL=http://<server>:8000       # control plane
 export E2B_SANDBOX_URL=http://<server>:8000   # data plane (envd proxy)
 # plain-HTTP deployments only; the default is https
 export OPENENV_E2B_URL_SCHEME=http
+# the SDK sends the template name as `alias`; AgentENV reads `name`
+# (radixark/AgentENV#8). Drop this once the deployed server accepts `alias`.
+export OPENENV_E2B_TEMPLATE_NAME_FIELD=name
 # required, but any well-formed key passes: AgentENV does not check it, while
 # recent SDKs do validate the format client-side
 export E2B_API_KEY=e2b_0000000000000000000000000000000000000000

--- a/examples/experimental/openenv/e2b_template_name_compat.py
+++ b/examples/experimental/openenv/e2b_template_name_compat.py
@@ -1,0 +1,52 @@
+"""Send the template name under the field a self-hosted server expects.
+
+The e2b Python SDK (every release through 2.10.2) submits a template build as
+``POST /v3/templates`` with the name in ``alias``. AgentENV's endpoint reads
+``name`` and rejects a body without it (radixark/AgentENV#8, fix proposed
+upstream). Until a server that accepts ``alias`` is deployed, this copies the
+value into the field named by OPENENV_E2B_TEMPLATE_NAME_FIELD before the
+request is serialized. The SDK's own field is kept, so a server that reads
+either works.
+
+Patching the request model is the narrowest hook: the SDK builds the body in
+its generated client, below anything the caller can pass through
+``Template.build``. Remove this module once the deployed AgentENV reads
+``alias``.
+"""
+
+import os
+
+ENV_VAR = "OPENENV_E2B_TEMPLATE_NAME_FIELD"
+_APPLIED_ATTR = "_openenv_template_name_field"
+
+
+def apply_from_env() -> str | None:
+    """Install the shim if OPENENV_E2B_TEMPLATE_NAME_FIELD is set; return the
+    field name it maps to, or None when the variable is unset or empty."""
+    field = os.getenv(ENV_VAR, "").strip()
+    if not field:
+        return None
+    apply(field)
+    return field
+
+
+def apply(field: str) -> None:
+    """Make TemplateBuildRequestV3 serialize its alias under *field* too.
+    Idempotent: a second call with the same field is a no-op; a different field
+    replaces the mapping."""
+    # In-function import: the e2b SDK is an optional dependency of this recipe,
+    # and the module must import without it (the offline tests fake `e2b`).
+    from e2b.api.client.models import template_build_request_v3 as request_model
+
+    cls = request_model.TemplateBuildRequestV3
+    original = getattr(cls, "_openenv_original_to_dict", None) or cls.to_dict
+
+    def to_dict(self):
+        body = original(self)
+        if "alias" in body and field not in body:
+            body[field] = body["alias"]
+        return body
+
+    cls._openenv_original_to_dict = original
+    cls.to_dict = to_dict
+    setattr(cls, _APPLIED_ATTR, field)

--- a/examples/experimental/openenv/openenv_launch_common.py
+++ b/examples/experimental/openenv/openenv_launch_common.py
@@ -276,7 +276,13 @@ _PROVIDER_CREDENTIALS = {
         "sdk_hint": "pip install e2b",
         # E2B_API_URL unset means E2B Cloud; set, it usually points at a
         # self-hosted AgentENV deployment.
-        "forward": ("E2B_API_URL", "E2B_SANDBOX_URL", "E2B_DOMAIN", "OPENENV_E2B_URL_SCHEME"),
+        "forward": (
+            "E2B_API_URL",
+            "E2B_SANDBOX_URL",
+            "E2B_DOMAIN",
+            "OPENENV_E2B_URL_SCHEME",
+            "OPENENV_E2B_TEMPLATE_NAME_FIELD",
+        ),
         "target": ("E2B_API_URL", "endpoint", "E2B Cloud (default)"),
     },
     "modal": {

--- a/examples/experimental/openenv/tb2_sandbox_e2b.py
+++ b/examples/experimental/openenv/tb2_sandbox_e2b.py
@@ -138,11 +138,16 @@ def ensure_task_template(
     # `e2b` in sys.modules, and the sibling backends defer their SDKs the same way.
     from e2b import Template
 
+    import e2b_template_name_compat
+
     task_dir = Path(task_dir)
     alias = template_alias(task_dir)
     with _build_lock(alias):
         if not force and Template.alias_exists(alias, **_connection_opts()):
             return alias
+        # Some self-hosted servers want the name in a different field than the
+        # SDK sends (see the module); a no-op unless the variable is set.
+        e2b_template_name_compat.apply_from_env()
         base = resolve_docker_image(task_dir, None)
         # set_user before the first command: E2B runs template-build commands as
         # a NON-root user by default, which fails every layer of the recipe

--- a/tests/fast/examples/experimental/openenv/test_tb2_sandbox_e2b.py
+++ b/tests/fast/examples/experimental/openenv/test_tb2_sandbox_e2b.py
@@ -332,3 +332,53 @@ def test_keepalive_beats_then_exits_on_persistent_failure(monkeypatch):
             break
         time.sleep(0.01)
     assert not any("keepalive" in t.name for t in threading.enumerate())
+
+
+# --- template name field compat (e2b_template_name_compat) -------------------
+
+
+def _fake_request_model(monkeypatch):
+    """A stand-in for e2b.api.client.models.template_build_request_v3 whose
+    model serializes like the SDK's: alias only."""
+    import types
+
+    class TemplateBuildRequestV3:
+        def __init__(self, alias):
+            self.alias = alias
+
+        def to_dict(self):
+            return {"alias": self.alias, "cpuCount": 1}
+
+    mod = types.ModuleType("e2b.api.client.models.template_build_request_v3")
+    mod.TemplateBuildRequestV3 = TemplateBuildRequestV3
+    pkg_models = types.ModuleType("e2b.api.client.models")
+    pkg_models.template_build_request_v3 = mod
+    for name, m in (
+        ("e2b.api", types.ModuleType("e2b.api")),
+        ("e2b.api.client", types.ModuleType("e2b.api.client")),
+        ("e2b.api.client.models", pkg_models),
+        ("e2b.api.client.models.template_build_request_v3", mod),
+    ):
+        monkeypatch.setitem(sys.modules, name, m)
+    return TemplateBuildRequestV3
+
+
+def test_template_name_compat_copies_alias_into_named_field(monkeypatch, fake_e2b):
+    import e2b_template_name_compat as compat
+
+    cls = _fake_request_model(monkeypatch)
+    monkeypatch.setenv(compat.ENV_VAR, "name")
+    assert compat.apply_from_env() == "name"
+    assert cls("tb2-x").to_dict() == {"alias": "tb2-x", "cpuCount": 1, "name": "tb2-x"}
+    # idempotent: applying again does not wrap the wrapper
+    compat.apply_from_env()
+    assert cls("tb2-y").to_dict() == {"alias": "tb2-y", "cpuCount": 1, "name": "tb2-y"}
+
+
+def test_template_name_compat_is_a_no_op_when_unset(monkeypatch, fake_e2b):
+    import e2b_template_name_compat as compat
+
+    cls = _fake_request_model(monkeypatch)
+    monkeypatch.delenv(compat.ENV_VAR, raising=False)
+    assert compat.apply_from_env() is None
+    assert cls("tb2-x").to_dict() == {"alias": "tb2-x", "cpuCount": 1}


### PR DESCRIPTION
Interim client-side fix so `Template.build` works against a self-hosted AgentENV: an opt-in env var, `OPENENV_E2B_TEMPLATE_NAME_FIELD`, that makes the e2b SDK also send the template name under the field the server reads (`name`).

## Why

Every e2b Python SDK release through 2.10.2 submits a template build with the name in `alias`; AgentENV's `POST /v3/templates` reads `name` and rejects the request (`400 template name must be provided`), so `ensure_task_template` cannot bake a single task image and the whole e2b/agentenv backend stops at step one. Reproduced 2026-08-28 against the dev sandbox-service cluster (AgentENV v0.1.3); with the field added, the build takes 7 s and the rest of the path (create from alias, `commands.run`, `get_host`) works unchanged.

The proper fix is server-side — [radixark/AgentENV#8](https://github.com/radixark/AgentENV/issues/8), PR to upstream in flight. This module goes away once a server that accepts `alias` is deployed; the env var is off by default, so E2B Cloud and any other provider are untouched.

## What

- `examples/experimental/openenv/e2b_template_name_compat.py`: patches the SDK's `TemplateBuildRequestV3.to_dict` to copy `alias` into the named field. Idempotent; a no-op when the variable is unset.
- `tb2_sandbox_e2b.ensure_task_template`: applies it right before `Template.build`.
- `openenv_launch_common`: forwards the variable to rollout workers like the other `E2B_*` settings.
- `examples/experimental/agentenv/README.md`: the export line, with the reason and the removal condition.
- Tests: the shim under a fake SDK model (copies the field, idempotent, no-op when unset).

## Verification

`tests/fast/examples/experimental/openenv/` (37 tests) pass in `radixark/miles:latest`. End to end from a laptop against the dev sandbox-service cluster with `OPENENV_E2B_TEMPLATE_NAME_FIELD=name`: `scan_golden.py --tasks fix-git` scores 1.0 (35.7 s including the template bake).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

