### PR TITLE
dashboard: give a step with no samples the summary schema

### DIFF
--- a/miles/dashboard/advisory.py
+++ b/miles/dashboard/advisory.py
@@ -236,6 +236,8 @@ def _rollout_advisories(reader: DumpReader, args: dict) -> list[Advisory]:
             out.append(Advisory(level="warning", message=message))
 
     summary = reader.summary(rollout_id)
+    if summary.height == 0:
+        return out
     truncated_frac = summary["truncated"].cast(float).mean()
     if truncated_frac is not None and truncated_frac >= TRUNCATED_FRAC_WARN:
         message = f"{truncated_frac:.0%} of samples in rollout {rollout_id} are truncated"

--- a/miles/dashboard/dump_reader.py
+++ b/miles/dashboard/dump_reader.py
@@ -303,7 +303,7 @@ class DumpReader:
     FRESH_SECONDS: ClassVar[float] = 60.0
 
     # bump to invalidate summary parquet caches when their columns change
-    SUMMARY_VERSION: ClassVar[int] = 4  # v4: per-sample staleness
+    SUMMARY_VERSION: ClassVar[int] = 5  # v5: no-sample steps get the declared schema (v4 cached them columnless)
 
     # Column order of summary(). Only needed to give a step with no samples the
     # same shape as any other step; with rows present the schema comes from

--- a/miles/dashboard/dump_reader.py
+++ b/miles/dashboard/dump_reader.py
@@ -305,6 +305,43 @@ class DumpReader:
     # bump to invalidate summary parquet caches when their columns change
     SUMMARY_VERSION: ClassVar[int] = 4  # v4: per-sample staleness
 
+    # Column order of summary(). Only needed to give a step with no samples the
+    # same shape as any other step; with rows present the schema comes from
+    # _summary_row itself. test_summary_columns_declaration_matches_reality
+    # pins the two together, so adding a column there fails loudly here.
+    SUMMARY_COLUMNS: ClassVar[tuple[str, ...]] = (
+        "sample_index",
+        "group_index",
+        "status",
+        "remove_sample",
+        "response_length",
+        "total_length",
+        "reward",
+        "weight_version",
+        "weight_version_min",
+        "mixed_version",
+        "staleness",
+        "turns",
+        "tool_calls",
+        "non_generation_time",
+        "spec_accept_rate",
+        "prefix_cache_hit_rate",
+        "raw_reward",
+        "normalized_reward",
+        "truncated",
+        "dumped_rank",
+        "mean_entropy",
+        "max_entropy",
+        "ref_entropy_mean",
+        "mean_abs_lp_diff",
+        "max_abs_lp_diff",
+        "mean_imp_ratio",
+        "adv_mean",
+        "adv_std",
+        "return_mean",
+        "alignment_failed",
+    )
+
     def __init__(self, dump_dir: Path | str, *, cache_dir: Path | str | None = None, tensor_lru: int = 2):
         self.dump_dir = Path(dump_dir)
         self.rollout_dir = self.dump_dir / "rollout_data"
@@ -410,9 +447,16 @@ class DumpReader:
             return pl.read_parquet(cache_path)
 
         joined = self.joined(rollout_id, evaluation=evaluation)
-        df = pl.DataFrame(
-            [self._summary_row(s, joined.train_rows.get(s.index), rollout_id=rollout_id) for s in joined.samples],
-            strict=False,
+        rows = [self._summary_row(s, joined.train_rows.get(s.index), rollout_id=rollout_id) for s in joined.samples]
+        # A step can be dumped with no samples at all (aborted before any
+        # generation landed). Inferring the schema from an empty row list gives
+        # a frame with no COLUMNS, and every view below this one then dies on a
+        # missing column instead of simply reporting an empty step, so the
+        # declared schema is supplied explicitly in that case.
+        df = (
+            pl.DataFrame(rows, strict=False)
+            if rows
+            else pl.DataFrame(schema={name: pl.Null for name in self.SUMMARY_COLUMNS})
         )
         self.cache_dir.mkdir(parents=True, exist_ok=True)
         df.write_parquet(cache_path)

--- a/miles/dashboard/dump_reader.py
+++ b/miles/dashboard/dump_reader.py
@@ -17,6 +17,7 @@ surfacing as corruption.
 from __future__ import annotations
 
 import json
+import os
 import time
 from collections import OrderedDict
 from dataclasses import dataclass
@@ -459,7 +460,9 @@ class DumpReader:
             else pl.DataFrame(schema={name: pl.Null for name in self.SUMMARY_COLUMNS})
         )
         self.cache_dir.mkdir(parents=True, exist_ok=True)
