### PR TITLE
feat(ci): add user allowlists for command tiers

### DIFF
--- a/.github/workflows/policies/comment-command-access.json
+++ b/.github/workflows/policies/comment-command-access.json
@@ -1,15 +1,16 @@
 {
-  "version": 3,
+  "version": 4,
   "groups": {
     "add_label_access": {
       "repository_permissions": ["write", "admin"],
-      "user_ids": []
+      "users": []
     },
     "repo_write_access": {
       "repository_permissions": ["write", "admin"]
     },
     "prior_contributor_access": {
       "repository_permissions": ["write", "admin"],
+      "users": [],
       "author_associations": ["OWNER", "MEMBER", "COLLABORATOR", "CONTRIBUTOR"]
     }
   },

--- a/.github/workflows/policies/comment-command-access.json
+++ b/.github/workflows/policies/comment-command-access.json
@@ -3,7 +3,12 @@
   "groups": {
     "add_label_access": {
       "repository_permissions": ["write", "admin"],
-      "users": []
+      "users": [
+        {"id": 82826991, "login": "zyzshishui"},
+        {"id": 59716405, "login": "nanjiangwill"},
+        {"id": 101526713, "login": "xiuhu17"},
+        {"id": 106564213, "login": "zianglih"}
+      ]
     },
     "repo_write_access": {
       "repository_permissions": ["write", "admin"]

--- a/.github/workflows/scripts/comment_ci_command.py
+++ b/.github/workflows/scripts/comment_ci_command.py
@@ -162,16 +162,6 @@ def _validate_permissions(name, values):
     return frozenset(values)
 
 
-def _validate_user_ids(name, values):
-    if not isinstance(values, list):
-        raise CommentCommandError(f"{name} must be an array")
-    if any(type(value) is not int or value <= 0 for value in values):
-        raise CommentCommandError(f"{name} must contain only positive integers")
-    if len(set(values)) != len(values):
-        raise CommentCommandError(f"{name} contains duplicate user IDs")
-    return frozenset(values)
-
-
 def _validate_author_associations(name, values):
     if not isinstance(values, list) or not values:
         raise CommentCommandError(f"{name} must be a non-empty array")
@@ -197,8 +187,8 @@ def load_policy(path):
     raw = load_json(path)
     if not isinstance(raw, dict) or set(raw) != {"version", "groups", "commands"}:
         raise CommentCommandError("policy must contain only version, groups, and commands")
-    if type(raw["version"]) is not int or raw["version"] != 3:
-        raise CommentCommandError("policy version must be 3")
+    if type(raw["version"]) is not int or raw["version"] != 4:
+        raise CommentCommandError("policy version must be 4")
 
     raw_groups = raw["groups"]
     if not isinstance(raw_groups, dict) or set(raw_groups) != POLICY_GROUPS:
@@ -208,8 +198,8 @@ def load_policy(path):
     groups = {}
     for name, raw_group in raw_groups.items():
         expected_keys = {"repository_permissions"}
-        if name == "add_label_access":
-            expected_keys.add("user_ids")
+        if name in {"add_label_access", "prior_contributor_access"}:
+            expected_keys.add("users")
         if name == "prior_contributor_access":
             expected_keys.add("author_associations")
         if not isinstance(raw_group, dict) or set(raw_group) != expected_keys:
@@ -219,9 +209,10 @@ def load_policy(path):
                 f"groups.{name}.repository_permissions",
                 raw_group["repository_permissions"],
             ),
-            "user_ids": _validate_user_ids(
-                f"groups.{name}.user_ids",
-                raw_group.get("user_ids", []),
+            "user_ids": (
+                frozenset(user["id"] for user in raw_group["users"])
+                if "users" in raw_group
+                else frozenset()
             ),
             "author_associations": (
                 _validate_author_associations(
@@ -1018,7 +1009,7 @@ COMMAND_REGISTRY = {
         None,
         None,
         None,
-        False,
+        True,
         "command",
         _rerun_command_value,
         "none",
@@ -1030,7 +1021,7 @@ COMMAND_REGISTRY = {
         None,
         None,
         None,
-        False,
+        True,
         "test_file",
         _run_file_value,
         "+1",

--- a/.github/workflows/scripts/comment_ci_command.py
+++ b/.github/workflows/scripts/comment_ci_command.py
@@ -210,9 +210,7 @@ def load_policy(path):
                 raw_group["repository_permissions"],
             ),
             "user_ids": (
-                frozenset(user["id"] for user in raw_group["users"])
-                if "users" in raw_group
-                else frozenset()
+                frozenset(user["id"] for user in raw_group["users"]) if "users" in raw_group else frozenset()
             ),
             "author_associations": (
                 _validate_author_associations(

--- a/docs/ci/05-command-identity.md
+++ b/docs/ci/05-command-identity.md
@@ -9,7 +9,7 @@ This page owns the identity and authorization rules of the PR-comment command ga
 
 ## Identity binding
 
-Every command arrives as an `issue_comment` event on a pull request. The gateway accepts only comments whose author is a human `User` — bot authors are rejected, which also stops the gateway's own `github-actions[bot]` replies from re-triggering it — and requires the event `sender` to match the comment author. Three identity facts are bound from the event: the author's stable numeric user ID, their login, and the `author_association` GitHub stamped on the comment at creation time. An association outside GitHub's documented enum fails closed. Grants never match on login text: the login exists only to re-query the live repository permission, and that lookup verifies the returned identity's numeric ID against the comment author before trusting the permission value.
+Every command arrives as an `issue_comment` event on a pull request. The gateway accepts only comments whose author is a human `User` — bot authors are rejected, which also stops the gateway's own `github-actions[bot]` replies from re-triggering it — and requires the event `sender` to match the comment author. Three identity facts are bound from the event: the author's stable numeric user ID, their login, and the `author_association` GitHub stamped on the comment at creation time. An association outside GitHub's documented enum fails closed. Grants never match on login text: the event login exists only to re-query the live repository permission, and that lookup verifies the returned identity's numeric ID against the comment author before trusting the permission value; the policy's `users[].login` is display-only.
 
 ## Access groups
 
@@ -17,23 +17,25 @@ Every command arrives as an `issue_comment` event on a pull request. The gateway
 
 | Group | Commands | Admits |
 |---|---|---|
-| `add_label_access` | `/run-ci-<x>`, `/bypass-fastfail` | live `write`/`admin`, or an explicit numeric `user_ids` entry |
+| `add_label_access` | `/run-ci-<x>`, `/bypass-fastfail` | live `write`/`admin`, or an explicit numeric user `id` entry |
 | `repo_write_access` | `/clear-labels` | live `write`/`admin` |
-| `prior_contributor_access` | `/rerun-test <test-file>`, `/rerun-failed-ci` | comment `author_association` in `OWNER`/`MEMBER`/`COLLABORATOR`/`CONTRIBUTOR`, else live `write`/`admin` |
+| `prior_contributor_access` | `/rerun-test <test-file>`, `/rerun-failed-ci` | comment `author_association` in `OWNER`/`MEMBER`/`COLLABORATOR`/`CONTRIBUTOR`, an explicit numeric user `id` entry, or live `write`/`admin` |
 
-Only `add_label_access` can contain explicit `user_ids`; those IDs let workflow owners grant a specific contributor label-command access without granting repository write, and they never grant any non-label operation. GitHub reports the `maintain` role as legacy `write`; custom roles follow their base repository access.
+`add_label_access` and `prior_contributor_access` each contain an independent `users` allowlist whose entries have the shape `{"id": 123, "login": "alice"}`. Authorization uses only the stable numeric `id`; `login` is a required display annotation and may be stale without changing access. These entries let workflow owners grant a specific user one existing command tier without granting repository write: the label list grants only label commands, while the prior-contributor list grants only the two rerun commands. `repo_write_access` has no allowlist, so `/clear-labels` always requires live `write`/`admin`. GitHub reports the `maintain` role as legacy `write`; custom roles follow their base repository access.
+
+This policy is checked in and reviewed as trusted configuration. Maintainers must keep each `users` entry to one unique positive numeric `id` plus a non-empty `login` annotation; the gateway deliberately does not verify that annotation against GitHub. Moving this policy to an external or dynamically updated source would require a separate design for validation, update authority, and auditability.
 
 ## Tier constraints
 
 The tiers are deliberate, not incidental:
 
 - **Label mutations stay write-gated because a label is CI policy.** A `run-ci-*` label selects what CI spends and, for fork PRs, doubles as the standing Approve-and-run decision (see [Labels](/ci/01-label)); granting it below write would let non-maintainers set policy.
-- **The rerun commands are cheaper to grant, so they sit at the prior-contributor tier.** The author association GitHub stamps on the comment admits `OWNER`, `MEMBER`, `COLLABORATOR`, and `CONTRIBUTOR` — anyone with a commit already merged into `radixark/miles` — without a live-permission lookup; anyone else needs live `write` or `admin`. First-time contributors and users with no history in the repository are denied. A failed-job rerun re-executes an already-authorized run with its original privileges and SHA, and a file run is bounded by one registered file, its registration's timeout, and per-PR serialization, so the residual exposure is runner time rather than code trust.
+- **The rerun commands are cheaper to grant, so they sit at the prior-contributor tier.** The author association GitHub stamps on the comment admits `OWNER`, `MEMBER`, `COLLABORATOR`, and `CONTRIBUTOR` — anyone with a commit already merged into `radixark/miles` — without a live-permission lookup; an explicit numeric user `id` entry admits a named exception, and anyone else needs live `write` or `admin`. First-time contributors and users with no history in the repository are denied unless they are explicitly allowlisted. A failed-job rerun re-executes an already-authorized run with its original privileges and SHA, and a file run is bounded by one registered file, its registration's timeout, and per-PR serialization, so the residual exposure is runner time rather than code trust.
 - **Constraint: a fork head is the normal shape of a contribution from someone without write permission** — pushing a same-repository branch already requires write. `/rerun-test` therefore adds no fork-specific approval: the policy tier is the whole gate for both head shapes, and requiring anything extra of forks would exclude exactly the contributors the command exists for. What changes on a fork head is containment, not authorization: the head identity is re-verified against its unique open pull request before dispatch, and the run receives no repository secrets (`WANDB_API_KEY` and `HF_TOKEN` are withheld), matching the pr-test fork policy.
 
 ## Evaluation points
 
-The handler evaluates the caller against the checked-in policy twice: once in the preflight job, and again in the capability-specific job immediately before the command mutates GitHub state. An explicit `user_ids` match uses the numeric comment-author identity bound to the event; an admitted author association is likewise the value bound to the comment; only the fallback path performs a live repository-permission lookup, and each lookup is a point-in-time result.
+The handler evaluates the caller against the checked-in policy twice: once in the preflight job, and again in the capability-specific job immediately before the command mutates GitHub state. An explicit `users[].id` match uses the numeric comment-author identity bound to the event; `users[].login` is never compared with the event. An admitted author association is likewise the value bound to the comment; only the fallback path performs a live repository-permission lookup, and each lookup is a point-in-time result.
 
 ## Token identity
 

--- a/tests/ci/test/test_comment_ci_command.py
+++ b/tests/ci/test/test_comment_ci_command.py
@@ -577,7 +577,7 @@ def test_checked_in_policy_exposes_exact_labels_and_access_groups():
     }
     assert loaded["groups"]["add_label_access"] == {
         "repository_permissions": WRITE_PERMISSIONS,
-        "user_ids": frozenset(),
+        "user_ids": frozenset({82826991, 59716405, 101526713, 106564213}),
         "author_associations": frozenset(),
     }
     assert loaded["groups"]["repo_write_access"] == {

--- a/tests/ci/test/test_comment_ci_command.py
+++ b/tests/ci/test/test_comment_ci_command.py
@@ -196,6 +196,7 @@ def policy(
     *,
     permissions=("write", "admin"),
     user_ids=(),
+    prior_user_ids=(),
     labels=("run-ci-short", "bypass-fastfail"),
     repo_permissions=("write", "admin"),
     author_associations=("OWNER", "MEMBER", "COLLABORATOR", "CONTRIBUTOR"),
@@ -214,7 +215,7 @@ def policy(
             },
             "prior_contributor_access": {
                 "repository_permissions": frozenset(repo_permissions),
-                "user_ids": frozenset(),
+                "user_ids": frozenset(prior_user_ids),
                 "author_associations": frozenset(author_associations),
             },
         },
@@ -358,15 +359,16 @@ def test_unknown_request_type_fails_closed():
 
 def raw_policy():
     return {
-        "version": 3,
+        "version": 4,
         "groups": {
             "add_label_access": {
                 "repository_permissions": ["write", "admin"],
-                "user_ids": [],
+                "users": [],
             },
             "repo_write_access": {"repository_permissions": ["write", "admin"]},
             "prior_contributor_access": {
                 "repository_permissions": ["write", "admin"],
+                "users": [],
                 "author_associations": ["OWNER", "MEMBER", "COLLABORATOR", "CONTRIBUTOR"],
             },
         },
@@ -471,12 +473,10 @@ def test_policy_parser_rejects_legacy_or_nonstandard_schema(tmp_path, text, mess
 @pytest.mark.parametrize(
     ("path_parts", "value", "message"),
     [
-        (("version",), 2, "version must be 3"),
+        (("version",), 3, "version must be 4"),
         (("groups", "add_label_access", "repository_permissions"), [True], "only write or admin"),
         (("groups", "add_label_access", "repository_permissions"), ["read"], "only write or admin"),
         (("groups", "add_label_access", "repository_permissions"), ["write", "write"], "duplicate permissions"),
-        (("groups", "add_label_access", "user_ids"), [True], "only positive integers"),
-        (("groups", "add_label_access", "user_ids"), [123, 123], "duplicate user IDs"),
         (("groups", "prior_contributor_access", "author_associations"), [], "non-empty array"),
         (("groups", "prior_contributor_access", "author_associations"), [True], "only GitHub author associations"),
         (
@@ -493,7 +493,7 @@ def test_policy_parser_rejects_legacy_or_nonstandard_schema(tmp_path, text, mess
         (("commands", "add_label", "allowed_labels"), ["run-ci-short", "run-ci-short"], "duplicate labels"),
         (("commands", "add_label", "group"), "missing", "unknown group"),
         (("commands", "clear_labels", "unexpected"), True, "invalid fields"),
-        (("groups", "repo_write_access", "user_ids"), [123], "invalid fields"),
+        (("groups", "repo_write_access", "users"), [{"id": 123, "login": "actor"}], "invalid fields"),
         (("groups", "repo_write_access", "author_associations"), ["MEMBER"], "invalid fields"),
         (("groups", "add_label_access", "author_associations"), ["MEMBER"], "invalid fields"),
     ],
@@ -510,6 +510,43 @@ def test_policy_parser_rejects_invalid_group_command_or_resource(tmp_path, path_
         HANDLER.load_policy(path)
 
 
+def test_policy_parser_loads_independent_users_for_both_customizable_tiers(tmp_path):
+    raw = raw_policy()
+    raw["groups"]["add_label_access"]["users"] = [{"id": 111, "login": "alice"}]
+    raw["groups"]["prior_contributor_access"]["users"] = [{"id": 222, "login": "bob"}]
+    path = tmp_path / "policy.json"
+    path.write_text(json.dumps(raw))
+
+    loaded = HANDLER.load_policy(path)
+
+    assert loaded["groups"]["add_label_access"]["user_ids"] == {111}
+    assert loaded["groups"]["prior_contributor_access"]["user_ids"] == {222}
+
+
+@pytest.mark.parametrize(
+    ("group", "body"),
+    [
+        ("add_label_access", "/run-ci-short"),
+        ("prior_contributor_access", RUN_FILE_BODY),
+    ],
+)
+def test_user_login_is_display_only_for_authorization(tmp_path, group, body):
+    raw = raw_policy()
+    raw["groups"][group]["users"] = [{"id": ACTOR_ID, "login": "stale-login"}]
+    path = tmp_path / "policy.json"
+    path.write_text(json.dumps(raw))
+    api = FakeAPI(pull(), permission="none")
+
+    result = HANDLER.authorize_policy(
+        event(body=body, author_association="FIRST_TIMER"),
+        HANDLER.load_policy(path),
+        api,
+    )
+
+    assert result[0:2] == (123, ACTOR_ID)
+    assert api.calls == []
+
+
 @pytest.mark.parametrize("section", ["groups", "commands"])
 def test_policy_parser_rejects_unknown_group_or_command(tmp_path, section):
     raw = raw_policy()
@@ -521,9 +558,9 @@ def test_policy_parser_rejects_unknown_group_or_command(tmp_path, section):
         HANDLER.load_policy(path)
 
 
-def test_non_label_commands_cannot_use_a_group_with_explicit_user_ids(tmp_path):
+def test_repo_write_command_cannot_use_a_group_with_explicit_user_ids(tmp_path):
     raw = raw_policy()
-    raw["groups"]["add_label_access"]["user_ids"] = [ACTOR_ID]
+    raw["groups"]["add_label_access"]["users"] = [{"id": ACTOR_ID, "login": "actor"}]
     raw["commands"]["clear_labels"]["group"] = "add_label_access"
     path = tmp_path / "policy.json"
     path.write_text(json.dumps(raw))
@@ -531,7 +568,7 @@ def test_non_label_commands_cannot_use_a_group_with_explicit_user_ids(tmp_path):
         HANDLER.load_policy(path)
 
 
-def test_checked_in_policy_exposes_exact_labels_and_add_label_access_group():
+def test_checked_in_policy_exposes_exact_labels_and_access_groups():
     loaded = HANDLER.load_policy(POLICY_PATH)
     labels = loaded["commands"]["add_label"]["allowed_labels"]
     assert labels == {f"run-ci-{key}" for key in KNOWN_LABELS} | {
@@ -624,6 +661,27 @@ def test_add_label_access_user_id_preflight_does_not_require_repository_permissi
         HANDLER.AddLabel("run-ci-short"),
         HANDLER.COMMAND_REGISTRY[HANDLER.AddLabel],
     )
+    assert api.calls == []
+
+
+@pytest.mark.parametrize(
+    ("body", "request_type"),
+    [
+        (RUN_FILE_BODY, HANDLER.RunTestFile),
+        ("/rerun-failed-ci", HANDLER.RerunFailedCI),
+    ],
+)
+def test_prior_contributor_access_user_id_preflight_does_not_require_repository_permission(body, request_type):
+    api = FakeAPI(pull(), permission="none")
+
+    result = HANDLER.authorize_policy(
+        event(body=body, author_association="FIRST_TIMER"),
+        policy(prior_user_ids=(ACTOR_ID,)),
+        api,
+    )
+
+    assert result[0:2] == (123, ACTOR_ID)
+    assert type(result[2]) is request_type
     assert api.calls == []
 
 
@@ -1725,6 +1783,26 @@ def test_first_time_contributor_cannot_dispatch_a_file_run(author_association):
     assert api.dispatch_calls == []
 
 
+def test_prior_contributor_access_user_id_dispatches_a_file_run():
+    api = FakeAPI(pull(), permission="none")
+
+    result = HANDLER.process_event(
+        event(body=RUN_FILE_BODY, author_association="FIRST_TIMER"),
+        policy(prior_user_ids=(ACTOR_ID,)),
+        api,
+    )
+
+    assert api.permission_calls == []
+    assert api.dispatch_calls == [
+        (
+            "run-ci-file.yml",
+            "main",
+            {"pull_number": "123", "head_sha": HEAD_SHA, "test_file": RUN_FILE_PATH},
+        )
+    ]
+    assert result["decision"] == "ALLOW_FILE_RUN_DISPATCHED"
+
+
 @pytest.mark.parametrize("body", ["/run-ci-short", "/clear-labels"])
 def test_contributor_association_grants_no_label_command(body):
     api = FakeAPI(pull(labels=("run-ci-short",)), permission="read")
@@ -1738,12 +1816,45 @@ def test_contributor_association_grants_no_label_command(body):
     assert api.dispatch_calls == []
 
 
+@pytest.mark.parametrize("body", ["/run-ci-short", "/clear-labels"])
+def test_prior_contributor_access_user_id_grants_no_label_command(body):
+    api = FakeAPI(pull(labels=("run-ci-short",)), permission="none")
+
+    with pytest.raises(HANDLER.CommentCommandError, match="not authorized"):
+        HANDLER.process_event(
+            event(body=body, author_association="FIRST_TIMER"),
+            policy(prior_user_ids=(ACTOR_ID,)),
+            api,
+        )
+
+    assert api.add_calls == []
+    assert api.remove_calls == []
+    assert api.rerun_calls == []
+    assert api.dispatch_calls == []
+
+
 def test_contributor_reruns_failed_ci_without_a_permission_lookup():
     api = FakeAPI(pull(), permission="none")
     workflow_file, workflow_path = HANDLER.RERUN_WORKFLOWS[0]
     api.workflow_runs[workflow_file] = [workflow_run(workflow_path)]
 
     result = HANDLER.process_event(event(body="/rerun-failed-ci", author_association="CONTRIBUTOR"), policy(), api)
+
+    assert api.permission_calls == []
+    assert api.rerun_calls == [10]
+    assert result["decision"] == "ALLOW_RERUN_REQUESTED"
+
+
+def test_prior_contributor_access_user_id_reruns_failed_ci():
+    api = FakeAPI(pull(), permission="none")
+    workflow_file, workflow_path = HANDLER.RERUN_WORKFLOWS[0]
+    api.workflow_runs[workflow_file] = [workflow_run(workflow_path)]
+
+    result = HANDLER.process_event(
+        event(body="/rerun-failed-ci", author_association="FIRST_TIMER"),
+        policy(prior_user_ids=(ACTOR_ID,)),
+        api,
+    )
 
     assert api.permission_calls == []
     assert api.rerun_calls == [10]


### PR DESCRIPTION
## Summary

Grant selected GitHub users tier-specific CI command access and seed four label-command users.

## Motivation

The label-command tier and prior-contributor rerun tier currently have fixed repository-permission and author-association gates. Maintainers need to grant a small number of contributors one of those existing capabilities without granting repository write access or broadening the other tier.

## Usage

Add an entry to the relevant tier in `.github/workflows/policies/comment-command-access.json`:

```json
"users": [{"id": 123456, "login": "alice"}]
```

The numeric `id` grants access only to that tier; `login` is display-only metadata. The checked-in label allowlist is seeded with `zyzshishui` (`82826991`), `nanjiangwill` (`59716405`), `xiuhu17` (`101526713`), and `zianglih` (`106564213`).

## Design Notes

- **Mental model:** The policy file owns tier exceptions: the gateway binds the event author's stable numeric ID, selects the command group, and admits the request when `users[].id` matches or the group's unchanged default gate passes, while `users[].login` remains outside authorization.
- `add_label_access` and `prior_contributor_access` have independent allowlists, while `repo_write_access` keeps `/clear-labels` restricted to live `write` or `admin` permission.
- Policy schema v4 treats the checked-in JSON as trusted configuration. The documentation defines the maintenance contract for unique positive IDs and display annotations; external dynamic policy is out of scope.

## Verification

- `python -m pytest -q tests/ci/test/test_comment_ci_command.py`: 284 tests passed on the exact prospective tip, covering both allowlists, the four checked-in label users, stale display logins, tier isolation, and the unchanged default gates.
- `pre-commit run --all-files --show-diff-on-failure --color=always`: all 14 configured hooks passed on the exact final tree, including Black.

## Review Focus

- `.github/workflows/scripts/comment_ci_command.py`: verify each rerun command now participates in the prior-contributor allowlist without changing `/clear-labels`.
- `.github/workflows/policies/comment-command-access.json`: verify the four seeded login/ID pairs and that numeric IDs remain the sole allowlist authorization identity.
