### PR TITLE
fix(rollout): drop groups with missing rewards

### DIFF
--- a/examples/experimental/verifiers/verifiers_rollout.py
+++ b/examples/experimental/verifiers/verifiers_rollout.py
@@ -37,7 +37,8 @@ from miles.rollout.base_types import (
     RolloutFnTrainInput,
     RolloutFnTrainOutput,
 )
-from miles.rollout.filter_hub.base_types import MetricGatherer, call_dynamic_filter
+from miles.rollout.filter_hub.base_types import MetricGatherer
+from miles.rollout.filter_hub.common_filters import apply_preput_filters
 from miles.rollout.generate_utils.prefill_logprobs import recompute_samples_rollout_logprobs_via_prefill
 from miles.utils.lora import LORA_ADAPTER_NAME, is_lora_enabled
 from miles.utils.types import Sample
@@ -767,6 +768,7 @@ class VerifiersRolloutFn(BaseRolloutFn):
         all_groups = []
         all_traces = []
         metrics = MetricGatherer()
+
         semaphore = asyncio.Semaphore(self.max_concurrent)
         pending: set[asyncio.Task] = set()
         async with self.env.serving():
@@ -807,13 +809,13 @@ class VerifiersRolloutFn(BaseRolloutFn):
                             continue
                         await self._apply_miles_rewards(group)
                         all_groups.append(group)
