### PR TITLE
fix(debug): fail closed on invalid logprob comparisons

### DIFF
--- a/miles/utils/debug_utils/run_megatron/cli/commands/args.py
+++ b/miles/utils/debug_utils/run_megatron/cli/commands/args.py
@@ -64,7 +64,7 @@ class RunAndCompareArgs(CommonRunArgs):
     baseline_extra_args: str = _field(default="", help="Extra megatron args for baseline run only")
     target_extra_args: str = _field(default="", help="Extra megatron args for target run only")
     diff_threshold: float | None = _field(default=None, help="Activation diff pass/fail threshold")
-    logprob_threshold: float | None = _field(default=None, help="Logprob max abs diff threshold")
+    logprob_threshold: float | None = _field(default=None, help="Logprob mean abs diff threshold")
 
 
 @dataclasses.dataclass
@@ -78,4 +78,4 @@ class CompareArgs:
     diff_threshold: float | None = _field(default=None, help="Pass/fail threshold")
     baseline_logprob_dir: Path | None = _field(default=None, help="Baseline logprob JSON directory")
     target_logprob_dir: Path | None = _field(default=None, help="Target logprob JSON directory")
-    logprob_threshold: float | None = _field(default=None, help="Logprob max abs diff threshold")
+    logprob_threshold: float | None = _field(default=None, help="Logprob mean abs diff threshold")

--- a/miles/utils/debug_utils/run_megatron/cli/commands/compare.py
+++ b/miles/utils/debug_utils/run_megatron/cli/commands/compare.py
@@ -20,11 +20,14 @@ def compare_impl(args: CompareArgs) -> None:
     """Core compare logic, called by both ``compare`` command and ``run_and_compare``."""
     activation_passed = _run_activation_comparison(args)
 
-    logprob_passed = True
-    if args.baseline_logprob_dir is not None and args.target_logprob_dir is not None:
+    baseline_logprob_dir = args.baseline_logprob_dir
+    target_logprob_dir = args.target_logprob_dir
+    logprob_dirs = (baseline_logprob_dir, target_logprob_dir)
+    logprob_passed = all(directory is None for directory in logprob_dirs)
+    if baseline_logprob_dir is not None and target_logprob_dir is not None:
         logprob_passed = compare_logprobs(
-            baseline_dir=args.baseline_logprob_dir,
-            target_dir=args.target_logprob_dir,
+            baseline_dir=baseline_logprob_dir,
+            target_dir=target_logprob_dir,
             threshold=args.logprob_threshold if args.logprob_threshold is not None else 1e-3,
         )
 

--- a/miles/utils/debug_utils/run_megatron/logprob_comparator.py
+++ b/miles/utils/debug_utils/run_megatron/logprob_comparator.py
@@ -3,10 +3,14 @@
 from __future__ import annotations
 
 import json
+import math
 import statistics
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
+
+_LOG_RATIO_EXP_CLAMP = 20.0
+_LOW_VAR_KL_MAX = 10.0
 
 
 @dataclass
@@ -19,6 +23,9 @@ class _PositionLogprob:
 @dataclass
 class _CompareResult:
     passed: bool
+    failure_reasons: tuple[str, ...]
+    num_baseline_positions: int
+    num_target_positions: int
     num_positions: int
     max_abs_diff: float
     max_diff_position: int
@@ -29,6 +36,9 @@ class _CompareResult:
     median_abs_diff: float
     p95_abs_diff: float
     p99_abs_diff: float
+    k3_kl: float
+    first_position_mean_abs_diff: float | None
+    remaining_position_mean_abs_diff: float | None
     baseline_mean_logprob: float
     target_mean_logprob: float
     threshold: float
@@ -43,23 +53,20 @@ def compare_logprobs(
 ) -> bool:
     """Compare logprob JSON files between baseline and target.
 
-    Returns True if the comparison passes (mean abs diff <= threshold).
+    Returns True only when both inputs contain the same finite token positions
+    and the mean absolute difference is within ``threshold``.
     """
