### PR TITLE
examples: launcher for the in-process Harbor path

### DIFF
--- a/examples/experimental/harbor/launch_common.py
+++ b/examples/experimental/harbor/launch_common.py
@@ -1,0 +1,74 @@
+"""The Harbor-side launcher wiring, shared by this example's launchers.
+
+Separate from run.py so it imports without the trainer's heavy dependencies:
+the launchers pull in miles' command utils, while this module needs only the
+credential contract.
+"""
+
+import os
+
+from miles.rollout.agentic.credentials import PROVIDER_CREDENTIALS, provision_provider
+
+
+def harbor_env_vars(args) -> dict[str, str]:
+    """The Harbor-side environment for rollout workers, preflighted on the launcher.
+
+    HARBOR_ENV_TYPE is passed through untouched (Harbor validates it). The
+    provider's credential goes by key-file PATH, its endpoint variables by
+    value, on the contract every sandbox backend shares.
+    """
+    if not args.harbor_env_type:
+        raise ValueError(
+            "set --harbor-env-type / HARBOR_ENV_TYPE (e.g. e2b, daytona): in-process trials need a sandbox backend the worker can reach"
+        )
+    if args.harbor_env_type == "docker":
+        raise ValueError(
+            "docker needs a Docker daemon next to Trial.run(); use examples/swe-agent-harbor-docker (agent server) for it"
+        )
+    try:
+        import harbor  # noqa: F401  # the fork branch, see README
+    except ImportError as e:
+        raise RuntimeError(
+            "harbor is not importable in the rollout process's environment; see the README install line"
+        ) from e
+
+    env = {
+        "HARBOR_ENV_TYPE": args.harbor_env_type,
+        "HARBOR_TASKS_DIR": args.harbor_tasks_dir,
+        "HARBOR_TRIALS_DIR": args.harbor_trials_dir,
+        "AGENT_MODEL_NAME": args.agent_model_name,
+        "AGENT_TIMEOUT": str(args.agent_timeout),
+        "MILES_ROUTER_EXTERNAL_HOST": args.router_external_host,
+    }
+    if args.harbor_env_kwargs:
+        env["HARBOR_ENV_KWARGS"] = args.harbor_env_kwargs
+    if spec := PROVIDER_CREDENTIALS.get(args.harbor_env_type):
+        provision_provider(env, spec, arg_path=getattr(args, spec["arg_attr"], "") or "")
+    else:
+        # Any other Harbor backend still passes straight through; there is just
+        # no credential wiring known here, so the worker environment must carry
+        # whatever that provider's SDK reads.
+        print(
+            f"harbor: no credential wiring known for {args.harbor_env_type!r}; "
+            "assuming the worker environment carries the provider's credentials",
+            flush=True,
+        )
+    # per-server knobs, forwarded when set
+    for var in (
+        "AGENT_MAX_INPUT_TOKENS",
+        "AGENT_MAX_OUTPUT_TOKENS",
+        "AGENT_TRIAL_TIMEOUT",
+        "HARBOR_MAX_SEQ_LEN",
+        "HARBOR_AGENT_MAX_ITERATIONS",
+        "HARBOR_RESPONSE_LENGTH_POLICY",
+        "HARBOR_TERMINUS_2_ENABLE_SUMMARIZE",
+        "HARBOR_TERMINUS_2_LINEAR_HISTORY",
+        "HARBOR_OVERRIDE_MEMORY_MB",
+        "HARBOR_TIMEOUT_MULTIPLIER",
+        "HARBOR_VERIFIER_TIMEOUT_SEC",
+        "HARBOR_ENV_BUILD_TIMEOUT_MULTIPLIER",
+        "HARBOR_AGENT_ALLOWED_HOSTS",
+    ):
+        if value := os.environ.get(var, "").strip():
+            env[var] = value
+    return env

