### PR TITLE
fix(session): use incremental R3 for all non-retract cases, and fix asserts

### DIFF
--- a/docs/user-guide/agentic-rollout.md
+++ b/docs/user-guide/agentic-rollout.md
@@ -145,9 +145,7 @@ Whether a replayed message counts as "the same" as the stored one is decided by
 `--session-message-matcher` (default `strict`); see
 [Choose replay matching](#choose-replay-matching).
 
-The v1 wrapper returns one `Sample`. The v2 wrapper returns a `list[Sample]`, one
-for each selected tree leaf. Both versions reject `--pause-generation-mode=abort`
-and `--partial-rollout`, and use in-place weight update as instead to avoid harness pause.
+The v1 wrapper returns one `Sample`. The v2 wrapper returns a `list[Sample]`, one for each selected tree leaf. Both versions reject `--partial-rollout`. With R3 replay, colocated `abort` and `in_place` request only additional R3 rows, while `retract` returns full R3 data on every turn and emits a warning because the payloads can become very large. Non-colocated session servers cannot use `abort`.
 
 Set `--max-seq-len` to cap the context length. Miles also includes this value in the
 metadata passed to your agent so an external environment can stop early.

--- a/docs/user-guide/agentic-rollout.md
+++ b/docs/user-guide/agentic-rollout.md
@@ -145,7 +145,11 @@ Whether a replayed message counts as "the same" as the stored one is decided by
 `--session-message-matcher` (default `strict`); see
 [Choose replay matching](#choose-replay-matching).
 
-The v1 wrapper returns one `Sample`. The v2 wrapper returns a `list[Sample]`, one for each selected tree leaf. Both versions reject `--partial-rollout`. With R3 replay, colocated `abort` and `in_place` request only additional R3 rows, while `retract` returns full R3 data on every turn and emits a warning because the payloads can become very large. Non-colocated session servers cannot use `abort`.
+The v1 wrapper returns one `Sample`. The v2 wrapper returns a `list[Sample]`, one
+for each selected tree leaf. Both versions reject `--partial-rollout`. With R3
+replay, every pause mode except `retract` requests only additional R3 rows.
+`retract` returns full R3 data on every turn and emits a warning because the
+payloads can become very large.
 
 Set `--max-seq-len` to cap the context length. Miles also includes this value in the
 metadata passed to your agent so an external environment can stop early.

--- a/miles/rollout/session/server.py
+++ b/miles/rollout/session/server.py
@@ -41,10 +41,9 @@ class SessionServer:
         # Close the httpx connection pool when uvicorn shuts down to avoid FD leaks.
         self.app.router.on_shutdown.append(self.client.aclose)
 
-        # Validated `abort` (colocated only) and `in_place` produce append-only
-        # R3; `retract` may recompute earlier rows and must return full R3.
-        pause_generation_mode = getattr(args, "pause_generation_mode", None)
-        self.use_addition_r3 = pause_generation_mode in ("abort", "in_place")
+        # `retract` may recompute earlier rows and must return full R3; all other
+        # pause modes preserve prior rows and can request only the appended R3.
+        self.use_addition_r3 = args.pause_generation_mode != "retract"
         setup_session_routes(self.app, self, args, use_addition_r3=self.use_addition_r3)
 
     async def do_proxy(self, request: ProxyRequest, path: str, *, body: bytes, headers: dict) -> dict:

--- a/miles/rollout/session/server.py
+++ b/miles/rollout/session/server.py
@@ -41,9 +41,10 @@ class SessionServer:
         # Close the httpx connection pool when uvicorn shuts down to avoid FD leaks.
         self.app.router.on_shutdown.append(self.client.aclose)
 
-        # `in_place` weight updates keep the active request and its KV-backed
-        # prefix, so the session may request only additional R3 rows.
-        self.use_addition_r3 = getattr(args, "pause_generation_mode", None) == "in_place"
+        # Validated `abort` (colocated only) and `in_place` produce append-only
+        # R3; `retract` may recompute earlier rows and must return full R3.
+        pause_generation_mode = getattr(args, "pause_generation_mode", None)
+        self.use_addition_r3 = pause_generation_mode in ("abort", "in_place")
         setup_session_routes(self.app, self, args, use_addition_r3=self.use_addition_r3)
 
     async def do_proxy(self, request: ProxyRequest, path: str, *, body: bytes, headers: dict) -> dict:

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -2931,7 +2931,7 @@ def miles_validate_args(args):
         logger.warning(
             "--use-session-server with --use-rollout-routing-replay and "
             "--pause-generation-mode=retract returns full R3 data on every turn; "
-            "R3 payloads can become very large. TODO: Retract-mode weight updates "
+            "R3 payloads can become very large. TODO: Retract-mode weight updates R3 "
             "have known issues in SGLang and need to be fixed."
         )
 

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -2909,12 +2909,15 @@ def miles_validate_args(args):
             "tree serving."
         )
 
+    assert not (
+        args.use_session_server and args.partial_rollout
+    ), "--use-session-server does not support --partial-rollout"
+
     if args.use_session_server == "v2":
         unsupported = [
             flag
             for enabled, flag in (
                 (args.group_rm, "--group-rm"),
-                (args.partial_rollout, "--partial-rollout"),
                 (args.recompute_logprobs_via_prefill, "--recompute-logprobs-via-prefill"),
             )
             if enabled
@@ -2924,15 +2927,12 @@ def miles_validate_args(args):
                 f"--use-session-server v2 does not support {', '.join(unsupported)}; v2 returns list[Sample]"
             )
 
-    assert not (
-        args.use_session_server and not args.colocate and args.pause_generation_mode == "abort"
-    ), "--use-session-server with --pause-generation-mode=abort requires --colocate"
-
     if args.use_session_server and args.use_rollout_routing_replay and args.pause_generation_mode == "retract":
         logger.warning(
             "--use-session-server with --use-rollout-routing-replay and "
             "--pause-generation-mode=retract returns full R3 data on every turn; "
-            "R3 payloads can become very large."
+            "R3 payloads can become very large. TODO: Retract-mode weight updates "
+            "have known issues in SGLang and need to be fixed."
         )
 
     if not args.use_session_server and args.tito_model != TITOTokenizerType.DEFAULT.value:

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -2925,8 +2925,15 @@ def miles_validate_args(args):
             )
 
     assert not (
-        args.use_session_server and args.pause_generation_mode == "abort"
-    ), "--use-session-server is incompatible with --pause-generation-mode=abort"
+        args.use_session_server and not args.colocate and args.pause_generation_mode == "abort"
+    ), "--use-session-server with --pause-generation-mode=abort requires --colocate"
+
+    if args.use_session_server and args.use_rollout_routing_replay and args.pause_generation_mode == "retract":
+        logger.warning(
+            "--use-session-server with --use-rollout-routing-replay and "
+            "--pause-generation-mode=retract returns full R3 data on every turn; "
+            "R3 payloads can become very large."
+        )
 
     if not args.use_session_server and args.tito_model != TITOTokenizerType.DEFAULT.value:
         raise ValueError(

--- a/tests/fast/router/session_pretokenized_test_utils.py
+++ b/tests/fast/router/session_pretokenized_test_utils.py
@@ -52,6 +52,7 @@ def make_router_env(
         use_session_server="v2",
         use_rollout_routing_replay=False,
         sglang_speculative_algorithm=None,
+        pause_generation_mode="retract",
         session_sample_picker_path="miles.rollout.session.v2.picker_hub.drop_retries",
         session_sample_postprocessor_path="miles.rollout.session.v2.postprocessor_hub.default_postprocess",
     )

--- a/tests/fast/router/test_session_anthropic.py
+++ b/tests/fast/router/test_session_anthropic.py
@@ -59,7 +59,7 @@ def _anthropic_env(extra_args: dict | None = None, *, latency: float = 0.0):
             trajectory_manager="linear_trajectory",
             session_server_instance_id=uuid.uuid4().hex,
             save_debug_trajectory_data=None,
-            **(extra_args or {}),
+            **({"pause_generation_mode": "retract"} | (extra_args or {})),
         )
         server_obj = SessionServer(args, backend_url=backend.url)
         port = find_available_port(31000)

