### PR TITLE
openenv e2b backend: declare the SDK as an extra, floor it at 2.12

### DIFF
--- a/examples/experimental/agentenv/README.md
+++ b/examples/experimental/agentenv/README.md
@@ -54,7 +54,7 @@ documented in the [AgentENV docs](https://kvcache-ai.github.io/AgentENV/).
 ## 2. Point the E2B SDK at it
 
 ```bash
-pip install e2b
+pip install -e '<miles>[e2b]'   # e2b>=2.12: older releases send the template name in a field AgentENV does not read
 export E2B_API_URL=http://<server>:8000       # control plane
 export E2B_SANDBOX_URL=http://<server>:8000   # data plane (envd proxy)
 # plain-HTTP deployments only; the default is https

--- a/examples/experimental/openenv/README.md
+++ b/examples/experimental/openenv/README.md
@@ -97,7 +97,7 @@ microVM platform whose native API *is* the E2B API — set `E2B_API_URL` and
 `agentenv` is accepted as an alias for this backend.
 
 ```bash
-pip install e2b
+pip install -e '<miles>[e2b]'   # e2b>=2.12 (see the AgentENV recipe)
 export E2B_API_KEY=e2b_...     # or E2B_API_KEY_FILE (default ~/.config/e2b/api_key)
 export OPENENV_TB2_TASKS_DIR=/workspace/terminal-bench-2
 OPENENV_SANDBOX_BACKEND=e2b python run-openenv-tbench2.py

--- a/examples/experimental/openenv/openenv_launch_common.py
+++ b/examples/experimental/openenv/openenv_launch_common.py
@@ -206,7 +206,7 @@ def apply_optional_env_vars(env: dict[str, str], args: LaunchArgs) -> None:
             default_path=spec["default_path"],
             provision_hint=spec["provision_hint"],
         )
-        preflight_sdk(spec["sdk"], spec["sdk_hint"])
+        preflight_sdk(spec["sdk"], spec["sdk_hint"], spec.get("sdk_min_version"))
         # Addresses, not secrets: the SDK reads these from the environment on
         # every worker, so forward whatever is set here BY VALUE.
         for var in spec["forward"]:

--- a/miles/rollout/agentic/credentials.py
+++ b/miles/rollout/agentic/credentials.py
@@ -166,7 +166,16 @@ def preflight_sdk(module: str, install_hint: str, min_version: str | None = None
         ) from e
     if min_version is None:
         return
-    installed = importlib.metadata.version(module)
+    try:
+        # Looking the distribution up by the module name assumes the two match,
+        # which holds for every backend that sets a floor today (e2b).
+        installed = importlib.metadata.version(module)
+    except importlib.metadata.PackageNotFoundError:
+        # Importable but no dist-info (a vendored copy): the version cannot be
+        # verified, and blocking a possibly-fine install is worse than leaving
+        # a too-old one to fail at the provider with its own error.
+        print(f"{module} has no package metadata; cannot verify {module}>={min_version}", flush=True)
+        return
     if _version_tuple(installed) < _version_tuple(min_version):
         raise RuntimeError(f"this sandbox mode needs {module}>={min_version} (installed: {installed}): {install_hint}")
 

--- a/miles/rollout/agentic/credentials.py
+++ b/miles/rollout/agentic/credentials.py
@@ -15,9 +15,12 @@ growing a branch:
   forward        addresses/selectors, safe to forward by value
   target         (var, label, default description) echoed so a launch says
                  which endpoint/environment it will actually use
+  sdk_min_version  optional; the floor the extra in setup.py declares,
+                 enforced by preflight_sdk
 """
 
 import importlib
+import importlib.metadata
 import os
 from pathlib import Path
 
@@ -43,7 +46,10 @@ PROVIDER_CREDENTIALS = {
         "provision_hint": "mkdir -p ~/.config/e2b && echo <key> > ~/.config/e2b/api_key"
         "  # AgentENV accepts any non-empty key today",
         "sdk": "e2b",
-        "sdk_hint": "pip install e2b",
+        "sdk_hint": "pip install -e '<miles>[e2b]'",
+        # Older releases send the template name as `alias`, which self-hosted
+        # AgentENV does not read; the failure is a bare 400 at the first bake.
+        "sdk_min_version": "2.12",
         # E2B_API_URL unset means E2B Cloud; set, it usually points at a
         # self-hosted AgentENV deployment.
         "forward": ("E2B_API_URL", "E2B_SANDBOX_URL", "E2B_DOMAIN", "OPENENV_E2B_URL_SCHEME"),
@@ -143,17 +149,42 @@ def sandbox_key_supply(
         )
 
 
-def preflight_sdk(module: str, install_hint: str) -> None:
+def preflight_sdk(module: str, install_hint: str, min_version: str | None = None) -> None:
     """Preflight the lazily-imported provider SDK. Without this, a missing
     install only surfaces inside each episode's sandbox start, where the
     failed sample is aborted, the group dropped, and the rollout loop refills