--- a/examples/experimental/harbor/launch_common.py
+++ b/examples/experimental/harbor/launch_common.py
@@ -6,8 +6,40 @@ credential contract.
 """
 
 import os
+from pathlib import Path
 
 from miles.rollout.agentic.credentials import PROVIDER_CREDENTIALS, provision_provider
+
+HARBOR_EXAMPLE_DIR = Path(__file__).resolve().parent
+# reward_func / RolloutFn (agent-metric aggregation) are reused from the agent-server example
+HARBOR_DOCKER_EXAMPLE_DIR = HARBOR_EXAMPLE_DIR.parents[1] / "swe-agent-harbor-docker"
+
+
+def agentic_pythonpath_dirs() -> list[str]:
+    """Directories every Harbor launcher puts on the workers' PYTHONPATH: the
+    agent function here, and the reward hook it reuses from the agent-server
+    example."""
+    return [str(HARBOR_EXAMPLE_DIR), str(HARBOR_DOCKER_EXAMPLE_DIR)]
+
+
+def agentic_train_args(*, tito_model: str, session_server_workers: int) -> str:
+    """The agentic wiring every Harbor launcher passes to train.py.
+
+    One copy, shared by the recipes and the GPU e2e, so the flags the test
+    exercises are the flags the recipes ship. Model-specific values come from
+    the caller.
+    """
+    return (
+        "--custom-generate-function-path miles.rollout.generate_hub.agentic_tool_call.generate "
+        "--custom-agent-function-path harbor_agent_function.run "
+        "--custom-rm-path generate.reward_func "
+        "--rollout-function-path generate.RolloutFn "
+        "--dynamic-sampling-filter-path miles.rollout.filter_hub.dynamic_sampling_filters.check_no_aborted "
+        f"--tito-model {tito_model} "
+        "--use-session-server "
+        "--session-server-port 30000 "
+        f"--session-server-workers {session_server_workers} "
+    )
 
 
 def harbor_env_vars(args) -> dict[str, str]:

--- a/examples/experimental/harbor/launch_common.py
+++ b/examples/experimental/harbor/launch_common.py
@@ -22,7 +22,7 @@ def agentic_pythonpath_dirs() -> list[str]:
     return [str(HARBOR_EXAMPLE_DIR), str(HARBOR_DOCKER_EXAMPLE_DIR)]
 
 
-def agentic_train_args(*, tito_model: str, session_server_workers: int) -> str:
+def agentic_train_args(*, tito_model: str, session_server_workers: int, session_server_port: int = 30000) -> str:
     """The agentic wiring every Harbor launcher passes to train.py.
 
     One copy, shared by the recipes and the GPU e2e, so the flags the test
@@ -37,7 +37,7 @@ def agentic_train_args(*, tito_model: str, session_server_workers: int) -> str:
         "--dynamic-sampling-filter-path miles.rollout.filter_hub.dynamic_sampling_filters.check_no_aborted "
         f"--tito-model {tito_model} "
         "--use-session-server "
-        "--session-server-port 30000 "
+        f"--session-server-port {session_server_port} "
         f"--session-server-workers {session_server_workers} "
     )
 