--- a/tests/fast/router/test_session_race_conditions.py
+++ b/tests/fast/router/test_session_race_conditions.py
@@ -65,6 +65,7 @@ def _router_env(process_fn, *, latency: float = 0.0):
                 chat_template_path=None,
                 trajectory_manager="linear_trajectory",
                 sglang_speculative_algorithm=None,
+                pause_generation_mode="retract",
             )
             server_obj = SessionServer(args, backend_url=backend.url)
 

--- a/tests/fast/router/test_sessions.py
+++ b/tests/fast/router/test_sessions.py
@@ -73,6 +73,7 @@ def router_env():
                 trajectory_manager="linear_trajectory",
                 session_server_instance_id=uuid.uuid4().hex,
                 save_debug_trajectory_data=None,
+                pause_generation_mode="retract",
             )
             server_obj = SessionServer(args, backend_url=backend.url)
 
@@ -578,7 +579,7 @@ class TestChatFakeStreaming:
         assert finish_reason == "stop"
 
 
-# ── additional R3 (colocated abort and in-place weight updates): derivation and request offsets ──
+# ── additional R3 (non-retract pause modes): derivation and request offsets ──
 
 
 @contextmanager
@@ -600,7 +601,7 @@ def _serve_router(extra_args: dict | None = None):
             trajectory_manager="linear_trajectory",
             session_server_instance_id=uuid.uuid4().hex,
             save_debug_trajectory_data=None,
