### PR TITLE
docs: the in-process Harbor example

### DIFF
--- a/docs/user-guide/environments.md
+++ b/docs/user-guide/environments.md
@@ -29,14 +29,17 @@ where the environment itself comes from:
 | [τ-bench](https://github.com/sierra-research/tau-bench) | generate function | [example](https://github.com/radixark/miles/tree/main/examples/experimental/tau-bench) |
 
 Sandbox providers are a different axis: they provision the task containers
-*inside* a connector rather than occupying a rollout layer.
+*inside* a connector rather than occupying a rollout layer. Harbor accepts any
+of its own environment backends when run
+[in-process](https://github.com/radixark/miles/tree/main/examples/experimental/harbor)
+(`HARBOR_ENV_TYPE` is passed through); the table lists the ones exercised.
 
 | Sandbox provider | Used within | Guide |
 |---|---|---|
-| [AgentENV](https://github.com/kvcache-ai/AgentENV) | OpenEnv | [example](https://github.com/radixark/miles/tree/main/examples/experimental/agentenv) |
+| [AgentENV](https://github.com/kvcache-ai/AgentENV) | Harbor, OpenEnv | [example](https://github.com/radixark/miles/tree/main/examples/experimental/agentenv) |
 | [Daytona](https://www.daytona.io/) | Harbor, HUD, NeMo Gym, OpenEnv | [example](https://github.com/radixark/miles/tree/main/examples/experimental/openenv) |
-| [E2B](https://e2b.dev/) | OpenEnv | [example](https://github.com/radixark/miles/tree/main/examples/experimental/openenv) |
-| [Modal](https://modal.com/) | OpenEnv | [example](https://github.com/radixark/miles/tree/main/examples/experimental/openenv) |
+| [E2B](https://e2b.dev/) | Harbor, OpenEnv | [example](https://github.com/radixark/miles/tree/main/examples/experimental/harbor) |
+| [Modal](https://modal.com/) | Harbor, OpenEnv | [example](https://github.com/radixark/miles/tree/main/examples/experimental/openenv) |
 
 Everything above is experimental, and listed alphabetically.
 

--- a/docs/user-guide/environments.md
+++ b/docs/user-guide/environments.md
@@ -38,7 +38,7 @@ Harbor backend; the table lists only pairs a training run has used.
 |---|---|---|
 | [AgentENV](https://github.com/kvcache-ai/AgentENV) | Harbor, OpenEnv | [example](https://github.com/radixark/miles/tree/main/examples/experimental/agentenv) |
 | [Daytona](https://www.daytona.io/) | Harbor, HUD, NeMo Gym, OpenEnv | [example](https://github.com/radixark/miles/tree/main/examples/experimental/openenv) |
-| [E2B](https://e2b.dev/) | OpenEnv | [example](https://github.com/radixark/miles/tree/main/examples/experimental/openenv) |
+| [E2B](https://e2b.dev/) | Harbor, OpenEnv | [example](https://github.com/radixark/miles/tree/main/examples/experimental/harbor) |
 | [Modal](https://modal.com/) | OpenEnv | [example](https://github.com/radixark/miles/tree/main/examples/experimental/openenv) |
 
 Everything above is experimental, and listed alphabetically.

--- a/docs/user-guide/environments.md
+++ b/docs/user-guide/environments.md
@@ -36,7 +36,7 @@ Harbor backend; the table lists only pairs a training run has used.
 
 | Sandbox provider | Used within | Guide |
 |---|---|---|
-| [AgentENV](https://github.com/kvcache-ai/AgentENV) | OpenEnv | [example](https://github.com/radixark/miles/tree/main/examples/experimental/agentenv) |
+| [AgentENV](https://github.com/kvcache-ai/AgentENV) | Harbor, OpenEnv | [example](https://github.com/radixark/miles/tree/main/examples/experimental/agentenv) |
 | [Daytona](https://www.daytona.io/) | Harbor, HUD, NeMo Gym, OpenEnv | [example](https://github.com/radixark/miles/tree/main/examples/experimental/openenv) |
 | [E2B](https://e2b.dev/) | OpenEnv | [example](https://github.com/radixark/miles/tree/main/examples/experimental/openenv) |
 | [Modal](https://modal.com/) | OpenEnv | [example](https://github.com/radixark/miles/tree/main/examples/experimental/openenv) |

--- a/docs/user-guide/environments.md
+++ b/docs/user-guide/environments.md
@@ -29,17 +29,17 @@ where the environment itself comes from:
 | [τ-bench](https://github.com/sierra-research/tau-bench) | generate function | [example](https://github.com/radixark/miles/tree/main/examples/experimental/tau-bench) |
 
 Sandbox providers are a different axis: they provision the task containers
-*inside* a connector rather than occupying a rollout layer. Harbor accepts any
-of its own environment backends when run
-[in-process](https://github.com/radixark/miles/tree/main/examples/experimental/harbor)
-(`HARBOR_ENV_TYPE` is passed through); the table lists the ones exercised.
+*inside* a connector rather than occupying a rollout layer. The
+[in-process Harbor path](https://github.com/radixark/miles/tree/main/examples/experimental/harbor)
+passes `HARBOR_ENV_TYPE` straight to Harbor, so mechanically it reaches any
+Harbor backend; the table lists only pairs a training run has used.
 
 | Sandbox provider | Used within | Guide |
 |---|---|---|
-| [AgentENV](https://github.com/kvcache-ai/AgentENV) | Harbor, OpenEnv | [example](https://github.com/radixark/miles/tree/main/examples/experimental/agentenv) |
+| [AgentENV](https://github.com/kvcache-ai/AgentENV) | OpenEnv | [example](https://github.com/radixark/miles/tree/main/examples/experimental/agentenv) |
 | [Daytona](https://www.daytona.io/) | Harbor, HUD, NeMo Gym, OpenEnv | [example](https://github.com/radixark/miles/tree/main/examples/experimental/openenv) |
-| [E2B](https://e2b.dev/) | Harbor, OpenEnv | [example](https://github.com/radixark/miles/tree/main/examples/experimental/harbor) |
-| [Modal](https://modal.com/) | Harbor, OpenEnv | [example](https://github.com/radixark/miles/tree/main/examples/experimental/openenv) |
+| [E2B](https://e2b.dev/) | OpenEnv | [example](https://github.com/radixark/miles/tree/main/examples/experimental/openenv) |
+| [Modal](https://modal.com/) | OpenEnv | [example](https://github.com/radixark/miles/tree/main/examples/experimental/openenv) |
 
 Everything above is experimental, and listed alphabetically.
 

--- a/docs/user-guide/environments.md
+++ b/docs/user-guide/environments.md
@@ -36,9 +36,9 @@ Harbor backend; the table lists only pairs a training run has used.
 
 | Sandbox provider | Used within | Guide |
 |---|---|---|
-| [AgentENV](https://github.com/kvcache-ai/AgentENV) | Harbor, OpenEnv | [example](https://github.com/radixark/miles/tree/main/examples/experimental/agentenv) |
+| [AgentENV](https://github.com/kvcache-ai/AgentENV) | Harbor, OpenEnv | [Harbor](https://github.com/radixark/miles/tree/main/examples/experimental/harbor), [OpenEnv](https://github.com/radixark/miles/tree/main/examples/experimental/agentenv) |
 | [Daytona](https://www.daytona.io/) | Harbor, HUD, NeMo Gym, OpenEnv | [example](https://github.com/radixark/miles/tree/main/examples/experimental/openenv) |
-| [E2B](https://e2b.dev/) | Harbor, OpenEnv | [example](https://github.com/radixark/miles/tree/main/examples/experimental/harbor) |
+| [E2B](https://e2b.dev/) | Harbor, OpenEnv | [Harbor](https://github.com/radixark/miles/tree/main/examples/experimental/harbor), [OpenEnv](https://github.com/radixark/miles/tree/main/examples/experimental/openenv) |
 | [Modal](https://modal.com/) | OpenEnv | [example](https://github.com/radixark/miles/tree/main/examples/experimental/openenv) |
 
 Everything above is experimental, and listed alphabetically.

--- a/docs/user-guide/harbor.md
+++ b/docs/user-guide/harbor.md
@@ -18,8 +18,14 @@ hook.
 
 ## Try it
 
-The maintained recipe lives in
-[`examples/swe-agent-harbor-docker`](https://github.com/radixark/miles/tree/main/examples/swe-agent-harbor-docker),
-with synchronous and fully-async launchers. Follow the
-[recipe README](https://github.com/radixark/miles/blob/main/examples/swe-agent-harbor-docker/README.md)
-for the architecture, Harbor server setup, task format, and launch scripts.
+Two execution modes:
+
+- **Agent server** — Harbor runs on a separate host with a Docker daemon and
+  the trainer calls it over HTTP. The maintained recipe is
+  [`examples/swe-agent-harbor-docker`](https://github.com/radixark/miles/tree/main/examples/swe-agent-harbor-docker),
+  with synchronous and fully-async launchers; its
+  [README](https://github.com/radixark/miles/blob/main/examples/swe-agent-harbor-docker/README.md)
+  covers the architecture, server setup, task format, and launch scripts.
+- **In-process** — Harbor runs inside the rollout worker against a cloud
+  sandbox backend (E2B / AgentENV, Daytona, Modal, ...), with no server in
+  between: [`examples/experimental/harbor`](https://github.com/radixark/miles/tree/main/examples/experimental/harbor).

--- a/docs/user-guide/harbor.md
+++ b/docs/user-guide/harbor.md
@@ -11,21 +11,16 @@ SWE-bench, Terminal-Bench, custom tasks — train through one endpoint.
 
 Miles integrates Harbor as an
 [agent-function integration](/user-guide/environments): the agent function
-hands each session's OpenAI-compatible URL to a Harbor server, which runs the
-per-task container, installs and runs the agent against that URL, and grades
-the result; the grade becomes the sample's reward through a custom reward
-hook.
+hands each session's OpenAI-compatible URL to Harbor, which runs the per-task
+sandbox, runs the agent against that URL, and grades the result; the grade
+becomes the sample's reward through a custom reward hook.
 
 ## Try it
 
-Two execution modes:
+Two execution modes; each example README is the complete guide for its mode:
 
-- **Agent server** — Harbor runs on a separate host with a Docker daemon and
-  the trainer calls it over HTTP. The maintained recipe is
-  [`examples/swe-agent-harbor-docker`](https://github.com/radixark/miles/tree/main/examples/swe-agent-harbor-docker),
-  with synchronous and fully-async launchers; its
-  [README](https://github.com/radixark/miles/blob/main/examples/swe-agent-harbor-docker/README.md)
-  covers the architecture, server setup, task format, and launch scripts.
-- **In-process** — Harbor runs inside the rollout worker against a cloud
-  sandbox backend (E2B / AgentENV, Daytona, Modal, ...), with no server in
-  between: [`examples/experimental/harbor`](https://github.com/radixark/miles/tree/main/examples/experimental/harbor).
+- Tasks on a **local Docker daemon** → the agent-server mode:
+  [`examples/swe-agent-harbor-docker`](https://github.com/radixark/miles/tree/main/examples/swe-agent-harbor-docker).
+- Tasks on a **cloud sandbox backend** (E2B, Daytona, Modal, ...) → the
+  in-process mode, no server in between:
+  [`examples/experimental/harbor`](https://github.com/radixark/miles/tree/main/examples/experimental/harbor).

--- a/examples/experimental/harbor/README.md
+++ b/examples/experimental/harbor/README.md
@@ -1,0 +1,121 @@
+# Harbor in-process on cloud sandboxes
+
+This example runs [Harbor](https://github.com/harbor-framework/harbor) trials
+**inside the rollout worker**: the agent function builds a `TrialConfig` and
+calls `Trial.run()` directly, with the task sandbox on a cloud backend the worker
+reaches over the network — E2B Cloud or a self-hosted
+[AgentENV](../agentenv/README.md) (E2B API), Daytona, Modal, or any other Harbor
+`EnvironmentType`. There is no agent server.
+
+Compared with [`examples/swe-agent-harbor-docker`](../../swe-agent-harbor-docker/README.md):
+
+| | agent server (`swe-agent-harbor-docker`) | in-process (this example) |
+| --- | --- | --- |
+| Where `Trial.run()` runs | a separate host with a Docker daemon | the rollout worker |
+| Sandbox backends | `docker` (local), `daytona` via the server's env | any Harbor backend the worker can reach; `HARBOR_ENV_TYPE` is passed straight to Harbor |
+| Moving parts | trainer → HTTP → agent server → Harbor | trainer → Harbor |
+| Use it when | tasks must run on the local Docker daemon | sandboxes are cloud-hosted |
+
+Everything on the trainer side is the same: TITO, the session server, GRPO, the
+reward hook (`generate.py` from the agent-server example).
+
+## Files
+
+| File | Purpose |
+| --- | --- |
+| `harbor_agent_function.py` | Builds and runs one Harbor trial per sample; maps the result to sample metadata. Header lists which `harbor-miles-*` fork patches this path depends on. |
+| `run.py` | GLM-4.7-Flash launcher. |
+| `launch_common.py` | The launcher's Harbor-side wiring: passes `HARBOR_ENV_TYPE` through and forwards the provider credential (by key-file path) to rollout workers. |
+
+## 1. Install Harbor in the rollout environment
+
+Harbor now runs where the rollout workers run, so it goes into the Miles
+image / environment. Use the `harbor-miles-v0.20.0` branch of
+`harbor-framework/harbor` — the terminus-2 truncation policy it carries is
+required for TITO (see the agent function's header for the full list) —
+with the extra for your backend:
+
+```bash
+pip install "harbor[e2b] @ git+https://github.com/harbor-framework/harbor@harbor-miles-v0.20.0"
+# or harbor[daytona], harbor[modal], ...
+```
+
+mini-swe-agent does not need the fork's patches for correctness; public
+`harbor[e2b]` works for it, and is the smoke-test configuration.
+
+## 2. Provision the sandbox backend
+
+Credentials follow the contract every Miles sandbox integration uses: the
+worker reads the provider key from its own environment or from a key file; the
+launcher forwards only the file's path.
+
+```bash
+# E2B Cloud
+mkdir -p ~/.config/e2b && echo e2b_... > ~/.config/e2b/api_key
+# self-hosted AgentENV instead: point the SDK at it (see ../agentenv/README.md)
+export E2B_API_URL=http://<server>:8000 E2B_SANDBOX_URL=http://<server>:8000
+# Daytona
+mkdir -p ~/.config/daytona && echo dtn_... > ~/.config/daytona/api_key
+```
+
+Task directories: `HARBOR_TASKS_DIR` must contain one Harbor task dir per
+`metadata.instance_id` in the training data (same as the agent-server example);
+put it on a filesystem every worker can read.
+
+**Network.** In-sandbox agents (mini-swe-agent, claude-code) call the model
+from inside the sandbox, so the sandbox platform must reach the Miles session
+server: `--router-external-host` is the address substituted into the URL the
+agent gets, and ports 30000/31000 must route from the sandbox network (for
+AgentENV, allow the trainer's subnet in the server's egress config; see the
+AgentENV recipe). Host-process agents (terminus-2) call the model from the
+worker and need no sandbox egress.
+
+## 3. Prepare data
+
+Same as the agent-server example:
+
+```bash
+python examples/swe-agent-harbor-docker/download_and_process_data.py \
+    --input /path/to/terminal-bench.jsonl \
+    --output /path/to/tb2_train.jsonl \
+    --agent-name mini-swe-agent \
+    --prompt-key instruction
+```
+
+## 4. Launch
+
+```bash
+HARBOR_ENV_TYPE=e2b python examples/experimental/harbor/run.py \
+    --num-nodes 1 --num-gpus-per-node 8 --skip-prepare \
+    --megatron-path /root/Megatron-LM \
+    --hf-checkpoint /path/to/GLM-4.7-Flash \
+    --ref-load /path/to/GLM-4.7-Flash_torch_dist \
+    --save-dir /path/to/checkpoints \
+    --prompt-data /path/to/tb2_train.jsonl \
+    --harbor-tasks-dir /path/to/harbor_tasks \
+    --router-external-host <trainer-address-reachable-from-the-sandboxes> \
+    --rollout-batch-size 4 --n-samples-per-prompt 8 --global-batch-size 32 \
+    --num-rollout 200 --save-interval 10
+```
+
+`HARBOR_ENV_TYPE` has no default: the backend decides whose quota a run spends.
+Backend-specific settings go in `HARBOR_ENV_KWARGS` as a JSON object (Harbor's
+`EnvironmentConfig.kwargs`), e.g. `'{"auto_snapshot": true}'` for Daytona.
+
+## Timeouts and failure semantics
+
+`AGENT_TIMEOUT` is Harbor's per-trial agent budget; `AGENT_TRIAL_TIMEOUT`
+(default 7200 s) is the wall-clock cap around the whole trial and must stay
+above it. A trial that ends without a verdict scores 0 with a named
+`exit_status` (`TimeLimitExceeded`, `SequenceLengthLimitExceeded`,
+`AgentError`), the same vocabulary the agent-server path reports. Nothing is
+discarded on this path yet; see the
+[agentic rollout guide](../../../docs/user-guide/agentic-rollout.md) for which
+outcomes should be.
+
+## Status
+
+Offline tests cover the config built per harness, the `HARBOR_ENV_TYPE`
+pass-through, and the result mapping. Validation on a live backend
+(AgentENV, public `harbor[e2b]`, mini-swe-agent, then a GRPO smoke) is pending
+and will be recorded here.

--- a/examples/experimental/harbor/README.md
+++ b/examples/experimental/harbor/README.md
@@ -28,7 +28,8 @@ required for TITO (see the agent function's header for the full list) —
 with the extra for your backend:
 
 ```bash
-pip install "harbor[e2b] @ git+https://github.com/harbor-framework/harbor@harbor-miles-v0.20.0"
+# uv, not pip: the branch carries a uv-workspace dependency pip cannot resolve
+uv pip install "harbor[e2b] @ git+https://github.com/harbor-framework/harbor@harbor-miles-v0.20.0"
 # or harbor[daytona], harbor[modal], ...
 ```
 

--- a/examples/experimental/harbor/README.md
+++ b/examples/experimental/harbor/README.md
@@ -105,5 +105,9 @@ Daytona via the sandbox smoke, `scripts/sandbox_smoke`. The GPU e2e — one GRPO
 step with terminus-2 on real e2b sandboxes,
 `tests/e2e/agentic/test_harbor_e2b_training.py` — **passed 2026-09-04** on a
 2×H200 devbox against a self-hosted E2B-compatible service (2 trials
-submitted, optimizer step completed). `run.py` itself: one-step rollout smoke
-pending.
+submitted, optimizer step completed). `run.py` itself **ran 2026-09-04** on 8×H200
+with this README's exact command (data via the documented pipeline, real
+training mode, batch dials reduced to 1×2×1 rollout): both trials scored
+**reward 1.0**, one GRPO step completed. The end-of-run checkpoint save needs
+real headroom: a GLM-4.7-Flash torch_dist checkpoint with optimizer state is
+several hundred GB, so make sure `--save-dir` has that much free.

--- a/examples/experimental/harbor/README.md
+++ b/examples/experimental/harbor/README.md
@@ -102,5 +102,8 @@ next to the code that reads it.
 
 The platform round trip (golden agent, real sandbox APIs) passes on e2b and
 Daytona via the sandbox smoke, `scripts/sandbox_smoke`. The GPU e2e — one GRPO
-step on real e2b sandboxes — is `tests/e2e/agentic/test_harbor_e2b_training.py`
-(run manually; not yet exercised).
+step with terminus-2 on real e2b sandboxes,
+`tests/e2e/agentic/test_harbor_e2b_training.py` — **passed 2026-09-04** on a
+2×H200 devbox against a self-hosted E2B-compatible service (2 trials
+submitted, optimizer step completed). `run.py` itself: one-step rollout smoke
+pending.

--- a/examples/experimental/harbor/README.md
+++ b/examples/experimental/harbor/README.md
@@ -19,14 +19,6 @@ Compared with [`examples/swe-agent-harbor-docker`](../../swe-agent-harbor-docker
 Everything on the trainer side is the same: TITO, the session server, GRPO, the
 reward hook (`generate.py` from the agent-server example).
 
-## Files
-
-| File | Purpose |
-| --- | --- |
-| `harbor_agent_function.py` | Builds and runs one Harbor trial per sample; maps the result to sample metadata. Header lists which `harbor-miles-*` fork patches this path depends on. |
-| `run.py` | GLM-4.7-Flash launcher. |
-| `launch_common.py` | The launcher's Harbor-side wiring: passes `HARBOR_ENV_TYPE` through and forwards the provider credential (by key-file path) to rollout workers. |
-
 ## 1. Install Harbor in the rollout environment
 
 Harbor now runs where the rollout workers run, so it goes into the Miles
@@ -41,7 +33,7 @@ pip install "harbor[e2b] @ git+https://github.com/harbor-framework/harbor@harbor
 ```
 
 mini-swe-agent does not need the fork's patches for correctness; public
-`harbor[e2b]` works for it, and is the smoke-test configuration.
+`harbor[e2b]` works for it.
 
 ## 2. Provision the sandbox backend
 
@@ -102,20 +94,13 @@ HARBOR_ENV_TYPE=e2b python examples/experimental/harbor/run.py \
 Backend-specific settings go in `HARBOR_ENV_KWARGS` as a JSON object (Harbor's
 `EnvironmentConfig.kwargs`), e.g. `'{"auto_snapshot": true}'` for Daytona.
 
-## Timeouts and failure semantics
+Every remaining knob — timeouts and their layering, failure semantics, the
+full env-var reference — is documented in `harbor_agent_function.py`'s header,
+next to the code that reads it.
 
-`AGENT_TIMEOUT` is Harbor's per-trial agent budget; `AGENT_TRIAL_TIMEOUT`
-(default 7200 s) is the wall-clock cap around the whole trial and must stay
-above it. A trial that ends without a verdict scores 0 with a named
-`exit_status` (`TimeLimitExceeded`, `SequenceLengthLimitExceeded`,
-`AgentError`), the same vocabulary the agent-server path reports. Nothing is
-discarded on this path yet; see the
-[agentic rollout guide](../../../docs/user-guide/agentic-rollout.md) for which
-outcomes should be.
+## Validation
 
-## Status
-
-Offline tests cover the config built per harness, the `HARBOR_ENV_TYPE`
-pass-through, and the result mapping. Validation on a live backend
-(AgentENV, public `harbor[e2b]`, mini-swe-agent, then a GRPO smoke) is pending
-and will be recorded here.
+The platform round trip (golden agent, real sandbox APIs) passes on e2b and
+Daytona via the sandbox smoke, `scripts/sandbox_smoke`. The GPU e2e — one GRPO
+step on real e2b sandboxes — is `tests/e2e/agentic/test_harbor_e2b_training.py`
+(run manually; not yet exercised).

--- a/examples/experimental/harbor/README.md
+++ b/examples/experimental/harbor/README.md
@@ -33,9 +33,6 @@ uv pip install "harbor[e2b] @ git+https://github.com/harbor-framework/harbor@har
 # or harbor[daytona], harbor[modal], ...
 ```
 
-mini-swe-agent does not need the fork's patches for correctness; public
-`harbor[e2b]` works for it.
-
 ## 2. Provision the sandbox backend
 
 Credentials follow the contract every Miles sandbox integration uses: the
@@ -43,9 +40,9 @@ worker reads the provider key from its own environment or from a key file; the
 launcher forwards only the file's path.
 
 ```bash
-# E2B Cloud
+# E2B, cloud or self-hosted: the key first
 mkdir -p ~/.config/e2b && echo e2b_... > ~/.config/e2b/api_key
-# self-hosted AgentENV instead: point the SDK at it (see ../agentenv/README.md)
+# a self-hosted E2B-compatible service also needs the SDK pointed at it
 export E2B_API_URL=http://<server>:8000 E2B_SANDBOX_URL=http://<server>:8000
 # Daytona
 mkdir -p ~/.config/daytona && echo dtn_... > ~/.config/daytona/api_key
@@ -57,11 +54,11 @@ put it on a filesystem every worker can read.
 
 **Network.** In-sandbox agents (mini-swe-agent, claude-code) call the model
 from inside the sandbox, so the sandbox platform must reach the Miles session
-server: `--router-external-host` is the address substituted into the URL the
-agent gets, and ports 30000/31000 must route from the sandbox network (for
-AgentENV, allow the trainer's subnet in the server's egress config; see the
-AgentENV recipe). Host-process agents (terminus-2) call the model from the
-worker and need no sandbox egress.
+server. `--router-external-host` is the address substituted into the URL the
+agent gets. Two port ranges must route from the sandbox network: one
+session-server port per worker starting at `--session-server-port` (30000-30031
+for `run.py`'s 32 workers) and the SGLang router's 31000. Host-process agents
+(terminus-2) call the model from the worker and need no sandbox egress.
 
 ## 3. Prepare data
 

--- a/examples/experimental/harbor/README.md
+++ b/examples/experimental/harbor/README.md
@@ -102,11 +102,11 @@ next to the code that reads it.
 ## Validation
 
 The platform round trip (golden agent, real sandbox APIs) passes on e2b and
-Daytona via the sandbox smoke, `scripts/sandbox_smoke`. The GPU e2e — one GRPO
-step with terminus-2 on real e2b sandboxes,
-`tests/e2e/agentic/test_harbor_e2b_training.py` — **passed 2026-09-04** on a
-2×H200 devbox against a self-hosted E2B-compatible service (2 trials
-submitted, optimizer step completed). `run.py` itself **ran 2026-09-04** on 8×H200
+Daytona via the sandbox smoke, `scripts/sandbox_smoke`. The GPU e2e —
+terminus-2 on real e2b sandboxes through the full rollout path with the TITO
+strict gate armed, `tests/e2e/agentic/test_harbor_e2b_rollout.py` — **passed
+2026-09-09** on a 2×H200 devbox against a self-hosted E2B-compatible service
+(2 trials, both reward 1.0, no TITO mismatches). `run.py` itself **ran 2026-09-04** on 8×H200
 with this README's exact command (data via the documented pipeline, real
 training mode, batch dials reduced to 1×2×1 rollout): both trials scored
 **reward 1.0**, one GRPO step completed. The end-of-run checkpoint save needs


### PR DESCRIPTION
Stacked on the launcher PR. Tracking: #2804.

## Purpose

Documentation for the in-process Harbor path, with one complete guide per mode and no restating between layers.

## What

- `examples/experimental/harbor/README.md` — **the complete guide for the in-process mode**: mode comparison vs the agent server, install (`harbor[e2b] @ git+…@harbor-miles-v0.20.0`; public harbor suffices for mini-swe-agent), backend provisioning by key file, the network requirement (in-sandbox agents call the session server from inside the sandbox, so `--router-external-host` must route from the platform), and a Validation section stating exactly what ran (golden PASS on e2b and Daytona; GPU e2e not yet exercised). Code-contract details (timeouts, failure semantics, env vars) stay in the agent function's header; the README points there.
- `docs/user-guide/harbor.md` — shrinks to the mode choice plus links; its integration paragraph no longer describes a Harbor server (wrong for the in-process mode).
- `docs/user-guide/environments.md` — one sentence on mechanism vs evidence: `HARBOR_ENV_TYPE` pass-through makes any Harbor backend reachable, but the provider table claims only pairs a **training run** has used, so no rows change here. The harbor × e2b/AgentENV cells flip when the GPU e2e (#2876) first runs.

Docs only; no behaviour change.

## Ordering

Sits above #2876 (this PR's base): docs merge after the e2e evidence.



