### PR TITLE
feat(dsv4): run the sparse-MLA and indexer kernels on a 64 KiB shared-memory GPU

### DIFF
--- a/miles_plugins/models/deepseek_v4/ops/kernel/tilelang_indexer_fwd.py
+++ b/miles_plugins/models/deepseek_v4/ops/kernel/tilelang_indexer_fwd.py
@@ -133,6 +133,40 @@ def _make_causal_cu_seqlens(seq_len_q, seq_len_kv, compress_ratio, device):
     return cu_seqlen_ks, cu_seqlen_ke
 
 
+_SHARED_MEM_ERROR = "exceeds device limit"
+_fitted_block_N: dict[tuple, int] = {}
+
+
+def _indexer_fwd_within_shared_mem(heads, index_dim, block_N=256):
+    """Build tl_indexer_fwd_impl, halving block_N until its shared memory fits this GPU.
+
+    index_k_shared is [block_N, index_dim] bf16 and index_q_shared is [block_Q*heads, index_dim];
+    at the tuned block_N=256 that asks for 96 KiB, which fits gfx950's 160 KiB LDS but not the 64 KiB
+    of gfx942 (MI300/MI308). block_N only sets how much of the KV axis one workgroup sweeps per
+    iteration, so halving it costs performance, not correctness. Memoized per shape.
+    """
+    key = (heads, index_dim, block_N)
+    if key in _fitted_block_N:
+        return tl_indexer_fwd_impl(heads=heads, index_dim=index_dim, block_N=_fitted_block_N[key])
+
+    fitted = block_N
+    while True:
+        try:
+            kernel = tl_indexer_fwd_impl(heads=heads, index_dim=index_dim, block_N=fitted)
+        except RuntimeError as e:
+            if _SHARED_MEM_ERROR not in str(e) or fitted <= 32:
+                raise
+            fitted //= 2
+            continue
+        _fitted_block_N[key] = fitted
+        if fitted != block_N:
+            print(
+                f"[tl_indexer_fwd] shared memory forced block_N={fitted} on this GPU " f"(requested {block_N})",
+                flush=True,
+            )
+        return kernel
+
+
 def indexer_fwd_interface(q, kv, weights, cu_seqlen_ks, cu_seqlen_ke, clean_logits=True):
     """Forward interface matching GLM-5's API but for a single batch element.
 
@@ -150,7 +184,7 @@ def indexer_fwd_interface(q, kv, weights, cu_seqlen_ks, cu_seqlen_ke, clean_logi
     seq_len_kv = kv.shape[0]
 
     clean_logits_kernel = clean_logits_()
-    tl_indexer_fwd_kernel = tl_indexer_fwd_impl(heads=heads, index_dim=index_dim)
+    tl_indexer_fwd_kernel = _indexer_fwd_within_shared_mem(heads=heads, index_dim=index_dim)
 
     logits = torch.empty([seq_len, seq_len_kv], device=q.device, dtype=torch.float32)
     tl_indexer_fwd_kernel(

--- a/miles_plugins/models/deepseek_v4/ops/kernel/tilelang_sparse_mla.py
+++ b/miles_plugins/models/deepseek_v4/ops/kernel/tilelang_sparse_mla.py
@@ -1,7 +1,34 @@
+import os
+
 import torch
 
 from miles_plugins.models.deepseek_v4.ops.kernel import tilelang_sparse_mla_bwd as sparse_mla_bwd
 from miles_plugins.models.deepseek_v4.ops.kernel import tilelang_sparse_mla_fwd as sparse_mla_fwd
+from miles_plugins.models.deepseek_v4.ops.kernel.torch_sparse_mla import sparse_attn_torch
+
+_bwd_fits: dict[tuple, bool] = {}
+
+# Which training-time backward to use: "auto", "kernel", or "torch".
+#
+# On gfx942 neither option dominates. The tiling the fused kernel has to shrink to (one head and one
+# KV slot per tile, a single wave64 per workgroup, 52 KiB of LDS) leaves one wave per CU, and
+# measured on MI308X at H=8, D=512, topk=512 it runs ~3x SLOWER than the PyTorch reference at every
+# sequence length from 64 to 4096. What it does win is footprint: the reference materializes
+# [B, S, topk, D] fp32 gathered KV and keeps it for the backward, so at S=4096 it peaks at 18.9 GiB
+# against the kernel's 390 MiB.
+#
+# So "auto" runs the reference -- the faster of the two, and the path this configuration was
+# validated on -- until its gathered-KV allocation gets big enough to threaten the device, and
+# switches to the kernel from there.
+_BWD_IMPL = os.environ.get("MILES_DSV4_SPARSE_MLA_BWD", "auto").lower()
+# Share of FREE device memory the reference backward is allowed to plan for.
+_REFERENCE_BUDGET_FRACTION = float(os.environ.get("MILES_DSV4_SPARSE_MLA_BWD_BUDGET", "0.5"))
+# The reference peaks well above its gathered-KV tensor: einsum casts it to fp32, autograd keeps it,
+# and the score tensors add to that. Measured on MI308X at H=8, D=512, topk=512, peak / (S*topk*D*4)
+# was 3.3x at S=1024, 4.6x at S=4096 and 8.6x at S=8192, so 8x is used as the planning figure.
+_REFERENCE_PEAK_MULTIPLE = 8
+_INT_MAX = 2**31 - 1
+_logged_choice: set = set()
 
 
 class DeepSeekV4SparseAttention(torch.autograd.Function):
@@ -27,5 +54,96 @@ class DeepSeekV4SparseAttention(torch.autograd.Function):
         return dq, dkv, d_attn_sink, None, None
 
 
+def _backward_kernel_fits(q, kv, topk_idxs, sm_scale) -> bool:
+    """Can the tilelang backward kernel be built for this shape on this GPU?
+
+    bwd_within_shared_mem retiles until something builds, which on gfx942 means one head and one KV
+    slot per tile on a single wave. If even that fails the reference implementation has to take
+    over. Probing costs one compile per shape and the answer is cached; the forward kernel is
+    unaffected either way.
+    """
+    B, S, H, D = q.shape
+    S_kv = kv.shape[1]
+    topk = topk_idxs.shape[-1]
+    block_size = 32
+    topk = (topk + block_size - 1) // block_size * block_size
+
+    key = (B, S, S_kv, H, D, topk, sm_scale)
+    if key not in _bwd_fits:
+        try:
+            sparse_mla_bwd.bwd_within_shared_mem(B, S, S_kv, H, D, topk, sm_scale)
+            _bwd_fits[key] = True
+        except Exception as e:
+            # bwd_within_shared_mem re-raises the last candidate's error, which is whichever of the
+            # three build failures that tiling hit -- not necessarily the shared-memory one.
+            if not any(marker in str(e) for marker in sparse_mla_bwd.RETRYABLE_BUILD_ERRORS):
+                raise
+            _bwd_fits[key] = False
+            print(
+                f"[sparse_attn] tilelang backward does not fit this GPU's shared memory "
+                f"({str(e).strip().splitlines()[0]}); falling back to the reference "
+                f"implementation for training. Forward-only passes keep using the kernel.",
+                flush=True,
+            )
+    return _bwd_fits[key]
+
+
+def _reference_is_affordable(q, topk_idxs) -> bool:
+    """Can sparse_attn_torch's activations be planned for out of what is free right now?
+
+    Its footprint is dominated by the [B, S, topk, D] gathered KV, which the fused kernel never
+    materializes -- the one axis on which the kernel beats the reference on this GPU.
+    """
+    B, S, _, D = q.shape
+    estimated_peak = _REFERENCE_PEAK_MULTIPLE * B * S * topk_idxs.shape[-1] * D * 4
+    free_bytes = torch.cuda.mem_get_info(q.device)[0]
+    return estimated_peak <= _REFERENCE_BUDGET_FRACTION * free_bytes
+
+
+def _reference_backward_is_representable(q, topk_idxs) -> bool:
+    """Can gather's backward index the gathered KV without overflowing a 32-bit element count?
+
+    It ends in ``index_put_(accumulate=True)``, which sorts one key per indexed element with a cub
+    radix sort. Past INT_MAX elements that sort raises, and B*S*topk*D reaches 5.4e9 for a 128K
+    DeepSeek-V4 layer at topk=640. Because ``_reference_is_affordable`` reads free memory at call
+    time, whether the run ever gets there depends on the moment -- so without this check the same
+    configuration crashes on some runs and not others.
+    """
+    B, S, _, D = q.shape
+    return B * S * topk_idxs.shape[-1] * D <= _INT_MAX
+
+
+def _log_choice(which, q, topk_idxs, reason):
+    """Report the backward each shape settled on, once per shape.
+
+    The two implementations differ by tens of GiB, and only one of the paths into the reference
+    announces itself, so without this line two runs of the same configuration are not comparable.
+    """
+    key = (which, tuple(q.shape), topk_idxs.shape[-1])
+    if key in _logged_choice:
+        return
+    _logged_choice.add(key)
+    print(
+        f"[sparse_attn] backward={which} for q={tuple(q.shape)} topk={topk_idxs.shape[-1]} ({reason})",
+        flush=True,
+    )
+
+
 def sparse_attn_tilelang(q, kv, attn_sink, topk_idxs, sm_scale=None):
+    if not torch.is_grad_enabled():
+        return DeepSeekV4SparseAttention.apply(q, kv, attn_sink, topk_idxs, sm_scale)
+
+    if _BWD_IMPL == "torch":
+        return sparse_attn_torch(q, kv, attn_sink, topk_idxs, sm_scale)
+    if not _backward_kernel_fits(q, kv, topk_idxs, sm_scale):
+        _log_choice("reference", q, topk_idxs, "kernel does not fit shared memory")
+        return sparse_attn_torch(q, kv, attn_sink, topk_idxs, sm_scale)
+    if (
+        _BWD_IMPL == "auto"
+        and _reference_is_affordable(q, topk_idxs)
+        and _reference_backward_is_representable(q, topk_idxs)
+    ):
+        _log_choice("reference", q, topk_idxs, "affordable and representable")
+        return sparse_attn_torch(q, kv, attn_sink, topk_idxs, sm_scale)
+    _log_choice("kernel", q, topk_idxs, f"impl={_BWD_IMPL}")
     return DeepSeekV4SparseAttention.apply(q, kv, attn_sink, topk_idxs, sm_scale)

--- a/miles_plugins/models/deepseek_v4/ops/kernel/tilelang_sparse_mla_bwd.py
+++ b/miles_plugins/models/deepseek_v4/ops/kernel/tilelang_sparse_mla_bwd.py
@@ -95,11 +95,15 @@ def bwd(
     block_size=32,
     num_stages=0,
     threads=128,
+    split_store=2,
+    stage_dq_through_shared=True,
+    max_block_H=None,
     indices_dtype=T.int32,
     dtype=T.bfloat16,
     accum_dtype=T.float32,
 ):
     assert topk % block_size == 0, f"topk ({topk}) must be divisible by block_size ({block_size})"
+    assert block_size % split_store == 0, f"block_size ({block_size}) must be divisible by split_store ({split_store})"
     assert dtype == T.bfloat16
     assert accum_dtype == T.float32
 
@@ -116,19 +120,18 @@ def bwd(
     attn_sink_shape = [H]
 
     padded_H = max(tilelang.math.next_power_of_2(H), 16)
-    is_hip = getattr(torch.version, "hip", None)
-    if is_hip:
-        # Split large HIP head tiles to reduce LDS use.
-        max_block_H = 32 if padded_H >= 64 else 64
-    else:
-        max_block_H = 64
+    if max_block_H is None:
+        is_hip = getattr(torch.version, "hip", None)
+        if is_hip:
+            # Split large HIP head tiles to reduce LDS use.
+            max_block_H = 32 if padded_H >= 64 else 64
+        else:
+            max_block_H = 64
     block_H = min(max_block_H, padded_H)
     assert padded_H % block_H == 0
     NH = padded_H // block_H
     BS = block_size
     NS = tilelang.cdiv(topk, block_size)
-
-    split_store = 2
 
     @T.prim_func
     def sparse_mqa_bwd_kernel(
@@ -151,7 +154,8 @@ def bwd(
 
             P_shared_cast = T.alloc_shared([block_H, BS], dtype)
             dP_shared_cast = T.alloc_shared([block_H, BS], dtype)
-            dQ_shared = T.alloc_shared([block_H, D], dtype)
+            if stage_dq_through_shared:
+                dQ_shared = T.alloc_shared([block_H, D], dtype)
 
             acc_p = T.alloc_fragment([block_H, BS], accum_dtype)
             acc_dp = T.alloc_fragment([block_H, BS], accum_dtype)
@@ -227,8 +231,11 @@ def bwd(
                         )
 
             # Store dQ
-            T.copy(acc_dq, dQ_shared)
-            T.copy(dQ_shared, dQ[by, s_i, bz * block_H : (bz + 1) * block_H, :D])
+            if stage_dq_through_shared:
+                T.copy(acc_dq, dQ_shared)
+                T.copy(dQ_shared, dQ[by, s_i, bz * block_H : (bz + 1) * block_H, :D])
+            else:
+                T.copy(acc_dq, dQ[by, s_i, bz * block_H : (bz + 1) * block_H, :D])
 
             # dAttnSink[h] = -sum_{b,s}( Delta[b,s,h] * p_sink[b,s,h] )
             # where p_sink = exp(attn_sink[h]) / Z = exp2(attn_sink[h]*log2e - LSE)
@@ -241,6 +248,98 @@ def bwd(
                 )
 
     return sparse_mqa_bwd_kernel
+
+
+# tilelang rejects an unbuildable tiling in three different places -- the shared-memory check at
+# codegen, warp partitioning inside T.gemm, and the vectorizer on the atomic store loop -- so all
+# three have to be treated as "try the next candidate" rather than as a hard error.
+RETRYABLE_BUILD_ERRORS = ("exceeds device limit", "Divide by zero", "is_scalar")
+
+# (block_size, threads, split_store, stage_dq_through_shared, max_block_H), in decreasing order of
+# expected performance. The first entry is the shipped tiling, sized for gfx950's 160 KiB LDS.
+#
+# The second is the only one that builds on gfx942's 64 KiB, and every part of it is forced:
+#   - block_size and max_block_H both at 16, because Q_shared/dO_shared [block_H, D] and KV_shared
+#     [block_size, D] are 16 KiB each at D=512 and three of them is already 48 KiB;
+#   - stage_dq_through_shared off, because dQ_shared is a fourth [block_H, D] buffer and 64 KiB does
+#     not hold four of them plus the accumulators;
+#   - threads=64, because a 16x16 gemm output cannot be split across two wave64s under
+#     GemmWarpPolicy.FullCol (N=8 is below MFMA's 16 and tilelang divides by zero);
+#   - split_store == block_size, because at threads=64 anything wider than a single row in
+#     acc_dkv_shared makes the atomic_addx4 store loop fail tilelang's vectorization pass.
+# Total shared memory is 52224 B, 80% of the limit. Costs: one head and one KV slot per tile
+# instead of 32, a single wave per workgroup, and 16 separate atomic store passes per KV block.
+_FALLBACK_TILINGS = (
+    (32, 128, 2, True, None),
+    (16, 64, 16, False, 16),
+)
+_fitted_tiling: dict[tuple, tuple] = {}
+
+
+def bwd_within_shared_mem(B, S, S_kv, H, D, topk, sm_scale=None):
+    """Build the backward kernel with the best tiling this GPU can host.
+
+    Which tiling fits is not worth predicting: tilelang merges and pads shared buffers, and two of
+    the three failure modes are not about size at all. The only reliable check is asking it to
+    build. Memoized per shape, so the cost is at most one wasted compile per shape.
+    """
+    key = (B, S, S_kv, H, D, topk, sm_scale)
+    if key in _fitted_tiling:
+        block_size, threads, split_store, stage_dq, max_block_H = _fitted_tiling[key]
+        return bwd(
+            B,
+            S,
+            S_kv,
+            H,
+            D,
+            topk,
+            sm_scale,
+            block_size=block_size,
+            threads=threads,
+            split_store=split_store,
+            stage_dq_through_shared=stage_dq,
+            max_block_H=max_block_H,
+        )
+
+    # `.with_traceback(None)` is not cosmetic: an exception carried out of its `except` block keeps
+    # the frame chain of every caller alive, which here means the model forward's activations, in a
+    # cycle only the cyclic collector can break. Only the message survives, which is all
+    # `raise last_error` needs.
+    last_error = None
+    for candidate in _FALLBACK_TILINGS:
+        block_size, threads, split_store, stage_dq, max_block_H = candidate
+        if topk % block_size != 0:
+            continue
+        try:
+            kernel = bwd(
+                B,
+                S,
+                S_kv,
+                H,
+                D,
+                topk,
+                sm_scale,
+                block_size=block_size,
+                threads=threads,
+                split_store=split_store,
+                stage_dq_through_shared=stage_dq,
+                max_block_H=max_block_H,
+            )
+        except Exception as e:  # tilelang raises RuntimeError or tvm InternalError
+            if not any(marker in str(e) for marker in RETRYABLE_BUILD_ERRORS):
+                raise
+            last_error = e.with_traceback(None)
+            continue
+        _fitted_tiling[key] = candidate
+        if candidate is not _FALLBACK_TILINGS[0]:
+            print(
+                f"[sparse_mqa_bwd] shared memory forced a smaller tiling on this GPU: "
+                f"block_size={block_size} threads={threads} split_store={split_store} "
+                f"stage_dq_through_shared={stage_dq} max_block_H={max_block_H}",
+                flush=True,
+            )
+        return kernel
+    raise last_error
 
 
 def sparse_mqa_bwd_interface(q, kv, attn_sink, o, do, topk_idxs, lse, sm_scale=None):
@@ -276,7 +375,7 @@ def sparse_mqa_bwd_interface(q, kv, attn_sink, o, do, topk_idxs, lse, sm_scale=N
         topk = padded_topk
 
     preprocess_kernel = preprocess(B, S, H, D)
-    bwd_kernel = bwd(B, S, S_kv, H, D, topk, sm_scale)
+    bwd_kernel = bwd_within_shared_mem(B, S, S_kv, H, D, topk, sm_scale)
     postprocess_kernel = postprocess(B, S_kv, D)
 
     delta = preprocess_kernel(o, do)

--- a/miles_plugins/models/deepseek_v4/ops/kernel/tilelang_sparse_mla_fwd.py
+++ b/miles_plugins/models/deepseek_v4/ops/kernel/tilelang_sparse_mla_fwd.py
@@ -25,6 +25,7 @@ def sparse_mqa_fwd(
     block_I=64,
     num_stages=2,
     threads=256,
+    block_H=None,
 ):
     assert dim == tilelang.math.next_power_of_2(dim), f"dim must be power of 2, got {dim}"
     assert topk % block_I == 0, f"topk ({topk}) must be divisible by block_I ({block_I})"
@@ -53,13 +54,20 @@ def sparse_mqa_fwd(
     NI = tilelang.cdiv(topk, block_I)
     D = dim
 
-    if heads > 64:
-        assert heads % 64 == 0, "heads should be a multiple of 64"
-        REPLICATE_H = heads // 64
+    # block_H caps how many heads one workgroup stages in LDS. Q_shared/O_shared are
+    # [H_per_block, D], so at D=512 bf16 a 64-head block is 65536 B for Q_shared alone -- the
+    # entire gfx942 (64 KiB) budget, with nothing left for KV_shared/S_shared/Lse_shared. Shrinking
+    # block_H is the only lever that helps; num_stages only multiplies KV_shared.
+    # block_H=None keeps the original behaviour (blocks of 64, and only when heads > 64).
+    if block_H is None:
+        block_H = 64
+    if heads > block_H:
+        assert heads % block_H == 0, f"heads ({heads}) should be a multiple of block_H ({block_H})"
+        REPLICATE_H = heads // block_H
+        H_per_block = block_H
     else:
         REPLICATE_H = 1
-
-    H_per_block = padded_H if REPLICATE_H == 1 else 64
+        H_per_block = padded_H
 
     is_hip = getattr(torch.version, "hip", None)
     if is_hip:
@@ -100,7 +108,7 @@ def sparse_mqa_fwd(
             b_i = by
             s_i = bx if REPLICATE_H == 1 else (bx // REPLICATE_H)
 
-            H0 = 0 if REPLICATE_H == 1 else (bx % REPLICATE_H) * 64
+            H0 = 0 if REPLICATE_H == 1 else (bx % REPLICATE_H) * H_per_block
             H1 = H0 + H_per_block
 
             T.copy(Q[b_i, s_i, H0:H1, :D], Q_shared)
@@ -156,6 +164,80 @@ def sparse_mqa_fwd(
     return main
 
 
+_SHARED_MEM_ERROR = "exceeds device limit"
+# (num_stages, block_I, threads) in decreasing order of expected performance, tried when the
+# requested tiling does not build on this GPU. The default is sized for a 160 KiB LDS (gfx950);
+# gfx942 (MI300/MI308) has 64 KiB per workgroup, where KV_shared alone (block_I*dim*2 bytes per
+# pipeline stage) is the whole budget at block_I=64 and dim=512. Shrinking block_I in turn needs
+# fewer threads, or tilelang's warp partitioning degenerates into a divide-by-zero.
+# (num_stages, block_I, threads, block_H). block_H=None means "one block of padded_H", the
+# pre-existing behaviour. The first four entries are the original list and are tried first, so
+# nothing that used to build changes tiling. The block_H entries exist for 64-head models on a
+# 64 KiB-LDS GPU, where no block_H=None tiling can fit:
+#   block_H=32, block_I=16 -> Q 32768 + KV 16384 + S 1024 + Lse 128 = 50304 B
+#   block_H=16, block_I=32 -> Q 16384 + KV 32768 + S 1024 + Lse  64 = 50240 B
+#   block_H=16, block_I=16 -> Q 16384 + KV 16384 + S  512 + Lse  64 = 33344 B
+_FALLBACK_TILINGS = (
+    (1, 64, 256, None),
+    (1, 32, 128, None),
+    (1, 32, 64, None),
+    (1, 16, 64, None),
+    (1, 16, 64, 32),
+    (1, 32, 128, 16),
+    (1, 16, 64, 16),
+)
+_fitted_tiling: dict[tuple, tuple] = {}
+
+
+def _compile_within_shared_mem(heads, dim, topk, sm_scale, block_I, num_stages, threads):
+    """Compile sparse_mqa_fwd, shrinking the tiling if the GPU cannot host its shared memory.
+
+    Which tiling fits is not worth predicting: tilelang reuses and pads shared buffers, so the only
+    reliable check is asking it to build the kernel. The result is memoized per shape.
+
+    Candidates are (num_stages, block_I, threads, block_H). block_H shrinks the head block, which is
+    the only thing that helps a 64-head model on a 64 KiB-LDS GPU -- Q_shared alone is [64, 512] bf16
+    = 65536 B there, and num_stages only multiplies KV_shared.
+    """
+    key = (heads, dim, topk, sm_scale, block_I, num_stages, threads)
+    candidates = [_fitted_tiling[key]] if key in _fitted_tiling else [(num_stages, block_I, threads, None)]
+    candidates += [c for c in _FALLBACK_TILINGS if c not in candidates and topk % c[1] == 0]
+
+    # Carrying a rejected candidate's exception out of its `except` block keeps its __traceback__,
+    # and through the frame chain every local of every caller -- here the whole model forward, whose
+    # locals are activation tensors. The reference cycle that forms is only breakable by the cyclic
+    # collector, so those activations sit on the device until something triggers a full gc pass.
+    # Strip the traceback: the message is all `raise last_error` needs.
+    last_error = None
+    for stages, bi, thr, bh in candidates:
+        try:
+            kernel = sparse_mqa_fwd(heads, dim, topk, sm_scale, block_I=bi, num_stages=stages, threads=thr, block_H=bh)
+        except RuntimeError as e:
+            if _SHARED_MEM_ERROR not in str(e):
+                raise
+            last_error = e.with_traceback(None)
+            continue
+        except AssertionError as e:  # block_H does not divide this head count
+            last_error = e.with_traceback(None)
+            continue
+        except Exception as e:  # tilelang raises tvm InternalError for an unsupported tile shape
+            if "Divide by zero" not in str(e):
+                raise
+            last_error = e.with_traceback(None)
+            continue
+        if key not in _fitted_tiling:
+            _fitted_tiling[key] = (stages, bi, thr, bh)
+            if (stages, bi, thr, bh) != (num_stages, block_I, threads, None):
+                print(
+                    f"[sparse_mqa_fwd] shared memory forced a smaller tiling on this GPU: "
+                    f"num_stages={stages} block_I={bi} threads={thr} block_H={bh} "
+                    f"(requested {num_stages}/{block_I}/{threads}/None)",
+                    flush=True,
+                )
+        return kernel
+    raise last_error
+
+
 def sparse_mqa_fwd_interface(q, kv, attn_sink, topk_idxs, sm_scale=None, block_I=64, num_stages=2, threads=256):
     """Forward interface for V4 sparse MQA attention.
 
