### PR TITLE
Fix checksum audit mapping for distributed optimizer shards

### DIFF
--- a/miles/backends/megatron_utils/local_weight_checksum.py
+++ b/miles/backends/megatron_utils/local_weight_checksum.py
@@ -102,13 +102,13 @@ def _collect_optimizer_hashes(
     """Collect optimizer state snapshots with tensors replaced by hashes."""
     from miles.utils.audit_utils.event_logger.models import OptimizerStateInfo
 
-    name_by_tensor_id = _build_name_by_tensor_id(model)
     result: list[OptimizerStateInfo] = []
 
     for sub_opt in _iter_sub_optimizers(optimizer):
         inner = sub_opt.optimizer
         assert isinstance(inner, torch.optim.Optimizer), f"Expected torch.optim.Optimizer, got {type(inner)}"
 
+        name_by_tensor_id = _build_name_by_tensor_id(model, optimizer=sub_opt)
         param_names = _build_param_names_for_optimizer(inner, name_by_tensor_id=name_by_tensor_id)
         sd = inner.state_dict()
         hashed_sd = _transform_tensor_to_hash(sd)
@@ -123,20 +123,57 @@ def _collect_optimizer_hashes(
     return result
 
 
-def _build_name_by_tensor_id(model: Sequence[DDP]) -> dict[_MainParamId, str]:
-    """Build _MainParamId(fp32_main_param) → name mapping from model parameters."""
+def _build_name_by_tensor_id(
+    model: Sequence[DDP],
+    *,
+    optimizer: MegatronOptimizer | None = None,
+) -> dict[_MainParamId, str]:
+    """Build optimizer tensor ID → model parameter name mapping.
+
+    DistributedOptimizer records every locally owned optimizer tensor in
+    ``model_param_group_index_map``. This is authoritative for both regular
+    mixed-precision main shards and precision-aware optimizer shards, where
+    ``main_param`` is intentionally ``None``. Non-distributed optimizers fall
+    back to the model parameter's ``main_param`` handle.
+    """
     name_map: dict[_MainParamId, str] = {}
+    inner = optimizer.optimizer if optimizer is not None else None
+    distributed_param_map = (
+        getattr(optimizer, "model_param_group_index_map", None) if optimizer is not None else None
+    )
+
     for pp_idx, model_chunk in enumerate(model):
         for name, param in model_chunk.named_parameters():
             assert param is not None, f"pp{pp_idx}.{name}: param is None"
-            main_param = getattr(param, "main_param", None)
-            if main_param is None:
-                assert getattr(param, "main_param_sharded", False), (
-                    f"pp{pp_idx}.{name}: main_param is None but main_param_sharded is not set. "
-                    "Expected only for distributed optimizer params not owned by this DP rank."
-                )
+            qualified_name = f"pp{pp_idx}.{name}"
+
+            if distributed_param_map is not None:
+                group_location = distributed_param_map.get(param)
+                if group_location is None:
+                    # Chained optimizers partition model parameters; another
+                    # sub-optimizer or DP rank owns this parameter.
+                    continue
+                assert inner is not None
+                group_index, group_order = group_location
+                optimizer_param = inner.param_groups[group_index]["params"][group_order]
+                name_map[_MainParamId.from_tensor(optimizer_param)] = qualified_name
                 continue
-            name_map[_MainParamId.from_tensor(main_param)] = f"pp{pp_idx}.{name}"
+
+            main_param = getattr(param, "main_param", None)
+            if main_param is not None:
+                name_map[_MainParamId.from_tensor(main_param)] = qualified_name
+                continue
+
+            if getattr(param, "main_param_sharded", False):
+                continue
+
+            assert param.dtype == torch.float32, (
+                f"{qualified_name}: main_param is None but main_param_sharded is not set "
+                f"for non-fp32 parameter dtype {param.dtype}."
+            )
+
+            # Non-distributed optimizers use the original fp32 parameter.
+            name_map[_MainParamId.from_tensor(param)] = qualified_name
     return name_map
 
 
@@ -148,10 +185,10 @@ def _build_param_names_for_optimizer(
     param_names: dict[int, str] = {}
     idx = 0
     for group in inner.param_groups:
-        for fp32_param in group["params"]:
-            key = _MainParamId.from_tensor(fp32_param)
+        for optimizer_param in group["params"]:
+            key = _MainParamId.from_tensor(optimizer_param)
             name = name_by_tensor_id.get(key)
-            assert name is not None, f"fp32 param {key} not found in model name mapping"
+            assert name is not None, f"optimizer param {key} not found in model name mapping"
             param_names[idx] = name
             idx += 1
     return param_names

--- a/tests/fast/backends/megatron_utils/test_local_weight_checksum.py
+++ b/tests/fast/backends/megatron_utils/test_local_weight_checksum.py
@@ -206,15 +206,150 @@ class TestFailFastAssertions:
         with pytest.raises(AssertionError, match="No sub-optimizers found"):
             _compute_weight_checksum_state(model=model, optimizer=optimizer)
 
-    def test_assert_param_without_main_param_fails(self) -> None:
+    def test_assert_non_fp32_param_without_main_param_fails(self) -> None:
         from miles.backends.megatron_utils.local_weight_checksum import _build_name_by_tensor_id
 
         chunk = MagicMock()
-        param = torch.randn(2, 2)
+        param = torch.randn(2, 2, dtype=torch.bfloat16)
         chunk.named_parameters.return_value = [("weight", param)]
 
         with pytest.raises(AssertionError, match="main_param is None"):
             _build_name_by_tensor_id([chunk])
+
+    def test_native_fp32_param_uses_distributed_optimizer_shard(self) -> None:
+        from miles.backends.megatron_utils.local_weight_checksum import (
+            _MainParamId,
+            _build_name_by_tensor_id,
+        )
+
+        model_param = torch.nn.Parameter(torch.randn(2, 2, dtype=torch.float32))
+        optimizer_shard = torch.nn.Parameter(model_param.detach().view(-1)[:2])
+        chunk = MagicMock()
+        chunk.named_parameters.return_value = [(
+            "module.layers.0.native_fp32_weight",
+            model_param,
+        )]
+
+        inner = MagicMock(spec=torch.optim.Adam)
+        inner.param_groups = [{"params": [optimizer_shard]}]
+        sub_optimizer = MagicMock(spec=["optimizer", "model_param_group_index_map"])
+        sub_optimizer.optimizer = inner
+        sub_optimizer.model_param_group_index_map = {model_param: (0, 0)}
+
+        name_map = _build_name_by_tensor_id([chunk], optimizer=sub_optimizer)
+
+        assert name_map[_MainParamId.from_tensor(optimizer_shard)] == (
+            "pp0.module.layers.0.native_fp32_weight"
+        )
+
+    def test_mixed_precision_param_still_uses_main_param(self) -> None:
+        from miles.backends.megatron_utils.local_weight_checksum import (
+            _MainParamId,
+            _build_name_by_tensor_id,
+        )
+
+        model_param = torch.nn.Parameter(torch.randn(2, 2, dtype=torch.bfloat16))
+        main_param = torch.nn.Parameter(model_param.detach().float())
+        model_param.main_param = main_param
+        chunk = MagicMock()
+        chunk.named_parameters.return_value = [("weight", model_param)]
+
+        inner = MagicMock(spec=torch.optim.Adam)
+        inner.param_groups = [{"params": [main_param]}]
+        sub_optimizer = MagicMock(spec=["optimizer", "model_param_group_index_map"])
+        sub_optimizer.optimizer = inner
+        sub_optimizer.model_param_group_index_map = {model_param: (0, 0)}
+
+        name_map = _build_name_by_tensor_id([chunk], optimizer=sub_optimizer)
+
+        assert name_map[_MainParamId.from_tensor(main_param)] == "pp0.weight"
+
+    def test_precision_aware_param_uses_distributed_optimizer_shard(self) -> None:
+        from miles.backends.megatron_utils.local_weight_checksum import (
+            _MainParamId,
+            _build_name_by_tensor_id,
+        )
+
+        model_param = torch.nn.Parameter(torch.randn(2, 2, dtype=torch.bfloat16))
+        model_param.main_param = None
+        model_param.main_param_sharded = True
+        optimizer_shard = model_param.detach().view(-1)
+        chunk = MagicMock()
+        chunk.named_parameters.return_value = [("module.layers.0.weight", model_param)]
+
+        inner = MagicMock(spec=torch.optim.Adam)
+        inner.param_groups = [{"params": [optimizer_shard]}]
+        sub_optimizer = MagicMock(spec=["optimizer", "model_param_group_index_map"])
+        sub_optimizer.optimizer = inner
+        sub_optimizer.model_param_group_index_map = {model_param: (0, 0)}
+
+        name_map = _build_name_by_tensor_id([chunk], optimizer=sub_optimizer)
+
+        assert name_map[_MainParamId.from_tensor(optimizer_shard)] == "pp0.module.layers.0.weight"
+
+    def test_unowned_distributed_shard_is_still_skipped(self) -> None:
+        from miles.backends.megatron_utils.local_weight_checksum import _build_name_by_tensor_id
+
+        model_param = torch.nn.Parameter(torch.randn(2, 2, dtype=torch.bfloat16))
+        model_param.main_param = None
+        model_param.main_param_sharded = True
+        chunk = MagicMock()
+        chunk.named_parameters.return_value = [("weight", model_param)]
+
+        assert _build_name_by_tensor_id([chunk]) == {}
+
+    def test_native_fp32_params_map_per_chained_optimizer(self) -> None:
+        from miles.backends.megatron_utils.local_weight_checksum import _collect_optimizer_hashes
+
+        first_param = torch.nn.Parameter(torch.randn(2, 2, dtype=torch.float32))
+        second_param = torch.nn.Parameter(torch.randn(2, 2, dtype=torch.float32))
+        first_shard = torch.nn.Parameter(first_param.detach().view(-1)[:2])
+        second_shard = torch.nn.Parameter(second_param.detach().view(-1)[:2])
+        chunk = MagicMock()
+        chunk.named_parameters.return_value = [
+            ("first", first_param),
+            ("second", second_param),
+        ]
+
+        def make_sub_optimizer(
+            model_param: torch.nn.Parameter,
+            optimizer_shard: torch.nn.Parameter,
+        ) -> MagicMock:
+            inner = MagicMock(spec=torch.optim.Adam)
+            inner.param_groups = [{"params": [optimizer_shard]}]
+            inner.state_dict.return_value = {
+                "state": {},
+                "param_groups": [{"params": [0]}],
+            }
+            sub_optimizer = MagicMock(spec=["optimizer", "model_param_group_index_map"])
+            sub_optimizer.optimizer = inner
+            sub_optimizer.model_param_group_index_map = {model_param: (0, 0)}
+            return sub_optimizer
+
+        optimizer = MagicMock(spec=["chained_optimizers"])
+        optimizer.chained_optimizers = [
+            make_sub_optimizer(first_param, first_shard),
+            make_sub_optimizer(second_param, second_shard),
+        ]
+
+        first_info, second_info = _collect_optimizer_hashes([chunk], optimizer)
+
+        assert first_info.param_names == {0: "pp0.first"}
+        assert second_info.param_names == {0: "pp0.second"}
+
+    def test_native_fp32_param_uses_original_tensor_for_non_distributed_optimizer(self) -> None:
+        from miles.backends.megatron_utils.local_weight_checksum import (
+            _MainParamId,
+            _build_name_by_tensor_id,
+        )
+
+        model_param = torch.nn.Parameter(torch.randn(2, 2, dtype=torch.float32))
+        chunk = MagicMock()
+        chunk.named_parameters.return_value = [("weight", model_param)]
+
+        name_map = _build_name_by_tensor_id([chunk])
+
+        assert name_map[_MainParamId.from_tensor(model_param)] == "pp0.weight"
 
     def test_assert_unmapped_fp32_param_fails(self) -> None:
         from miles.backends.megatron_utils.local_weight_checksum import _build_param_names_for_optimizer


### PR DESCRIPTION
## Summary

- map locally owned model parameters to optimizer tensors through the distributed optimizer's index map
- support native FP32 and precision-aware optimizer shard layouts
- preserve non-distributed, unowned-shard, and chained-optimizer behavior

## Problem

The checksum audit assumed every locally owned mixed-precision model parameter
exposes its optimizer tensor through `main_param`. That is not true for all
supported optimizer layouts:

- native FP32 parameters use flattened optimizer shards; and
- precision-aware optimizers intentionally leave `main_param` unset.

In both cases, `DistributedOptimizer` records the authoritative optimizer tensor
location in `model_param_group_index_map`. Ignoring that mapping can make
checksum collection fail while correlating optimizer state with canonical model
parameter names.

## Implementation

Build the tensor-to-name map independently for each sub-optimizer. When the
distributed index map is present, resolve every locally owned parameter through
its optimizer group and position. Use the existing `main_param` or original
FP32 tensor only for non-distributed optimizers. Parameters owned by another
rank or chained sub-optimizer remain excluded.

## Testing

```text
24 passed
```

The focused checksum test module passes in the Miles v0.1.0 CUDA 13 image,
including native FP32, ordinary mixed precision, precision-aware optimization,
chained optimizers, and unowned distributed shards.