-            **(extra_args or {}),
+            **({"pause_generation_mode": "retract"} | (extra_args or {})),
         )
         server_obj = SessionServer(args, backend_url=backend.url)
         port = find_available_port(31000)
@@ -620,10 +621,6 @@ class TestUseAdditionR3Derivation:
     def test_mode_mapping(self, mode, expected):
         args = SimpleNamespace(hf_checkpoint=None, pause_generation_mode=mode)
         assert SessionServer(args, backend_url="http://127.0.0.1:9").use_addition_r3 is expected
-
-    def test_absent_mode_keeps_full_r3(self):
-        args = SimpleNamespace(hf_checkpoint=None)
-        assert SessionServer(args, backend_url="http://127.0.0.1:9").use_addition_r3 is False
 
 
 class TestAdditionR3RequestOffset:

--- a/tests/fast/router/test_sessions.py
+++ b/tests/fast/router/test_sessions.py
@@ -578,7 +578,7 @@ class TestChatFakeStreaming:
         assert finish_reason == "stop"
 
 
-# ── additional R3 (in-place weight updates): derivation and request offsets ──
+# ── additional R3 (colocated abort and in-place weight updates): derivation and request offsets ──
 
 
 @contextmanager
@@ -616,7 +616,7 @@ class TestUseAdditionR3Derivation:
     """use_addition_r3 is derived once at server bootstrap from
     pause_generation_mode; it is not independently configurable."""
 
-    @pytest.mark.parametrize(("mode", "expected"), [("in_place", True), ("retract", False)])
+    @pytest.mark.parametrize(("mode", "expected"), [("abort", True), ("in_place", True), ("retract", False)])
     def test_mode_mapping(self, mode, expected):
         args = SimpleNamespace(hf_checkpoint=None, pause_generation_mode=mode)
         assert SessionServer(args, backend_url="http://127.0.0.1:9").use_addition_r3 is expected
@@ -640,8 +640,9 @@ class TestAdditionR3RequestOffset:
             {"role": "tool", "content": tool_content, "tool_call_id": "t0"},
         ]
 
-    def test_in_place_offsets_across_turns_and_rollback(self):
-        with _serve_router({"use_rollout_routing_replay": True, "pause_generation_mode": "in_place"}) as env:
+    @pytest.mark.parametrize("mode", ["abort", "in_place"])
+    def test_incremental_offsets_across_turns_and_rollback(self, mode):
+        with _serve_router({"use_rollout_routing_replay": True, "pause_generation_mode": mode}) as env:
             session_id = _create_session(env.url)
 
             first = _post_chat(env.url, session_id, {"messages": self.MESSAGES})

--- a/tests/fast/router/test_sessions_v2.py
+++ b/tests/fast/router/test_sessions_v2.py
@@ -48,7 +48,7 @@ def _serve_router(extra_args: dict | None = None):
             save_debug_trajectory_data=None,
             session_sample_picker_path="miles.rollout.session.v2.picker_hub.drop_retries",
             session_sample_postprocessor_path="miles.rollout.session.v2.postprocessor_hub.default_postprocess",
-            **(extra_args or {}),
+            **({"pause_generation_mode": "retract"} | (extra_args or {})),
         )
         server_obj = SessionServer(args, backend_url=backend.url)
         port = find_available_port(31000)
@@ -454,7 +454,7 @@ class TestTruncationAndCompaction:
         assert nodes[1]["parent"] == nodes[0]["id"]
 
 
