### PR TITLE
Let off-cluster agents reach session servers on more than one host

### DIFF
--- a/docs/examples/swe-agent-harbor-docker.md
+++ b/docs/examples/swe-agent-harbor-docker.md
@@ -108,7 +108,7 @@ python examples/swe-agent-harbor-docker/run.py \
     --num-rollout 200 \
     --save-interval 20 \
     --agent-server-url http://<agent-server>:30000 \
-    --router-external-host <trainer-host-reachable-from-agent-server> \
+    --node-external-ip <trainer-host-reachable-from-agent-server> \
     --miles-host-ip 0.0.0.0 \
     --save-traces-dir /path/to/traces
 ```
@@ -117,7 +117,9 @@ For a smoke test, set `--num-rollout 1`. Expect roughly 10 minutes per step at
 this shape; because synchronous rollout waits for the slowest trajectory in the
 batch, a step that draws an unusually slow task can take several times that.
 
-`--router-external-host` is the address Harbor sandboxes use to call the Miles session server and SGLang router. It must resolve and route from the agent-server machine. `--miles-host-ip 0.0.0.0` is useful when those services must accept connections forwarded from another host. The launcher starts 32 session-server workers on ports 30000-30031 and the SGLang router on port 31000, so ensure that range and port are reachable end to end; Tailscale is one option when the machines are on different networks.
+`--node-external-ip` is the address Harbor sandboxes use to call the Miles session server and SGLang router. It must resolve and route from the agent-server machine. `--miles-host-ip 0.0.0.0` is useful when those services must accept connections forwarded from another host. The launcher starts 32 session-server workers on ports 30000-30031 and the SGLang router on port 31000, so ensure that range and port are reachable end to end; Tailscale is one option when the machines are on different networks.
+
+`--node-external-ip` sets `MILES_NODE_EXTERNAL_IP` for every node at once, which reaches the right instance only while the session servers all sit on one host. On a multi-node job, leave the flag unset and have the deployment set that variable in each trainer pod to that node's own reachable address -- a tailscale sidecar's `tailscale ip -4`, for instance; a DNS name also works. Each node then reports its own, and Miles hands every sandbox the address of the one instance holding its session. Nothing is needed at all when the pod addresses already route from the sandbox network, which is the case whenever the sandbox platform is allowed the trainer's subnet.
 
 ## 4. Verify progress
 

--- a/examples/experimental/nemo-gym/README.md
+++ b/examples/experimental/nemo-gym/README.md
@@ -147,8 +147,9 @@ skip):
 ```bash
 export NEMO_GYM_URL="http://<nemo-gym-host>:12000"
 # Only if the NeMo Gym host cannot resolve the trainer's hostname (e.g. it
-# reaches the trainer over a tailnet):
-export MILES_ROUTER_EXTERNAL_HOST="<trainer host/IP reachable from that host>"
+# reaches the trainer over a tailnet). This sets one address for every node; on
+# a multi-node job have the deployment set it per trainer pod instead:
+export MILES_NODE_EXTERNAL_IP="<trainer host/IP reachable from that host>"
 python examples/experimental/nemo-gym/run.py
 ```
 

--- a/examples/experimental/nemo-gym/nemogym_agent_function.py
+++ b/examples/experimental/nemo-gym/nemogym_agent_function.py
@@ -25,9 +25,6 @@ Env vars:
   NEMO_GYM_RUN_TIMEOUT  hard wall-clock cap in seconds for one /run call
                  (default: 3600). SWE episodes pull per-task docker images on
                  first use, which can dominate early rollouts.
-  MILES_ROUTER_EXTERNAL_HOST  optional host rewrite for the session URL when
-                 the NeMo Gym server cannot resolve the trainer's hostname
-                 (e.g. it runs outside the trainer's docker network).
 """
 
 import asyncio
@@ -37,7 +34,8 @@ import random
 from typing import Any
 
 import httpx
-from miles.rollout.agentic.session import resolve_session_url
+
+from miles.rollout.agentic.session import openai_session_url
 
 logger = logging.getLogger(__name__)
 
@@ -112,7 +110,7 @@ async def run(
     request: dict[str, Any] = {
         **metadata,
         "responses_create_params": build_responses_create_params(request_kwargs),
-        "policy_base_url": resolve_session_url(base_url),
+        "policy_base_url": openai_session_url(base_url),
     }
 
     try:

--- a/examples/experimental/nemo-gym/run.py
+++ b/examples/experimental/nemo-gym/run.py
@@ -52,10 +52,11 @@ class ScriptArgs(U.ExecuteTrainConfig):
 
     # NeMo Gym settings
     nemo_gym_url: str = os.environ.get("NEMO_GYM_URL", "http://localhost:12000")
-    # Trainer address reachable from the NeMo Gym host; only needed when that
-    # host cannot resolve the trainer's hostname (e.g. it dials back over a
-    # tailnet).
-    router_external_host: str = os.environ.get("MILES_ROUTER_EXTERNAL_HOST", "")
+    # Trainer address reachable from the NeMo Gym host; only needed when that host
+    # cannot resolve the trainer's hostname (e.g. it dials back over a tailnet).
+    # Sets MILES_NODE_EXTERNAL_IP for every node at once, so on a multi-node job
+    # leave it empty and have the deployment set that variable per pod instead.
+    node_external_ip: str = os.environ.get("MILES_NODE_EXTERNAL_IP", "")
 
 
 def cleanup():
@@ -183,8 +184,8 @@ def execute(args: ScriptArgs):
         "PYTHONPATH": f"{args.megatron_path}:{SCRIPT_DIR}:{U.repo_base_dir}",
         "NEMO_GYM_URL": args.nemo_gym_url,
     }
-    if args.router_external_host:
-        extra_env_vars["MILES_ROUTER_EXTERNAL_HOST"] = args.router_external_host
+    if args.node_external_ip:
+        extra_env_vars["MILES_NODE_EXTERNAL_IP"] = args.node_external_ip
 
     U.execute_train(
         train_args=train_args,

--- a/examples/experimental/openenv/openenv_agent_function.py
+++ b/examples/experimental/openenv/openenv_agent_function.py
@@ -25,7 +25,6 @@ Env vars:
                      terminated and scored reward 0 (bounds long-trajectory
                      stragglers that would otherwise stall the whole rollout batch).
   AGENT_MODEL_NAME   model name sent to the policy (default: "model")
-  MILES_ROUTER_EXTERNAL_HOST  optional host rewrite for off-cluster agents
 
 Server contract: the env server must run tbench2_env at or after the
 huggingface/OpenEnv#1025 merge (38b2a3135; install per the README) —
@@ -55,7 +54,8 @@ from collections.abc import Callable
 from typing import Any
 
 from openai import AsyncOpenAI
-from miles.rollout.agentic.session import resolve_session_url
+
+from miles.rollout.agentic.session import openai_session_url
 
 logger = logging.getLogger(__name__)
 
@@ -414,7 +414,7 @@ async def run_for_training(
     request_kwargs = request_kwargs or {}
     metadata = metadata or {}
 
-    session_url = resolve_session_url(base_url)
+    session_url = openai_session_url(base_url)
     model_name = os.getenv("AGENT_MODEL_NAME", os.getenv("SWE_AGENT_MODEL_NAME", "model"))
 
     policy = AsyncOpenAI(base_url=session_url, api_key="EMPTY")

--- a/examples/experimental/openenv/openenv_launch_common.py
+++ b/examples/experimental/openenv/openenv_launch_common.py
@@ -37,7 +37,7 @@ class LaunchArgs(Protocol):
     daytona_api_key_file: str
     e2b_api_key_file: str
     modal_config_file: str
-    router_external_host: str
+    node_external_ip: str
     miles_host_ip: str
 
     wandb_key: str
@@ -192,8 +192,8 @@ def apply_optional_env_vars(env: dict[str, str], args: LaunchArgs) -> None:
     """Add host-rewrite / Daytona-sandbox env vars when the args request them."""
     if args.miles_host_ip:
         env["MILES_HOST_IP"] = args.miles_host_ip
-    if args.router_external_host:
-        env["MILES_ROUTER_EXTERNAL_HOST"] = args.router_external_host
+    if args.node_external_ip:
+        env["MILES_NODE_EXTERNAL_IP"] = args.node_external_ip
     backend = resolve_sandbox_backend(args)
     if backend:
         spec = PROVIDER_CREDENTIALS[backend]

--- a/examples/experimental/openenv/run-openenv-tbench2.py
+++ b/examples/experimental/openenv/run-openenv-tbench2.py
@@ -108,9 +108,11 @@ class ScriptArgs(U.ExecuteTrainConfig):
     # loss masks, reward, multi-turn messages) to <dir>/rollout_data/{rollout_id}.pt
     # for post-hoc inspection via miles.utils.debug_utils.display_debug_rollout_data.
     dump_details: str = os.environ.get("OPENENV_DUMP_DETAILS", "")
-    # Optional host rewrite for the policy URL (only needed if the in-process
-    # agent cannot reach the session server at its raw base_url host).
-    router_external_host: str = os.environ.get("MILES_ROUTER_EXTERNAL_HOST", "")
+    # The address the in-process agent reaches the session server on, when its
+    # placed address does not route from there. Sets MILES_NODE_EXTERNAL_IP for
+    # every node at once, so on a multi-node job leave it empty and have the
+    # deployment set that variable per pod instead.
+    node_external_ip: str = os.environ.get("MILES_NODE_EXTERNAL_IP", "")
     # Leave empty so miles resolves the numeric LAN IP itself. sgl-router's Rust
     # binder rejects a hostname ("invalid socket address syntax"), and a numeric
     # base_url host keeps the in-process policy client off hostname DNS too.

--- a/examples/experimental/swe-agent-harbor-daytona/README.md
+++ b/examples/experimental/swe-agent-harbor-daytona/README.md
@@ -108,20 +108,22 @@ python examples/swe-agent-harbor-docker/run.py \
     --num-rollout 200 \
     --save-interval 10 \
     --agent-server-url http://127.0.0.1:11000 \
-    --router-external-host <trainer-address-reachable-from-agent-server> \
+    --node-external-ip <trainer-address-reachable-from-agent-server> \
     --save-traces-dir /path/to/traces \
     --wandb-project <your-wandb-project>
 ```
 
 For a smoke test, set `--num-rollout 1`.
 