-    forever — a silent GPU-burning churn instead of a launch-time error."""
+    forever — a silent GPU-burning churn instead of a launch-time error.
+    *min_version*, when given, is the floor the extra in setup.py declares;
+    checking it here catches an SDK installed by hand or preinstalled in an
+    image, whose failure mode would otherwise be a provider error with no hint
+    that the version is the cause."""
     try:
         importlib.import_module(module)
     except ImportError as e:
         raise RuntimeError(
             f"this sandbox mode needs the {module} SDK in the rollout process's environment: {install_hint}"
         ) from e
+    if min_version is None:
+        return
+    installed = importlib.metadata.version(module)
+    if _version_tuple(installed) < _version_tuple(min_version):
+        raise RuntimeError(f"this sandbox mode needs {module}>={min_version} (installed: {installed}): {install_hint}")
+
+
+def _version_tuple(version: str) -> tuple[int, ...]:
+    """Numeric leading components of a version string, enough to compare
+    release floors like 2.12 against 2.46.0 or 2.12.0rc1."""
+    parts = []
+    for piece in version.split("."):
+        digits = ""
+        for ch in piece:
+            if not ch.isdigit():
+                break
+            digits += ch
+        if not digits:
+            break
+        parts.append(int(digits))
+    return tuple(parts)
 
 
 def resolve_provider_api_key(env_var: str, file_env_var: str, default_path: str) -> str:

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,13 @@ setup(
             "uvicorn>=0.41",
             "prometheus_client>=0.24",
         ],