-        df.write_parquet(cache_path)
+        tmp_path = cache_path.with_suffix(f".{os.getpid()}.tmp")
+        df.write_parquet(tmp_path)
+        tmp_path.replace(cache_path)
         sources_path.write_text(json.dumps(sources))
         return df
 

--- a/miles/dashboard/dump_reader.py
+++ b/miles/dashboard/dump_reader.py
@@ -683,25 +683,22 @@ class DumpReader:
             ),
         )
         if row is None:
-            train_columns = dict.fromkeys(
-                (
-                    "raw_reward",
-                    "normalized_reward",
-                    "dumped_rank",
-                    "mean_entropy",
-                    "max_entropy",
-                    "ref_entropy_mean",
-                    "mean_abs_lp_diff",
-                    "max_abs_lp_diff",
-                    "mean_imp_ratio",
-                    "adv_mean",
-                    "adv_std",
-                    "return_mean",
-                )
+            return entry | dict(
+                raw_reward=None,
+                normalized_reward=None,
+                truncated=sample.status == Sample.Status.TRUNCATED,
+                dumped_rank=None,
+                mean_entropy=None,
+                max_entropy=None,
+                ref_entropy_mean=None,
+                mean_abs_lp_diff=None,
+                max_abs_lp_diff=None,
+                mean_imp_ratio=None,
+                adv_mean=None,
+                adv_std=None,
+                return_mean=None,
+                alignment_failed=False,
             )
-            train_columns["alignment_failed"] = False
-            train_columns["truncated"] = sample.status == Sample.Status.TRUNCATED
-            return entry | train_columns
 
         mask = row.loss_mask > 0
         lp_diff = (

--- a/tests/fast/dashboard/dummy_dump.py
+++ b/tests/fast/dashboard/dummy_dump.py
@@ -36,7 +36,7 @@ from pathlib import Path
 
 import torch
 
-from miles.ray.rollout.debug_data import save_debug_rollout_data
+from miles.ray.rollout.debug_data import save_dashboard_columns, save_debug_rollout_data
 from miles.ray.rollout.train_data_conversion import (
     convert_samples_to_train_data,
     process_rollout_data_shard,
@@ -233,3 +233,19 @@ def age_files(dump_dir: Path, *, seconds: float = 100.0) -> None:
     stamp = time.time() - seconds
     for path in dump_dir.rglob("*.pt"):
         os.utime(path, (stamp, stamp))
+
+
+def blank_samples(dump_dir: Path, rollout_id: int, *, seconds: float = 100.0) -> None:
+    """Rewrite a step as one aborted before any generation landed."""
+    path = dump_dir / "rollout_data" / f"{rollout_id}.pt"
+    pack = torch.load(path, map_location="cpu", weights_only=False)
+    pack["samples"] = []
+    torch.save(pack, path)
+
+    save_dashboard_columns([], dump_dir / "dashboard_columns" / f"rollout_{rollout_id}.parquet")
+    (dump_dir / "trajectory" / f"{rollout_id}.jsonl").unlink(missing_ok=True)
+    for shard in (dump_dir / "train_data").glob(f"{rollout_id}_*.pt"):
+        shard.unlink()
+
+    stamp = time.time() - seconds
+    os.utime(path, (stamp, stamp))

--- a/tests/fast/dashboard/test_advisory.py
+++ b/tests/fast/dashboard/test_advisory.py
@@ -1,7 +1,8 @@
 import polars as pl
+from tests.fast.dashboard.dummy_dump import blank_samples, dump_dummy_run
 
 from miles.dashboard.advisory import compute_advisories
-from miles.dashboard.dump_reader import RolloutIds
+from miles.dashboard.dump_reader import DumpReader, RolloutIds
 from miles.dashboard.store import EngineSample, Meta, MetricsRecord, MetricStore, PhaseEvent, Stream
 
 
@@ -433,3 +434,11 @@ def test_no_mfu_metric_no_claim(tmp_path):
         )
     writer.flush()
     assert compute_advisories(MetricStore.load(tmp_path)) == []
+
+
+def test_blank_newest_step_does_not_break_rollout_advisories(tmp_path):
+    dump_dir = tmp_path / "dump"
+    dump_dummy_run(dump_dir, steps=2, with_eval=False)
+    blank_samples(dump_dir, 1)
+    store = _store(tmp_path, args={}, engine_samples=[])
+    assert compute_advisories(store, DumpReader(dump_dir)) == []

--- a/tests/fast/dashboard/test_dump_reader_views.py
+++ b/tests/fast/dashboard/test_dump_reader_views.py
@@ -1,3 +1,4 @@
+import json
 import os
 import statistics
 import time
@@ -317,3 +318,20 @@ def test_empty_step_survives_the_parquet_cache(tmp_path):
     reloaded = DumpReader(tmp_path, cache_dir=tmp_path / "c").summary(1)  # served from the parquet written above
     assert reloaded.height == 0
     assert reloaded.columns == list(DumpReader.SUMMARY_COLUMNS)
+
+
+def test_pre_fix_columnless_cache_is_not_served(tmp_path):
+    """A cache dir populated before the no-sample schema fix holds a columnless
+    parquet for the aborted step, and its mtime stamps still match the dump.
+    Only SUMMARY_VERSION tells it apart from a valid cache, so the schema fix
+    had to ship with a bump past 4 -- the version that wrote those caches."""
+    dump_dummy_run(tmp_path, steps=2, with_eval=False)
+    _blank_samples(tmp_path, 1)
+    reader = DumpReader(tmp_path, cache_dir=tmp_path / "c")
+    reader.cache_dir.mkdir(parents=True, exist_ok=True)
+    pl.DataFrame([], strict=False).write_parquet(reader.cache_dir / "rollout_1.parquet")
+    stale = {**reader._source_stamps(1, evaluation=False), "_summary_version": 4}
+    (reader.cache_dir / "rollout_1.sources.json").write_text(json.dumps(stale))
+
+    assert reader.summary(1).columns == list(DumpReader.SUMMARY_COLUMNS)
+    assert DumpReader.SUMMARY_VERSION > 4  # regressing the bump re-serves those caches

--- a/tests/fast/dashboard/test_dump_reader_views.py
+++ b/tests/fast/dashboard/test_dump_reader_views.py
@@ -4,6 +4,7 @@ import time
 
 import polars as pl
 import pytest
+import torch
 from tests.fast.dashboard.dummy_dump import dump_dummy_run
 
 from miles.dashboard.dump_reader import DumpReader
@@ -261,3 +262,58 @@ def test_groups_null_rewards_are_not_zero_std(tmp_path):
         }
     )
     assert not reader.groups(0)["zero_std"].any()