--- a/examples/experimental/harbor/launch_common.py
+++ b/examples/experimental/harbor/launch_common.py
@@ -17,11 +17,14 @@ def harbor_env_vars(args) -> dict[str, str]:
     provider's credential goes by key-file PATH, its endpoint variables by
     value, on the contract every sandbox backend shares.
     """
-    if not args.harbor_env_type:
+    # normalized the same way the agent function reads it, so the guards
+    # below see the value the worker will act on
+    env_type = args.harbor_env_type.strip().lower()
+    if not env_type:
         raise ValueError(
             "set --harbor-env-type / HARBOR_ENV_TYPE (e.g. e2b, daytona): in-process trials need a sandbox backend the worker can reach"
         )
-    if args.harbor_env_type == "docker":
+    if env_type == "docker":
         raise ValueError(
             "docker needs a Docker daemon next to Trial.run(); use examples/swe-agent-harbor-docker (agent server) for it"
         )
@@ -33,7 +36,7 @@ def harbor_env_vars(args) -> dict[str, str]:
         ) from e
 
     env = {
-        "HARBOR_ENV_TYPE": args.harbor_env_type,
+        "HARBOR_ENV_TYPE": env_type,
         "HARBOR_TASKS_DIR": args.harbor_tasks_dir,
         "HARBOR_TRIALS_DIR": args.harbor_trials_dir,
         "AGENT_MODEL_NAME": args.agent_model_name,
@@ -42,14 +45,14 @@ def harbor_env_vars(args) -> dict[str, str]:
     }
     if args.harbor_env_kwargs:
         env["HARBOR_ENV_KWARGS"] = args.harbor_env_kwargs
-    if spec := PROVIDER_CREDENTIALS.get(args.harbor_env_type):
+    if spec := PROVIDER_CREDENTIALS.get(env_type):
         provision_provider(env, spec, arg_path=getattr(args, spec["arg_attr"], "") or "")
     else:
         # Any other Harbor backend still passes straight through; there is just
         # no credential wiring known here, so the worker environment must carry
         # whatever that provider's SDK reads.
         print(
-            f"harbor: no credential wiring known for {args.harbor_env_type!r}; "
+            f"harbor: no credential wiring known for {env_type!r}; "
             "assuming the worker environment carries the provider's credentials",
             flush=True,
         )

--- a/examples/experimental/harbor/run.py
+++ b/examples/experimental/harbor/run.py
@@ -1,0 +1,221 @@
+"""Launcher: GLM-4.7-Flash GRPO on Harbor tasks, with Harbor run in-process on a
+cloud sandbox backend (no agent server).
+
+Usage:
+    HARBOR_ENV_TYPE=e2b python run.py --harbor-tasks-dir /path/to/harbor_tasks ...
+
+The trainer side is examples/swe-agent-harbor-docker/run.py with the agent
+server swapped for harbor_agent_function.run; the reward hook and metrics come
+from that example (generate.py), which this launcher puts on PYTHONPATH.
+"""
+
+import os
+import socket
+import subprocess
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+import typer
+from launch_common import harbor_env_vars
+
+import miles.utils.external_utils.command_utils as U
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+# reward_func / RolloutFn (agent-metric aggregation) are shared with the agent-server example
+HARBOR_DOCKER_EXAMPLE_DIR = SCRIPT_DIR.parents[1] / "swe-agent-harbor-docker"
+
+
+@dataclass
+class ScriptArgs(U.ExecuteTrainConfig):
+    mode: Literal["normal", "debug_rollout_only"] = "normal"
+    run_id: str = U.create_run_id()
+    megatron_model_type: str = "glm4.7-flash"
+    num_gpus_per_node: int = 8
+    megatron_path: str = "/root/Megatron-LM"
+
+    # Paths
+    skip_prepare: bool = False
+    base_dir: str = "/root"
+    model_name: str = "GLM-4.7-Flash"
+    hf_checkpoint: str = "zai-org/GLM-4.7-Flash"
+    ref_load: str = "/root/GLM-4.7-Flash_torch_dist"
+    save_dir: str = "/root/GLM-4.7-Flash_harbor/"
+    prompt_data: str = "/root/tb2_train.jsonl"
+
+    # Training settings
+    max_seq_len: int = 65536
+    num_rollout: int = 3000
+    rollout_batch_size: int = 4
+    n_samples_per_prompt: int = 8
+    global_batch_size: int = 32
+    save_interval: int = 100
+    save_traces_dir: str = ""
+
+    # Harbor settings (see harbor_agent_function.py for what each does)
+    harbor_env_type: str = os.environ.get("HARBOR_ENV_TYPE", "")
+    harbor_env_kwargs: str = os.environ.get("HARBOR_ENV_KWARGS", "")
+    harbor_tasks_dir: str = os.environ.get("HARBOR_TASKS_DIR", "/root/harbor_tasks")
+    harbor_trials_dir: str = os.environ.get("HARBOR_TRIALS_DIR", "/tmp/harbor_trials")
+    agent_model_name: str = os.environ.get("AGENT_MODEL_NAME", "model")
+    agent_timeout: int = int(os.environ.get("AGENT_TIMEOUT", "5400"))
+    # provider key files; the launcher forwards the PATH, workers read the file
+    daytona_api_key_file: str = os.environ.get("DAYTONA_API_KEY_FILE", "")
+    e2b_api_key_file: str = os.environ.get("E2B_API_KEY_FILE", "")
+    modal_config_file: str = os.environ.get("MODAL_CONFIG_PATH", "")
+
+    router_external_host: str = os.environ.get("MILES_ROUTER_EXTERNAL_HOST", socket.gethostname())
+    miles_host_ip: str = os.environ.get("MILES_HOST_IP", "")
+
+    # W&B settings
+    wandb_key: str = os.environ.get("WANDB_KEY", os.environ.get("WANDB_API_KEY", ""))
+    wandb_project: str = os.environ.get("WANDB_PROJECT", "my-wandb-project")
+    wandb_team: str = os.environ.get("WANDB_TEAM", "")
+    wandb_run_name: str = "glm47-flash-harbor-inprocess"
+
+
+def cleanup():
+    """Kill old Ray jobs and stale processes to free GPU resources."""
+    my_pid = os.getpid()
+    ppid = os.getppid()
+    exclude = f"grep -v '^{my_pid}$' | grep -v '^{ppid}$'"
+    for t in ["sglang", "train.py", "MegatronTrain"]:
+        subprocess.run(f"pgrep -f '{t}' | {exclude} | xargs -r kill 2>/dev/null || true", shell=True)
+    time.sleep(5)
+
+
+def prepare(args: ScriptArgs):
+    U.convert_checkpoint(
+        model_name=args.model_name,
+        megatron_model_type=args.megatron_model_type,
+        num_gpus_per_node=args.num_gpus_per_node,
+        dir_dst=args.base_dir,
+        hf_checkpoint=args.hf_checkpoint,
+        megatron_path=args.megatron_path,
+    )
+
+
+def execute(args: ScriptArgs):
+    ckpt_args = (
+        f"--hf-checkpoint {args.hf_checkpoint} "
+        f"--ref-load {args.ref_load} "
+        f"--save {args.save_dir} "
+        f"--save-interval {args.save_interval} "
+    )
+    rollout_args = (
+        f"--prompt-data {args.prompt_data} "
+        "--input-key prompt "
+        "--metadata-key metadata "
+        "--rollout-shuffle "
+        f"--num-rollout {args.num_rollout} "
+        f"--rollout-batch-size {args.rollout_batch_size} "
+        f"--n-samples-per-prompt {args.n_samples_per_prompt} "
+        "--rollout-temperature 0.8 "
+        "--rollout-max-response-len 8192 "
+        f"--max-seq-len {args.max_seq_len} "
+        f"--global-batch-size {args.global_batch_size} "
+        "--balance-data "
+    )
+    perf_args = (
+        "--tensor-model-parallel-size 4 "
+        "--sequence-parallel "
+        "--pipeline-model-parallel-size 1 "
+        "--context-parallel-size 1 "
+        "--expert-model-parallel-size 8 "
+        "--expert-tensor-parallel-size 1 "
+        "--recompute-granularity full "
+        "--recompute-method uniform "
+        "--recompute-num-layers 1 "
+        "--use-dynamic-batch-size "
+        "--max-tokens-per-gpu 16384 "
+        "--optimizer-cpu-offload "
+        "--overlap-cpu-optimizer-d2h-h2d "
+        "--use-precision-aware-optimizer "
+    )
+    grpo_args = (
+        "--advantage-estimator grpo "
+        "--use-kl-loss "
+        "--kl-loss-coef 0.01 "
+        "--kl-loss-type low_var_kl "
+        "--entropy-coef 0.0 "
+        "--eps-clip 0.2 "
+        "--eps-clip-high 0.28 "
+    )
+    optimizer_args = (
+        "--optimizer adam "
+        "--lr 1e-6 "
+        "--lr-decay-style constant "
+        "--weight-decay 0.1 "
+        "--adam-beta1 0.9 "
+        "--adam-beta2 0.98 "
+    )
+    sglang_args = (
+        "--rollout-num-gpus-per-engine 1 "
+        "--sglang-mem-fraction-static 0.7 "
+        "--sglang-tool-call-parser glm47 "
+        "--sglang-reasoning-parser glm45 "
+        "--sglang-router-port 31000 "
+    )
+    agent_args = (
+        "--custom-generate-function-path miles.rollout.generate_hub.agentic_tool_call.generate "
+        "--custom-agent-function-path harbor_agent_function.run "
+        "--custom-rm-path generate.reward_func "
+        "--rollout-function-path generate.RolloutFn "
+        "--dynamic-sampling-filter-path miles.rollout.filter_hub.dynamic_sampling_filters.check_no_aborted "
+        "--tito-model glm47 "
+        "--use-session-server "
+        "--session-server-port 30000 "
+        "--session-server-workers 32 "
+    )
+    misc_args = (
+        "--attention-dropout 0.0 "
+        "--hidden-dropout 0.0 "
+        "--accumulate-allreduce-grads-in-fp32 "
+        "--attention-softmax-in-fp32 "
+        "--attention-backend flash "
+        "--colocate "
+        f"--actor-num-nodes {args.num_nodes} "
+        f"--actor-num-gpus-per-node {args.num_gpus_per_node} "
+        f"--rollout-num-gpus {args.num_gpus_per_node} "
+    )
+    debug_args = "--debug-rollout-only " if args.mode == "debug_rollout_only" else ""
+    trace_args = f"--dump-details {args.save_traces_dir} " if args.save_traces_dir else ""
+    wandb_args = ""
+    if args.wandb_key:
+        wandb_args = f"--use-wandb --wandb-project {args.wandb_project} --wandb-group {args.wandb_run_name} --wandb-key {args.wandb_key} "
+        if args.wandb_team:
+            wandb_args += f"--wandb-team {args.wandb_team} "
+
+    train_args = (
+        f"{ckpt_args}{rollout_args}{optimizer_args}{grpo_args}{wandb_args}{trace_args}"
+        f"{perf_args}{sglang_args}{agent_args}{misc_args}{debug_args}"
+    )
+
+    extra_env_vars = {
+        "PYTHONPATH": f"{args.megatron_path}:{SCRIPT_DIR}:{HARBOR_DOCKER_EXAMPLE_DIR}:{U.repo_base_dir}",
+        **harbor_env_vars(args),
+    }
+    if args.miles_host_ip:
+        extra_env_vars["MILES_HOST_IP"] = args.miles_host_ip
+
+    U.execute_train(
+        train_args=train_args,
+        config=args,
+        num_gpus_per_node=args.num_gpus_per_node,
+        megatron_model_type=args.megatron_model_type,
+        megatron_path=args.megatron_path,
+        extra_env_vars=extra_env_vars,
+    )
+
+
+@U.dataclass_cli
+def main(args: ScriptArgs):
+    cleanup()
+    if not args.skip_prepare:
+        prepare(args)
+    execute(args)
+
+
+if __name__ == "__main__":
+    typer.run(main)

--- a/examples/experimental/harbor/run.py
+++ b/examples/experimental/harbor/run.py
@@ -14,17 +14,12 @@ import socket
 import subprocess
 import time
 from dataclasses import dataclass
-from pathlib import Path
 from typing import Literal
 
 import typer
-from launch_common import harbor_env_vars
+from launch_common import agentic_pythonpath_dirs, agentic_train_args, harbor_env_vars
 
 import miles.utils.external_utils.command_utils as U
-
-SCRIPT_DIR = Path(__file__).resolve().parent
-# reward_func / RolloutFn (agent-metric aggregation) are shared with the agent-server example
-HARBOR_DOCKER_EXAMPLE_DIR = SCRIPT_DIR.parents[1] / "swe-agent-harbor-docker"
 
 
 @dataclass
@@ -157,17 +152,7 @@ def execute(args: ScriptArgs):
         "--sglang-reasoning-parser glm45 "
         "--sglang-router-port 31000 "
     )
-    agent_args = (
-        "--custom-generate-function-path miles.rollout.generate_hub.agentic_tool_call.generate "
-        "--custom-agent-function-path harbor_agent_function.run "
-        "--custom-rm-path generate.reward_func "
-        "--rollout-function-path generate.RolloutFn "
-        "--dynamic-sampling-filter-path miles.rollout.filter_hub.dynamic_sampling_filters.check_no_aborted "
-        "--tito-model glm47 "
-        "--use-session-server "
-        "--session-server-port 30000 "
-        "--session-server-workers 32 "
-    )
+    agent_args = agentic_train_args(tito_model="glm47", session_server_workers=32)
     misc_args = (
         "--attention-dropout 0.0 "
         "--hidden-dropout 0.0 "
@@ -193,7 +178,7 @@ def execute(args: ScriptArgs):
     )
 
     extra_env_vars = {
-        "PYTHONPATH": f"{args.megatron_path}:{SCRIPT_DIR}:{HARBOR_DOCKER_EXAMPLE_DIR}:{U.repo_base_dir}",
+        "PYTHONPATH": ":".join([args.megatron_path, *agentic_pythonpath_dirs(), U.repo_base_dir]),
         **harbor_env_vars(args),
     }
     if args.miles_host_ip:

--- a/examples/experimental/harbor/run.py
+++ b/examples/experimental/harbor/run.py
@@ -178,7 +178,7 @@ def execute(args: ScriptArgs):
     )
 
     extra_env_vars = {
-        "PYTHONPATH": ":".join([args.megatron_path, *agentic_pythonpath_dirs(), U.repo_base_dir]),
+        "PYTHONPATH": ":".join([args.megatron_path, *agentic_pythonpath_dirs(), str(U.repo_base_dir)]),
         **harbor_env_vars(args),
     }
     if args.miles_host_ip:

--- a/examples/experimental/openenv/openenv_launch_common.py
+++ b/examples/experimental/openenv/openenv_launch_common.py
@@ -16,7 +16,7 @@ from pathlib import Path
 from typing import Protocol
 
 import openenv_sandbox_common as sandbox_common
-from miles.rollout.agentic.credentials import PROVIDER_CREDENTIALS, forward_address, preflight_sdk, sandbox_key_supply
+from miles.rollout.agentic.credentials import PROVIDER_CREDENTIALS, provision_provider
 
 
 class LaunchArgs(Protocol):
@@ -197,25 +197,7 @@ def apply_optional_env_vars(env: dict[str, str], args: LaunchArgs) -> None:
     backend = resolve_sandbox_backend(args)
     if backend:
         spec = PROVIDER_CREDENTIALS[backend]
-        sandbox_key_supply(
-            env,
-            provider=spec["provider"],
-            key_env_vars=spec["key_env_vars"],
-            file_env_var=spec["file_env_var"],
-            arg_path=getattr(args, spec["arg_attr"], "") or "",
-            default_path=spec["default_path"],
-            provision_hint=spec["provision_hint"],
-        )
-        preflight_sdk(spec["sdk"], spec["sdk_hint"], spec.get("sdk_min_version"))
-        # Addresses, not secrets: the SDK reads these from the environment on
-        # every worker, so forward whatever is set here BY VALUE.
-        for var in spec["forward"]:
-            value = os.environ.get(var, "").strip()
-            if value:
-                forward_address(env, var, value)
-        if spec["target"]:
-            var, label, default_desc = spec["target"]
-            print(f"openenv: {spec['provider']} {label}: {env.get(var, default_desc)}", flush=True)
+        provision_provider(env, spec, arg_path=getattr(args, spec["arg_attr"], "") or "")
         # Preflight the env package the recipe bakes into each task image —
         # shared by every sandbox backend. The import check catches a missing
         # install; the source probe catches an install that imports fine but

--- a/miles/rollout/agentic/credentials.py
+++ b/miles/rollout/agentic/credentials.py
@@ -217,3 +217,25 @@ def resolve_provider_api_key(env_var: str, file_env_var: str, default_path: str)
     if not key:
         raise RuntimeError(f"no API key: {env_var} is unset and {key_file} is missing or empty")
     return key
+
+
+def provision_provider(env: dict[str, str], spec: dict, *, arg_path: str = "") -> None:
+    """One provider's whole launcher-side provisioning, from its PROVIDER_CREDENTIALS spec:
+    key supply (the file's path, never the value), SDK preflight, forwarding the
+    address-like vars by value, and echoing which endpoint is in effect."""
+    sandbox_key_supply(
+        env,
+        provider=spec["provider"],
+        key_env_vars=spec["key_env_vars"],
+        file_env_var=spec["file_env_var"],
+        arg_path=arg_path,
+        default_path=spec["default_path"],
+        provision_hint=spec["provision_hint"],
+    )
+    preflight_sdk(spec["sdk"], spec["sdk_hint"], spec.get("sdk_min_version"))
+    for var in spec["forward"]:
+        if value := os.environ.get(var, "").strip():
+            forward_address(env, var, value)
+    if spec["target"]:
+        var, label, default_desc = spec["target"]
+        print(f"{spec['provider']} {label}: {env.get(var, default_desc)}", flush=True)

--- a/tests/fast/examples/experimental/harbor/test_launch_common.py
+++ b/tests/fast/examples/experimental/harbor/test_launch_common.py
@@ -1,0 +1,84 @@
+"""Offline tests for the launcher's Harbor-side wiring (no harbor, no keys)."""
+
+import sys
+import types
+from types import SimpleNamespace
+
+import launch_common
+import pytest
+
+
+def _args(**overrides):
+    defaults = dict(
+        harbor_env_type="e2b",
+        harbor_env_kwargs="",
+        harbor_tasks_dir="/tasks",
+        harbor_trials_dir="/trials",
+        agent_model_name="model",
+        agent_timeout=5400,
+        router_external_host="trainer.tailnet",
+        daytona_api_key_file="",
+        e2b_api_key_file="",
+        modal_config_file="",
+    )
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+@pytest.fixture(autouse=True)
+def fake_harbor_and_sdk(monkeypatch):
+    """harbor and the provider SDKs only need to be importable for the preflight."""
+    for name in ("harbor", "e2b", "daytona", "modal"):
+        monkeypatch.setitem(sys.modules, name, types.ModuleType(name))
+
+
+def test_env_type_is_required(monkeypatch):
+    with pytest.raises(ValueError, match="HARBOR_ENV_TYPE"):
+        launch_common.harbor_env_vars(_args(harbor_env_type=""))
+
+
+def test_docker_is_refused_with_a_pointer_to_the_agent_server():
+    with pytest.raises(ValueError, match="swe-agent-harbor-docker"):
+        launch_common.harbor_env_vars(_args(harbor_env_type="docker"))
+
+
+def test_missing_harbor_names_the_install(monkeypatch):
+    monkeypatch.setitem(sys.modules, "harbor", None)
+    with pytest.raises(RuntimeError, match="README install line"):
+        launch_common.harbor_env_vars(_args())
+
+
+def test_known_provider_is_provisioned_by_key_path(monkeypatch, tmp_path):
+    key_file = tmp_path / "api_key"
+    key_file.write_text("e2b_secret\n")
+    monkeypatch.setenv("E2B_API_URL", "http://agentenv.internal:8000")
+
+    env = launch_common.harbor_env_vars(_args(e2b_api_key_file=str(key_file)))
+
+    assert env["HARBOR_ENV_TYPE"] == "e2b"
+    assert env["HARBOR_TASKS_DIR"] == "/tasks"
+    assert env["MILES_ROUTER_EXTERNAL_HOST"] == "trainer.tailnet"
+    assert env["E2B_API_KEY_FILE"] == str(key_file)
+    assert env["E2B_API_URL"] == "http://agentenv.internal:8000"
+    assert "e2b_secret" not in str(env)
+
+
+def test_unknown_provider_passes_through_with_a_notice(monkeypatch, capsys):
+    """The backend still reaches Harbor untouched; the operator is told no
+    credential wiring exists for it."""
+    env = launch_common.harbor_env_vars(_args(harbor_env_type="runloop"))
+    assert env["HARBOR_ENV_TYPE"] == "runloop"
+    assert "no credential wiring known for 'runloop'" in capsys.readouterr().out
+    assert not any("KEY" in var for var in env)
+
+
+def test_env_kwargs_and_server_knobs_are_forwarded_when_set(monkeypatch):
+    monkeypatch.setenv("E2B_API_KEY", "e2b_x")  # worker-env key supply
+    monkeypatch.setenv("HARBOR_RESPONSE_LENGTH_POLICY", "abort")
+    monkeypatch.delenv("HARBOR_MAX_SEQ_LEN", raising=False)
+
+    env = launch_common.harbor_env_vars(_args(harbor_env_kwargs='{"auto_snapshot": true}'))
+
+    assert env["HARBOR_ENV_KWARGS"] == '{"auto_snapshot": true}'
+    assert env["HARBOR_RESPONSE_LENGTH_POLICY"] == "abort"
+    assert "HARBOR_MAX_SEQ_LEN" not in env

--- a/tests/fast/examples/experimental/harbor/test_launch_common.py
+++ b/tests/fast/examples/experimental/harbor/test_launch_common.py
@@ -40,6 +40,9 @@ def test_env_type_is_required(monkeypatch):
 def test_docker_is_refused_with_a_pointer_to_the_agent_server():
     with pytest.raises(ValueError, match="swe-agent-harbor-docker"):
         launch_common.harbor_env_vars(_args(harbor_env_type="docker"))
+    # the worker normalizes HARBOR_ENV_TYPE, so the guard must see the same value
+    with pytest.raises(ValueError, match="Docker daemon"):
+        launch_common.harbor_env_vars(_args(harbor_env_type=" Docker "))
 
 
 def test_missing_harbor_names_the_install(monkeypatch):

--- a/tests/fast/examples/experimental/harbor/test_launch_common.py
+++ b/tests/fast/examples/experimental/harbor/test_launch_common.py
@@ -2,6 +2,7 @@
 
 import sys
 import types
+from pathlib import Path
 from types import SimpleNamespace
 
 import launch_common
@@ -85,3 +86,18 @@ def test_env_kwargs_and_server_knobs_are_forwarded_when_set(monkeypatch):
     assert env["HARBOR_ENV_KWARGS"] == '{"auto_snapshot": true}'
     assert env["HARBOR_RESPONSE_LENGTH_POLICY"] == "abort"
     assert "HARBOR_MAX_SEQ_LEN" not in env
+
+
+def test_agentic_wiring_is_the_shipped_wiring():
+    """One shared copy: the flags the GPU e2e exercises are the flags the recipes ship."""
+    args = launch_common.agentic_train_args(tito_model="qwen3", session_server_workers=4)
+    assert "--custom-agent-function-path harbor_agent_function.run" in args
+    assert "--custom-generate-function-path miles.rollout.generate_hub.agentic_tool_call.generate" in args
+    assert "--dynamic-sampling-filter-path miles.rollout.filter_hub.dynamic_sampling_filters.check_no_aborted" in args
+    assert "--tito-model qwen3" in args and "--session-server-workers 4" in args
+    # the miles-side paths must resolve, or every launcher fails at load_function time
+    from miles.rollout.filter_hub.dynamic_sampling_filters import check_no_aborted  # noqa: F401
+    from miles.rollout.generate_hub.agentic_tool_call import generate  # noqa: F401
+
+    for d in launch_common.agentic_pythonpath_dirs():
+        assert Path(d).is_dir(), d

--- a/tests/fast/examples/experimental/harbor/test_launch_common.py
+++ b/tests/fast/examples/experimental/harbor/test_launch_common.py
@@ -95,6 +95,7 @@ def test_agentic_wiring_is_the_shipped_wiring():
     assert "--custom-generate-function-path miles.rollout.generate_hub.agentic_tool_call.generate" in args
     assert "--dynamic-sampling-filter-path miles.rollout.filter_hub.dynamic_sampling_filters.check_no_aborted" in args
     assert "--tito-model qwen3" in args and "--session-server-workers 4" in args
+    assert "--session-server-port 30000" in args  # the default; multi-launcher hosts pass their own
     # the miles-side paths must resolve, or every launcher fails at load_function time
     from miles.rollout.filter_hub.dynamic_sampling_filters import check_no_aborted  # noqa: F401
     from miles.rollout.generate_hub.agentic_tool_call import generate  # noqa: F401

--- a/tests/fast/rollout/agentic/test_credentials.py
+++ b/tests/fast/rollout/agentic/test_credentials.py
@@ -8,6 +8,7 @@ from miles.rollout.agentic.credentials import (
     PROVIDER_CREDENTIALS,
     forward_address,
     preflight_sdk,
+    provision_provider,
     resolve_provider_api_key,
     sandbox_key_supply,
 )
@@ -222,3 +223,24 @@ def test_resolve_missing_key_names_both_supplies(monkeypatch, tmp_path):
     monkeypatch.setenv("PROV_API_KEY_FILE", str(tmp_path / "absent"))
     with pytest.raises(RuntimeError, match="PROV_API_KEY is unset"):
         resolve_provider_api_key("PROV_API_KEY", "PROV_API_KEY_FILE", "~/nope")
+
+
+# --- whole-provider provisioning ------------------------------------------------
+
+
+def test_provision_provider_wires_key_path_addresses_and_preflight(monkeypatch, tmp_path):
+    """The one call a launcher makes per provider: key file by path, endpoint
+    vars by value, SDK importable."""
+    key_file = tmp_path / "api_key"
+    key_file.write_text("e2b_secret\n")
+    monkeypatch.setenv("E2B_API_URL", "http://agentenv.internal:8000")
+    monkeypatch.delenv("E2B_SANDBOX_URL", raising=False)
+    monkeypatch.setitem(sys.modules, "e2b", types.ModuleType("e2b"))
+
+    env: dict[str, str] = {}
+    provision_provider(env, PROVIDER_CREDENTIALS["e2b"], arg_path=str(key_file))
+
+    assert env["E2B_API_KEY_FILE"] == str(key_file)
+    assert env["E2B_API_URL"] == "http://agentenv.internal:8000"
+    assert "E2B_SANDBOX_URL" not in env  # unset vars are not forwarded
+    assert "e2b_secret" not in str(env)


### PR DESCRIPTION
Stacked on #2806. Tracking: #2804.

## Purpose

A launcher for the in-process Harbor path, plus the one piece of launcher logic the OpenEnv and Harbor examples would otherwise duplicate.

## What

- `miles/rollout/agentic/credentials.py` gains `provision_provider`: the per-provider sequence (key file by path → SDK preflight → forward address vars by value → echo the endpoint) that the OpenEnv launcher spelled out call by call and this launcher would have repeated. The OpenEnv launcher switches to it.
- `examples/experimental/harbor/run.py` — GLM-4.7-Flash launcher for `harbor_agent_function`. Its Harbor-side wiring lives in `launch_common.py` (importable without the trainer's heavy deps): `HARBOR_ENV_TYPE` passes through untouched; `docker` is refused with a pointer to the agent-server example; a provider without credential wiring (anything beyond daytona/e2b/modal) passes through with a printed notice instead of silently; per-trial knobs are forwarded only when set.
- `launch_common.py` also carries the **agentic wiring as one shared copy** (`agentic_train_args` / `agentic_pythonpath_dirs`): the recipe and the GPU e2e (#2876) both call it, so the flags the test exercises are the flags the recipe ships.
- Tests: `provision_provider` in the library suite; `harbor_env_vars` covered end to end (required env type, docker refusal — case/whitespace-proof, key-path forwarding, unknown-provider notice, knob forwarding); the wiring test also imports the miles-side function paths, so a path typo fails in seconds instead of at `load_function` time. No harbor install, no keys.

## Behaviour change

One line of OpenEnv launcher output loses its `openenv: ` prefix (the echo moved into the shared helper). Everything else is new.


## Known duplication

`run.py`'s recipe blocks (perf/GRPO/optimizer/sglang) follow the repo's launcher pattern and are largely shared with the other legs' launchers; researching a shared shape is #3110. This PR deduplicates only where the sharing is already real (`provision_provider` → shared layer).


## Tested by

The offline tests here cover the wiring's logic; its live validation is **#2876** (one GRPO step on real e2b sandboxes, assembled through this PR's `harbor_env_vars`). `run.py` itself **ran 2026-09-04** with the README's exact command (documented data pipeline, real training mode, batch dials reduced): 2/2 trials reward 1.0, one GRPO step. The end-of-run checkpoint save ran out of disk — a GLM-scale torch_dist checkpoint with optimizer state needs several hundred GB at `--save-dir` (README in #2837 records this); everything up to and including the optimizer step passed.