@@ -183,14 +265,6 @@ def sparse_mqa_fwd_interface(q, kv, attn_sink, topk_idxs, sm_scale=None, block_I
         topk_idxs = torch.cat([topk_idxs, pad], dim=-1).contiguous()
         topk = padded_topk
 
-    kernel = sparse_mqa_fwd(
-        heads,
-        dim,
-        topk,
-        sm_scale,
-        block_I=block_I,
-        num_stages=num_stages,
-        threads=threads,
-    )
+    kernel = _compile_within_shared_mem(heads, dim, topk, sm_scale, block_I, num_stages, threads)
     out, lse = kernel(q, kv, attn_sink, topk_idxs)
     return out, lse

--- a/miles_plugins/models/deepseek_v4/ops/kernel/torch_sparse_mla.py
+++ b/miles_plugins/models/deepseek_v4/ops/kernel/torch_sparse_mla.py
@@ -1,0 +1,54 @@
+# ruff: noqa
+"""Reference (autograd) implementation of DeepSeek-V4 sparse MQA attention.
+
+Used where the tilelang backward kernel cannot be built. On gfx942 (MI300X/MI308X) that kernel's
+three unavoidable shared-memory buffers — Q_shared and dO_shared at [block_H, D] plus KV_shared at
+[block_size, D] — already total the whole 64 KiB LDS budget at the smallest tiling tilelang will
+compile, so it cannot be made to fit without tiling the D dimension.
+
+Semantics follow tilelang_sparse_mla_fwd.sparse_mqa_fwd exactly: scores are q@kv^T scaled by
+sm_scale, index -1 marks a masked slot, and attn_sink[h] is a pre-scaled logit that joins the softmax
+denominator. That is the same as a softmax over the topk logits plus one extra sink logit whose value
+vector is zero, which is how it is expressed here so autograd can differentiate it.
+
+This is orders of magnitude slower and far more memory-hungry than the fused kernel: it materializes
+[B, S, H, topk] scores and gathers [B, S, topk, D] of KV.
+"""
+
+import torch
+
+
+def sparse_attn_torch(
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    attn_sink: torch.Tensor,
+    topk_idxs: torch.Tensor,
+    sm_scale: float | None = None,
+) -> torch.Tensor:
+    """q: [B, S, H, D] bf16, kv: [B, S_kv, D] bf16, attn_sink: [H] fp32, topk_idxs: [B, S, topk]."""
+    B, S, H, D = q.shape
+    if sm_scale is None:
+        sm_scale = D**-0.5
+
+    valid = topk_idxs != -1
+    safe_idx = topk_idxs.masked_fill(~valid, 0).long()
+    topk = safe_idx.shape[-1]
+
+    # Gather from kv itself, [B, S_kv, D], rather than from a [B, S, S_kv, D] `expand` of it. The
+    # forward is identical either way -- expand is a view and gather reads it strided -- but
+    # gather's backward scatters into a freshly zeroed tensor shaped like its INPUT, and that shape
+    # is 2048 GiB at B=1, S=16384, S_kv=131072, D=512. Flattened, the same values accumulate into
+    # [B, S_kv, D] = 128 MiB.
+    flat_idx = safe_idx.reshape(B, S * topk)
+    kv_gathered = torch.gather(kv, 1, flat_idx.unsqueeze(-1).expand(-1, -1, D))
+    kv_gathered = kv_gathered.view(B, S, topk, D).float()  # [B, S, topk, D]
+
+    scores = torch.einsum("bshd,bstd->bsht", q.float(), kv_gathered) * sm_scale
+    scores = scores.masked_fill(~valid.unsqueeze(2), float("-inf"))
+
+    # The sink is an extra logit with a zero value vector, so it only inflates the denominator.
+    sink = attn_sink.float().view(1, 1, H, 1).expand(B, S, H, 1)
+    probs = torch.softmax(torch.cat([scores, sink], dim=-1), dim=-1)[..., :-1]
+
+    out = torch.einsum("bsht,bstd->bshd", probs, kv_gathered)
+    return out.to(q.dtype)

--- a/tests/fast/test_dsv4_sparse_mla_reference.py
+++ b/tests/fast/test_dsv4_sparse_mla_reference.py
@@ -1,0 +1,105 @@
+"""CPU tests for the DeepSeek-V4 sparse-MQA reference backward and how it gets selected.
+
+The reference exists for GPUs whose shared memory cannot host the fused backward kernel. Both
+things it has to get right are cheap to check without a GPU:
+
+  * gathering the top-k KV rows must not make autograd allocate a gradient the size of the
+    *unexpanded* KV cross product, and
+  * it must not be chosen for a shape whose backward would overflow a 32-bit element count.
+"""
+
+import pytest
+import torch
+
+from miles_plugins.models.deepseek_v4.ops.kernel.torch_sparse_mla import sparse_attn_torch
+
+
+def _reference_inputs(B=2, S=7, H=4, D=16, S_kv=11, topk=5, seed=0):
+    g = torch.Generator().manual_seed(seed)
+    q = torch.randn(B, S, H, D, generator=g, dtype=torch.float32)
+    kv = torch.randn(B, S_kv, D, generator=g, dtype=torch.float32)
+    attn_sink = torch.randn(H, generator=g, dtype=torch.float32)
+    topk_idxs = torch.randint(0, S_kv, (B, S, topk), generator=g)
+    # Mask a few slots so the -1 path is covered.
+    topk_idxs[0, 0, 0] = -1
+    topk_idxs[-1, -1, -1] = -1
+    return q, kv, attn_sink, topk_idxs
+
+
+def _expanded_gather_reference(q, kv, attn_sink, topk_idxs, sm_scale):
+    """The straightforward writing: gather from a [B, S, S_kv, D] expand of kv."""
+    B, S, H, D = q.shape
+    valid = topk_idxs != -1
+    safe_idx = topk_idxs.masked_fill(~valid, 0).long()
+    kv_gathered = torch.gather(
+        kv.unsqueeze(1).expand(B, S, kv.shape[1], D),
+        2,
+        safe_idx.unsqueeze(-1).expand(-1, -1, -1, D),
+    )
+    scores = torch.einsum("bshd,bstd->bsht", q.float(), kv_gathered.float()) * sm_scale
+    scores = scores.masked_fill(~valid.unsqueeze(2), float("-inf"))
+    sink = attn_sink.float().view(1, 1, H, 1).expand(B, S, H, 1)
+    probs = torch.softmax(torch.cat([scores, sink], dim=-1), dim=-1)[..., :-1]
+    return torch.einsum("bsht,bstd->bshd", probs, kv_gathered.float()).to(q.dtype)
+
+
+def test_flat_gather_matches_the_expanded_writing_forward_and_backward():
+    """Same function, so the forward and dq/dsink agree bit for bit.
+
+    dkv does not, and cannot: the expanded writing scatters into [B, S, S_kv, D] and then reduces
+    along S, while the flat one scatter-adds straight into [B, S_kv, D]. Same terms, different
+    summation order, and the reference computes in fp32 throughout (it casts its inputs), so the
+    two disagree at fp32 rounding.
+    """
+    q, kv, attn_sink, topk_idxs = _reference_inputs()
+    sm_scale = q.shape[-1] ** -0.5
+
+    inputs = [(t.clone().requires_grad_(True), t.clone().requires_grad_(True)) for t in (q, kv, attn_sink)]
+    (q_a, q_b), (kv_a, kv_b), (sink_a, sink_b) = inputs
+
+    out_a = sparse_attn_torch(q_a, kv_a, sink_a, topk_idxs, sm_scale)
+    out_b = _expanded_gather_reference(q_b, kv_b, sink_b, topk_idxs, sm_scale)
+    torch.testing.assert_close(out_a, out_b, rtol=0, atol=0)
+
+    grad = torch.randn_like(out_a)
+    out_a.backward(grad)
+    out_b.backward(grad)
+    torch.testing.assert_close(q_a.grad, q_b.grad, rtol=0, atol=0, msg="q gradient differs")
+    torch.testing.assert_close(sink_a.grad, sink_b.grad, rtol=0, atol=0, msg="attn_sink gradient differs")
+    torch.testing.assert_close(kv_a.grad, kv_b.grad, rtol=1e-6, atol=1e-6, msg="kv gradient differs")
+
+
+def test_masked_slots_do_not_contribute():
+    """A -1 index is a masked slot: its KV row must receive no gradient through that slot."""
+    q, kv, attn_sink, topk_idxs = _reference_inputs(B=1, S=1, H=2, D=8, S_kv=6, topk=3)
+    topk_idxs[:] = torch.tensor([[[-1, -1, -1]]])
+    kv = kv.double().requires_grad_(True)
+    out = sparse_attn_torch(q.double(), kv, attn_sink.double(), topk_idxs, sm_scale=0.125)
+
+    # Every slot is masked, so the softmax keeps only the sink and the output is exactly zero.
+    torch.testing.assert_close(out, torch.zeros_like(out), rtol=0, atol=0)
+    out.sum().backward()
+    torch.testing.assert_close(kv.grad, torch.zeros_like(kv.grad), rtol=0, atol=0)
+
+
+def test_kv_gradient_is_shaped_like_kv_not_like_the_cross_product():
+    """The bug this guards against allocated [B, S, S_kv, D] -- 2048 GiB at production shapes."""
+    q, kv, attn_sink, topk_idxs = _reference_inputs()
+    kv = kv.requires_grad_(True)
+    sparse_attn_torch(q, kv, attn_sink, topk_idxs, sm_scale=0.25).sum().backward()
+    assert kv.grad.shape == kv.shape
+
+
+def test_reference_backward_is_refused_past_int_max():
+    tilelang_sparse_mla = pytest.importorskip(
+        "miles_plugins.models.deepseek_v4.ops.kernel.tilelang_sparse_mla",
+        reason="needs tilelang",
+    )
+    representable = tilelang_sparse_mla._reference_backward_is_representable
+
+    small = torch.empty(1, 128, 8, 64, device="meta")
+    assert representable(small, torch.empty(1, 128, 32, device="meta"))
+
+    # A 128K DeepSeek-V4 layer under CP=8: 1 * 16384 * 640 * 512 = 5.37e9 elements.
+    big = torch.empty(1, 16384, 64, 512, device="meta")
+    assert not representable(big, torch.empty(1, 16384, 640, device="meta"))


### PR DESCRIPTION
## Problem

The DeepSeek-V4 tilelang kernels are tiled for a 160 KiB shared-memory budget (gfx950). On a GPU
with 64 KiB per workgroup — gfx942, i.e. MI300X and MI308X — three of them cannot be built at all,
and the failure is a hard `RuntimeError: Requested dynamic shared memory N exceeds device limit
65536` on the first forward pass:

| kernel | what it stages | asks for |
|---|---|---|
| `tl_indexer_fwd_impl` | `[block_N, index_dim]` of K plus `[block_Q*heads, index_dim]` of Q | 96 KiB at the tuned `block_N=256` |
| `sparse_mqa_fwd` | Q/O as `[H_per_block, D]` | 64 KiB for `Q_shared` alone at 64 heads, D=512, bf16 — the entire budget, with nothing left for KV/S/Lse |
| `bwd` | `Q_shared`, `dO_shared`, `dQ_shared` at `[block_H, D]` plus `KV_shared` at `[block_size, D]` | four 16 KiB buffers |

64 local heads is not an exotic configuration: on a single 8-GPU node `TP*PP*CP*DP = 8`, so any
`CP=8` layout forces `TP=1` and every rank holds all 64 heads.

There is also no fallback. When the backward cannot be built there is no backward at all, so a run
that survives the forward dies at the first optimizer step.

## What this does

Two commits.

**1. Retile until it fits.** Each of the three entry points now walks a list of progressively
smaller tilings and keeps the first that builds, memoized per shape. The first candidate is always
the tiling that shipped, so nothing that used to build changes — verified byte-identical tilings at
8, 16 and 32 heads.

`block_H` is the one new parameter, and it is plumbing rather than arithmetic: the forward already
blocked over heads through `REPLICATE_H` and the `H0` offset, only the block size was hardwired to
64. It is safe to shrink because V4 attention is MQA (`KV_shared` has no head axis) and the
online-softmax state (`m_i`, `sumexp`, `alpha`) is already per-head, so head blocks are independent.
`num_stages` cannot substitute for it — it only multiplies `KV_shared`, and the HIP branch already
pins it to 1.

tilelang rejects an unbuildable tiling in three unrelated places — the shared-memory check at
codegen, warp partitioning inside `T.gemm`, and the vectorizer on the atomic store loop — so all
three are treated as "try the next candidate" rather than as a hard error.

**2. An autograd reference, and a policy for when to use it.** `sparse_attn_torch` follows
`sparse_mqa_fwd`'s semantics exactly: `sm_scale`, `-1` as a masked slot, and `attn_sink[h]` as an
extra logit whose value vector is zero. Selection defaults to `auto` and is overridable with
`MILES_DSV4_SPARSE_MLA_BWD`.

## Two things in the reference that are easy to get wrong

**Gather from `kv`, not from an `expand` of it.** The obvious writing is

```python
torch.gather(kv.unsqueeze(1).expand(B, S, S_kv, D), 2, idx.unsqueeze(-1).expand(-1, -1, -1, D))
```

whose forward is free — `expand` is a view and `gather` reads it strided. Its backward is not:
`gather` scatters into a freshly zeroed tensor shaped like its *input*, which at `B=1, S=16384,
S_kv=131072, D=512` is exactly 2048 GiB. Flattening the index and gathering from `kv` itself
accumulates into `[B, S_kv, D]` = 128 MiB. Forward, `dq` and `d(attn_sink)` stay bit-identical;
`dkv` differs only by summation order.

**Refuse the reference past `INT_MAX` elements.** `gather`'s backward ends in
`index_put_(accumulate=True)`, which sorts one key per indexed element with a 32-bit cub radix sort.
A 128K V4 layer at `topk=640` needs `1 * 16384 * 640 * 512` = 5.4e9 keys and raises

```
RuntimeError: cub sort does not support sorting more than INT_MAX elements
```

Because the memory-affordability test reads *free device memory at call time*, whether a run ever
reaches that shape depends on the moment — so without the guard the same configuration crashes on
some runs and not others. This was the hardest failure in this series to attribute.

Related: every shape now logs which backward it settled on. The two differ by tens of GiB, and only
one of the two paths into the reference announced itself before, so grepping for a fallback message
found nothing and wrongly exonerated the path.

## Why the retry loop strips tracebacks

`last_error = e.with_traceback(None)` is not cosmetic. Carrying an exception out of its `except`
block defeats the implicit `del e` that Python inserts there, and the exception's `__traceback__`
holds the frame chain of every caller — during a model forward, that is its activation tensors. The
cycle that closes around `last_error` can only be broken by the cyclic collector, so on a 128K
DeepSeek-V4 step roughly 22 GiB of device memory stayed unreclaimable after the first microbatch's
JIT compiles. Only the message is needed for the final `raise`.

## Verification

- `tests/fast/test_dsv4_sparse_mla_reference.py` (new, CPU): the flat and expanded gathers agree
  bit for bit on the forward, `dq` and `d(attn_sink)`; `dkv` agrees to fp32 rounding; a fully
  masked row produces exactly zero output and zero KV gradient; `dkv` is shaped like `kv`; the
  `INT_MAX` guard accepts a small shape and refuses a 128K one.
- `tests/manual/models/deepseek_v4/test_v4_tilelang_sparse_mla.py` passes unchanged.
- 64-head forward builds at `(num_stages=1, block_I=16, threads=64, block_H=32)` on gfx942.
- End to end on 8x MI308X: 4-layer DeepSeek-V4-Flash, 131072-token input, `CP=8`/`TP=1`, three
  iterations, no OOM, no NaN, no shared-memory overflow.

Nothing in this PR is reachable on a GPU whose shared memory already fits the shipped tilings: the
first candidate in every list is the current one, and the reference is only consulted when the
kernel cannot be built or when the selection policy prefers it.
