### PR TITLE
openenv: raise the tbench2_env contract floor to OpenEnv#1025

### DIFF
--- a/examples/experimental/openenv/README.md
+++ b/examples/experimental/openenv/README.md
@@ -51,11 +51,11 @@ few tasks at a time if it does.
 
 Whichever provider you pick, install `tbench2_env` **editable**: the recipe
 bakes the installed source into each task image, so that install must carry
-the `>=` #1012 server contract. The launcher preflights the installed source
+the `>=` #1025 server contract. The launcher preflights the installed source
 and fails fast on an older one.
 
 ```bash
-git clone https://github.com/huggingface/OpenEnv.git   # >= the #1012 merge (04d259ea6, the full canonical contract for both modes); pin that sha if you need frozen reward semantics across a long run
+git clone https://github.com/huggingface/OpenEnv.git   # >= the #1025 merge (38b2a3135: canonical contract for both modes, and a missing verdict is an error rather than reward 0); pin that sha if you need frozen reward semantics across a long run
 pip install -e OpenEnv/envs/tbench2_env
 ```
 
@@ -159,7 +159,7 @@ launcher uses `--openenv-env-url` instead. `MAX_CONCURRENT_ENVS` caps live
 containers; keep it at or below the rollout batch concurrency. Those containers
 are heavy on disk, so if you'd rather not colocate them with the GPU workload,
 run the server on a separate Docker host and point the launcher at it with
-`--openenv-env-url http://<env-host>:8003`. The same `>=` #1012 `tbench2_env`
+`--openenv-env-url http://<env-host>:8003`. The same `>=` #1025 `tbench2_env`
 contract applies: the adapter drops every episode (with a warning) from a
 server that doesn't carry it.
 

--- a/examples/experimental/openenv/openenv_agent_function.py
+++ b/examples/experimental/openenv/openenv_agent_function.py
@@ -28,9 +28,10 @@ Env vars:
   MILES_ROUTER_EXTERNAL_HOST  optional host rewrite for off-cluster agents
 
 Server contract: the env server must run tbench2_env at or after the
-huggingface/OpenEnv#1012 merge (04d259ea6; install per the README) —
+huggingface/OpenEnv#1025 merge (38b2a3135; install per the README) —
 canonical tests/test.sh scoring inside the standard ``evaluate`` action, task
