### PR TITLE
feat(memory): report torch high-water marks in available_memory

### DIFF
--- a/miles/utils/memory_utils.py
+++ b/miles/utils/memory_utils.py
@@ -25,6 +25,8 @@ def available_memory():
         "used_GB": _byte_to_gb(total - free),
         "allocated_GB": _byte_to_gb(torch.cuda.memory_allocated(device)),
         "reserved_GB": _byte_to_gb(torch.cuda.memory_reserved(device)),
+        "max_allocated_GB": _byte_to_gb(torch.cuda.max_memory_allocated(device)),
+        "max_reserved_GB": _byte_to_gb(torch.cuda.max_memory_reserved(device)),
     }
 
 


### PR DESCRIPTION
## Summary

- Add `max_allocated_GB` and `max_reserved_GB` to `available_memory()`
- Unlike the existing instantaneous readings, these are monotonic and give the true per-rank peak regardless of when `print_memory` is called