### PR TITLE
fix(megatron): keep SFT logits in model precision

### DIFF
--- a/miles/backends/megatron_utils/model.py
+++ b/miles/backends/megatron_utils/model.py
@@ -547,7 +547,7 @@ def train_one_step(
             if (x := batch["multimodal_train_inputs"]) is not None:
                 forward_kwargs.update(x)
 
-            output_tensor = model(**forward_kwargs, fp32_output=args.loss_type != "policy_loss")
+            output_tensor = model(**forward_kwargs, fp32_output=args.loss_type not in ("policy_loss", "sft_loss"))
 
         for m, old_stage in zip(all_replay_managers, old_stages, strict=True):
             m.stage = old_stage

--- a/miles/backends/training_utils/loss_hub/losses.py
+++ b/miles/backends/training_utils/loss_hub/losses.py
@@ -493,9 +493,9 @@ def sft_loss_function(
     log_probs = torch.cat(log_probs, dim=0)
     loss = -sum_of_sample_mean(log_probs)
 
-    # make sure the gradient could backprop correctly.
+    # make sure the gradient could backprop correctly; fp32 sum avoids fp16 inf -> nan
     if log_probs.numel() == 0:
-        loss += 0 * logits.sum()
+        loss += 0 * logits.sum(dtype=torch.float32)
 
     return (
         loss,

--- a/miles/backends/training_utils/loss_hub/math_utils.py
+++ b/miles/backends/training_utils/loss_hub/math_utils.py
@@ -1027,9 +1027,9 @@ def calculate_log_probs_and_entropy(
             if with_entropy:
                 entropy = compute_entropy(logits)
     else:
-        log_prob = logits.new_zeros((0,))
+        log_prob = logits.new_zeros((0,), dtype=torch.float32)
         if with_entropy:
-            entropy = logits.new_zeros((0,))
+            entropy = logits.new_zeros((0,), dtype=torch.float32)
 
     return log_prob, entropy
 

--- a/tests/fast/backends/training_utils/loss/test_loss_snapshot.py
+++ b/tests/fast/backends/training_utils/loss/test_loss_snapshot.py
@@ -86,6 +86,13 @@ CONFIGS = [
         [40, 60],
         [20, 40],
     ),
+    (
+        "sft_chunked_b2",
+        dict(loss_type="sft_loss", true_on_policy_mode=False, log_probs_chunk_size=8),
+        2,
+        [64, 128],
+        [32, 64],
+    ),
     # bshd format (padded sequences)
     (
         "grpo_bshd_b3",

--- a/tests/fast/backends/training_utils/test_sft_logit_precision.py
+++ b/tests/fast/backends/training_utils/test_sft_logit_precision.py
@@ -1,0 +1,23 @@
+import torch
+from tests.fast.backends.training_utils.loss.loss_test_utils import make_args, make_parallel_state
+
+from miles.backends.training_utils.loss_hub.losses import sft_loss_function
+
+
+def test_sft_graph_placeholder_survives_fp16_logits():
+    # With every response token on another CP rank, the loss reduces to the
+    # `0 * logits.sum()` graph placeholder; an fp16 sum overflows to inf.
+    make_parallel_state()
+    args = make_args(loss_type="sft_loss", true_on_policy_mode=False)
+    batch = {
+        "unconcat_tokens": [torch.zeros(5, dtype=torch.long)],
+        "total_lengths": [5],
+        "response_lengths": [0],
+    }
+    logits = torch.full((1, 5, 70_000), 2.0, dtype=torch.float16)
+    assert torch.isinf(logits.sum())
+
+    loss, _ = sft_loss_function(args, batch, logits, sum_of_sample_mean=torch.sum)
+
+    assert torch.isfinite(loss)
+    assert loss == 0


### PR DESCRIPTION
## Summary

Extends #2764 to SFT: keep the Megatron SFT training forward output in model precision instead of materializing the full-size FP32 logits tensor. The SFT loss already slices response logits and upcasts each `--log-probs-chunk-size` chunk to FP32 before the fused vocab-parallel cross-entropy, so the full-size upcast adds memory without adding information.

- `model.py`: `fp32_output=args.loss_type not in ("policy_loss", "sft_loss")` — value and other losses keep FP32 outputs
- `losses.py`: the SFT `0 * logits.sum()` graph placeholder now sums in FP32 (an fp16 sum can overflow to inf, and `0 * inf` is nan); same fix #2764 applied to the policy placeholder
- `math_utils.py`: empty log-probs/entropy from the chunked path are pinned to fp32. With model-precision logits, a CP rank whose contiguous half holds no response logits otherwise returns an empty bf16/fp16 tensor while other ranks return fp32 CE outputs; the dtype leaks through `allgather_cp_redistribute` into the cross-rank `dist.nn.all_reduce`, and the byte-size mismatch crashes the collective (`gloo::EnforceNotMet: 24 vs 12`). Found by the CP=2 consistency tests in #2826 (stacked on this PR).

## Why

`Float16Module.forward()` defaults to `fp32_output=True`. For SFT with `labels=None`, that widens the complete last-stage `[T, V/TP]` logits tensor before the chunked loss runs. For a long-context batch (255,675 tokens, 31,104-entry local vocab shard) the conversion alone is an ~29.6 GiB FP32 allocation per last-stage TP rank. A long-context 8xH200 SFT run that previously failed at this conversion ran 1,000+ optimizer updates with model-precision output.

The combined 1F1B schedule is unchanged (separate schedule-plan output path with its own unconditional upcast).

## Tests

- `test_sft_logit_precision.py`: the SFT graph placeholder stays finite with overflowing fp16 logits (fails without the fix)
- `sft_chunked_b2` loss snapshot config: SFT through the chunked non-true-on-policy path; snapshot generated from the pre-PR baseline (post-#2764) and compared bitwise
- The empty-rank dtype fix is exercised end-to-end by #2826's `contiguous_empty_rank` case (crashes without it)
- Chunk-level upcast and fp16 admission are covered by #2764's tests

Includes changes by @yueming-yuan (rebase onto #2764, dropping the helper superseded by #2764's inline expression).