-`--router-external-host` is the address the agent server uses to reach the Miles
-session server, substituted into the base URL handed to the agent. It only has
-to resolve from the agent-server host, so a hostname is fine — use one when the
-agent server reaches the trainer over a tailnet or other overlay. Do not confuse
-it with `--miles-host-ip`, which is bound locally on the trainer and must be an
-address that already exists on one of its interfaces. Ports 30000 and 31000 must
-be reachable from the agent-server host.
+`--node-external-ip` is the address the agent server uses to reach the Miles
+session server: it sets `MILES_NODE_EXTERNAL_IP` on every node, and the driver
+builds the base URL handed to the agent from it. It only has to resolve from
+the agent-server host, so a hostname is fine — use one when the agent server
+reaches the trainer over a tailnet or other overlay. Do not confuse it with
+`--miles-host-ip`, which is bound locally on the trainer and must be an address
+that already exists on one of its interfaces. Ports 30000 and 31000 must be
+reachable from the agent-server host. On a multi-node job see the network note
+in [the docker recipe](../../swe-agent-harbor-docker/README.md).
 
 ## Sizing the per-turn response cap
 

--- a/examples/experimental/terminus-compaction/README.md
+++ b/examples/experimental/terminus-compaction/README.md
@@ -132,10 +132,10 @@ python examples/experimental/terminus-compaction/run.py \
     --prompt-data /path/to/tb2_train_89.jsonl \
     --agent-server-url http://<agent-server>:11000 \
     --session-server-ip 0.0.0.0 \
-    --router-external-host <trainer-address-reachable-from-agent-server>
+    --node-external-ip <trainer-address-reachable-from-agent-server>
 ```
 
-`--session-server-ip` is the local bind address. `--router-external-host` is the address Harbor uses to call back into the session server and SGLang router; it must resolve from the agent-server host. The launcher starts 32 session-server workers on ports 30000-30031 and the SGLang router on port 31000, so allow inbound TCP connections to that range and port from the agent-server host.
+`--session-server-ip` is the local bind address. `--node-external-ip` is the address Harbor uses to call back into the session server and SGLang router; it must resolve from the agent-server host. The launcher starts 32 session-server workers on ports 30000-30031 and the SGLang router on port 31000, so allow inbound TCP connections to that range and port from the agent-server host.
 
 For a local smoke test, run Harbor on the trainer, use
 `--agent-server-url http://127.0.0.1:11000`, and set both session addresses to a

--- a/examples/experimental/terminus-compaction/run.py
+++ b/examples/experimental/terminus-compaction/run.py
@@ -15,7 +15,7 @@ Example:
         --output-dir /path/to/output \
         --agent-server-url http://agent-server.example:11000 \
         --session-server-ip 0.0.0.0 \