+
+
+def test_summary_columns_declaration_matches_reality(reader):
+    # SUMMARY_COLUMNS only shapes the no-sample case, so nothing else would
+    # notice it drifting: pin it against the columns a real summary produces
+    assert list(DumpReader.SUMMARY_COLUMNS) == reader.summary(0).columns
+
+
+def _blank_samples(dump_dir, rollout_id):
+    """Rewrite a step's rollout dump with no samples, as a step aborted before
+    any generation landed is written."""
+    path = dump_dir / "rollout_data" / f"{rollout_id}.pt"
+    pack = torch.load(path, map_location="cpu", weights_only=False)
+    pack["samples"] = []
+    torch.save(pack, path)
+    for shard in (dump_dir / "train_data").glob(f"{rollout_id}_*.pt"):
+        shard.unlink()
+    stale = time.time() - 3600  # past MIN_AGE_SECONDS, so the step stays listed
+    os.utime(path, (stale, stale))
+
+
+def test_step_with_no_samples_reads_as_empty_not_broken(tmp_path):
+    """A step can be dumped with no samples at all. Its summary must still
+    carry the full schema, or every view below it fails on a missing column
+    instead of reporting an empty step -- and because step_aggregates() walks
+    every step, one such step would take the whole metrics page down with it."""
+    dump_dummy_run(tmp_path, steps=3, with_eval=False)
+    _blank_samples(tmp_path, 1)  # a MIDDLE step, so step_aggregates must walk past it
+    reader = DumpReader(tmp_path)
+
+    empty = reader.summary(1)
+    assert empty.height == 0
+    assert empty.columns == list(DumpReader.SUMMARY_COLUMNS)
+    assert empty["sample_index"].to_list() == []  # the trajectories endpoint indexes this
+
+    assert reader.groups(1).height == 0
+    assert "zero_std" in reader.groups(1).columns
+
+    aggregates = reader.step_aggregates()
+    assert aggregates["rollout_id"].to_list() == [0, 1, 2]
+    blank = aggregates.filter(pl.col("rollout_id") == 1).row(0, named=True)
+    assert blank["n_samples"] == 0
+    assert blank["reward_mean"] is None
+    # the steps on either side are still measured normally
+    assert aggregates.filter(pl.col("rollout_id") == 2).row(0, named=True)["n_samples"] == reader.summary(2).height
+
+
+def test_empty_step_survives_the_parquet_cache(tmp_path):
+    # the all-null frame is written to parquet and read back on the next call
+    dump_dummy_run(tmp_path, steps=2, with_eval=False)
+    _blank_samples(tmp_path, 1)
+    assert DumpReader(tmp_path, cache_dir=tmp_path / "c").summary(1).columns == list(DumpReader.SUMMARY_COLUMNS)
+    reloaded = DumpReader(tmp_path, cache_dir=tmp_path / "c").summary(1)  # served from the parquet written above
+    assert reloaded.height == 0
+    assert reloaded.columns == list(DumpReader.SUMMARY_COLUMNS)

