### PR TITLE
perf(memory): toggle expandable segments around the training step

### DIFF
--- a/miles/backends/megatron_utils/actor.py
+++ b/miles/backends/megatron_utils/actor.py
@@ -23,7 +23,7 @@ from miles.utils.context_utils import with_defer
 from miles.utils.distributed_utils import get_gloo_group
 from miles.utils.ft_utils.indep_dp import IndepDPInfo
 from miles.utils.hf_config import load_hf_config
-from miles.utils.memory_utils import clear_memory, print_memory
+from miles.utils.memory_utils import clear_memory, expandable_segments_during_training, print_memory
 from miles.utils.multi_lora import is_multi_lora_enabled
 from miles.utils.processing_utils import load_tokenizer
 from miles.utils.ray_utils import Box
@@ -431,13 +431,14 @@ class MegatronTrainRayActor(TrainRayActor):
                 with timer("critic_train"):
                     result = self.train_critic(rollout_id, rollout_data)
             else:
-                result = self.train_actor(
-                    rollout_id,
-                    rollout_data,
-                    external_data=external_data,
-                    witness_info=witness_info,
-                    attempt=attempt,
-                )
+                with expandable_segments_during_training():
+                    result = self.train_actor(
+                        rollout_id,
+                        rollout_data,
+                        external_data=external_data,
+                        witness_info=witness_info,
+                        attempt=attempt,
+                    )
 
             return result
 

--- a/miles/utils/memory_utils.py
+++ b/miles/utils/memory_utils.py
@@ -1,10 +1,35 @@
+import contextlib
 import gc
 import logging
+import os
 
 import torch
 import torch.distributed as dist
 
 logger = logging.getLogger(__name__)
+
+_EXPANDABLE_DURING_TRAIN = os.environ.get("MILES_EXPANDABLE_SEGMENTS_DURING_TRAIN", "0") == "1"
+
+
+def _set_expandable_segments(enabled: bool) -> None:
+    setting = f"expandable_segments:{'True' if enabled else 'False'}"
+    try:
+        torch._C._accelerator_setAllocatorSettings(setting)
+    except AttributeError:
+        torch.cuda.memory._set_allocator_settings(setting)
+
+
+@contextlib.contextmanager
+def expandable_segments_during_training():
+    if not _EXPANDABLE_DURING_TRAIN:
+        yield
+        return
+    _set_expandable_segments(True)
+    try:
+        yield
+    finally:
+        clear_memory()
+        _set_expandable_segments(False)
 
 
 def clear_memory(clear_host_memory: bool = False):


### PR DESCRIPTION
## Summary

- Enable PyTorch's `expandable_segments` allocator mode during actor training and disable it before offload/rollout, gated by `MILES_EXPANDABLE_SEGMENTS_DURING_TRAIN=1` (default off)
- Uses the runtime allocator API (`torch._C._accelerator_setAllocatorSettings`) rather than `PYTORCH_ALLOC_CONF` so the setting does not propagate to SGLang child processes, which would break IPC weight transfer and `torch_memory_saver` offloading

### Known limitation under colocate

In colocated mode, tensors still referenced when the window closes (e.g. `train_actor`'s return value) land in VMM segments that `torch_memory_saver`'s `pause()` cannot reach (it hooks `hipMalloc`/`hipFree`, not `hipMemCreate`/`hipMemMap`). This raises the device-level peak during rollout. The training-phase peak still drops, so the net effect depends on which phase is the bottleneck. This is a pre-existing TMS limitation, not introduced by this change; a follow-up could extend the window to include `offload_train` or release the training output before the window closes.