### PR TITLE
dashboard: land Rollouts on the newest step that has data

### DIFF
--- a/miles/dashboard/README.md
+++ b/miles/dashboard/README.md
@@ -52,7 +52,9 @@ Views:
   lane-selection grammar (`g:` / `rank:` / `node:` / `every:`) and outlier
   quick-picks.
 - **Rollouts** — per-step trajectory table and scatter, GRPO group degeneracy
-  (`zero_std`), average weight-version staleness, eval tab.
+  (`zero_std`), average weight-version staleness, eval tab. Opens on the newest
+  step that has samples, skipping one still being dumped; a step named in the
+  URL is always shown as asked.
 - **sample view** — a `conversation` tab (role-tagged turns with thinking /
   tool calls, from the trajectory sidecar) and a lazily-loaded `tokens` tab
   (the whole sequence in one scrollable metric-colored strip, opened at the

--- a/miles/dashboard/static/api.js
+++ b/miles/dashboard/static/api.js
@@ -1,13 +1,13 @@
 const RETRIES_503 = 3;
 
-async function fetchOk(path, params) {
+async function fetchOk(path, params, { retry503 = true } = {}) {
   const url = new URL(path, location.origin);
   for (const [k, v] of Object.entries(params)) {
     if (v !== undefined && v !== null) url.searchParams.set(k, v);
   }
   for (let attempt = 0; ; attempt++) {
     const res = await fetch(url);
-    if (res.status === 503 && attempt < RETRIES_503) {
+    if (res.status === 503 && retry503 && attempt < RETRIES_503) {
       await new Promise((r) => setTimeout(r, 1500));
       continue;
     }
@@ -24,8 +24,8 @@ async function fetchOk(path, params) {
   }
 }
 
-export async function api(path, params = {}) {
-  return (await fetchOk(path, params)).json();
+export async function api(path, params = {}, options = {}) {
+  return (await fetchOk(path, params, options)).json();
 }
 
 // framed binary endpoints (/api/timeline/heatmap):

--- a/miles/dashboard/static/app.js
+++ b/miles/dashboard/static/app.js
@@ -64,7 +64,8 @@ function parseRoute() {
 }
 
 function crumbs(route, meta) {
-  const nav = (label, href, active) => el("a", { class: `nav${active ? " active" : ""}`, href }, [label]);
+  const nav = (label, href, active, onclick = null) =>
+    el("a", { class: `nav${active ? " active" : ""}`, href, onclick }, [label]);
   const parts = [nav("Metrics", "#/", route.view === "metrics")];
   if (meta.capabilities.has_timeline) {
     parts.push(nav("Compute Utilization", "#/timeline", route.view === "timeline"));
@@ -72,7 +73,12 @@ function crumbs(route, meta) {
   // the per-step data view is a top-level destination, not a hidden
   // click-through from chart points; land on the newest usable train step
   if (meta.rollout_ids.train.length) {
-    parts.push(nav("Rollouts", "#/rollout/latest", route.view === "rollout" || route.view === "tokens"));
+    const onRollout = route.view === "rollout" || route.view === "tokens";
+    const replaceInPlace = (event) => {
+      event.preventDefault();
+      location.replace("#/rollout/latest");
+    };
+    parts.push(nav("Rollouts", "#/rollout/latest", onRollout, onRollout ? replaceInPlace : null));
   }
   if ((route.view === "rollout" || route.view === "tokens") && route.rolloutId !== null) {
     const evalSuffix = route.evaluation ? "?eval=1" : "";

--- a/miles/dashboard/static/app.js
+++ b/miles/dashboard/static/app.js
@@ -47,8 +47,14 @@ function parseRoute() {
     return { view: "timeline", lanes: params.get("lanes") };
   }
   if (segments[0] === "rollout" && segments.length >= 2) {
-    const rolloutId = Number(segments[1]);
     const evaluation = params.get("eval") === "1";
+    // "latest" is resolved against the dump at render time rather than baked
+    // into the link, because the newest step is often listed before it is
+    // readable; a typed step number is always honoured exactly
+    if (segments[1] === "latest") {
+      return { view: "rollout", rolloutId: null, evaluation };
+    }
+    const rolloutId = Number(segments[1]);
     if (segments[2] === "sample" && segments.length === 4) {
       return { view: "tokens", rolloutId, sampleIndex: Number(segments[3]), evaluation };
     }
@@ -64,12 +70,11 @@ function crumbs(route, meta) {
     parts.push(nav("Compute Utilization", "#/timeline", route.view === "timeline"));
   }
   // the per-step data view is a top-level destination, not a hidden
-  // click-through from chart points; land on the newest train step
-  const latest = meta.rollout_ids.train.at(-1);
-  if (latest !== undefined) {
-    parts.push(nav("Rollouts", `#/rollout/${latest}`, route.view === "rollout" || route.view === "tokens"));
+  // click-through from chart points; land on the newest usable train step
+  if (meta.rollout_ids.train.length) {
+    parts.push(nav("Rollouts", "#/rollout/latest", route.view === "rollout" || route.view === "tokens"));
   }
-  if (route.view === "rollout" || route.view === "tokens") {
+  if ((route.view === "rollout" || route.view === "tokens") && route.rolloutId !== null) {
     const evalSuffix = route.evaluation ? "?eval=1" : "";
     parts.push(
       el("span", { class: "crumb" }, [

--- a/miles/dashboard/static/views_rollout.js
+++ b/miles/dashboard/static/views_rollout.js
@@ -94,7 +94,11 @@ export async function renderRollout(view, meta, route) {
       return;
     }
     view.replaceChildren(el("p", { class: "muted" }, ["finding the newest step with data…"]));
+    const entryHash = location.hash;
     rolloutId = await resolveLatest(candidates, evaluation);
+    // the resolve spans several requests; if the user navigated away in the
+    // meantime, rewriting the URL now would drag them back into this view
+    if (location.hash !== entryHash) return;
     // rewrite the URL to the step actually shown, so reloads, Prev/Next and
     // the breadcrumb all work off a real id
     location.replace(`#/rollout/${rolloutId}${evaluation ? "?eval=1" : ""}`);

--- a/miles/dashboard/static/views_rollout.js
+++ b/miles/dashboard/static/views_rollout.js
@@ -60,8 +60,46 @@ function sortableTable(rows, columns, { onRowClick, flagRow, sortState }) {
   return wrap;
 }
 
+// How far back the "latest" landing will look for a step it can actually show.
+// Anything deeper than this is not a fresh-dump race any more, so stopping lets
+// the real error surface instead of silently walking the reader into old data.
+const LANDING_LOOKBACK = 5;
+
+// The newest step is listed as soon as its dump file exists, which is earlier
+// than it can be read: the dump may still be mid-write (503), truncated, or
+// recorded with no samples at all. Land on the newest step that actually has
+// samples instead of on an error page.
+async function resolveLatest(ids, evaluation) {
+  for (const id of ids.slice(-LANDING_LOOKBACK).reverse()) {
+    try {
+      const summary = await api(`/api/rollout/${id}/summary`, { eval: evaluation });
+      if (summary.rows.length) return id;
+    } catch {
+      /* mid-write, truncated, or already rotated away: try the step before it */
+    }
+  }
+  // nothing readable nearby: go to the newest anyway so the reader sees the
+  // real error rather than a silent redirect into stale data
+  return ids.at(-1);
+}
+
 export async function renderRollout(view, meta, route) {
-  const { rolloutId, evaluation } = route;
+  const { evaluation } = route;
+  let { rolloutId } = route;
+  if (rolloutId === null) {
+    const candidates = evaluation ? meta.rollout_ids.eval : meta.rollout_ids.train;
+    if (!candidates.length) {
+      const kind = evaluation ? "eval" : "rollout";
+      view.replaceChildren(el("p", { class: "muted" }, [`No ${kind} steps have been dumped yet.`]));
+      return;
+    }
+    view.replaceChildren(el("p", { class: "muted" }, ["finding the newest step with data…"]));
+    rolloutId = await resolveLatest(candidates, evaluation);
+    // rewrite the URL to the step actually shown, so reloads, Prev/Next and
+    // the breadcrumb all work off a real id
+    location.replace(`#/rollout/${rolloutId}${evaluation ? "?eval=1" : ""}`);
+    return;
+  }
   const [summary, groups] = await Promise.all([
     api(`/api/rollout/${rolloutId}/summary`, { eval: evaluation }),
     api(`/api/rollout/${rolloutId}/groups`, { eval: evaluation }),

--- a/miles/dashboard/static/views_rollout.js
+++ b/miles/dashboard/static/views_rollout.js
@@ -72,7 +72,7 @@ const LANDING_LOOKBACK = 5;
 async function resolveLatest(ids, evaluation) {
   for (const id of ids.slice(-LANDING_LOOKBACK).reverse()) {
     try {
-      const summary = await api(`/api/rollout/${id}/summary`, { eval: evaluation });
+      const summary = await api(`/api/rollout/${id}/summary`, { eval: evaluation }, { retry503: false });
       if (summary.rows.length) return id;
     } catch {
       /* mid-write, truncated, or already rotated away: try the step before it */


### PR DESCRIPTION
## Summary

The **Rollouts** tab baked the newest step id straight into its `href`. A step is listed as soon as its rollout dump file appears, which is earlier than that step can be read, so during a live run clicking the tab regularly landed on an error page — and the only way out was editing the step number in the URL by hand.

The tab now points at `#/rollout/latest`, which the view resolves against the dump: walk back from the newest step and take the first one that both loads and has at least one sample.

| before | after |
| --- | --- |
| <a href="https://raw.githubusercontent.com/radixark/miles/7746fc9ae148a38d7a28f281496a71412298f063/rollout-landing/before.png"><img src="https://raw.githubusercontent.com/radixark/miles/7746fc9ae148a38d7a28f281496a71412298f063/rollout-landing/before.png" width="420"></a> | <a href="https://raw.githubusercontent.com/radixark/miles/7746fc9ae148a38d7a28f281496a71412298f063/rollout-landing/after.png"><img src="https://raw.githubusercontent.com/radixark/miles/7746fc9ae148a38d7a28f281496a71412298f063/rollout-landing/after.png" width="420"></a> |

Same dump, one click on **Rollouts**. On the left the newest step (2) is unreadable and the page is a dead end; on the right it falls through to step 1 and shows data.

## The three states that break the landing

I damaged a real dummy dump each way and asked the reader directly, because the fix should not be tuned to one error shape:

| newest step's state | `summary()` | `groups()` | what the page shows |
| --- | --- | --- | --- |
| train shards not written yet | ok | ok | fine — already tolerated, not a bug |
| dump still being written | `DumpStillWriting` | `DumpStillWriting` | **503** |
| dump truncated, mtime stale | `RuntimeError` from `torch.load` | same | **500** |
| recorded with **no samples** | ok, but 0 rows and **0 columns** | `ColumnNotFoundError` | **500** |
| dump file already rotated away | `FileNotFoundError` | same | **404** |

The no-samples row is the one that matches "the most recent step hasn't generated any rollout yet": `summary()` succeeds but returns a frame with no columns, so the `group_by("group_index")` inside `groups()` fails. Since `renderRollout` fetches both in a `Promise.all`, either failure takes the whole page down.

Rather than special-case each status, the landing treats "threw" and "loaded but has no samples" identically as *not usable yet*.

## What changed

- `app.js` — the Rollouts link becomes `#/rollout/latest`; `parseRoute` maps that to `rolloutId: null`; the step breadcrumb is skipped while the id is unresolved.
- `views_rollout.js` — `renderRollout` resolves a null id via `resolveLatest`, then `location.replace`s the hash to the step it picked, so reloads, Prev/Next and the breadcrumb all work off a real id. `location.replace` rather than assignment keeps the unresolved URL out of history.

Two deliberate limits:

- **The lookback is bounded at 5 steps.** Past that this is not a fresh-dump race any more, so the newest step is shown and its real error surfaces, instead of the reader being walked silently into old data with no indication anything was skipped.
- **A step named in the URL is never redirected.** Only the tab's own landing resolves. Typing `#/rollout/2` on a broken step still shows that step's error — a shared link or a jump-box entry has to mean exactly what it says.

## Verification

No JS test harness exists in the repo (no `package.json`; the Python tests under `tests/fast/dashboard/` never load the static files), so this was driven in real Chrome via Playwright against dumps built by `tests/fast/dashboard/dummy_dump.py` through the real dump pipeline, then damaged as above.

Clicking **Rollouts**, on a 3-step dump:

| dump | lands on | result |
| --- | --- | --- |
| all steps healthy | `#/rollout/2` | newest, unchanged behaviour |
| newest recorded with no samples | `#/rollout/1` | table renders, 8 samples |
| newest truncated | `#/rollout/1` | table renders, 8 samples |
| two newest truncated | `#/rollout/0` | walks back twice |

Guard rails, on the dump whose newest step is broken:

| check | result |
| --- | --- |
| explicit `#/rollout/2` | hash stays `#/rollout/2`, shows `HTTP 500` — honoured exactly, no redirect |
| Back after a resolved landing | returns to `#/`, not into a redirect loop |
| reloading the resolved URL | stable, 8 rows, no error |
| `#/rollout/latest?eval=1` with no eval steps | "No eval steps have been dumped yet." |
| Metrics → Rollouts → sample row → token view → breadcrumb back | whole chain intact, no page errors |

## Test plan

`pre-commit` covers Python only and no Python file is touched. This is static frontend only: no API, schema or reader behaviour changes, so the dashboard's Python tests are unaffected.