--- a/tests/fast/dashboard/test_dump_reader_views.py
+++ b/tests/fast/dashboard/test_dump_reader_views.py
@@ -268,6 +268,7 @@ def test_summary_columns_declaration_matches_reality(reader):
     # SUMMARY_COLUMNS only shapes the no-sample case, so nothing else would
     # notice it drifting: pin it against the columns a real summary produces
     assert list(DumpReader.SUMMARY_COLUMNS) == reader.summary(0).columns
+    assert list(DumpReader.SUMMARY_COLUMNS) == reader.summary(0, evaluation=True).columns
 
 
 def test_step_with_no_samples_reads_as_empty_not_broken(tmp_path):

--- a/tests/fast/dashboard/test_dump_reader_views.py
+++ b/tests/fast/dashboard/test_dump_reader_views.py
@@ -5,8 +5,7 @@ import time
 
 import polars as pl
 import pytest
-import torch
-from tests.fast.dashboard.dummy_dump import dump_dummy_run
+from tests.fast.dashboard.dummy_dump import blank_samples, dump_dummy_run
 
 from miles.dashboard.dump_reader import DumpReader
 
@@ -271,26 +270,13 @@ def test_summary_columns_declaration_matches_reality(reader):
     assert list(DumpReader.SUMMARY_COLUMNS) == reader.summary(0).columns
 
 
-def _blank_samples(dump_dir, rollout_id):
-    """Rewrite a step's rollout dump with no samples, as a step aborted before
-    any generation landed is written."""
-    path = dump_dir / "rollout_data" / f"{rollout_id}.pt"
-    pack = torch.load(path, map_location="cpu", weights_only=False)
-    pack["samples"] = []
-    torch.save(pack, path)
-    for shard in (dump_dir / "train_data").glob(f"{rollout_id}_*.pt"):
-        shard.unlink()
-    stale = time.time() - 3600  # past MIN_AGE_SECONDS, so the step stays listed
-    os.utime(path, (stale, stale))
-
-
 def test_step_with_no_samples_reads_as_empty_not_broken(tmp_path):
     """A step can be dumped with no samples at all. Its summary must still
     carry the full schema, or every view below it fails on a missing column
     instead of reporting an empty step -- and because step_aggregates() walks
     every step, one such step would take the whole metrics page down with it."""
     dump_dummy_run(tmp_path, steps=3, with_eval=False)
-    _blank_samples(tmp_path, 1)  # a MIDDLE step, so step_aggregates must walk past it
+    blank_samples(tmp_path, 1)  # a MIDDLE step, so step_aggregates must walk past it
     reader = DumpReader(tmp_path)
 
     empty = reader.summary(1)
@@ -313,7 +299,7 @@ def test_step_with_no_samples_reads_as_empty_not_broken(tmp_path):
 def test_empty_step_survives_the_parquet_cache(tmp_path):
     # the all-null frame is written to parquet and read back on the next call
     dump_dummy_run(tmp_path, steps=2, with_eval=False)
-    _blank_samples(tmp_path, 1)
+    blank_samples(tmp_path, 1)
     assert DumpReader(tmp_path, cache_dir=tmp_path / "c").summary(1).columns == list(DumpReader.SUMMARY_COLUMNS)
     reloaded = DumpReader(tmp_path, cache_dir=tmp_path / "c").summary(1)  # served from the parquet written above
     assert reloaded.height == 0