-# ── additional R3 (colocated abort and in-place weight updates): request offsets on the tree ──
+# ── additional R3 (non-retract pause modes): request offsets on the tree ──
 
 
 class TestAdditionR3RequestOffsetV2:

--- a/tests/fast/router/test_sessions_v2.py
+++ b/tests/fast/router/test_sessions_v2.py
@@ -454,7 +454,7 @@ class TestTruncationAndCompaction:
         assert nodes[1]["parent"] == nodes[0]["id"]
 
 
-# ── additional R3 (in-place weight updates): request offsets on the tree ──
+# ── additional R3 (colocated abort and in-place weight updates): request offsets on the tree ──
 
 
 class TestAdditionR3RequestOffsetV2:
@@ -464,8 +464,9 @@ class TestAdditionR3RequestOffsetV2:
         data = requests.get(f"{url}/sessions/{session_id}", timeout=5.0).json()
         return data["metadata"]["accumulated_token_ids"]
 
-    def test_in_place_offsets_across_turns_and_branches(self):
-        with _serve_router({"use_rollout_routing_replay": True, "pause_generation_mode": "in_place"}) as env:
+    @pytest.mark.parametrize("mode", ["abort", "in_place"])
+    def test_incremental_offsets_across_turns_and_branches(self, mode):
+        with _serve_router({"use_rollout_routing_replay": True, "pause_generation_mode": mode}) as env:
             session_id = _create_session(env.url)
 
             first = _post_chat(env.url, session_id, {"messages": self.MESSAGES})

--- a/tests/fast/utils/test_arguments.py
+++ b/tests/fast/utils/test_arguments.py
@@ -429,13 +429,16 @@ class TestSessionServerPauseGenerationMode:
         get_miles_extra_args_provider()(parser)
         return parser.parse_args(extra + ["--num-rollout", "1"] + REQUIRED_ARGS)
 
-    def test_session_server_rejects_abort(self):
+    def test_session_server_rejects_non_colocate_abort(self):
         args = self._parse(["--use-session-server", "--pause-generation-mode", "abort"])
 
-        with pytest.raises(
-            AssertionError, match="--use-session-server is incompatible with --pause-generation-mode=abort"
-        ):
+        with pytest.raises(AssertionError, match="requires --colocate"):
             miles_validate_args(args)
+
+    def test_session_server_accepts_colocate_abort(self):
+        args = self._parse(["--use-session-server", "--colocate", "--pause-generation-mode", "abort"])
+
+        miles_validate_args(args)
 
     def test_abort_without_session_server_passes(self):
         miles_validate_args(self._parse(["--pause-generation-mode", "abort"]))
@@ -443,6 +446,40 @@ class TestSessionServerPauseGenerationMode:
     @pytest.mark.parametrize("mode", ["retract", "in_place"])
     def test_session_server_accepts_non_abort_modes(self, mode):
         miles_validate_args(self._parse(["--use-session-server", "--pause-generation-mode", mode]))
+
+    @pytest.mark.parametrize(
+        ("extra", "expect_warning"),
+        [
+            (
+                ["--use-session-server", "--use-rollout-routing-replay", "--pause-generation-mode", "retract"],
+                True,
+            ),
+            (["--use-session-server", "--pause-generation-mode", "retract"], False),
+            (["--use-rollout-routing-replay", "--pause-generation-mode", "retract"], False),
+            (
+                [
+                    "--use-session-server",
+                    "--use-rollout-routing-replay",
+                    "--colocate",
+                    "--pause-generation-mode",
+                    "abort",
+                ],
+                False,
+            ),
+            (
+                ["--use-session-server", "--use-rollout-routing-replay", "--pause-generation-mode", "in_place"],
+                False,
+            ),
+        ],
+    )
+    def test_retract_r3_warning(self, caplog, extra, expect_warning):
+        args = self._parse(extra)
+
+        with caplog.at_level(logging.WARNING, logger="miles.utils.arguments"):
+            miles_validate_args(args)
+
+        warned = any("R3 payloads can become very large" in record.message for record in caplog.records)
+        assert warned is expect_warning
 
 
 class TestTitoFixedTemplateConfiguration:

--- a/tests/fast/utils/test_arguments.py
+++ b/tests/fast/utils/test_arguments.py
@@ -360,7 +360,6 @@ class TestSessionServerV2Validation:
         ("extra", "flag"),
         [
             (["--group-rm"], "--group-rm"),
-            (["--partial-rollout"], "--partial-rollout"),
             (
                 ["--true-on-policy-mode", "--recompute-logprobs-via-prefill"],
                 "--recompute-logprobs-via-prefill",
@@ -429,14 +428,12 @@ class TestSessionServerPauseGenerationMode:
         get_miles_extra_args_provider()(parser)
         return parser.parse_args(extra + ["--num-rollout", "1"] + REQUIRED_ARGS)
 
-    def test_session_server_rejects_non_colocate_abort(self):
-        args = self._parse(["--use-session-server", "--pause-generation-mode", "abort"])
-
-        with pytest.raises(AssertionError, match="requires --colocate"):
-            miles_validate_args(args)
-
-    def test_session_server_accepts_colocate_abort(self):
-        args = self._parse(["--use-session-server", "--colocate", "--pause-generation-mode", "abort"])
+    @pytest.mark.parametrize("colocate", [False, True])
+    def test_session_server_accepts_abort(self, colocate):
+        extra = ["--use-session-server", "--pause-generation-mode", "abort"]
+        if colocate:
+            extra.append("--colocate")
+        args = self._parse(extra)
 
         miles_validate_args(args)
 
@@ -446,6 +443,16 @@ class TestSessionServerPauseGenerationMode:
     @pytest.mark.parametrize("mode", ["retract", "in_place"])
     def test_session_server_accepts_non_abort_modes(self, mode):
         miles_validate_args(self._parse(["--use-session-server", "--pause-generation-mode", mode]))
+
+    @pytest.mark.parametrize(
+        "session_server_args",
+        [["--use-session-server"], ["--use-session-server", "v1"], ["--use-session-server", "v2"]],
+    )
+    def test_session_server_rejects_partial_rollout(self, session_server_args):
+        args = self._parse([*session_server_args, "--partial-rollout"])
+
+        with pytest.raises(AssertionError, match="does not support --partial-rollout"):
+            miles_validate_args(args)
 
     @pytest.mark.parametrize(
         ("extra", "expect_warning"),

--- a/tests/session_parity_utils.py
+++ b/tests/session_parity_utils.py
@@ -240,6 +240,7 @@ def _serve_session(*, backend_url: str, hf_checkpoint: str, version: str) -> Ite
         use_session_server=version,
         use_rollout_routing_replay=False,
         use_rollout_indexer_replay=False,
+        pause_generation_mode="retract",
         session_server_instance_id=instance_id,
         session_server_ip="127.0.0.1",
         session_server_ports=[port],


### PR DESCRIPTION
## Summary
Use incremental session R3 for every non-retract pause mode.

## Symptom & Reproduction
- **Report:** Shi Dong reported `partial_rollout`, rather than disaggregated `abort`, as the incompatible session-server case.
- **Symptom:** `SessionServer` returned full R3 for `abort`, and argument validation rejected disaggregated session-server `abort`, even though completed R3 rows remain append-only.
- **Reproduction:** Constructing `SessionServer` with `pause_generation_mode="abort"` selected full-R3 behavior instead of incremental offsets.

## Root Cause
1. `SessionServer.__init__` enabled additional R3 only for `in_place`.
2. `miles_validate_args` rejected `abort` instead of the incompatible `partial_rollout` behavior.

## Fix
Derive `use_addition_r3` directly from `pause_generation_mode != "retract"`, so `abort` works for both colocated and disaggregated serving. Reject `partial_rollout` for every session-server version. Keep `retract` on full R3 and warn that its payloads can become large and R3 from retract-mode weight updates has known issues in SGLang. The v1 and v2 offset tests cover `abort`, `in_place`, and `retract`, while test fixtures now provide the required pause-mode argument explicitly.

## Verification
- `git diff 2975c576320875bc02ecf86793e8b4384b16bcb1 420acf35a94947c4ea0df543d706eb731c90cc70 --check`: passed.
- `black==24.3.0 --check`: passed for all nine changed Python files.
- `ruff==0.14.7 check`: passed for all nine changed Python files.
- `python -m compileall`: passed for all nine changed Python files.
- Focused pytest did not collect because the local environment lacks `sglang`; `ld` also found no compatible Running devbox.

## Review Focus
- `SessionServer.use_addition_r3`: only `retract` requests full R3.
- `miles_validate_args`: session serving rejects `partial_rollout`, independent of `abort` topology.
- Retract warning: payload-size and SGLang R3 risks remain explicit.