-    baseline_entries = _load_and_merge(baseline_dir)
-    target_entries = _load_and_merge(target_dir)
-
-    if not baseline_entries:
-        print("[logprob-compare] WARNING: no valid baseline logprob entries found", flush=True)
-        return True
-    if not target_entries:
-        print("[logprob-compare] WARNING: no valid target logprob entries found", flush=True)
-        return True
-
-    result = _compute_comparison(
-        baseline_entries=baseline_entries,
-        target_entries=target_entries,
-        threshold=threshold,
-    )
+    try:
+        baseline_entries = _load_and_merge(baseline_dir)
+        target_entries = _load_and_merge(target_dir)
+        result = _compute_comparison(
+            baseline_entries=baseline_entries,
+            target_entries=target_entries,
+            threshold=threshold,
+        )
+    except (KeyError, OSError, TypeError, ValueError) as error:
+        print(f"[logprob-compare] FAILED to compare logprobs: {error}", flush=True)
+        return False
 
     _print_report(result)
     return result.passed
@@ -88,12 +95,15 @@ def _load_and_merge(directory: Path) -> dict[tuple[int, int], _PositionLogprob]:
                     continue
 
                 key = (batch_idx, entry["global_position"])
-                if key not in merged:
-                    merged[key] = _PositionLogprob(
-                        global_position=entry["global_position"],
-                        token_id=entry["token_id"],
-                        logprob=entry["logprob"],
-                    )
+                position = _PositionLogprob(
+                    global_position=entry["global_position"],
+                    token_id=entry["token_id"],
+                    logprob=entry["logprob"],
+                )
+                previous = merged.get(key)
+                if previous is not None and previous != position:
+                    raise ValueError(f"conflicting duplicate logprob entry for batch={batch_idx}, position={entry['global_position']} in {json_file}")
+                merged[key] = position
 
     return merged
 
@@ -104,41 +114,65 @@ def _compute_comparison(
     target_entries: dict[tuple[int, int], _PositionLogprob],
     threshold: float,
 ) -> _CompareResult:
-    common_keys = sorted(set(baseline_entries.keys()) & set(target_entries.keys()))
+    if not math.isfinite(threshold) or threshold < 0:
+        raise ValueError(f"logprob threshold must be finite and non-negative, got {threshold}")
 