+        # the openenv e2b sandbox backend, imported only when that backend is
+        # selected. 2.12 is the first release that sends the template name in
+        # the `name` field, which self-hosted AgentENV reads; older ones send
+        # the deprecated `alias` and every Template.build fails with 400
+        "e2b": [
+            "e2b>=2.12",
+        ],
     },
     python_requires=">=3.10",
     classifiers=[

--- a/tests/fast/rollout/agentic/test_credentials.py
+++ b/tests/fast/rollout/agentic/test_credentials.py
@@ -169,6 +169,19 @@ def test_preflight_enforces_min_version(monkeypatch):
     preflight_sdk("fakesdk", "pip install fakesdk")  # no floor, no check
 
 
+def test_preflight_skips_floor_without_package_metadata(monkeypatch, capsys):
+    """A vendored copy imports fine but has no dist-info; the floor check is
+    skipped with a note rather than blocking a possibly-fine install."""
+    monkeypatch.setitem(sys.modules, "fakesdk", types.ModuleType("fakesdk"))
+
+    def raise_not_found(name):
+        raise credentials.importlib.metadata.PackageNotFoundError(name)
+
+    monkeypatch.setattr(credentials.importlib.metadata, "version", raise_not_found)
+    preflight_sdk("fakesdk", "pip install fakesdk", "2.12")  # no error
+    assert "cannot verify fakesdk>=2.12" in capsys.readouterr().out
+
+
 def test_version_tuple_reads_leading_numbers():
     assert credentials._version_tuple("2.12") == (2, 12)
     assert credentials._version_tuple("2.46.0") == (2, 46, 0)

--- a/tests/fast/rollout/agentic/test_credentials.py
+++ b/tests/fast/rollout/agentic/test_credentials.py
@@ -3,6 +3,7 @@ import types
 
 import pytest
 
+import miles.rollout.agentic.credentials as credentials
 from miles.rollout.agentic.credentials import (
     PROVIDER_CREDENTIALS,
     forward_address,
@@ -23,6 +24,8 @@ _SPEC_KEYS = {
     "forward",
     "target",
 }
+# Per-backend extras a spec may carry; the launchers read them with .get().
+_OPTIONAL_SPEC_KEYS = {"sdk_min_version"}
 
 
 # --- the credential table ----------------------------------------------------
@@ -31,7 +34,7 @@ _SPEC_KEYS = {
 @pytest.mark.parametrize("backend", sorted(PROVIDER_CREDENTIALS))
 def test_credential_spec_is_complete(backend):
     spec = PROVIDER_CREDENTIALS[backend]
-    assert set(spec) == _SPEC_KEYS, backend
+    assert _SPEC_KEYS <= set(spec) <= _SPEC_KEYS | _OPTIONAL_SPEC_KEYS, backend
     assert spec["key_env_vars"], backend
     assert spec["default_path"], backend
 
@@ -154,6 +157,23 @@ def test_preflight_passes_when_the_sdk_imports(monkeypatch):
 def test_preflight_names_the_install_hint_when_the_sdk_is_missing():
     with pytest.raises(RuntimeError, match="pip install nonexistent-sdk"):
         preflight_sdk("nonexistent_provider_sdk", "pip install nonexistent-sdk")
+
+
+def test_preflight_enforces_min_version(monkeypatch):
+    monkeypatch.setitem(sys.modules, "fakesdk", types.ModuleType("fakesdk"))
+    monkeypatch.setattr(credentials.importlib.metadata, "version", lambda name: "2.11.0")
+    with pytest.raises(RuntimeError, match=r"fakesdk>=2\.12 \(installed: 2\.11\.0\)"):
+        preflight_sdk("fakesdk", "pip install fakesdk", "2.12")
+    monkeypatch.setattr(credentials.importlib.metadata, "version", lambda name: "2.46.0")
+    preflight_sdk("fakesdk", "pip install fakesdk", "2.12")  # no error
+    preflight_sdk("fakesdk", "pip install fakesdk")  # no floor, no check
+
+
+def test_version_tuple_reads_leading_numbers():
+    assert credentials._version_tuple("2.12") == (2, 12)
+    assert credentials._version_tuple("2.46.0") == (2, 46, 0)
+    assert credentials._version_tuple("2.12.0rc1") == (2, 12, 0)
+    assert credentials._version_tuple("2.12") < credentials._version_tuple("2.46.0")
 
 
 # --- worker-side key resolution -------------------------------------------------


### PR DESCRIPTION
Declare the e2b SDK as an extra with a version floor, checked at launch.

## Why

The openenv per-episode backends import their provider SDK lazily and nothing in the repo said which version to install; the READMEs said `pip install e2b`. With e2b ≤ 2.11 (the last release for Python 3.9 is 2.10.2), `Template.build` sends the template name in the deprecated `alias` field, which a self-hosted AgentENV does not read: every bake fails with a bare `400 template name must be provided`, and nothing points at the SDK version. 2.12 and later send `name` and work (verified 2026-08-28: e2b 2.46.0, an unbaked task, golden reward 1.0 on the dev sandbox-service cluster).

## What

- `setup.py`: extra `e2b` (`e2b>=2.12`), next to the existing `fsdp`/`mlflow`/`dashboard`. Nothing is added to the core install; the extra is pulled in only by users of that backend.
- `miles.rollout.agentic.credentials.preflight_sdk` (the SDK preflight moved there in #2805; this PR originally targeted its old home in `openenv_launch_common`): an optional minimum version per backend, checked with `importlib.metadata` after the import succeeds. Set for e2b (2.12). This catches an SDK installed by hand or preinstalled in an image, and names the cause in the error. If the module imports but has no dist-info (a vendored copy), the floor check is skipped with a note instead of blocking a possibly-fine install (review nit).
- READMEs: the e2b install lines become `pip install -e '<miles>[e2b]'`.
- Tests (`tests/fast/rollout/agentic/test_credentials.py`): the version floor (below → error naming both versions; at/above → passes; no floor → no check; missing metadata → skipped with a note) and the version parser.

## Verification

CI was green on the pre-rebase `0bc7a125d` (pre-commit and all CPU stages, 588 fast tests); rebased onto #2805 and re-pushed as `b643a433b`, tests re-run locally in the new location. The first push failed one of the suite's own checks — `test_credential_spec_is_complete` requires each backend's spec to have exactly the known keys — which now admits the optional `sdk_min_version`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