-        --router-external-host trainer.example
+        --node-external-ip trainer.example
 """
 
 import os
@@ -58,7 +58,11 @@ class ScriptArgs(U.ExecuteTrainConfig):
     agent_server_url: str = field(default_factory=lambda: os.environ.get("AGENT_SERVER_URL", "http://127.0.0.1:11000"))
     agent_model_name: str = field(default_factory=lambda: os.environ.get("AGENT_MODEL_NAME", "model"))
     agent_trial_timeout: int = 7200
-    router_external_host: str = field(default_factory=lambda: os.environ.get("MILES_ROUTER_EXTERNAL_HOST", ""))
+    # Sets MILES_NODE_EXTERNAL_IP for every node at once, so it addresses the right
+    # instance only while the session servers share a host. On a multi-node job leave
+    # it empty and have the deployment set that variable per pod, or leave it empty
+    # anyway when the placed addresses already route from the sandbox network.
+    node_external_ip: str = field(default_factory=lambda: os.environ.get("MILES_NODE_EXTERNAL_IP", ""))
     miles_host_ip: str = field(default_factory=lambda: os.environ.get("MILES_HOST_IP", ""))
     session_server_ip: str = field(default_factory=lambda: os.environ.get("MILES_SESSION_SERVER_IP", ""))
 
@@ -233,8 +237,8 @@ def _extra_env_vars(args: ScriptArgs) -> dict[str, str]:
         "AGENT_MODEL_NAME": args.agent_model_name,
         "AGENT_TRIAL_TIMEOUT": str(args.agent_trial_timeout),
     }
-    if args.router_external_host:
-        env["MILES_ROUTER_EXTERNAL_HOST"] = args.router_external_host
+    if args.node_external_ip:
+        env["MILES_NODE_EXTERNAL_IP"] = args.node_external_ip
     if args.miles_host_ip:
         env["MILES_HOST_IP"] = args.miles_host_ip
     return env

--- a/examples/swe-agent-harbor-docker/README.md
+++ b/examples/swe-agent-harbor-docker/README.md
@@ -105,7 +105,7 @@ python examples/swe-agent-harbor-docker/run.py \
     --num-rollout 200 \
     --save-interval 20 \
     --agent-server-url http://<agent-server>:30000 \
-    --router-external-host <trainer-host-reachable-from-agent-server> \
+    --node-external-ip <trainer-host-reachable-from-agent-server> \
     --miles-host-ip 0.0.0.0 \
     --save-traces-dir /path/to/traces
 ```
@@ -114,7 +114,9 @@ For a smoke test, set `--num-rollout 1`. Expect roughly 10 minutes per step at
 this shape; because synchronous rollout waits for the slowest trajectory in the
 batch, a step that draws an unusually slow task can take several times that.
 
-`--router-external-host` is the address Harbor sandboxes use to call the Miles session server and SGLang router. It must resolve and route from the agent-server machine. `--miles-host-ip 0.0.0.0` is useful when those services must accept connections forwarded from another host. The launcher starts 32 session-server workers on ports 30000-30031 and the SGLang router on port 31000, so ensure that range and port are reachable end to end; Tailscale is one option when the machines are on different networks.
+`--node-external-ip` is the address Harbor sandboxes use to call the Miles session server and SGLang router. It must resolve and route from the agent-server machine. `--miles-host-ip 0.0.0.0` is useful when those services must accept connections forwarded from another host. The launcher starts 32 session-server workers on ports 30000-30031 and the SGLang router on port 31000, so ensure that range and port are reachable end to end; Tailscale is one option when the machines are on different networks.
+
+`--node-external-ip` sets `MILES_NODE_EXTERNAL_IP` for every node at once, which reaches the right instance only while the session servers all sit on one host. On a multi-node job, leave the flag unset and have the deployment set that variable in each trainer pod to that node's own reachable address -- a tailscale sidecar's `tailscale ip -4`, for instance; a DNS name also works. Each node then reports its own, and Miles hands every sandbox the address of the one instance holding its session. Nothing is needed at all when the pod addresses already route from the sandbox network, which is the case whenever the sandbox platform is allowed the trainer's subnet.
 
 ## 4. Verify progress
 

--- a/examples/swe-agent-harbor-docker/run-glm47-flash-agentic-async.py
+++ b/examples/swe-agent-harbor-docker/run-glm47-flash-agentic-async.py
@@ -78,7 +78,11 @@ class ScriptArgs(U.ExecuteTrainConfig):
     agent_server_url: str = os.environ.get("AGENT_SERVER_URL", "http://localhost:8080")
     agent_model_name: str = os.environ.get("AGENT_MODEL_NAME", "model")
     harbor_tasks_dir: str = os.environ.get("HARBOR_TASKS_DIR", "/root/harbor_tasks")
-    router_external_host: str = os.environ.get("MILES_ROUTER_EXTERNAL_HOST", "")
+    # Sets MILES_NODE_EXTERNAL_IP for every node at once, so it addresses the right
+    # instance only while the session servers share a host. On a multi-node job leave
+    # it empty and have the deployment set that variable per pod, or leave it empty
+    # anyway when the placed addresses already route from the sandbox network.
+    node_external_ip: str = os.environ.get("MILES_NODE_EXTERNAL_IP", "")
     miles_host_ip: str = os.environ.get("MILES_HOST_IP", "")
 
     # Disaggregated fully-async settings
@@ -354,8 +358,8 @@ def execute(args: ScriptArgs):
         "HARBOR_TASKS_DIR": args.harbor_tasks_dir,
         **sglang_extra_env_vars,
     }
-    if args.router_external_host:
-        extra_env_vars["MILES_ROUTER_EXTERNAL_HOST"] = args.router_external_host
+    if args.node_external_ip:
+        extra_env_vars["MILES_NODE_EXTERNAL_IP"] = args.node_external_ip
     if args.miles_host_ip:
         extra_env_vars["MILES_HOST_IP"] = args.miles_host_ip
 

--- a/examples/swe-agent-harbor-docker/run.py
+++ b/examples/swe-agent-harbor-docker/run.py
@@ -9,7 +9,6 @@ Usage:
 """
 
 import os
-import socket
 import subprocess
 import time
 from dataclasses import dataclass
@@ -55,7 +54,11 @@ class ScriptArgs(U.ExecuteTrainConfig):
     )
     agent_model_name: str = os.environ.get("AGENT_MODEL_NAME", "model")
     harbor_tasks_dir: str = os.environ.get("HARBOR_TASKS_DIR", "/root/harbor_tasks")
-    router_external_host: str = os.environ.get("MILES_ROUTER_EXTERNAL_HOST", socket.gethostname())  # public IP
+    # Sets MILES_NODE_EXTERNAL_IP for every node at once, so it addresses the right
+    # instance only while the session servers share a host. On a multi-node job leave
+    # it empty and have the deployment set that variable per pod, or leave it empty
+    # anyway when the placed addresses already route from the sandbox network.
+    node_external_ip: str = os.environ.get("MILES_NODE_EXTERNAL_IP", "")
     miles_host_ip: str = os.environ.get("MILES_HOST_IP", "")  # optional cluster/pod IP override
 
     # W&B settings
@@ -235,9 +238,10 @@ def execute(args: ScriptArgs):
         "PYTHONPATH": f"{args.megatron_path}:{SCRIPT_DIR}:{miles_root}",
         "AGENT_SERVER_URL": args.agent_server_url,
         "AGENT_MODEL_NAME": args.agent_model_name,
-        "MILES_ROUTER_EXTERNAL_HOST": args.router_external_host,
         "HARBOR_TASKS_DIR": args.harbor_tasks_dir,
     }
+    if args.node_external_ip:
+        extra_env_vars["MILES_NODE_EXTERNAL_IP"] = args.node_external_ip
     if args.miles_host_ip:
         extra_env_vars["MILES_HOST_IP"] = args.miles_host_ip
 