-                        result = call_dynamic_filter(
-                            self.dynamic_filter,
+                        filter_output = apply_preput_filters(
                             self.args,
+                            self.dynamic_filter,
                             _flatten_samples(group),
                         )
-                        if not result.keep:
-                            metrics.on_dynamic_filter_drop(reason=result.reason)
+                        if not filter_output.keep:
+                            metrics.on_dynamic_filter_drop(reason=filter_output.reason)
                             continue
                         if len(groups) < target:
                             groups.append(group)

--- a/miles/rollout/filter_hub/common_filters.py
+++ b/miles/rollout/filter_hub/common_filters.py
@@ -2,16 +2,34 @@ from argparse import Namespace
 
 import torch
 
-from miles.rollout.filter_hub.base_types import FilterOutput, iter_samples
+from miles.rollout.filter_hub.base_types import FilterOutput, call_dynamic_filter, iter_samples
 from miles.utils.types import Sample
 
 Group = list[Sample | list[Sample]]
+
+
+def apply_preput_filters(args: Namespace, dynamic_filter, samples: Group, **kwargs) -> FilterOutput:
+    output = apply_aborted_filter(args, samples, **kwargs)
+    if not output.keep:
+        return output
+
+    output = check_no_missing_reward(args, samples, **kwargs)
+    if not output.keep:
+        return output
+
+    return call_dynamic_filter(dynamic_filter, args, samples, **kwargs)
 
 
 def apply_aborted_filter(args: Namespace, samples: Group, **kwargs) -> FilterOutput:
     """Reject entire group if any sample was aborted (e.g. env timeout, Docker crash)."""
     if any(sample.status == Sample.Status.ABORTED for sample in iter_samples(samples)):
         return FilterOutput(keep=False, reason="group_has_aborted")
+    return FilterOutput(keep=True)
+
+
+def check_no_missing_reward(args: Namespace, samples: Group, **kwargs) -> FilterOutput:
+    if any(sample.reward is None or sample.get_reward_value(args) is None for sample in iter_samples(samples)):
+        return FilterOutput(keep=False, reason="group_has_missing_reward")
     return FilterOutput(keep=True)
 
 

--- a/miles/rollout/filter_hub/common_filters.py
+++ b/miles/rollout/filter_hub/common_filters.py
@@ -13,7 +13,7 @@ def apply_preput_filters(args: Namespace, dynamic_filter, samples: Group, **kwar
     if not output.keep:
         return output
 
-    output = check_no_missing_reward(args, samples, **kwargs)
+    output = apply_missing_reward_filter(args, samples, **kwargs)
     if not output.keep:
         return output
 
@@ -27,7 +27,7 @@ def apply_aborted_filter(args: Namespace, samples: Group, **kwargs) -> FilterOut
     return FilterOutput(keep=True)
 
 
-def check_no_missing_reward(args: Namespace, samples: Group, **kwargs) -> FilterOutput:
+def apply_missing_reward_filter(args: Namespace, samples: Group, **kwargs) -> FilterOutput:
     if any(sample.reward is None or sample.get_reward_value(args) is None for sample in iter_samples(samples)):
         return FilterOutput(keep=False, reason="group_has_missing_reward")
     return FilterOutput(keep=True)

--- a/miles/rollout/fully_async_data_buffer.py
+++ b/miles/rollout/fully_async_data_buffer.py
@@ -15,7 +15,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 
 from miles.rollout.filter_hub.base_types import MetricGatherer, call_dynamic_filter
-from miles.rollout.filter_hub.common_filters import apply_aborted_filter, check_no_missing_reward, group_staleness
+from miles.rollout.filter_hub.common_filters import apply_aborted_filter, apply_missing_reward_filter, group_staleness
 from miles.utils.function_registry import load_function
 from miles.utils.types import Sample
 
@@ -127,7 +127,7 @@ class DefaultDataBuffer(DataBuffer):
             self._unused_handler_fn(input.prompt_group)
             return False
 
-        output = check_no_missing_reward(self._args, input.group)
+        output = apply_missing_reward_filter(self._args, input.group)
         if not output.keep:
             self._metric_gatherer.on_dynamic_filter_drop(reason=output.reason)
             return False

--- a/miles/rollout/fully_async_data_buffer.py
+++ b/miles/rollout/fully_async_data_buffer.py
@@ -15,7 +15,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 
 from miles.rollout.filter_hub.base_types import MetricGatherer, call_dynamic_filter
-from miles.rollout.filter_hub.common_filters import apply_aborted_filter, group_staleness
+from miles.rollout.filter_hub.common_filters import apply_aborted_filter, check_no_missing_reward, group_staleness
 from miles.utils.function_registry import load_function
 from miles.utils.types import Sample
 
@@ -73,6 +73,7 @@ class DefaultDataBuffer(DataBuffer):
     Rejected on put, because the verdict is fixed once the group is generated:
 
     - aborted groups (the generate function gave up, e.g. an agentic collect timeout)
+    - groups with a missing reward
     - groups ``--dynamic-sampling-filter-path`` does not keep
 
     Rejected on get, because staleness depends on when the group is consumed:
@@ -86,8 +87,8 @@ class DefaultDataBuffer(DataBuffer):
         training consumes.
     (2) unused handling: ``--async-unused-samples-handler`` decides what happens
         to aborted and stale groups: drop discards them, retry recycles their
-        prompts for regeneration. Dynamic-filter groups are processed per the
-        filter's ``keep``.
+        prompts for regeneration. Missing-reward and custom-filter rejections
+        are discarded directly.
     """
 
     def __init__(self, input: DataBufferConstructorInput):
@@ -124,6 +125,11 @@ class DefaultDataBuffer(DataBuffer):
         if not output.keep:
             self._metric_aborted_groups += 1
             self._unused_handler_fn(input.prompt_group)
+            return False
+
+        output = check_no_missing_reward(self._args, input.group)
+        if not output.keep:
+            self._metric_gatherer.on_dynamic_filter_drop(reason=output.reason)
             return False
 
         output = call_dynamic_filter(self._dynamic_filter, self._args, input.group)

--- a/miles/rollout/inference_rollout/inference_rollout_train.py
+++ b/miles/rollout/inference_rollout/inference_rollout_train.py
@@ -8,7 +8,8 @@ from packaging.version import parse
 from tqdm import tqdm
 
 from miles.rollout.base_types import RolloutFnTrainOutput
-from miles.rollout.filter_hub.base_types import MetricGatherer, call_dynamic_filter
+from miles.rollout.filter_hub.base_types import MetricGatherer
+from miles.rollout.filter_hub.common_filters import apply_preput_filters
 from miles.rollout.generate_utils.prefill_logprobs import recompute_samples_rollout_logprobs_via_prefill
 from miles.rollout.generate_utils.sample_utils import reward_log_summary, sample_text_preview
 from miles.rollout.inference_rollout.inference_rollout_common import GenerateState, generate_and_rm_group
@@ -138,9 +139,9 @@ async def generate_rollout_async(
 
             assert len(group) == args.n_samples_per_prompt
             all_data.append(group)
-            dynamic_filter_output = call_dynamic_filter(dynamic_filter, args, group)
-            if not dynamic_filter_output.keep:
-                metric_gatherer.on_dynamic_filter_drop(reason=dynamic_filter_output.reason)
+            filter_output = apply_preput_filters(args, dynamic_filter, group)
+            if not filter_output.keep:
+                metric_gatherer.on_dynamic_filter_drop(reason=filter_output.reason)
                 continue
 
             # add the samples to the data

--- a/miles/rollout/multi_lora/async_rollout.py
+++ b/miles/rollout/multi_lora/async_rollout.py
@@ -13,7 +13,7 @@ from typing import Any
 
 from miles.ray.multi_lora.controller import AdaptersCache, get_multi_lora_controller
 from miles.rollout.base_types import RolloutFnTrainOutput
-from miles.rollout.filter_hub.base_types import call_dynamic_filter
+from miles.rollout.filter_hub.common_filters import apply_preput_filters
 from miles.rollout.generate_utils.prefill_logprobs import recompute_samples_rollout_logprobs_via_prefill
 from miles.rollout.sglang_rollout import GenerateState, generate_and_rm_group, get_model_url
 from miles.utils.async_utils import run
@@ -359,10 +359,10 @@ class AsyncMultiLoRAWorker:
         if result is None:
             return
 
-        filter_result = call_dynamic_filter(self.dynamic_filter, self.args, result)
-        if not filter_result.keep:
-            if filter_result.reason:
-                self.metrics.record_dynamic_filter_drop(filter_result.reason)
+        filter_output = apply_preput_filters(self.args, self.dynamic_filter, result)
+        if not filter_output.keep:
+            if filter_output.reason:
+                self.metrics.record_dynamic_filter_drop(filter_output.reason)
             return
 
         adapter_name = group_adapter_name(result)

--- a/miles/rollout/sglang_rollout.py
+++ b/miles/rollout/sglang_rollout.py
@@ -14,7 +14,8 @@ from packaging.version import parse
 from tqdm import tqdm
 
 from miles.rollout.base_types import GenerateFnInput, RolloutFnEvalOutput, RolloutFnTrainOutput
-from miles.rollout.filter_hub.base_types import MetricGatherer, call_dynamic_filter
+from miles.rollout.filter_hub.base_types import MetricGatherer
+from miles.rollout.filter_hub.common_filters import apply_preput_filters
 from miles.rollout.inference_rollout.compatibility import load_generate_function
 from miles.utils import dumper_utils
 from miles.utils.async_utils import run
@@ -497,9 +498,9 @@ async def generate_rollout_async(
 
             assert len(group) == args.n_samples_per_prompt
             all_data.append(group)
-            dynamic_filter_output = call_dynamic_filter(dynamic_filter, args, group)
-            if not dynamic_filter_output.keep:
-                metric_gatherer.on_dynamic_filter_drop(reason=dynamic_filter_output.reason)
+            filter_output = apply_preput_filters(args, dynamic_filter, group)
+            if not filter_output.keep:
+                metric_gatherer.on_dynamic_filter_drop(reason=filter_output.reason)
                 state.remaining_batch_size -= 1
                 continue
 

--- a/tests/fast/ray/rollout/test_multi_lora_batch_collection.py
+++ b/tests/fast/ray/rollout/test_multi_lora_batch_collection.py
@@ -28,6 +28,7 @@ def make_args(**overrides) -> SimpleNamespace:
         multi_lora_dp_size=4,
         multi_lora_max_coalesce_wait_s=0.05,
         max_weight_staleness=None,
+        reward_key=None,
     )
     for key, value in overrides.items():
         setattr(args, key, value)
@@ -44,6 +45,9 @@ def make_worker(args=None) -> AsyncMultiLoRAWorker:
     worker.metrics = MultiLoRAWorkerMetrics()
     worker.registrations = {}
     worker.failure = None
+    worker.state = SimpleNamespace(sampling_params={})
+    worker.generate_fn = None
+    worker.data_source = None
     return worker
 
 
@@ -105,6 +109,25 @@ def snapshot_of(*adapters: AdapterRun, retiring: tuple[AdapterRun, ...] = ()) ->
 
 def collect(worker, snapshot):
     return asyncio.run(collect_batch(worker.args, worker, snapshot))
+
+
+@pytest.mark.asyncio
+async def test_process_and_enqueue_drops_missing_reward(monkeypatch):
+    worker = make_worker()
+    adapter = adapter_run("A", 0)
+    group = make_group(adapter)
+
+    async def fake_process_group(*args, **kwargs):
+        return group
+
+    monkeypatch.setattr("miles.rollout.multi_lora.async_rollout.process_group", fake_process_group)
+
+    await worker.process_and_enqueue(group)
+
+    assert len(worker.buffers["A"]) == 0
+    assert worker.metrics.pop_metrics() == {
+        "rollout/dynamic_filter/drop_group_has_missing_reward": 1,
+    }
 
 
 def test_no_pop_until_a_whole_group_multiple_is_buffered():

--- a/tests/fast/rollout/inference_rollout/test_sample_completion_backfill.py
+++ b/tests/fast/rollout/inference_rollout/test_sample_completion_backfill.py
@@ -6,8 +6,12 @@ import asyncio
 from argparse import Namespace
 
 import pytest
+import torch
+from tests.fast.ray.rollout.conftest import make_args as make_rollout_args
 
 import miles.rollout.inference_rollout.inference_rollout_train as train
+from miles.ray.rollout.rollout_data_conversion import postprocess_rollout_data
+from miles.ray.rollout.train_data_conversion import convert_samples_to_train_data
 from miles.rollout.submission_scheduler import (
     GroupLevelSubmission,
     SampleBackfillSubmission,
@@ -27,6 +31,7 @@ def make_args(**overrides) -> Namespace:
         rollout_submission_granularity=None,
         sglang_router_policy="round_robin",
         dynamic_sampling_filter_path=None,
+        reward_key=None,
         rollout_sample_filter_path=None,
         rollout_all_samples_process_path=None,
         sglang_router_ip="127.0.0.1",
@@ -71,6 +76,7 @@ class Harness:
         self.args = args
         self.state = FakeGenerateState(args)
         self.submitted_group_indices: list[int] = []
+        self.submitted_groups: list[list[Sample]] = []
         self.callbacks: list = []
         self._next_group_index = 0
         self._blockers: list[asyncio.Event] = []
@@ -79,6 +85,7 @@ class Harness:
             tasks = []
             for group in samples:
                 self.submitted_group_indices.append(group[0].group_index)
+                self.submitted_groups.append(group)
                 blocker = asyncio.Event()
                 self._blockers.append(blocker)
                 self.callbacks.append(sample_done_callback)
@@ -112,7 +119,11 @@ class Harness:
         groups = []
         for _ in range(num_groups):
             self._next_group_index += 1
-            groups.append(make_group(self._next_group_index))
+            group = make_group(self._next_group_index)
+            if self.args.reward_key is not None:
+                for sample in group:
+                    sample.reward = {self.args.reward_key: 1.0}
+            groups.append(group)
         return groups
 
     def run(self):
@@ -142,6 +153,65 @@ async def test_sync_driver_defaults_to_group_granularity(monkeypatch):
     harness.finish_group(1)
     output, _ = await task
     assert [group[0].group_index for group in output.samples] == [1, 2]
+
+
+@pytest.mark.parametrize(
+    ("reward_key", "missing_reward"),
+    [(None, None), ("score", None), ("score", {"score": None})],
+)
+async def test_missing_reward_group_is_refilled_before_default_conversion(monkeypatch, reward_key, missing_reward):
+    harness = Harness(monkeypatch, make_args(rollout_batch_size=1, reward_key=reward_key))
+    task = harness.run()
+    await asyncio.sleep(0)
+
+    harness.submitted_groups[0][0].reward = missing_reward
+    harness.finish_group(0)
+    await asyncio.sleep(0.01)
+
+    assert harness.submitted_group_indices == [1, 2]
+    harness.finish_group(1)
+    output, _ = await task
+    assert [group[0].group_index for group in output.samples] == [2]
+
+    args = make_rollout_args(
+        rollout_batch_size=1,
+        n_samples_per_prompt=GROUP_SIZE,
+        global_batch_size=GROUP_SIZE,
+        rewards_normalization=False,
+        reward_key=reward_key,
+    )
+    samples, metadata = postprocess_rollout_data(args, output.samples, train_parallel_config={"dp_size": 1})
+    train_data = convert_samples_to_train_data(
+        args,
+        samples,
+        metadata=metadata,
+        custom_convert_samples_to_train_data_func=None,
+        custom_reward_post_process_func=None,
+    )
+
+    assert len(samples) == GROUP_SIZE
+    assert all(reward is not None for reward in train_data["rewards"])
+    assert torch.isfinite(torch.tensor(train_data["rewards"], dtype=torch.float32)).all()
+    assert output.metrics["rollout/dynamic_filter/drop_group_has_missing_reward"] == 1
+
+
+async def test_aborted_group_is_classified_before_missing_reward(monkeypatch):
+    harness = Harness(monkeypatch, make_args(rollout_batch_size=1))
+    task = harness.run()
+    await asyncio.sleep(0)
+
+    for sample in harness.submitted_groups[0]:
+        sample.status = Sample.Status.ABORTED
+        sample.reward = None
+    harness.finish_group(0)
+    await asyncio.sleep(0.01)
+
+    harness.finish_group(1)
+    output, _ = await task
+
+    assert [group[0].group_index for group in output.samples] == [2]
+    assert output.metrics["rollout/dynamic_filter/drop_group_has_aborted"] == 1
+    assert "rollout/dynamic_filter/drop_group_has_missing_reward" not in output.metrics
 
 
 async def test_backfill_submits_replacement_before_the_group_returns(monkeypatch):

--- a/tests/fast/rollout/test_filters.py
+++ b/tests/fast/rollout/test_filters.py
@@ -11,7 +11,9 @@ from miles.rollout.filter_hub import dynamic_sampling_filters
 from miles.rollout.filter_hub.base_types import DynamicFilterOutput, FilterOutput, iter_samples
 from miles.rollout.filter_hub.common_filters import (
     apply_aborted_filter,
+    apply_preput_filters,
     apply_reward_nonzero_std_filter,
+    check_no_missing_reward,
     group_staleness,
 )
 from miles.utils.function_registry import load_function
@@ -111,12 +113,129 @@ def test_iter_samples_preserves_flat_and_mixed_nested_order():
     assert list(iter_samples([samples[0], samples[1:3], samples[3]])) == samples
 
 
-def test_common_filter_returns_structured_drop():
-    assert apply_aborted_filter(
+@pytest.mark.parametrize(
+    ("filter_fn", "group", "expected"),
+    [
+        (
+            apply_aborted_filter,
+            [make_sample(status=Sample.Status.ABORTED)],
+            FilterOutput(keep=False, reason="group_has_aborted"),
+        ),
+        (
+            check_no_missing_reward,
+            [make_sample(reward=None)],
+            FilterOutput(keep=False, reason="group_has_missing_reward"),
+        ),
+    ],
+)
+def test_common_filters_return_structured_drop(filter_fn, group, expected):
+    assert filter_fn(Namespace(reward_key=None), group, ignored=True) == expected
+
+
+@pytest.mark.parametrize("reward", [None, 1.0], ids=["missing-reward", "numeric-reward"])
+def test_preput_aborted_wins_before_missing_reward_and_dynamic_filter(reward):
+    custom_calls = []
+
+    def dynamic_filter(*args, **kwargs):
+        custom_calls.append((args, kwargs))
+        return True
+
+    output = apply_preput_filters(
         Namespace(reward_key=None),
-        [make_sample(status=Sample.Status.ABORTED)],
-        ignored=True,
-    ) == FilterOutput(keep=False, reason="group_has_aborted")
+        dynamic_filter,
+        [make_sample(reward=reward, status=Sample.Status.ABORTED)],
+    )
+
+    assert output == FilterOutput(keep=False, reason="group_has_aborted")
+    assert custom_calls == []
+
+
+@pytest.mark.parametrize(
+    ("reward_key", "group"),
+    [
+        (None, [make_sample(reward=None)]),
+        ("score", [make_sample(reward={"score": None})]),
+        (None, [make_sample(), [make_sample(reward=None)]]),
+    ],
+    ids=["raw", "selected", "nested"],
+)
+def test_preput_missing_reward_wins_before_dynamic_filter(reward_key, group):
+    custom_calls = []
+
+    def dynamic_filter(*args, **kwargs):
+        custom_calls.append((args, kwargs))
+        return True
+
+    output = apply_preput_filters(
+        Namespace(reward_key=reward_key),
+        dynamic_filter,
+        group,
+    )
+
+    assert output == FilterOutput(keep=False, reason="group_has_missing_reward")
+    assert custom_calls == []
+
+
+def test_preput_selected_reward_missing_key_propagates():
+    custom_calls = []
+
+    def dynamic_filter(*args, **kwargs):
+        custom_calls.append((args, kwargs))
+        return True
+
+    with pytest.raises(KeyError, match="score"):
+        apply_preput_filters(
+            Namespace(reward_key="score"),
+            dynamic_filter,
+            [make_sample(reward={"other": 1.0})],
+        )
+
+    assert custom_calls == []
+
+
+def test_preput_preserves_filter_output_identity():
+    output = FilterOutput(keep=False, reason="custom_reason")
+
+    assert apply_preput_filters(Namespace(reward_key=None), lambda *args, **kwargs: output, [make_sample()]) is output
+
+
+def test_preput_normalizes_legacy_false():
+    output = apply_preput_filters(Namespace(reward_key=None), lambda *args, **kwargs: False, [make_sample()])
+
+    assert output == FilterOutput(keep=False)
+
+
+def test_preput_passes_kwargs_and_returns_keep_output():
+    args = Namespace(reward_key=None)
+    group = [make_sample()]
+    marker = object()
+    calls = []
+
+    def dynamic_filter(received_args, received_group, **kwargs):
+        calls.append((received_args, received_group, kwargs))
+        return FilterOutput(keep=True)
+
+    output = apply_preput_filters(
+        args,
+        dynamic_filter,
+        group,
+        marker=marker,
+    )
+
+    assert output == FilterOutput(keep=True)
+    assert calls == [(args, group, {"marker": marker})]
+
+
+def test_preput_propagates_dynamic_filter_exception():
+    def dynamic_filter(*args, **kwargs):
+        raise RuntimeError("dynamic filter failed")
+
+    with pytest.raises(RuntimeError, match="dynamic filter failed"):
+        apply_preput_filters(
+            Namespace(reward_key=None),
+            dynamic_filter,
+            [make_sample()],
+        )
 
 
 def test_group_staleness_uses_oldest_version_across_nested_samples():

--- a/tests/fast/rollout/test_filters.py
+++ b/tests/fast/rollout/test_filters.py
@@ -11,9 +11,9 @@ from miles.rollout.filter_hub import dynamic_sampling_filters
 from miles.rollout.filter_hub.base_types import DynamicFilterOutput, FilterOutput, iter_samples
 from miles.rollout.filter_hub.common_filters import (
     apply_aborted_filter,
+    apply_missing_reward_filter,
     apply_preput_filters,
     apply_reward_nonzero_std_filter,
-    check_no_missing_reward,
     group_staleness,
 )
 from miles.utils.function_registry import load_function
@@ -122,7 +122,7 @@ def test_iter_samples_preserves_flat_and_mixed_nested_order():
             FilterOutput(keep=False, reason="group_has_aborted"),
         ),
         (
-            check_no_missing_reward,
+            apply_missing_reward_filter,
             [make_sample(reward=None)],
             FilterOutput(keep=False, reason="group_has_missing_reward"),
         ),

--- a/tests/fast/rollout/test_fully_async_rollout.py
+++ b/tests/fast/rollout/test_fully_async_rollout.py
@@ -83,6 +83,7 @@ def make_args(**overrides) -> Namespace:
         custom_async_data_buffer_path=None,
         rollout_submission_granularity=None,
         dynamic_sampling_filter_path=None,
+        reward_key=None,
         rollout_sample_filter_path=None,
         sglang_router_ip="127.0.0.1",
         sglang_router_port=30000,
@@ -196,6 +197,8 @@ async def test_eval_runs_on_dedicated_fleet(monkeypatch):
 
 async def test_aborted_group_recycled(monkeypatch):
     aborted = make_group(1, status=Sample.Status.ABORTED)
+    for sample in aborted:
+        sample.reward = None
     data_source = FakeDataSource(scripted=[aborted])
     args = make_args(rollout_batch_size=1, async_unused_samples_handler="retry")
     fn = make_fn(monkeypatch, args, data_source)
@@ -207,6 +210,21 @@ async def test_aborted_group_recycled(monkeypatch):
     assert all(sample.response == "" and sample.weight_versions == [] for sample in aborted)
     assert output.samples[0][0].group_index != 1
     assert output.metrics["rollout/fully_async/aborted_groups_filtered"] == 1
+    assert "rollout/dynamic_filter/drop_group_has_missing_reward" not in output.metrics
+
+
+async def test_missing_reward_group_dropped_without_recycling(monkeypatch):
+    missing_reward = make_group(1)
+    missing_reward[0].reward = None
+    data_source = FakeDataSource(scripted=[missing_reward])
+    args = make_args(rollout_batch_size=1, async_unused_samples_handler="retry")
+    fn = make_fn(monkeypatch, args, data_source)
+
+    output = await fn(RolloutFnTrainInput(rollout_id=0))
+
+    assert data_source.recycled == []
+    assert output.samples[0][0].group_index != 1
+    assert output.metrics["rollout/dynamic_filter/drop_group_has_missing_reward"] == 1
 
 
 async def test_stale_group_recycled(monkeypatch):


### PR DESCRIPTION
> **Depends on:** #3094
> Stacked on the parent PR's branch. Review / merge the parent first.

## Summary
Reject rollout groups with missing rewards before they reach training conversion.

## Symptom & Reproduction
- **Symptom:** A group containing `None` rewards can reach reward tensor construction and stop the batch before the optimizer. Guarding only the logger, as proposed in [#989](https://github.com/radixark/miles/pull/989), moves rather than fixes the failure.
- **Reproduction:** Complete a rollout group with a raw `None` reward or `{"score": None}` selected by `reward_key`, with no custom dynamic filter. The old collector counts it toward `rollout_batch_size`; the expected behavior is to reject it and refill or drop it according to the collector.

## Root Cause
1. Rollout collector paths such as `generate_rollout_async` accepted groups without mandatory reward validation.
2. `Sample.get_reward_value` could return an accepted `None` reward for conversion.
3. `torch.tensor` failed before optimization.

## Fix
`apply_preput_filters` evaluates `apply_aborted_filter`, `apply_missing_reward_filter`, then the configured custom filter. This preserves aborted retry/drop behavior while rejecting raw, selected, and nested missing rewards before conversion. Synchronous collectors refill rejected capacity; fully async, Multi-LoRA, and Verifiers retain their existing drop, no-enqueue, or resampling actions. A missing selected `reward_key` still raises `KeyError`.

The stock filters follow the parent's `apply_xxx_filter` naming convention. Existing dynamic sampling dotted paths remain available through deprecated wrappers inherited from #3094; their signatures, structured results, and exceptions are preserved without runtime deprecation warnings.

## Verification
- On `927a847f50909f4b0cdea83d23337a53c3219c5d`, `python -m pytest --confcutdir=tests/fast/rollout tests/fast/rollout/test_filters.py -o addopts= -q`: 21 passed, covering filter precedence, missing rewards, and wrapper compatibility; repository-wide integration fixtures were not loaded.
- Direct buffer probes passed for both legacy dotted paths, aborted recycling, reward-variance rejection, valid enqueue/get, and missing-reward rejection before custom filtering without recycling.
- The rebased tree equals the original child result plus the parent's wrapper change; independent replay preserved both source commits' raw author, committer, and message bytes.
- Ruff `0.14.7`, isort `5.13.2`, Black `24.3.0`, compilation, and `git diff --check` passed for the changed Python files.
- Full collector integration and GPU CI were not rerun locally.

## Review Focus
- `apply_preput_filters`: `aborted -> missing reward -> custom` ordering.
- Collector acceptance boundaries reject invalid rewards before conversion while retaining each collector's buffer action.
- Legacy dynamic filter paths remain compatible through the parent's deprecated wrappers.
