### PR TITLE
fix(megatron): import UpdateWeightP2P lazily so an older SGLang can still start

### DIFF
--- a/miles/backends/megatron_utils/actor.py
+++ b/miles/backends/megatron_utils/actor.py
@@ -59,7 +59,6 @@ from .parallel import verify_megatron_parallel_state
 from .replay_utils import register_replay_list_moe
 from .update_weight.common import named_params_and_buffers
 from .update_weight.update_weight_from_distributed.broadcast import UpdateWeightFromDistributed
-from .update_weight.update_weight_from_distributed.p2p import UpdateWeightP2P
 from .update_weight.update_weight_from_tensor import UpdateWeightFromTensor
 
 if TYPE_CHECKING:
@@ -265,6 +264,10 @@ class MegatronTrainRayActor(TrainRayActor):
 
                 update_weight_cls = UpdateWeightFromDiskDelta
             else:
+                # Lazy import: p2p.py needs sglang.srt.distributed.parallel_state.ParallelismContext
+                # and sglang.srt.model_loader.parameter_mapper, which older SGLang builds do not have.
+                from .update_weight.update_weight_from_distributed.p2p import UpdateWeightP2P
+
                 update_weight_cls = UpdateWeightP2P
         self.weight_updater = update_weight_cls(
             self.args,


### PR DESCRIPTION
## Problem

`miles/backends/megatron_utils/actor.py` imports `UpdateWeightP2P` at module scope, and
`p2p.py` in turn imports at module scope:

```python
from sglang.srt.distributed.parallel_state import ParallelismContext
from sglang.srt.model_loader.parameter_mapper import ...
```

Both are recent SGLang additions. Against an SGLang build that predates them, importing
`MegatronTrainRayActor` fails outright — so every Megatron run on that stack dies at import,
including the overwhelming majority that never select the P2P weight updater at all.

## What this does

Moves the import into the branch that instantiates it. The failure now happens where the feature
is actually requested, and nowhere else.

Two lines of code; the comment explains which SGLang symbols are the constraint so the next person
does not "tidy" it back to the top of the file.

## Verification

Megatron DeepSeek-V4 training on SGLang `0.0.0.dev15473+gb385bcfae` (2026-07-30), which has neither
symbol: imports and trains with this change, fails at import without it.