--- a/examples/swe-agent-harbor-docker/run_glm52_lora_tb2_daytona.py
+++ b/examples/swe-agent-harbor-docker/run_glm52_lora_tb2_daytona.py
@@ -123,8 +123,12 @@ class ScriptArgs(U.ExecuteTrainConfig):
     agent_server_url: str = os.environ.get("AGENT_SERVER_URL", "http://localhost:8080")
     agent_model_name: str = os.environ.get("AGENT_MODEL_NAME", "model")
     harbor_tasks_dir: str = os.environ.get("HARBOR_TASKS_DIR", "/root/harbor_tasks")
+    # Sets MILES_NODE_EXTERNAL_IP for every node at once, so it addresses the right
+    # instance only while the session servers share a host. On a multi-node job leave
+    # it empty and have the deployment set that variable per pod, or leave it empty
+    # anyway when the placed addresses already route from the sandbox network.
     # sgl-router binds with a Rust SocketAddr parse, so this MUST be a numeric IP.
-    router_external_host: str = os.environ.get("MILES_ROUTER_EXTERNAL_HOST", "")
+    node_external_ip: str = os.environ.get("MILES_NODE_EXTERNAL_IP", "")
     miles_host_ip: str = os.environ.get("MILES_HOST_IP", "")
 
     # W&B settings
@@ -413,8 +417,8 @@ def execute(args: ScriptArgs):
         # engines would inherit the cap and OOM below --sglang-mem-fraction-static.
         "PYTORCH_CUDA_ALLOC_CONF": "garbage_collection_threshold:0.8,max_split_size_mb:512",
     }
-    if args.router_external_host:
-        extra_env_vars["MILES_ROUTER_EXTERNAL_HOST"] = args.router_external_host
+    if args.node_external_ip:
+        extra_env_vars["MILES_NODE_EXTERNAL_IP"] = args.node_external_ip
     if args.miles_host_ip:
         extra_env_vars["MILES_HOST_IP"] = args.miles_host_ip
 

--- a/examples/swe-agent-harbor-docker/swe_agent_function.py
+++ b/examples/swe-agent-harbor-docker/swe_agent_function.py
@@ -18,7 +18,7 @@ from typing import Any
 from urllib.parse import urlsplit
 
 import httpx
-from miles.rollout.agentic.session import resolve_session_url
+from miles.rollout.agentic.session import openai_session_url
 from miles.utils.http_utils import post
 
 logger = logging.getLogger(__name__)
@@ -80,8 +80,7 @@ async def run(
         os.getenv("SWE_AGENT_MODEL_NAME", "model"),
     )
 
-    session_url = resolve_session_url(base_url)
-    external_host = os.getenv("MILES_ROUTER_EXTERNAL_HOST")
+    session_url = openai_session_url(base_url)
 
     request: dict[str, Any] = {
         **metadata,
@@ -94,12 +93,10 @@ async def run(
     if max_seq_len is not None:
         request["max_seq_len"] = int(max_seq_len)
 
-    session_server_id = metadata.get("session_server_id")
-    if session_server_id is not None:
-        if external_host:
-            port = urlsplit(f"http://{session_server_id}").port
-            session_server_id = f"{external_host}:{port}"
-        request["session_server_id"] = session_server_id
+    if metadata.get("session_server_id") is not None:
+        # metadata's id names the owning instance on the cluster network. The agent
+        # server sees that instance the way base_url does, so name it the same way.
+        request["session_server_id"] = urlsplit(session_url).netloc
 
     session_server_instance_id = metadata.get("session_server_instance_id")
     if session_server_instance_id is not None:

--- a/miles/ray/rollout/router_manager.py
+++ b/miles/ray/rollout/router_manager.py
@@ -55,7 +55,8 @@ async def wait_session_server_ready(args):
     # /health probe, so a pick never has to line up with any other structure.
     args.session_server_instances = [
         SessionServerInstance(
-            addr=f"{x.host}:{x.port}",
+            addr=x.netloc,
+            external_addr=x.external_netloc,
             instance_id=compute_session_server_instance_id(args, instance_index),
         )
         for instance_index, x in enumerate(addrs)
@@ -63,4 +64,7 @@ async def wait_session_server_ready(args):
 
     for addr in addrs:
         await wait_tcp_ready_async(addr.host, addr.port, timeout=_SERVER_READY_TIMEOUT_SECS)
-    logger.info(f"Session servers ready at {[x.addr for x in args.session_server_instances]} ({len(addrs)} instances)")
+    logger.info(
+        f"Session servers ready at {[x.addr for x in args.session_server_instances]} ({len(addrs)} instances), "
+        f"externally at {[x.external_addr for x in args.session_server_instances]}"
+    )

--- a/miles/ray/specs/inference.py
+++ b/miles/ray/specs/inference.py
@@ -108,7 +108,7 @@ def spec_session_server(args) -> CommandWorkerSpec:
             num_workers_per_cell=1,
             num_gpus_per_worker=0,
             num_cpus_per_worker=0,
-            pin_to_head=True,
+            pin_to_head=args.pin_rollout_manager_to_head,
         ),
         launch_command=_compute_launch_command,
     )

--- a/miles/rollout/agentic/session.py
+++ b/miles/rollout/agentic/session.py
@@ -1,15 +1,12 @@
 """The session-scoped policy URL an agent function hands to its agent."""
 
-import os
-from urllib.parse import urlparse, urlunparse
 
+def openai_session_url(base_url: str) -> str:
+    """The OpenAI-compatible API root of a session: its base URL plus the ``/v1``
+    suffix OpenAI-style clients expect.
 
-def resolve_session_url(base_url: str) -> str:
-    """Build the OpenAI-compatible policy URL, rewriting host for off-cluster agents."""
-    session_url = f"{base_url}/v1"
-    external_host = os.getenv("MILES_ROUTER_EXTERNAL_HOST")
-    if external_host:
-        parsed = urlparse(session_url)
-        netloc = f"{external_host}:{parsed.port}" if parsed.port else external_host
-        session_url = urlunparse(parsed._replace(netloc=netloc))
-    return session_url
+    ``base_url`` already names the session server as the agent reaches it (see
+    ``OpenAIEndpointTracer.agent_base_url``), so nothing is rewritten here. Shared
+    by the agent-function legs so the suffix cannot drift between them.
+    """
+    return f"{base_url}/v1"

--- a/miles/rollout/generate_hub/agentic_tool_call.py
+++ b/miles/rollout/generate_hub/agentic_tool_call.py
@@ -74,7 +74,7 @@ async def generate(input: GenerateFnInput) -> GenerateFnOutput:
     try:
         logger.debug(f"{log_prefix} Starting agent function call")
         agent_metadata = await custom_agent_function(
-            base_url=tracer.base_url,
+            base_url=tracer.agent_base_url,
             prompt=input.sample.prompt,
             request_kwargs=build_chat_request_kwargs(input.sampling_params),
             metadata=metadata,

--- a/miles/rollout/generate_utils/openai_endpoint_utils.py
+++ b/miles/rollout/generate_utils/openai_endpoint_utils.py
@@ -28,10 +28,14 @@ class OpenAIEndpointTracer:
         session_id: str,
         session_server_instance_id: str | None = None,
         samples_wire_fields: tuple[str, ...] = COMPUTED_FIELDS,
+        agent_router_url: str | None = None,
     ):
         self.router_url = router_url
         self.session_id = session_id
         self.base_url = f"{router_url}/sessions/{session_id}"
+        # What the agent function hands its agent, which may run outside the cluster.
+        # The driver's own calls stay on base_url and off any external path.
+        self.agent_base_url = f"{agent_router_url or router_url}/sessions/{session_id}"
         self.session_server_instance_id = session_server_instance_id
         # The samples-wire allowlist must match the server's encode: v1 default,
         # extended under --use-session-server v2 (create() selects from args;
@@ -51,7 +55,9 @@ class OpenAIEndpointTracer:
                 "session_server_instances is not set. Pass --use-session-server to start the session server."
             )
         # The only routing decision in the system: pick the owning instance once