-    if not common_keys:
-        return _CompareResult(
-            passed=True,
-            num_positions=0,
-            max_abs_diff=0.0,
-            max_diff_position=-1,
-            max_diff_baseline_logprob=0.0,
-            max_diff_target_logprob=0.0,
-            max_diff_token_id=-1,
-            mean_abs_diff=0.0,
-            median_abs_diff=0.0,
-            p95_abs_diff=0.0,
-            p99_abs_diff=0.0,
-            baseline_mean_logprob=0.0,
-            target_mean_logprob=0.0,
+    baseline_keys = set(baseline_entries)
+    target_keys = set(target_entries)
+    common_keys = sorted(baseline_keys & target_keys)
+    failure_reasons: list[str] = []
+
+    if not baseline_keys:
+        failure_reasons.append("baseline has no valid logprob positions")
+    if not target_keys:
+        failure_reasons.append("target has no valid logprob positions")
+
+    missing_from_target = baseline_keys - target_keys
+    missing_from_baseline = target_keys - baseline_keys
+    if missing_from_target:
+        failure_reasons.append(f"target is missing {len(missing_from_target)} baseline positions")
+    if missing_from_baseline:
+        failure_reasons.append(f"baseline is missing {len(missing_from_baseline)} target positions")
+
+    mismatched_token_keys = [key for key in common_keys if baseline_entries[key].token_id != target_entries[key].token_id]
+    if mismatched_token_keys:
+        failure_reasons.append(f"token IDs differ at {len(mismatched_token_keys)} positions")
+
+    nonfinite_keys = [key for key in common_keys if not (math.isfinite(baseline_entries[key].logprob) and math.isfinite(target_entries[key].logprob))]
+    if nonfinite_keys:
+        failure_reasons.append(f"non-finite logprobs found at {len(nonfinite_keys)} positions")
+
+    invalid_keys = set(mismatched_token_keys) | set(nonfinite_keys)
+    comparable_keys = [key for key in common_keys if key not in invalid_keys]
+    if not comparable_keys:
+        if common_keys:
+            failure_reasons.append("no aligned finite logprob positions remain")
+        elif baseline_keys or target_keys:
+            failure_reasons.append("baseline and target have no common positions")
+        return _empty_result(
+            failure_reasons=failure_reasons,
+            num_baseline_positions=len(baseline_keys),
+            num_target_positions=len(target_keys),
             threshold=threshold,
-            per_position_diffs=[],
         )
 
     diffs: list[float] = []
     max_abs_diff = 0.0
-    max_diff_key: tuple[int, int] = common_keys[0]
+    max_diff_key: tuple[int, int] = comparable_keys[0]
 
     baseline_logprobs: list[float] = []
     target_logprobs: list[float] = []
+    k3_values: list[float] = []
 
-    for key in common_keys:
+    for key in comparable_keys:
         baseline = baseline_entries[key]
         target = target_entries[key]
         abs_diff = abs(baseline.logprob - target.logprob)
         diffs.append(abs_diff)
         baseline_logprobs.append(baseline.logprob)
         target_logprobs.append(target.logprob)
+        log_ratio = max(-_LOG_RATIO_EXP_CLAMP, min(_LOG_RATIO_EXP_CLAMP, target.logprob - baseline.logprob))
+        k3_values.append(min(_LOW_VAR_KL_MAX, math.exp(log_ratio) - 1.0 - log_ratio))
 
         if abs_diff > max_abs_diff:
             max_abs_diff = abs_diff
@@ -146,22 +180,38 @@ def _compute_comparison(
 
     sorted_diffs = sorted(diffs)
     num = len(sorted_diffs)
+    first_keys_by_batch: dict[int, tuple[int, int]] = {}
+    for key in comparable_keys:
+        first_keys_by_batch.setdefault(key[0], key)
+    first_keys = set(first_keys_by_batch.values())
+    first_diffs = [diff for key, diff in zip(comparable_keys, diffs, strict=True) if key in first_keys]
+    remaining_diffs = [diff for key, diff in zip(comparable_keys, diffs, strict=True) if key not in first_keys]
 
     baseline_worst = baseline_entries[max_diff_key]
     target_worst = target_entries[max_diff_key]
 
+    mean_abs_diff = statistics.mean(diffs)
+    if mean_abs_diff > threshold:
+        failure_reasons.append(f"mean absolute difference {mean_abs_diff:.6e} exceeds threshold {threshold:.6e}")
+
     return _CompareResult(
-        passed=statistics.mean(diffs) <= threshold,
+        passed=not failure_reasons,
+        failure_reasons=tuple(failure_reasons),
+        num_baseline_positions=len(baseline_keys),
+        num_target_positions=len(target_keys),
         num_positions=num,
         max_abs_diff=max_abs_diff,
         max_diff_position=max_diff_key[1],
         max_diff_baseline_logprob=baseline_worst.logprob,
         max_diff_target_logprob=target_worst.logprob,
         max_diff_token_id=baseline_worst.token_id,
-        mean_abs_diff=statistics.mean(diffs),
+        mean_abs_diff=mean_abs_diff,
         median_abs_diff=statistics.median(diffs),
-        p95_abs_diff=sorted_diffs[int(num * 0.95)] if num > 0 else 0.0,
-        p99_abs_diff=sorted_diffs[int(num * 0.99)] if num > 0 else 0.0,
+        p95_abs_diff=_nearest_rank_percentile(sorted_diffs, 0.95),
+        p99_abs_diff=_nearest_rank_percentile(sorted_diffs, 0.99),
+        k3_kl=statistics.mean(k3_values),
+        first_position_mean_abs_diff=statistics.mean(first_diffs),
+        remaining_position_mean_abs_diff=statistics.mean(remaining_diffs) if remaining_diffs else None,
         baseline_mean_logprob=statistics.mean(baseline_logprobs),
         target_mean_logprob=statistics.mean(target_logprobs),
         threshold=threshold,
@@ -169,21 +219,72 @@ def _compute_comparison(
     )
 
 
+def _empty_result(
+    *,
+    failure_reasons: list[str],
+    num_baseline_positions: int,
+    num_target_positions: int,
+    threshold: float,
+) -> _CompareResult:
+    return _CompareResult(
+        passed=False,
+        failure_reasons=tuple(failure_reasons),
+        num_baseline_positions=num_baseline_positions,
+        num_target_positions=num_target_positions,
+        num_positions=0,
+        max_abs_diff=0.0,
+        max_diff_position=-1,
+        max_diff_baseline_logprob=0.0,
+        max_diff_target_logprob=0.0,
+        max_diff_token_id=-1,
+        mean_abs_diff=0.0,
+        median_abs_diff=0.0,
+        p95_abs_diff=0.0,
+        p99_abs_diff=0.0,
+        k3_kl=0.0,
+        first_position_mean_abs_diff=None,
+        remaining_position_mean_abs_diff=None,
+        baseline_mean_logprob=0.0,
+        target_mean_logprob=0.0,
+        threshold=threshold,
+        per_position_diffs=[],
+    )
+
+
+def _nearest_rank_percentile(sorted_values: list[float], quantile: float) -> float:
+    index = max(0, math.ceil(quantile * len(sorted_values)) - 1)
+    return sorted_values[index]
+
+
 def _print_report(result: _CompareResult) -> None:
     status = "PASSED" if result.passed else "FAILED"
     print(f"\n{'=' * 70}", flush=True)
     print(f"Logprob Comparison: {status}", flush=True)
     print(f"{'=' * 70}", flush=True)
+    print(f"  Baseline positions : {result.num_baseline_positions}", flush=True)
+    print(f"  Target positions   : {result.num_target_positions}", flush=True)
     print(f"  Positions compared : {result.num_positions}", flush=True)
+    for reason in result.failure_reasons:
+        print(f"  Failure            : {reason}", flush=True)
+
+    if result.num_positions == 0:
+        print(f"{'=' * 70}\n", flush=True)
+        return
+
     print(f"  Threshold (mean)   : {result.threshold}", flush=True)
     print(f"  Max abs diff       : {result.max_abs_diff:.6e}", flush=True)
+    threshold_status = "<= threshold" if result.mean_abs_diff <= result.threshold else "> threshold"
     print(
-        f"  Mean abs diff      : {result.mean_abs_diff:.6e}  {'<= threshold' if result.passed else '> threshold'}",
+        f"  Mean abs diff      : {result.mean_abs_diff:.6e}  {threshold_status}",
         flush=True,
     )
     print(f"  Median abs diff    : {result.median_abs_diff:.6e}", flush=True)
     print(f"  P95 abs diff       : {result.p95_abs_diff:.6e}", flush=True)
     print(f"  P99 abs diff       : {result.p99_abs_diff:.6e}", flush=True)
+    print(f"  K3 KL (clamped)    : {result.k3_kl:.6e}", flush=True)
+    print(f"  First-position mean: {result.first_position_mean_abs_diff:.6e}", flush=True)
+    if result.remaining_position_mean_abs_diff is not None:
+        print(f"  Remaining-pos mean : {result.remaining_position_mean_abs_diff:.6e}", flush=True)
 
     if result.num_positions > 0:
         print(f"\n  Worst position     : {result.max_diff_position}", flush=True)

--- a/tests/fast/utils/debug_utils/run_megatron/cli/commands/test_compare.py
+++ b/tests/fast/utils/debug_utils/run_megatron/cli/commands/test_compare.py
@@ -95,6 +95,30 @@ class TestLogprobBranch:
         compare_impl(_make_compare_args())
         mock_logprob.assert_not_called()
 
+    @pytest.mark.parametrize(
+        ("baseline_logprob_dir", "target_logprob_dir"),
+        [(Path("/bl"), None), (None, Path("/tg"))],
+    )
+    @patch("miles.utils.debug_utils.run_megatron.cli.commands.compare.compare_logprobs")
+    @patch("miles.utils.debug_utils.run_megatron.cli.commands.compare.exec_command_cpu")
+    def test_one_missing_logprob_dir_fails(
+        self,
+        mock_exec: MagicMock,
+        mock_logprob: MagicMock,
+        baseline_logprob_dir: Path | None,
+        target_logprob_dir: Path | None,
+    ) -> None:
+        with pytest.raises(SystemExit) as exc_info:
+            compare_impl(
+                _make_compare_args(
+                    baseline_logprob_dir=baseline_logprob_dir,
+                    target_logprob_dir=target_logprob_dir,
+                )
+            )
+
+        assert exc_info.value.code == 1
+        mock_logprob.assert_not_called()
+
     @patch("miles.utils.debug_utils.run_megatron.cli.commands.compare.compare_logprobs")
     @patch("miles.utils.debug_utils.run_megatron.cli.commands.compare.exec_command_cpu")
     def test_logprob_default_threshold(self, mock_exec: MagicMock, mock_logprob: MagicMock) -> None:

--- a/tests/fast/utils/debug_utils/run_megatron/test_logprob_comparator.py
+++ b/tests/fast/utils/debug_utils/run_megatron/test_logprob_comparator.py
@@ -96,6 +96,13 @@ class TestLoadAndMerge:
         result = _load_and_merge(tmp_path)
         assert len(result) == 1
 
+    def test_conflicting_tp_duplicate_fails(self, tmp_path: Path) -> None:
+        _write_rank_file(tmp_path, rank=0, entries_by_batch=[[_entry(0, 100, -1.0)]])
+        _write_rank_file(tmp_path, rank=1, entries_by_batch=[[_entry(0, 100, -2.0)]])
+
+        with pytest.raises(ValueError, match="conflicting duplicate logprob entry"):
+            _load_and_merge(tmp_path)
+
     def test_empty_directory(self, tmp_path: Path) -> None:
         result = _load_and_merge(tmp_path)
         assert result == {}
@@ -155,6 +162,17 @@ class TestComputeComparison:
         assert result.max_abs_diff == 0.0
         assert result.num_positions == 2
 
+    @pytest.mark.parametrize("threshold", [float("nan"), float("inf"), float("-inf"), -1.0])
+    def test_invalid_threshold_fails(self, threshold: float) -> None:
+        entries = self._make_entries([(0, 100, -1.0)])
+
+        with pytest.raises(ValueError, match="must be finite and non-negative"):
+            _compute_comparison(
+                baseline_entries=entries,
+                target_entries=entries,
+                threshold=threshold,
+            )
+
     def test_within_threshold_passes(self) -> None:
         baseline = self._make_entries([(0, 100, -1.0)])
         target = self._make_entries([(0, 100, -1.0005)])
@@ -177,18 +195,60 @@ class TestComputeComparison:
         assert result.passed is False
         assert result.max_abs_diff == pytest.approx(0.1)
 
-    def test_no_common_keys_passes(self) -> None:
+    def test_no_common_keys_fails(self) -> None:
         baseline = self._make_entries([(0, 100, -1.0)])
-        target: dict[tuple[int, int], _PositionLogprob] = {
-            (1, 0): _PositionLogprob(global_position=0, token_id=200, logprob=-2.0)
-        }
+        target: dict[tuple[int, int], _PositionLogprob] = {(1, 0): _PositionLogprob(global_position=0, token_id=200, logprob=-2.0)}
         result = _compute_comparison(
             baseline_entries=baseline,
             target_entries=target,
             threshold=1e-3,
         )
-        assert result.passed is True
+        assert result.passed is False
         assert result.num_positions == 0
+        assert "no common positions" in " ".join(result.failure_reasons)
+
+    def test_partial_position_coverage_fails(self) -> None:
+        baseline = self._make_entries([(0, 100, -1.0), (1, 101, -2.0)])
+        target = self._make_entries([(0, 100, -1.0)])
+
+        result = _compute_comparison(
+            baseline_entries=baseline,
+            target_entries=target,
+            threshold=1e-3,
+        )
+
+        assert result.passed is False
+        assert result.num_positions == 1
+        assert "target is missing 1 baseline positions" in result.failure_reasons
+
+    def test_token_id_mismatch_fails(self) -> None:
+        baseline = self._make_entries([(0, 100, -1.0), (1, 101, -2.0)])
+        target = self._make_entries([(0, 999, -1.0), (1, 101, -2.0)])
+
+        result = _compute_comparison(
+            baseline_entries=baseline,
+            target_entries=target,
+            threshold=1e-3,
+        )
+
+        assert result.passed is False
+        assert result.num_positions == 1
+        assert "token IDs differ at 1 positions" in result.failure_reasons
+
+    @pytest.mark.parametrize("nonfinite", [float("nan"), float("inf"), float("-inf")])
+    def test_nonfinite_logprob_fails(self, nonfinite: float) -> None:
+        baseline = self._make_entries([(0, 100, -1.0), (1, 101, -2.0)])
+        target = self._make_entries([(0, 100, nonfinite), (1, 101, -2.0)])
+
+        result = _compute_comparison(
+            baseline_entries=baseline,
+            target_entries=target,
+            threshold=1e-3,
+        )
+
+        assert result.passed is False
+        assert result.num_positions == 1
+        assert "non-finite logprobs found at 1 positions" in result.failure_reasons
 
     def test_statistics(self) -> None:
         baseline = self._make_entries(
@@ -215,6 +275,22 @@ class TestComputeComparison:
         assert result.max_abs_diff == pytest.approx(0.03)
         assert result.mean_abs_diff == pytest.approx(0.02)
         assert result.median_abs_diff == pytest.approx(0.02)
+        assert result.k3_kl > 0
+        assert result.first_position_mean_abs_diff == pytest.approx(0.01)
+        assert result.remaining_position_mean_abs_diff == pytest.approx(0.025)
+
+    def test_k3_kl_uses_low_variance_clamps(self) -> None:
+        baseline = self._make_entries([(0, 100, -100.0)])
+        target = self._make_entries([(0, 100, 100.0)])
+
+        result = _compute_comparison(
+            baseline_entries=baseline,
+            target_entries=target,
+            threshold=200.0,
+        )
+
+        assert result.passed is True
+        assert result.k3_kl == 10.0
 
     def test_worst_position_tracked(self) -> None:
         baseline = self._make_entries(
@@ -300,7 +376,17 @@ class TestCompareLogprobs:
             is False
         )
 
-    def test_empty_baseline_returns_true(self, tmp_path: Path) -> None:
+    def test_malformed_json_returns_false(self, tmp_path: Path) -> None:
+        baseline_dir = tmp_path / "baseline"
+        target_dir = tmp_path / "target"
+        baseline_dir.mkdir()
+        target_dir.mkdir()
+        _write_rank_file(baseline_dir, rank=0, entries_by_batch=[[_entry(0, 100, -1.0)]])
+        (target_dir / "rank_0.json").write_text("{")
+
+        assert compare_logprobs(baseline_dir=baseline_dir, target_dir=target_dir) is False
+
+    def test_empty_baseline_returns_false(self, tmp_path: Path) -> None:
         baseline_dir = tmp_path / "baseline"
         target_dir = tmp_path / "target"
         baseline_dir.mkdir()
@@ -318,10 +404,10 @@ class TestCompareLogprobs:
                 baseline_dir=baseline_dir,
                 target_dir=target_dir,
             )
-            is True
+            is False
         )
 
-    def test_empty_target_returns_true(self, tmp_path: Path) -> None:
+    def test_empty_target_returns_false(self, tmp_path: Path) -> None:
         baseline_dir = tmp_path / "baseline"
         target_dir = tmp_path / "target"
         baseline_dir.mkdir()
@@ -339,7 +425,7 @@ class TestCompareLogprobs:
                 baseline_dir=baseline_dir,
                 target_dir=target_dir,
             )
-            is True
+            is False
         )
 
     def test_custom_threshold(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- fail logprob comparisons for empty, incomplete, malformed, non-finite, or token-misaligned dumps
- reject conflicting duplicate rank entries and one-sided CLI logprob inputs
- report position coverage, error percentiles, clamped low-variance K3, and first-position versus remaining-position error

## Why

The existing comparator returns success when either dump is empty and only compares the intersection of positions. That can let an incomplete or failed parity run produce a false green result.

Related to #2722.

## Testing

- run_megatron fast test suite: 252 passed
- Ruff lint: passed
- Ruff format check: passed
- Python compileall: passed
