### PR TITLE
fix(optimizer): keep post-load main-param refresh bucketwise

### DIFF
--- a/docs/advanced/disk-offload.md
+++ b/docs/advanced/disk-offload.md
@@ -64,6 +64,13 @@ DDP's bucket sizes, which reach tens of GB at DP=1. Native-fp32 model params (a 
 `expert_bias`, a GDN/Mamba `A_log`) stay GPU-resident under a small separate Adam: they
 are tiny, and unlike the bf16 path their optimizer shards alias the model params directly.
 
+For the Adam/DistributedOptimizer path, streaming also bounds initialization: Megatron releases
+each fp32 main shard's storage after creating its tensor handle, then Miles fills one existing
+runtime bucket at a time directly in the final files. There is no temporary state file. Peak
+initialization HBM is the largest individual shard during construction and one main-only bucket
+afterward (normally at most about 200M fp32 elements, except for an oversized entry). Each
+initialized range is synchronized and evicted from page cache before continuing.
+
 `fp32` storage is bit-identical to keeping the state on GPU, so turning this on does not
 change results — it trades step time for memory. The step is I/O bound and the moments
 tolerate less precision than the master copy, so they can be stored narrower:

--- a/miles/backends/megatron_utils/model.py
+++ b/miles/backends/megatron_utils/model.py
@@ -175,6 +175,8 @@ def setup_model_and_optimizer(
         if hasattr(args, f.name):
             kwargs[f.name] = getattr(args, f.name)
     config = OptimizerConfig(**kwargs)
+    if args.stream_optimizer_state_to_disk and not _is_muon_optimizer(config.optimizer):
+        config.defer_main_param_initialization = True
     config.timers = None
 
     if _is_muon_optimizer(config.optimizer):

--- a/miles_plugins/optimizers/nvme_stream.py
+++ b/miles_plugins/optimizers/nvme_stream.py
@@ -625,9 +625,12 @@ def _bind(dist_opt: "DistributedOptimizer", store: NVMeOptimizerStateStore) -> N
         return update_successful
 
     def reload_model_params(self, state_dict=None) -> None:
-        store.refresh_main_from_model_params(
-            lambda: DistributedOptimizer.reload_model_params(self, state_dict=state_dict)
-        )
+        if state_dict is None:
+            store.initialize_main_from_model_params()
+        else:
+            store.refresh_main_from_model_params(
+                lambda: DistributedOptimizer.reload_model_params(self, state_dict=state_dict)
+            )
 
     # save_to()/load_from() carry the real state; returning empties here rather than forcing
     # --no-save-optim keeps opt_param_scheduler, saved under the same guard, working.

--- a/miles_plugins/optimizers/nvme_stream.py
+++ b/miles_plugins/optimizers/nvme_stream.py
@@ -312,9 +312,6 @@ class NVMeOptimizerStateStore:
         self.buckets = self._build_buckets()
         self._fp32_group_indices, self._fp32_adam = self._build_fp32_optimizer()
 
-        for bucket in self.buckets:
-            bucket.flush(segments=("main",))
-
         total_gb = sum(b.nbytes for b in self.buckets) / 1024**3
         logger.info(
             f"NVMe optimizer state store: {len(self.buckets)} buckets, {total_gb:.1f} GB at "
@@ -418,6 +415,22 @@ class NVMeOptimizerStateStore:
         return True
 
     @torch.no_grad()
+    def initialize_main_from_model_params(self) -> int:
+        dist_opt = self.dist_opt
+        written = 0
+        for bucket in self.buckets:
+            bucket.materialize_main()
+            for entry in bucket.entries:
+                param_range = dist_opt._get_model_param_range_map(entry.model_param)["param"]
+                assert param_range.size == entry.main_param.nelement()
+                source_shard = entry.model_param.view(-1)[param_range.start : param_range.end]
+                entry.main_param.copy_(source_shard)
+            written += bucket.flush(segments=("main",))
+            os.fdatasync(bucket.fd)
+            os.posix_fadvise(bucket.fd, 0, bucket.offsets["exp_avg"][0], os.POSIX_FADV_DONTNEED)
+        return written
+
+    @torch.no_grad()
     def refresh_main_from_model_params(self, copy_fn) -> None:
         for bucket in self.buckets:
             bucket.materialize_main()
@@ -498,8 +511,9 @@ class NVMeOptimizerStateStore:
 def setup_optimizer_state_streaming(args, optimizer) -> None:
     """Give every DistributedOptimizer in ``optimizer``'s chain a store and route it there.
 
-    Must run before load_checkpoint: the constructor evicts the fp32 main params, and the
-    bindings are what keep the load path from writing into the evicted storage.
+    Must run before load_checkpoint: Megatron constructs stable fp32 main-param handles with
+    deferred storage, this function populates them directly into final bucket files, and the
+    bindings keep the load path from writing into evicted storage.
     """
     from megatron.core.optimizer.distrib_optimizer import DistributedOptimizer
 
@@ -511,12 +525,20 @@ def setup_optimizer_state_streaming(args, optimizer) -> None:
         ), f"--stream-optimizer-state-to-disk requires the distributed optimizer, got {type(dist_opt).__name__}"
         if dist_opt.is_stub_optimizer:
             continue
+        assert dist_opt.config.defer_main_param_initialization, (
+            "--stream-optimizer-state-to-disk must defer distributed-optimizer main "
+            "initialization before constructing the optimizer"
+        )
         store = NVMeOptimizerStateStore(
             dist_opt,
             dir_root,
             args.offload_train_disk_chunk_mb,
             args.stream_optimizer_state_moment_dtype,
             allow_fresh_state=args.no_load_optim,
+        )
+        written = store.initialize_main_from_model_params()
+        logger.info(
+            f"NVMe optimizer main-param initialization: wrote {written / 1024**3:.1f} GB " f"directly to {store.dir}"
         )
         _bind(dist_opt, store)
 

--- a/tests/e2e/megatron/test_qwen3_4B_offload_disk_stream.py
+++ b/tests/e2e/megatron/test_qwen3_4B_offload_disk_stream.py
@@ -74,12 +74,20 @@ def _assert_streamed():
     logs = glob.glob("/tmp/ray/session_latest/logs/worker-*")
     assert logs, "no Ray worker logs to check for the streaming path"
 
+    initialized = set()
     streamed = set()
     for path in logs:
         with open(path, errors="ignore") as f:
-            if any("NVMe streaming step:" in line for line in f):
+            text = f.read()
+            if "NVMe optimizer main-param initialization:" in text:
+                initialized.add(path)
+            if "NVMe streaming step:" in text:
                 streamed.add(path)
 
+    assert len(initialized) == NUM_GPUS, (
+        f"expected {NUM_GPUS} ranks to initialize main params through NVMe, "
+        f"saw {len(initialized)}: {sorted(initialized)}"
+    )
     assert (
         len(streamed) == NUM_GPUS
     ), f"expected {NUM_GPUS} ranks to log streaming steps, saw {len(streamed)}: {sorted(streamed)}"

--- a/tests/fast-gpu/test_nvme_optimizer_main_init.py
+++ b/tests/fast-gpu/test_nvme_optimizer_main_init.py
@@ -1,0 +1,44 @@
+"""Focused GPU coverage for streamed optimizer main-param initialization."""
+
+import os
+from types import SimpleNamespace
+
+import torch
+from tests.ci.ci_register import register_cuda_ci
+
+from miles_plugins.optimizers.nvme_stream import NVMeOptimizerStateStore, _Bucket, _Entry, _resize, _Stager
+
+register_cuda_ci(
+    est_time=30,
+    suite="stage-b-2-gpu-h200",
+    labels=["miles-plugin"],
+)
+
+
+def test_bucketwise_main_initialization_preserves_bytes_and_releases_cuda_storage(tmp_path):
+    model_param = torch.nn.Parameter(torch.arange(600_000, dtype=torch.float32, device="cuda").to(torch.bfloat16))
+    main_param = torch.empty_like(model_param, dtype=torch.float32)
+    _resize(main_param, 0)
+    bucket = _Bucket(
+        str(tmp_path / "bucket.bin"),
+        entries=[_Entry(model_param, main_param, 0)],
+        adam=None,
+        stager=_Stager(1024 * 1024),
+        dtypes={segment: torch.float32 for segment in ("main", "exp_avg", "exp_avg_sq")},
+    )
+    param_range = SimpleNamespace(start=0, end=model_param.numel(), size=model_param.numel())
+    dist_opt = SimpleNamespace(
+        model_fp32_groups=[],
+        shard_fp32_groups=[],
+        _get_model_param_range_map=lambda _param: {"param": param_range},
+    )
+    store = object.__new__(NVMeOptimizerStateStore)
+    store.dist_opt = dist_opt
+    store.buckets = [bucket]
+
+    nbytes = main_param.numel() * main_param.element_size()
+    assert store.initialize_main_from_model_params() == nbytes
+    assert main_param.untyped_storage().nbytes() == 0
+    restored = torch.frombuffer(bytearray(os.pread(bucket.fd, nbytes, 0)), dtype=torch.float32)
+    torch.testing.assert_close(restored, model_param.float().cpu(), atol=0, rtol=0)
+    os.close(bucket.fd)


### PR DESCRIPTION
Stacked on #2653 (first commit is its `ab760c086`, unchanged); only the last commit is new. If #2653 lands first this rebases to a one-commit diff.

## Problem

#2653 bounds fp32 main initialization to one runtime bucket, but the very next step of the common startup path un-bounds it again. Fresh HF loads (`_load_checkpoint_hf`), `--finetune`/`--no-load-optim` Megatron loads, and the LoRA-adapter refresh all call `optimizer.reload_model_params()`, whose bound implementation enters `refresh_main_from_model_params()` — which materializes **every** bucket before copying:

```python
def refresh_main_from_model_params(self, copy_fn) -> None:
    for bucket in self.buckets:
        bucket.materialize_main()   # all buckets at once
    copy_fn()
```

So the whole fp32 main state returns to HBM moments after the bounded initialization, and the startup peak is unchanged on the exact path (fresh HF start) that motivated #2653.

## Fix

`reload_model_params(state_dict=None)` is a pure model→main copy — semantically identical to `initialize_main_from_model_params()`, which already does it bucket-by-bucket straight into the final files. Route it there. The `state_dict is not None` case (`--load-main-params-from-ckpt`) needs Megatron's name-matching map and keeps the original path.

## Verification (4x H200, Qwen3-4B, TP2, fresh HF-checkpoint start — same train-side startup path as `test_qwen3_4B_offload_disk_stream.py`)

Instrumented `torchrun` driver over `init()` + `initialize_model_and_optimizer()`, with `torch.cuda.max_memory_allocated()` probes around `reload_model_params()` and a resident-main-bytes probe per store path.

Before (pr2653 head `ab760c086`):

```
path=initialize  resident_main=0.752GB     # bounded init from #2653
path=refresh     resident_main=3.747GB     # reload re-materializes everything
reload_model_params delta=3.770GB          # peak over base during reload
startup_peak=16.704GB
```

After (this fix):

```
path=initialize  resident_main=0.752GB
reload_model_params delta=0.758GB          # one bucket
startup_peak=13.686GB                      # -3.0GB = full main minus one bucket
```

Bit-equivalence: with the fix applied, after the bucketwise reload wrote the bucket files, the same process re-ran the original monolithic path over the same files and hashed the on-disk main segments both times — sha256 identical on all 4 ranks.

All runs on the paired Megatron radixark/Megatron-LM#86 at `c0dad034d`.