### PR TITLE
openenv: stop the episode when the session crosses --max-seq-len

### DIFF
--- a/examples/experimental/openenv/openenv_agent_function.py
+++ b/examples/experimental/openenv/openenv_agent_function.py
@@ -266,13 +266,19 @@ async def multi_turn(
     action_cls = classes["action"]
     task_id = metadata.get("task_id") or metadata.get("task_name")
     max_turns = int(os.getenv("OPENENV_MAX_TURNS", "30"))
+    raw_budget = metadata.get("max_seq_len")
+    try:
+        max_seq_len = int(raw_budget) if raw_budget is not None else None
+    except (TypeError, ValueError):
+        max_seq_len = None
 
-    async def body(env: Any) -> tuple[float | None, int, str, list[float], list[float], float, float]:
+    async def body(env: Any) -> tuple[float | None, int, str, list[float], list[float], float, float, int]:
         # Per-turn wall-clock timings. gen_times[i] is turn i's policy generation
         # latency; tool_times[i] is turn i's env.step(exec) latency. reset_time and
         # eval_time bracket the one-off reset() and the final evaluate() env steps.
         gen_times: list[float] = []
         tool_times: list[float] = []
+        session_tokens = 0
 
         t0 = time.monotonic()
         reset_result = await (env.reset(task_id=task_id) if task_id else env.reset())
@@ -304,8 +310,24 @@ async def multi_turn(
             # (extras like reasoning_content included).
             convo.append(message.model_dump(exclude_none=True))
 
+            # Assignment, not +=: every turn re-sends the whole conversation, so this
+            # request's total_tokens (prompt + completion) already IS the session total.
+            # It lags by one env response -- turn N's output is appended below and only
+            # priced into turn N+1's prompt -- so we stop just after crossing, never before.
+            usage = getattr(completion, "usage", None)
+            turn_tokens = getattr(usage, "total_tokens", None)
+            if turn_tokens is not None:
+                session_tokens = int(turn_tokens)
+
             if choice.finish_reason == "length":
                 end_reason = "length"
+                break
+
+            # `turn_tokens is not None` again on purpose: if this turn reported no usage,
+            # session_tokens is a stale count from an earlier turn and must not end the
+            # episode. Better to overrun than to truncate a good rollout on a guess.
+            if max_seq_len is not None and turn_tokens is not None and session_tokens >= max_seq_len:
+                end_reason = "max_seq_len"
                 break
 
             command = _strip_fence(reply) if "```" in reply else reply.strip()
@@ -361,10 +383,10 @@ async def multi_turn(
         if post_episode is not None:
             await post_episode(env, action_cls)
 
-        return reward, turns, end_reason, gen_times, tool_times, reset_time, eval_time
+        return reward, turns, end_reason, gen_times, tool_times, reset_time, eval_time, session_tokens
 
     result = await run_body(classes["env"], metadata, body)
-    reward, turns, end_reason, gen_times, tool_times, reset_time, eval_time = result
+    reward, turns, end_reason, gen_times, tool_times, reset_time, eval_time, session_tokens = result
     total_gen_time = sum(gen_times)
     # non_generation_time = everything the rollout spent outside policy generation:
     # per-turn exec latency plus the one-off reset() and evaluate() env steps. Feeds
@@ -373,6 +395,7 @@ async def multi_turn(
     return reward, {
         "turns": turns,
         "end_reason": end_reason,
+        "session_tokens": session_tokens,
         "tool_calls": len(tool_times),
         "gen_times": gen_times,
         "tool_times": tool_times,

--- a/tests/fast/examples/experimental/openenv/test_openenv_agent_function.py
+++ b/tests/fast/examples/experimental/openenv/test_openenv_agent_function.py
@@ -14,6 +14,7 @@ import asyncio
 import types
 
 import openenv_agent_function as oaf
+import pytest
 
 
 def run_async(coro):
@@ -259,3 +260,84 @@ def test_truncated_turn_ends_the_episode(monkeypatch):
     assert any(a.action_type == "evaluate" for a in actions), "scoring still runs"
     assert reward == 1.0 and metrics["turns"] == 1
     assert metrics["end_reason"] == "length"
+
+
+class _BudgetPolicy:
+    """Reports total_tokens off a per-turn sequence; None when emit_usage is off."""
+
+    def __init__(self, totals, stop_after=None, emit_usage=True, finish="stop"):
+        self.totals = totals
+        self.stop_after = stop_after
+        self.emit_usage = emit_usage
+        self.finish = finish
+        self.n = 0
+        self.chat = types.SimpleNamespace(completions=types.SimpleNamespace(create=self._create))
+
+    async def _create(self, **kw):
+        self.n += 1
+        text = "TASK_COMPLETE" if (self.stop_after and self.n == self.stop_after) else "```bash\necho hi\n```"
+        msg = types.SimpleNamespace(
+            content=text, model_dump=lambda exclude_none=True: {"role": "assistant", "content": text}
+        )
+        usage = (
+            types.SimpleNamespace(total_tokens=self.totals[self.n - 1])
+            if (self.emit_usage and self.n <= len(self.totals))
+            else None
+        )
+        return types.SimpleNamespace(
+            choices=[types.SimpleNamespace(message=msg, finish_reason=self.finish)], usage=usage
+        )
+
+
+@pytest.mark.parametrize(
+    "case_id, extra_meta, totals, stop_after, emit_usage, finish, exp_calls, exp_cmds, exp_reason, exp_tokens",
+    [
+        # totals are cumulative session totals, as the server reports them.
+        ("crosses_mid_episode", {"max_seq_len": 1000}, [400, 1000], None, True, "stop", 2, 1, "max_seq_len", 1000),
+        ("crosses_on_first_turn", {"max_seq_len": 1000}, [1200], None, True, "stop", 1, 0, "max_seq_len", 1200),
+        ("stays_under_budget", {"max_seq_len": 100000}, [10, 20], 2, True, "stop", 2, 1, "task_complete", 20),
+        ("no_budget_in_metadata", {}, [10000, 20000], 2, True, "stop", 2, 1, "task_complete", 20000),
+        # A turn with no usage must not end the episode on an earlier turn's stale count.
+        ("no_usage_reported", {"max_seq_len": 1}, [0, 0], 2, False, "stop", 2, 1, "task_complete", 0),
+        # The per-turn cut closes the sample, so it wins even when the budget is also crossed.
+        ("length_beats_budget", {"max_seq_len": 1000}, [1200], None, True, "length", 1, 0, "length", 1200),
+    ],
+)
+def test_budget_capped_turn_ends_the_episode(
+    monkeypatch,
+    case_id,
+    extra_meta,
+    totals,
+    stop_after,
+    emit_usage,
+    finish,
+    exp_calls,
+    exp_cmds,
+    exp_reason,
+    exp_tokens,
+):
+    """--max-seq-len is enforced after the episode, in collect_samples, so the loop sees no
+    finish_reason and no error when a session crosses it. It has to watch usage.total_tokens
+    itself or it generates turns that sample assembly throws away."""
+    monkeypatch.setattr(oaf, "load_tbench2", lambda: _CLASSES)
+
+    async def spying_with_env(env_cls, env_url, body):
+        return await body(env_cls())
+
+    monkeypatch.setattr(oaf, "_with_env", spying_with_env)
+
+    metadata = {"task_id": "t1", **extra_meta}
+    policy = _BudgetPolicy(totals, stop_after=stop_after, emit_usage=emit_usage, finish=finish)
+    reward, metrics = run_async(oaf.run_episode(policy, "m", [{"role": "system", "content": "s"}], {}, metadata))
+
+    assert policy.n == exp_calls
+    cmds = [
+        a.command
+        for a in _FakeEnv.last_actions
+        if a.action_type == "exec" and "/tmp/tbench2_env_runs" not in (a.command or "")
+    ]
+    assert len(cmds) == exp_cmds, "a turn stopped on the budget must not execute its command"
+    assert any(a.action_type == "evaluate" for a in _FakeEnv.last_actions), "scoring still runs"
+    assert reward == 1.0 and metrics["turns"] == exp_calls
+    assert metrics["end_reason"] == exp_reason
+    assert metrics["session_tokens"] == exp_tokens


### PR DESCRIPTION
## Problem

`--max-seq-len` is enforced after the episode, inside `collect_samples`. The agent loop gets no
signal when a session crosses it — no `finish_reason`, no error — so an episode that crosses at
turn 12 keeps going to turn 30 or the wall clock, and everything past the cut is discarded. Same
waste #2587 removed at the per-turn boundary, one boundary over.

## What changes

`multi_turn` reads `usage.total_tokens` off each completion and breaks when it reaches the budget.

Assignment, not accumulation: every turn re-sends the whole conversation, so the request's
`total_tokens` (prompt + completion) already *is* the session total. It lags by one env response —
turn N's output is appended after the completion and only priced into turn N+1's prompt — so the
loop stops just after crossing, never before. That direction is deliberate; stopping early would
throw away a rollout that was still inside the budget.

The budget arrives via `metadata["max_seq_len"]`, which `agentic_tool_call.generate` already puts
there. If a turn reports no `usage`, the loop does not stop on a stale count from an earlier turn.

Two new metrics in `agent_metrics`: `session_tokens` and `stopped_on_budget`, so the frequency is
visible in a run rather than inferred.

## Testing

- `python -m pytest --confcutdir=tests/fast/examples/experimental/openenv tests/fast/examples/experimental/openenv -q`
  - 110 passed, 3 skipped
- Six new parametrized cases: crossing mid-episode, crossing on the first turn, staying under
  budget, no `max_seq_len` in metadata, a turn that reports no `usage`, and `finish_reason="length"` taking precedence.
- `ruff`, `black`, `isort` clean on both changed files

Closes #2591

cc @nblintao