@@ -326,7 +312,7 @@ def test_pre_fix_columnless_cache_is_not_served(tmp_path):
     Only SUMMARY_VERSION tells it apart from a valid cache, so the schema fix
     had to ship with a bump past 4 -- the version that wrote those caches."""
     dump_dummy_run(tmp_path, steps=2, with_eval=False)
-    _blank_samples(tmp_path, 1)
+    blank_samples(tmp_path, 1)
     reader = DumpReader(tmp_path, cache_dir=tmp_path / "c")
     reader.cache_dir.mkdir(parents=True, exist_ok=True)
     pl.DataFrame([], strict=False).write_parquet(reader.cache_dir / "rollout_1.parquet")


### PR DESCRIPTION
## Summary

Follow-up to #2815, which stopped the Rollouts tab from *landing* on an unusable step but left the underlying crash in place. This fixes the crash.

A step can be dumped with no samples at all. `summary()` inferred its schema from an empty row list, which yields a frame with **zero columns** rather than zero rows — so every view built on top of it died on a missing column instead of reporting an empty step.

## Blast radius

Measured by blanking one step's samples in a real dummy dump and calling each consumer directly:

| consumer | before | why it matters |
| --- | --- | --- |
| `groups()` | `ColumnNotFoundError: unable to find column "group_index"` | `_translate_errors` has no handler for it, so the rollout page returns **500** |
| `summary()["sample_index"]` | `ColumnNotFoundError: "sample_index" not found` | the trajectories endpoint indexes this |
| `step_aggregates()` | same `ColumnNotFoundError` | walks **every** step, so one empty step anywhere takes down the whole dump-derived metrics page, not just its own |

That third one is the reason this is worth fixing at the reader rather than patching `groups()`: a single empty step in the middle of a run poisons the metrics page for every other step.

## What changed

`summary()` supplies the declared schema when there are no rows. All three consumers then read an *empty* table instead of a broken one — `groups()` returns no groups, and `step_aggregates()` reports the step honestly as `n_samples: 0` with null aggregates while its neighbours keep their real values:

```
{'rollout_id': 0, 'n_samples': 8, 'reward_mean': 0.25,  ...}
{'rollout_id': 1, 'n_samples': 0, 'reward_mean': None,  ...}   <- the empty step
{'rollout_id': 2, 'n_samples': 8, 'reward_mean': 0.5,   ...}
```

`SUMMARY_COLUMNS` has to be declared because an empty row list carries no schema to infer. Since it only shapes the no-sample case, nothing else would notice it drifting away from `_summary_row`, so a test pins it against the columns a real summary produces — adding a column without updating it fails there. Dtypes are deliberately not pinned: they are data-dependent (`spec_accept_rate` infers as `Null` when every value is `None`, `Float64` otherwise), so the empty frame uses `Null`, which casts cleanly in the aggregations downstream.

## Verification

Three tests added to `tests/fast/dashboard/test_dump_reader_views.py`, all run locally.

The empty step is placed in the **middle** of a 3-step dump specifically so `step_aggregates()` has to walk past it and the neighbouring steps can be asserted intact. A separate test covers the parquet cache, because the all-null frame is written to disk and re-read only on the *second* call — a schema that failed to round-trip would otherwise pass on the first call and break in production.

Confirming the tests actually catch the bug, not just the new constant: reverting **only** the `summary()` behaviour while keeping `SUMMARY_COLUMNS` in place turns both behaviour tests red with the real `ColumnNotFoundError`, while the drift test stays green (correctly — it guards a different thing).

| run | result |
| --- | --- |
| `test_dump_reader_views.py`, with fix | 18 passed, 1 skipped |
| same file, `summary()` behaviour reverted | **2 failed**, 16 passed, 1 skipped |
| whole `tests/fast/dashboard/` | 245 passed, 4 skipped, 1 failed |
| `black==24.3.0`, `isort==5.13.2`, `ruff` | clean |

The one failure is `test_core_integration.py::test_engine_topology_gpu_range_logic`, which fails identically on a clean `origin/main` checkout with my changes stashed — pre-existing and unrelated to this diff.

The skipped test is `test_realdata_views`, which needs `MILES_DASHBOARD_REALDATA_DIR`.

## Test plan

Covered by the three new tests above. No API, schema, or frontend change — the empty step simply renders as an empty table rather than an error page.