-WORKDIR resolved server-side, verifier assets withheld. The adapter verifies
+WORKDIR resolved server-side, verifier assets withheld, and a verifier that
+never writes its verdict reported as a scoring error rather than reward 0. The adapter verifies
 the contract on every episode rather than trusting the deployment: an
 ``evaluate`` reply without the canonical-harness marker is treated as no
 verdict and the episode is dropped with a warning (see the guard in
@@ -338,7 +339,8 @@ async def multi_turn(
         # No canonical verdict -> reward None (the training wrapper drops the
         # sample instead of ingesting a false-negative 0):
         #   - reward=None / `error` set: the scoring step itself errored
-        #     server-side (toolkit timeout, staging I/O) -- not tests failing.
+        #     server-side (toolkit timeout, staging I/O, or test.sh never
+        #     wrote reward.txt) -- not tests failing.
         #   - harness marker absent: the server scored, but not through the
         #     canonical tests/test.sh (a tbench2_env install predating the
         #     contract in the module docstring, or a task dir without test.sh

--- a/examples/experimental/openenv/openenv_daytona_agent_function.py
+++ b/examples/experimental/openenv/openenv_daytona_agent_function.py
@@ -59,7 +59,7 @@ logger = logging.getLogger(__name__)
 # creates hit Daytona's build cache, and no named snapshot is involved.
 #
 # The sandbox's env server is the tbench2_env baked by the recipe, installed
-# per the README (at or after the huggingface/OpenEnv#1012 merge): canonical
+# per the README (at or after the huggingface/OpenEnv#1025 merge): canonical
 # tests/test.sh scoring built into `evaluate`, task WORKDIR resolved
 # server-side, verifier assets withheld. The launcher preflight rejects an
 # older install outright, and the shared agent loop's harness-marker guard

--- a/examples/experimental/openenv/openenv_e2b_agent_function.py
+++ b/examples/experimental/openenv/openenv_e2b_agent_function.py
@@ -51,7 +51,7 @@ logger = logging.getLogger(__name__)
 
 
 # The sandbox's env server is the tbench2_env baked by the recipe, installed
-# per the README (at or after the huggingface/OpenEnv#1012 merge): canonical
+# per the README (at or after the huggingface/OpenEnv#1025 merge): canonical
 # tests/test.sh scoring built into `evaluate`, task WORKDIR resolved
 # server-side, verifier assets withheld. The launcher preflight rejects an
 # older install outright, and the shared agent loop's harness-marker guard

--- a/examples/experimental/openenv/openenv_launch_common.py
+++ b/examples/experimental/openenv/openenv_launch_common.py
@@ -232,12 +232,17 @@ def apply_optional_env_vars(env: dict[str, str], args: LaunchArgs) -> None:
             ) from e
         server_src = Path(tbench2_env.__file__).resolve().parent / "server" / "tbench2_env_environment.py"
         src_text = server_src.read_text(encoding="utf-8") if server_src.is_file() else ""
-        if "TB2_WITHHOLD_TESTS" not in src_text:
+        # `_require_canonical_verdict` (#1025) is what turns a verifier that never
+        # wrote reward.txt into an error; before it, that reply was reward 0.0
+        # WITH the harness marker, which the per-episode guard cannot tell from
+        # a genuine failure.
+        if "TB2_WITHHOLD_TESTS" not in src_text or "_require_canonical_verdict" not in src_text:
             raise RuntimeError(
                 "the installed tbench2_env server lacks the native-evaluate "
-                "contract (canonical test.sh scoring / TB2_WITHHOLD_TESTS): "
-                "install from an OpenEnv checkout at or after the #1012 merge "
-                "(04d259ea6) — see this directory's README"
+                "contract (canonical test.sh scoring / TB2_WITHHOLD_TESTS / "
+                "missing verdict reported as an error): install from an OpenEnv "
+                "checkout at or after the #1025 merge (38b2a3135) — see this "
+                "directory's README"
             )
         env["OPENENV_TB2_TASKS_DIR"] = args.openenv_tb2_tasks_dir
 

--- a/examples/experimental/openenv/openenv_modal_agent_function.py
+++ b/examples/experimental/openenv/openenv_modal_agent_function.py
@@ -53,7 +53,7 @@ logger = logging.getLogger(__name__)
 
 
 # The sandbox's env server is the tbench2_env baked by the recipe, installed
-# per the README (at or after the huggingface/OpenEnv#1012 merge): canonical
+# per the README (at or after the huggingface/OpenEnv#1025 merge): canonical
 # tests/test.sh scoring built into `evaluate`, task WORKDIR resolved
 # server-side, verifier assets withheld. The launcher preflight rejects an
 # older install outright, and the shared agent loop's harness-marker guard


### PR DESCRIPTION
## Why

huggingface/OpenEnv#1025 (merged 2026-08-29, `38b2a3135`) closes the gap @Shi-Dong spotted: a canonical `tests/test.sh` run whose verifier never wrote `reward.txt` used to come back as `reward=0.0` **with** the `harness="tests/test.sh"` marker — byte-for-byte a genuine test failure. Now the server reports it through `observation.error` / `reward=None`.

Nothing on the miles side worked around that bug (nothing could — the reply looked valid), so there is nothing to delete. The fix lands in the existing guard's `reward is None or eval_error` branch and, in #2802, in the `eval_error` → `no_verdict_reason` mapping; neither changes. The `harness != "tests/test.sh"` branch stays: it covers pre-#1012 installs and the pytest fallback, which #1025 did not touch.

## What

- **Launcher preflight** (`openenv_launch_common.py`): the source probe of the installed `tbench2_env` now also requires `_require_canonical_verdict`. A pre-#1025 install is the one case the per-episode marker guard cannot catch (the fake 0 carries the marker), so the install-time probe is the only place to reject it. All three sandbox backends bake this install into their task images, so one probe covers them.
- **Contract floor** in the README and the four agent-function module docstrings: `#1012 (04d259ea6)` → `#1025 (38b2a3135)`.
- **Guard comment** in `multi_turn`: the `reward=None / error` bullet now names "test.sh never wrote reward.txt" alongside toolkit timeout / staging I/O.

## Not in this PR

- The remote docker-host env server behind `--openenv-env-url` cannot be preflighted; it needs a redeploy from a ≥ #1025 checkout to actually stop emitting the fake 0.
- #1025 routes both "uvx download failed" (infra, droppable) and "in-shell `timeout` fired" (possibly policy-caused) through the same error path, distinguishable only by the log tail. #2802 currently maps every `eval_error` to `VerifierError`/0; whether miles should split that by error text is a #2802 decision.

## Validation

No test changes: the guard and its tests are unchanged; the preflight has no unit test today (it imports the real `tbench2_env`). Fast tests run in CI (no torch locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