-        # per session; every later touch of the session reuses this URL.
+        # per session; every later touch of the session reuses this URL. The record
+        # carries both views of that one instance, so the agent and the driver can
+        # never split across two.
         instance = random.choice(instances)
         session_url = instance.url
         response = await post(f"{session_url}/sessions", {}, action="post")
@@ -62,6 +68,7 @@ class OpenAIEndpointTracer:
             session_id=session_id,
             session_server_instance_id=instance.instance_id,
             samples_wire_fields=COMPUTED_FIELDS_V2 if use_v2 else COMPUTED_FIELDS,
+            agent_router_url=instance.external_url,
         )
 
     async def collect_samples(

--- a/miles/rollout/session/types.py
+++ b/miles/rollout/session/types.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from miles.utils.pydantic_utils import FrozenStrictBaseModel
 
@@ -13,11 +13,25 @@ class SessionServerInstance(FrozenStrictBaseModel):
 
     # ``host:port`` the driver dials.
     addr: str
+    # ``host:port`` a peer outside the cluster dials; defaults to ``addr``, which
+    # is what a deployment whose node addresses already route from outside wants.
+    external_addr: str = None  # type: ignore[assignment]  # filled by the validator below
     instance_id: str | None = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def _default_external_addr_to_addr(cls, values: dict) -> dict:
+        if isinstance(values, dict) and not values.get("external_addr"):
+            values = {**values, "external_addr": values.get("addr")}
+        return values
 
     @property
     def url(self) -> str:
         return f"http://{self.addr}"
+
+    @property
+    def external_url(self) -> str:
+        return f"http://{self.external_addr}"
 
 
 class SessionRecord(BaseModel):

--- a/miles/utils/misc.py
+++ b/miles/utils/misc.py
@@ -69,6 +69,21 @@ def get_current_node_ip():
     return address
 
 
+MILES_NODE_EXTERNAL_IP_ENV = "MILES_NODE_EXTERNAL_IP"
+
+
+def get_node_external_ip() -> str | None:
+    """The address off-cluster peers reach this node on (a DNS name also works),
+    or None when its own address already routes from there.
+
+    The deployment supplies this per node -- a tailscale sidecar or an init
+    container writing the interface it joined. Passing it through ray's
+    runtime_env instead would give every node one shared value, which only
+    addresses the right instance while all of them sit on one host.
+    """
+    return os.environ.get(MILES_NODE_EXTERNAL_IP_ENV) or None
+
+
 def get_free_port(start_port=10000, consecutive=1):
     # find the port where port, port + 1, port + 2, ... port + consecutive - 1 are all available,
     # scanning upwards from start_port and wrapping around once the ports run out
@@ -119,6 +134,10 @@ class NodeProbeMixin:
     @staticmethod
     def _get_node_ip() -> str:
         return os.getenv(MILES_HOST_IP_ENV) or get_current_node_ip()
+
+    @staticmethod
+    def _get_node_external_ip() -> str | None:
+        return get_node_external_ip()
 
     @staticmethod
     def _get_free_port_block(*, start_port: int, count: int) -> int:

--- a/miles/utils/test_utils/mock_sglang_engine.py
+++ b/miles/utils/test_utils/mock_sglang_engine.py
@@ -95,6 +95,10 @@ class MockSGLangEngine:
         self._record("_get_node_ip", (), {})
         return NodeProbeMixin._get_node_ip()
 
+    def _get_node_external_ip(self):
+        self._record("_get_node_external_ip", (), {})
+        return NodeProbeMixin._get_node_external_ip()
+
     def _to_local_gpu_ids(self, *, gpu_ids: list[int]) -> list[int]:
         self._record("_to_local_gpu_ids", (), {"gpu_ids": gpu_ids})
         return list(range(len(gpu_ids)))

--- a/miles/utils/workers/ray_worker_manager.py
+++ b/miles/utils/workers/ray_worker_manager.py
@@ -250,8 +250,9 @@ class _BaseActorManager(Generic[SpecT]):
     async def alloc_ports(self) -> None:
         allocated: NamedHostAndPorts = {}
 
-        node_ip, self.local_gpu_ids = await asyncio.gather(
+        node_ip, external_ip, self.local_gpu_ids = await asyncio.gather(
             self.actor_handle._get_node_ip.remote(),
+            self.actor_handle._get_node_external_ip.remote(),
             self.actor_handle._to_local_gpu_ids.remote(gpu_ids=self.gpu_ids),
         )
         for port_info in self.spec.port_infos:
@@ -264,7 +265,11 @@ class _BaseActorManager(Generic[SpecT]):
             else:
                 port = port_info.static_port + (self.parent.cell_index if port_info.offset_by_cell else 0)
                 await self._assert_static_port_is_free(port=port, port_name=port_info.name, node_ip=node_ip)
-            allocated[port_info.name] = HostAndPort(host=_wrap_ipv6(node_ip), port=port)
+            allocated[port_info.name] = HostAndPort(
+                host=_wrap_ipv6(node_ip),
+                port=port,
+                external_host=_wrap_ipv6(external_ip) if external_ip else None,
+            )
 
         self.self_addrs = allocated
 

--- a/miles/utils/workers/worker_spec.py
+++ b/miles/utils/workers/worker_spec.py
@@ -71,10 +71,27 @@ class BaseWorkerSpec(FrozenStrictBaseModel):
 class HostAndPort(FrozenStrictBaseModel):
     host: str
     port: int
+    # The host that reaches this worker from outside the cluster, when the placed
+    # host does not route from there. The node reports its own value, so instances
+    # on different nodes carry different ones.
+    external_host: str | None = None
+
+    @property
+    def netloc(self) -> str:
+        return f"{self.host}:{self.port}"
+
+    @property
+    def external_netloc(self) -> str:
+        """``host:port`` for a peer outside the cluster.
+
+        Falls back to the placed address, which is what a deployment whose node
+        addresses already route from outside wants.
+        """
+        return f"{self.external_host or self.host}:{self.port}"
 
     @property
     def addr(self):
-        return f"http://{self.host}:{self.port}"
+        return f"http://{self.netloc}"
 
 
 # dict key: name

--- a/tests/fast/examples/experimental/nemo_gym/test_nemogym_agent_function.py
+++ b/tests/fast/examples/experimental/nemo_gym/test_nemogym_agent_function.py
@@ -47,7 +47,6 @@ def test_run_body_carries_instance_fields_and_policy_override(monkeypatch):
     captured = {}
     monkeypatch.setattr(naf, "post_json", _capture_post(captured))
     monkeypatch.setenv("NEMO_GYM_URL", "http://gym:12000")
-    monkeypatch.delenv("MILES_ROUTER_EXTERNAL_HOST", raising=False)
 
     run_async(
         naf.run(
@@ -83,16 +82,6 @@ def test_sampling_params_omitted_when_unset(monkeypatch):
     run_async(naf.run(base_url="http://t:1/sessions/s", prompt="", request_kwargs={}, metadata={}))
 
     assert captured["payload"]["responses_create_params"] == {"input": []}
-
-
-def test_external_host_rewrites_session_url(monkeypatch):
-    captured = {}
-    monkeypatch.setattr(naf, "post_json", _capture_post(captured))
-    monkeypatch.setenv("MILES_ROUTER_EXTERNAL_HOST", "100.64.0.7")
-
-    run_async(naf.run(base_url="http://pod-hostname:30000/sessions/s1", prompt="", metadata={}))
-
-    assert captured["payload"]["policy_base_url"] == "http://100.64.0.7:30000/sessions/s1/v1"
 
 
 # --- response mapping -----------------------------------------------------

--- a/tests/fast/examples/experimental/terminus_compaction/test_run.py
+++ b/tests/fast/examples/experimental/terminus_compaction/test_run.py
@@ -20,7 +20,7 @@ def args():
         model_dir="/models",
         output_dir="/output",
         session_server_ip="0.0.0.0",
-        router_external_host="trainer.example",
+        node_external_ip="trainer.example",
         agent_server_url="http://agent.example:11000",
     )
 
@@ -68,15 +68,15 @@ def test_agent_runtime_environment_reuses_harbor_adapters(args):
         "AGENT_SERVER_URL": "http://agent.example:11000",
         "AGENT_MODEL_NAME": "model",
         "AGENT_TRIAL_TIMEOUT": "7200",
-        "MILES_ROUTER_EXTERNAL_HOST": "trainer.example",
+        "MILES_NODE_EXTERNAL_IP": "trainer.example",
     }
 
 
 def test_agent_runtime_environment_omits_optional_hosts(args):
-    args.router_external_host = ""
+    args.node_external_ip = ""
     args.miles_host_ip = ""
 
     env = run._extra_env_vars(args)
 
-    assert "MILES_ROUTER_EXTERNAL_HOST" not in env
+    assert "MILES_NODE_EXTERNAL_IP" not in env
     assert "MILES_HOST_IP" not in env

--- a/tests/fast/ray/rollout/test_router_manager.py
+++ b/tests/fast/ray/rollout/test_router_manager.py
@@ -201,6 +201,54 @@ class TestWaitSessionServerReady:
         ]
         assert waited == [("10.0.0.1", 5005), ("10.0.0.2", 5005)]
 
+    async def test_instances_carry_each_host_external_address(self, monkeypatch):
+        """Every instance keeps its own external address, so an off-cluster agent reaches
+        the one instance that owns its session rather than whichever one an address
+        shared by all of them happens to point at."""
+
+        class _FakeProvider:
+            def __init__(self):
+                self._counter = 0
+
+            async def get_addrs(self, worker_name: str) -> NamedHostAndPorts:
+                self._counter += 1
+                return {
+                    "primary": HostAndPort(
+                        host=f"10.0.0.{self._counter}",
+                        port=5005,
+                        external_host=f"100.64.0.{self._counter}",
+                    )
+                }
+
+        waited: list[tuple[str, int]] = []
+        monkeypatch.setattr(
+            "miles.ray.rollout.router_manager.RayWorkerProvider",
+            SimpleNamespace(create=lambda: _FakeProvider()),
+        )
+        monkeypatch.setattr(
+            "miles.ray.rollout.router_manager.wait_tcp_ready_async",
+            _recording_probe(waited),
+        )
+
+        args = make_args(
+            use_session_server=True,
+            hf_checkpoint="/fake/model",
+            session_server_workers=2,
+            run_uuid="00112233445566aa",
+        )
+        await wait_session_server_ready(args)
+
+        assert args.session_server_instances == [
+            SessionServerInstance(
+                addr="10.0.0.1:5005", external_addr="100.64.0.1:5005", instance_id="00112233445566aa-0"
+            ),
+            SessionServerInstance(
+                addr="10.0.0.2:5005", external_addr="100.64.0.2:5005", instance_id="00112233445566aa-1"
+            ),
+        ]
+        # Readiness is the driver's own probe, so it runs against the cluster addresses.
+        assert waited == [("10.0.0.1", 5005), ("10.0.0.2", 5005)]
+
     async def test_one_unreachable_instance_fails_the_whole_readiness_wait(self, monkeypatch):
         """A single session server whose port never opens fails startup even if its siblings are up."""
 

--- a/tests/fast/ray/specs/test_inference.py
+++ b/tests/fast/ray/specs/test_inference.py
@@ -180,10 +180,9 @@ class TestComputeSpecSessionServer:
         assert config.instance_id == f"{args.run_uuid}-1"
 
     def test_it_reserves_no_cpu_on_the_head_node(self):
-        """Pinned to the head unconditionally, a CPU reservation would leave it pending forever on a head started with --num-cpus=0."""
+        """When pinned to the head, a CPU reservation would leave it pending forever on a head started with --num-cpus=0."""
         spec = spec_session_server(_make_session_server_args())
 
-        assert spec.scheduling.pin_to_head is True
         assert spec.scheduling.num_cpus_per_worker == 0
 
     def test_disabled_schedules_zero_cells(self):
@@ -528,15 +527,16 @@ class TestInferenceSpecPinToHead:
         assert router.scheduling.pin_to_head is pinned
 
     @pytest.mark.parametrize("pinned", [False, True])
-    def test_the_session_servers_are_always_pinned_to_the_head_node(self, pinned: bool):
-        """Session servers live on the driver host whatever the rollout manager flag says, as on main."""
+    def test_the_session_server_spec_follows_the_rollout_manager_flag(self, pinned: bool):
+        """Off-cluster agents dial each instance's own external address, so the servers no
+        longer need one shared host; pinning is the operator's choice again."""
         from miles.ray.specs.inference import spec_session_server
 
         args = _make_pin_args(pinned=pinned)
 
         session = spec_session_server(args)
 
-        assert session.scheduling.pin_to_head is True
+        assert session.scheduling.pin_to_head is pinned
 
 
 def _make_pin_args(*, pinned: bool):

--- a/tests/fast/rollout/agentic/test_session.py
+++ b/tests/fast/rollout/agentic/test_session.py
@@ -1,21 +1,11 @@
 import subprocess
 import sys
-from miles.rollout.agentic.session import resolve_session_url
+
+from miles.rollout.agentic.session import openai_session_url
 
 
-def test_appends_v1_to_the_session_url(monkeypatch):
-    monkeypatch.delenv("MILES_ROUTER_EXTERNAL_HOST", raising=False)
-    assert resolve_session_url("http://10.0.0.1:30000/sessions/abc") == "http://10.0.0.1:30000/sessions/abc/v1"
-
-
-def test_external_host_replaces_the_host_and_keeps_the_port(monkeypatch):
-    monkeypatch.setenv("MILES_ROUTER_EXTERNAL_HOST", "trainer.tailnet")
-    assert resolve_session_url("http://10.0.0.1:30000/sessions/abc") == "http://trainer.tailnet:30000/sessions/abc/v1"
-
-
-def test_external_host_without_a_port(monkeypatch):
-    monkeypatch.setenv("MILES_ROUTER_EXTERNAL_HOST", "trainer.tailnet")
-    assert resolve_session_url("http://10.0.0.1/sessions/abc") == "http://trainer.tailnet/sessions/abc/v1"
+def test_appends_v1_to_the_session_url():
+    assert openai_session_url("http://10.0.0.1:30000/sessions/abc") == "http://10.0.0.1:30000/sessions/abc/v1"
 
 
 def test_shared_package_is_torch_free():

--- a/tests/fast/rollout/generate_hub/test_agentic_v2.py
+++ b/tests/fast/rollout/generate_hub/test_agentic_v2.py
@@ -15,6 +15,7 @@ class _Tracer:
     session_server_id = "127.0.0.1:12345"
     session_server_instance_id = None
     base_url = "http://127.0.0.1:12345/sessions/sid-1"
+    agent_base_url = base_url
 
     def __init__(self, reply=None, error=None):
         self.reply = reply

--- a/tests/fast/rollout/generate_utils/test_openai_endpoint_utils.py
+++ b/tests/fast/rollout/generate_utils/test_openai_endpoint_utils.py
@@ -132,6 +132,47 @@ class TestOpenAIEndpointTracerCreate:
         assert tracer.session_server_instance_id == "instance-b"
 
     @pytest.mark.asyncio
+    @pytest.mark.asyncio
+    async def test_agent_url_names_the_same_instance_from_outside_the_cluster(self, monkeypatch):
+        """The agent's URL and the driver's URL are the chosen record's two views of one
+        instance, so a session is never opened on one instance and dialed on another."""
+        posted: list[str] = []
+
+        async def fake_post(url: str, payload: dict, action: str = "post"):
+            posted.append(url)
+            return {"session_id": "session-abc"}
+
+        monkeypatch.setattr("miles.rollout.generate_utils.openai_endpoint_utils.post", fake_post)
+        monkeypatch.setattr("miles.rollout.generate_utils.openai_endpoint_utils.random.choice", lambda xs: xs[1])
+
+        args = SimpleNamespace(
+            session_server_instances=[
+                SessionServerInstance(addr="10.0.0.1:5005", external_addr="100.64.0.1:5005"),
+                SessionServerInstance(addr="10.0.0.2:5005", external_addr="100.64.0.2:5005"),
+            ],
+        )
+        tracer = await OpenAIEndpointTracer.create(args)
+
+        # The session is opened over the cluster network, not the external one.
+        assert posted == ["http://10.0.0.2:5005/sessions"]
+        assert tracer.base_url == "http://10.0.0.2:5005/sessions/session-abc"
+        assert tracer.agent_base_url == "http://100.64.0.2:5005/sessions/session-abc"
+
+    @pytest.mark.asyncio
+    async def test_agent_url_falls_back_to_the_cluster_address(self, monkeypatch):
+        """A record built without an external address serves both views from the placed
+        one -- no external address configured means the agent dials what the driver dials."""
+
+        async def fake_post(url: str, payload: dict, action: str = "post"):
+            return {"session_id": "session-abc"}
+
+        monkeypatch.setattr("miles.rollout.generate_utils.openai_endpoint_utils.post", fake_post)
+
+        args = SimpleNamespace(session_server_instances=[SessionServerInstance(addr="10.0.0.1:5005")])
+        tracer = await OpenAIEndpointTracer.create(args)
+
+        assert tracer.agent_base_url == tracer.base_url
+
     @pytest.mark.parametrize(
         "addrs_kwargs", [{}, {"session_server_instances": None}, {"session_server_instances": []}]
     )

--- a/tests/fast/utils/test_misc.py
+++ b/tests/fast/utils/test_misc.py
@@ -125,6 +125,17 @@ class TestGetGpuUuids:
 
 
 class TestNodeProbeMixin:
+    def test_get_node_external_ip_is_absent_until_the_node_sets_it(self, monkeypatch):
+        """A node without the env var reports None, which keeps its placed address in use."""
+        monkeypatch.delenv("MILES_NODE_EXTERNAL_IP", raising=False)
+        assert NodeProbeMixin._get_node_external_ip() is None
+
+        monkeypatch.setenv("MILES_NODE_EXTERNAL_IP", "")
+        assert NodeProbeMixin._get_node_external_ip() is None
+
+        monkeypatch.setenv("MILES_NODE_EXTERNAL_IP", "100.64.0.7")
+        assert NodeProbeMixin._get_node_external_ip() == "100.64.0.7"
+
     def test_get_node_ip_returns_nonempty_string(self):
         """The node ip probe answers with a usable address string."""
         node_ip = NodeProbeMixin._get_node_ip()

--- a/tests/fast/utils/workers/fake_ray.py
+++ b/tests/fast/utils/workers/fake_ray.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass, field, replace
 from typing import Any
 
 _ASYNC_METHOD_NODE_IP = "_get_node_ip"
+_ASYNC_METHOD_NODE_EXTERNAL_IP = "_get_node_external_ip"
 _ASYNC_METHOD_FREE_PORT_BLOCK = "_get_free_port_block"
 _ASYNC_METHOD_IS_PORT_AVAILABLE = "_is_port_available"
 _ASYNC_METHOD_TO_LOCAL_GPU_IDS = "_to_local_gpu_ids"
@@ -122,6 +123,9 @@ class FakeRayModule:
 @dataclass
 class FakeRayCluster:
     node_ips: tuple[str, ...] = ("10.0.0.1",)
+    # node ip -> the address off-cluster peers reach that node on; a node absent
+    # from the mapping reports None, like one whose deployment set nothing.
+    node_external_ips: dict[str, str] = field(default_factory=dict)
     base_port: int = 15000
     handles: list[FakeRayActorHandle] = field(default_factory=list)
     calls: list[FakeRayActorCall] = field(default_factory=list)
@@ -191,6 +195,8 @@ class FakeRayCluster:
     def _compute_value(self, *, handle: FakeRayActorHandle, method: str, kwargs: dict[str, Any]) -> Any:
         if method == _ASYNC_METHOD_NODE_IP:
             return handle.node_ip
+        if method == _ASYNC_METHOD_NODE_EXTERNAL_IP:
+            return self.node_external_ips.get(handle.node_ip)
         if method == _ASYNC_METHOD_TO_LOCAL_GPU_IDS:
             # a worker whose visibility mask hides the leading gpus sees itself starting at 0
             return list(range(len(kwargs["gpu_ids"])))

--- a/tests/fast/utils/workers/real_ray/test_ray_worker_manager.py
+++ b/tests/fast/utils/workers/real_ray/test_ray_worker_manager.py
@@ -42,6 +42,7 @@ class TestLaunchOnRealRay:
             assert record["context"]["self_addrs"]["primary"] == {
                 "host": advertised.host,
                 "port": advertised.port,
+                "external_host": advertised.external_host,
             }
 
     def test_the_advertised_address_is_one_the_worker_can_serve_on(self, manager_factory, worker_probe_factory):
@@ -122,7 +123,11 @@ class TestNamedManagerActor:
         addr = (await RayWorkerProvider.create().get_addrs(worker_name="router-0-0"))["primary"]
 
         assert isinstance(addr, HostAndPort)
-        assert records["0-0"]["context"]["self_addrs"]["primary"] == {"host": addr.host, "port": addr.port}
+        assert records["0-0"]["context"]["self_addrs"]["primary"] == {
+            "host": addr.host,
+            "port": addr.port,
+            "external_host": addr.external_host,
+        }
         wait_tcp_ready(addr.host, addr.port, timeout=30)
 
     def test_an_unknown_worker_name_is_not_answered_with_another_workers_address(
@@ -340,7 +345,7 @@ class TestWorkerInfosOnRealRay:
         assert [info.gpu_ids for info in infos] == [[], []]
         for worker_in_cell_index, info in enumerate(infos):
             recorded = records[f"1-{worker_in_cell_index}"]["context"]["self_addrs"]["primary"]
-            assert {"host": info.self_addrs["primary"].host, "port": info.self_addrs["primary"].port} == recorded
+            assert info.self_addrs["primary"].model_dump() == recorded
             node_ip = await info.handle._get_node_ip()
             assert info.self_addrs["primary"].host.strip("[]") == node_ip
 

--- a/tests/fast/utils/workers/test_ray_worker_manager.py
+++ b/tests/fast/utils/workers/test_ray_worker_manager.py
@@ -281,6 +281,20 @@ class TestInitAllocatesPorts:
 
         assert manager.get_worker_addrs("router-0-0")["primary"].host == "10.1.2.3"
 
+    async def test_the_node_reported_external_address_reaches_the_worker_addr(self, fake_ray_cluster: FakeRayCluster):
+        """Each worker carries the external address its own node reported; a node that
+        reported none leaves the field unset and the placed address serves both views."""
+        fake_ray_cluster.use_node_ips("10.0.0.1", "10.0.0.2")
+        fake_ray_cluster.node_external_ips = {"10.0.0.1": "100.64.0.1"}
+        manager = await _launch([_make_spec("session-server", num_cells=2)])
+
+        with_external = manager.get_worker_addrs("session-server-0-0")["primary"]
+        without = manager.get_worker_addrs("session-server-1-0")["primary"]
+        assert with_external.external_host == "100.64.0.1"
+        assert with_external.external_netloc == f"100.64.0.1:{with_external.port}"
+        assert without.external_host is None
+        assert without.external_netloc == without.netloc
+
     async def test_ipv6_hosts_are_bracketed(self, fake_ray_cluster: FakeRayCluster):
         """An ipv6 node address is advertised in url-safe bracketed form."""
         fake_ray_cluster.use_node_ips("2001:db8::7")


### PR DESCRIPTION
Answers the multi-host question on #2305 ([comment](https://github.com/radixark/miles/pull/2305#issuecomment-5432764485)) by making the combination work rather than forbidding it.

## What is missing

#2305 lets the session servers sit on more than one host. Reaching them from outside the cluster was never built for that: the off-cluster legs (Harbor, OpenEnv, NeMo Gym) each rewrite the host of the URL they are handed to `MILES_ROUTER_EXTERNAL_HOST` — **one address, which can only ever point at one machine**. Spread the instances over several nodes and no single value reaches them all: the rewrite has replaced the one field that tells them apart. The interim answer on `main` pins every session server back onto the head node, fencing off the capability #2305 added.

## The approach: record the external view at the source

Each node reports the address that reaches it, read from `MILES_NODE_EXTERNAL_IP` **in that node's own environment** — the probe runs on the node, so every node reports its own value, the way a kubernetes node carries its own `ExternalIP`. Nothing has to hold a node-to-node table, which a dynamically scheduled pod could not fill in anyway: its address only exists after placement.

- `HostAndPort` gains `external_host`, falling back to the placed address — a deployment whose node addresses already route from the sandbox network needs no configuration at all.
- `SessionServerInstance` (#3108) gains `external_addr`; the tracer splits `base_url` (the driver's own calls) from `agent_base_url` (handed to the agent). Both views come from the one chosen record, so the two never name different instances, and the driver's traffic never leaves the cluster network.
- The legs stop rewriting: the URL they receive already names the instance as they reach it. `MILES_ROUTER_EXTERNAL_HOST` is removed; `resolve_session_url` keeps only the shared `/v1` join, renamed `openai_session_url`.
- With the rewrite gone the pin has nothing left to guard, so the session servers follow `--pin-rollout-manager-to-head` again instead of being pinned unconditionally.

The launcher flag is now `--node-external-ip`: one value for every node at once, correct only while the instances share a host, as its comment says. Its Harbor default changed from `socket.gethostname()` to empty, so it no longer overrides what a deployment sets per pod.

## Stacked on

#3108 (the session servers as one list of instance records). This PR adds the `external_addr` field to that record; as separate lists the external view would have been a third structure to keep aligned.

## Tests

**E2E smoke — passed (2026-09-04)**, on this stack: two-node ray cluster (8×H200 head + CPU-only second node), each node reporting its own tailnet address via `MILES_NODE_EXTERNAL_IP`; openenv e2b leg against the internal AgentENV sandbox service, GLM-4.7-Flash GRPO. Ray spread the 32 session servers across both nodes; the driver published each instance with its own node's external address; agents dialed those external addresses across nodes — 600+ session calls in the final run, zero `SessionNotFoundError` (3,000+ across all runs); a full train step completed with real rewards from the sandbox verifier (`rollout/raw_reward 0.375`, `train_step outcome=NORMAL valid_step=true`). Every failure along the way was test-rig or sandbox-provider territory (asymmetric node envs, orphaned processes between reruns, AgentENV#12/#15) — no defect surfaced in this stack's code.

Not executed — no torch on this machine. `ruff`, `isort`, `black` and `py_compile` are clean; the record and tracer paths were exercised under python 3.12:

```
OK record carries both views; one choice, never split
```

New cases cover the record's external field and its fallback, the worker manager threading each node's reported address into its workers, the driver publishing per-node external addresses, and the env-var contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
