### PR TITLE
[AMD] Fall back to mcore async checkpointing when NVRx is unavailable

### DIFF
--- a/miles/backends/megatron_utils/arguments.py
+++ b/miles/backends/megatron_utils/arguments.py
@@ -9,6 +9,15 @@ __all__ = ["validate_args", "parse_args", "set_default_megatron_args"]
 logger = logging.getLogger(__name__)
 
 
+def _has_nvrx_async_ckpt_support() -> bool:
+    """Whether the NVRx async-checkpoint backend Megatron would import is actually installed."""
+    try:
+        from megatron.training.utils import has_nvrx_checkpointing_async_support
+    except ImportError:
+        return False
+    return bool(has_nvrx_checkpointing_async_support())
+
+
 def set_default_megatron_args(args):
     if getattr(args, "true_on_policy_mode", False):
         raise NotImplementedError(
@@ -36,6 +45,17 @@ def set_default_megatron_args(args):
     # fp32, and 20260819 convert the default to TE gemm which is bf16 x bf16 -> fp32. Result show
     # the TE one increase log prob diff so manually set back
     args.moe_router_use_torch_mm = True
+    # Since 20260819, Megatron defaults --async-strategy to "nvrx", which hard-requires
+    # nvidia-resiliency-ext. That package is CUDA-only, so the ROCm images drop it and an
+    # --async-save run would otherwise only discover the missing backend when the first
+    # checkpoint is written. Fall back to Megatron's in-tree "mcore" saver instead.
+    if (
+        getattr(args, "async_save", False)
+        and getattr(args, "async_strategy", None) == "nvrx"
+        and not _has_nvrx_async_ckpt_support()
+    ):
+        logger.warning("nvidia-resiliency-ext is not installed, falling back to --async-strategy mcore.")
+        args.async_strategy = "mcore"
     # compatible for megatron
     if hasattr(args, "rope_type") and args.rope_type is None:
         args.rope_type = "yarn" if args.multi_latent_attention else "rope"

--- a/tests/fast/backends/megatron_utils/test_arguments_async_strategy.py
+++ b/tests/fast/backends/megatron_utils/test_arguments_async_strategy.py
@@ -1,0 +1,89 @@
+import pytest
+
+pytest.importorskip("megatron.training.arguments")
+
+from argparse import Namespace
+
+from miles.backends.megatron_utils import arguments as megatron_arguments
+
+
+def _args(**overrides) -> Namespace:
+    """A Namespace carrying only the fields set_default_megatron_args touches."""
+    base = dict(
+        true_on_policy_mode=False,
+        optimizer="adam",
+        debug_disable_optimizer=False,
+        multi_lora_n_adapters=0,
+        fp16=False,
+        seq_length=4096,
+        async_save=True,
+        async_strategy="nvrx",
+        multi_latent_attention=False,
+        rope_type="rope",
+        vocab_size=None,
+        padded_vocab_size=None,
+        tokenizer_model="/models/qwen3",
+        tokenizer_type="HuggingFaceTokenizer",
+        hf_checkpoint="/models/qwen3",
+    )
+    base.update(overrides)
+    return Namespace(**base)
+
+
+def test_async_save_falls_back_to_mcore_without_nvrx(monkeypatch) -> None:
+    """Without nvidia-resiliency-ext, --async-save downgrades to Megatron's in-tree saver."""
+    monkeypatch.setattr(megatron_arguments, "_has_nvrx_async_ckpt_support", lambda: False)
+
+    args = megatron_arguments.set_default_megatron_args(_args())
+
+    assert args.async_strategy == "mcore"
+
+
+def test_async_save_keeps_nvrx_when_available(monkeypatch) -> None:
+    """With nvidia-resiliency-ext installed the NVRx strategy is left alone."""
+    monkeypatch.setattr(megatron_arguments, "_has_nvrx_async_ckpt_support", lambda: True)
+
+    args = megatron_arguments.set_default_megatron_args(_args())
+
+    assert args.async_strategy == "nvrx"
+
+
+def test_explicit_mcore_strategy_is_preserved(monkeypatch) -> None:
+    """An explicitly requested mcore strategy is never probed for or rewritten."""
+    monkeypatch.setattr(
+        megatron_arguments,
+        "_has_nvrx_async_ckpt_support",
+        lambda: pytest.fail("NVRx availability must not be probed for a non-nvrx strategy"),
+    )
+
+    args = megatron_arguments.set_default_megatron_args(_args(async_strategy="mcore"))
+
+    assert args.async_strategy == "mcore"
+
+
+def test_sync_save_strategy_is_left_to_megatron(monkeypatch) -> None:
+    """Without --async-save, Megatron's own validation owns the strategy value."""
+    monkeypatch.setattr(
+        megatron_arguments,
+        "_has_nvrx_async_ckpt_support",
+        lambda: pytest.fail("NVRx availability must not be probed when async save is off"),
+    )
+
+    args = megatron_arguments.set_default_megatron_args(_args(async_save=False))
+
+    assert args.async_strategy == "nvrx"
+
+
+def test_missing_async_strategy_attribute_is_tolerated(monkeypatch) -> None:
+    """Older Megatron builds expose no async_strategy at all; the probe stays out of the way."""
+    monkeypatch.setattr(
+        megatron_arguments,
+        "_has_nvrx_async_ckpt_support",
+        lambda: pytest.fail("NVRx availability must not be probed without an async_strategy"),
+    )
+    args = _args()
+    del args.async_strategy
+
+    result = megatron_arguments.set_default_megatron_args(args)
+
+    assert not hasattr(result, "async_strategy")


### PR DESCRIPTION
> [!WARNING]
> **Do not merge as-is.** Hardware verification showed this change is necessary but not sufficient: it removes the `ModuleNotFoundError` but the run then hangs for 90 minutes on a second, independent ROCm defect. Merging only this would trade a fast, legible failure for a silent hang, which is worse. See [Verification](#verification) — the companion Megatron change is identified precisely and this PR should land with it, or be re-scoped.

## Summary

`--async-save` is broken on every ROCm image. Megatron defaults `--async-strategy` to `"nvrx"`, which hard-requires `nvidia-resiliency-ext`; `docker/Dockerfile.rocm` deliberately strips that CUDA-only package out of `requirements.txt`:

https://github.com/radixark/miles/blob/main/docker/Dockerfile.rocm#L167

So the run parses fine, trains fine, and then dies at the first checkpoint write:

```
ray::MegatronTrainRayActor.save_model()
  File "/root/Megatron-LM/megatron/core/dist_checkpointing/strategies/torch.py", line 1169, in get_async_strategy
    raise ModuleNotFoundError(
ModuleNotFoundError: A compatible `nvidia-resiliency-ext` installation is required for
`async_strategy="nvrx"`. Please install it or set `async_strategy` to `mcore`.
```

`set_default_megatron_args` now probes for the NVRx async-checkpoint API and falls back to Megatron's in-tree `"mcore"` saver when it is missing. CUDA images ship the package, so they keep using `nvrx` and are untouched.

## How this surfaced

`tests/e2e/ckpt/test_qwen3_4B_ckpt.py` in the MI350 nightly, which runs `execute("save")` → `execute("load")` → `execute("async_save")` → `execute("load")`. The first nightlies to run on a post-bump image all failed on the third step:

| nightly | miles image | `test_qwen3_4B_ckpt.py` |
| --- | --- | --- |
| 2026-08-26 | `miles-rocm720-mi35x-20260824` | pass |
| 2026-08-27 | `miles-rocm720-mi35x-20260824` | pass |
| 2026-08-28 | `miles-rocm720-mi35x-20260828` | **fail** |
| 2026-08-29 | `miles-rocm720-mi35x-20260829` | **fail** |

Failing run: [sgl-project/sglang actions/runs/33265909152](https://github.com/sgl-project/sglang/actions/runs/33265909152), job `nightly-stage-c-8-gpu-mi350`.

The 8/25–8/27 nightlies reused the stale `-20260824` tag because the ROCm image builds for those days had failed, which is why a change that landed on 8/24 only turned the nightly red on 8/28.

## Why the bump changed behaviour

`async_strategy` did not exist before the Megatron bump in #2673. Counting the Megatron argument dumps in each nightly's 8-GPU log makes the transition explicit — same test set, same 26 training invocations, exactly one of which asks for async save:

| | image `20260824` (8/27, passed) | image `20260829` (8/29, failed) |
| --- | --- | --- |
| `async_save ... False` | 25 | 24 |
| `async_save ... True` | 1 | 1 |
| `async_strategy ... mcore` | — not printed — | 24 |
| `async_strategy ... nvrx` | — not printed — | 1 |

On the old image the option is absent entirely, so async save always used the in-tree writer. On the new image the 24 sync-save runs get `mcore` (Megatron's own validation rewrites `nvrx` → `mcore` whenever `async_save` is off), and the single async-save run keeps the `nvrx` default and hits the missing module.

## Verification

Run on real MI350 hardware against the nightly's own image (`rocm/sgl-dev:miles-rocm720-mi35x-20260829`, torch `2.9.1+rocm7.2.0`, hip `7.2.26015`), by patching the in-image `/root/miles` from `refs/pull/2816/head` and measuring before and after in the same container: [sgl-project/sglang actions/runs/33305121208](https://github.com/sgl-project/sglang/actions/runs/33305121208).

**What works.** The stock image reproduces the nightly's exception exactly, and the patch clears it:

| | stock image | with this PR |
| --- | --- | --- |
| `nvidia_resiliency_ext present` | False | False |
| `resolved async_strategy` | `nvrx` | `mcore` |
| `backend import` | `ModuleNotFoundError: A compatible nvidia-resiliency-ext installation is required...` | `loaded mcore` |

All five new unit tests also ran in that container against the real Megatron rather than being skipped by their `importorskip`. In the end-to-end run, all four Megatron invocations reported `async_strategy ... mcore`, including the single `async_save=True` one — before the patch that one was `nvrx`.

**What does not.** `tests/e2e/ckpt/test_qwen3_4B_ckpt.py` then got past the missing module and hung in `execute("async_save")` until the 90-minute step timeout:

```
[actor_cell0_rank0] torch.py:763 - MCore's async save is deprecated ...
Traceback (most recent call last):
  File "/usr/lib/python3.10/multiprocessing/queues.py", line 244, in _feed
    obj = _ForkingPickler.dumps(obj)
  File "/sgl-workspace/sglang/python/sglang/srt/utils/patch_torch.py", line 73, in _reduce_tensor_modified
    output_fn, output_args = reductions._reduce_tensor_original(*args, **kwargs)
  File ".../torch/multiprocessing/reductions.py", line 354, in reduce_tensor
    ) = storage._share_cuda_()
torch.AcceleratorError: HIP error: invalid argument
```

This is a second defect, independent of the strategy default. mcore's persistent checkpoint worker is a separate process, so the state dict crosses the boundary as pickled CUDA IPC handles. `torch_memory_saver` backs colocate-training allocations with the CUDA VMM APIs, which cannot export a legacy IPC handle, so `_share_cuda_` raises — and because it raises inside the `multiprocessing` queue feeder thread, nothing propagates: the worker never receives the item and the trainer blocks forever.

Megatron already fixes exactly this, in e338fedb4 ("stage async-ckpt tensors for CUDA IPC under torch_memory_saver"), whose commit message describes this failure verbatim. But the call is gated to one strategy:

```python
# megatron/core/dist_checkpointing/strategies/torch.py:901
if async_strategy == "nvrx" and not _gpu_tensors_are_ipc_shareable(writer):
    _restage_gpu_tensors_ipc_shareable(writer)
```

The mcore worker has the same process architecture and the same need, so it should not be excluded. Everything downstream is already strategy-agnostic: `ipc_staging_scope()` wraps `schedule_async_save` for any `async_save` and no-ops unless restaging populated its slot list, and `ckpt_assume_constant_structure` defaults to `False`, so the restaging assertion holds.

## Suggested resolution

Two options, and I would like a maintainer's call:

1. **Land this together with dropping `async_strategy == "nvrx"` from that guard in `radixark/Megatron-LM@miles-main`.** Preserves async save on ROCm. It needs its own 8-GPU verification run.
2. **Re-scope this PR to disable async save on ROCm** rather than downgrade it, matching Megatron's own precedent for `--async-save` without `--use-persistent-ckpt-worker`. Sync save does not cross a process boundary — `TorchDistSaveShardedStrategy.save()` runs `execute_sync()` in-process — and its `execute("save")` and `execute("load")` phases passed in this very run. Slower, but correct and self-contained.

I have not pushed either yet.

## Not addressed here

The same nightly's 2-GPU job fails on `tests/e2e/fsdp/test_qwen3_0.6B_megatron_fsdp_align.py`, which is unrelated and much older — it has failed 15 of the last 16 nightlies, going back to 2026-08-15, with `train/ppo_kl` landing between `2e-9` and `2e-7` against `check_kl`'s `1e-9` gate. That is a ROCm numerics question about whether the replayed Megatron forward reproduces the saved rollout logprobs, not a config one, and relaxing the threshold would just hide it.
