### PR TITLE
perf(megatron): collect the log-prob pass's dead activations per microbatch

### DIFF
--- a/miles/backends/megatron_utils/actor.py
+++ b/miles/backends/megatron_utils/actor.py
@@ -387,7 +387,7 @@ class MegatronTrainRayActor(TrainRayActor):
     ) -> dict[str, list[torch.Tensor]]:
 
         with timer(f"{store_prefix}log_probs"):
-            return forward_only(
+            log_probs = forward_only(
                 get_log_probs_and_entropy,
                 self.args,
                 self.model,
@@ -397,6 +397,11 @@ class MegatronTrainRayActor(TrainRayActor):
                 store_prefix=store_prefix,
                 fp32_output=False,
             )
+        # The last microbatch's activations are still held by the cycles forward_only collects per
+        # microbatch, and the training step that follows is the memory peak of the rollout. Release
+        # them before it starts rather than whenever the next pass happens to collect.
+        clear_memory()
+        return log_probs
 
     @with_logs
     @event_logger_context(

--- a/miles/backends/megatron_utils/model.py
+++ b/miles/backends/megatron_utils/model.py
@@ -313,6 +313,15 @@ def forward_only(
 
         assert not return_schedule_plan, "forward_only step should never return schedule plan"
 
+        # The previous microbatch's activations are unreachable once its outputs are collected --
+        # this pass runs under no_grad, so nothing downstream reads them -- but part of them is held
+        # by reference cycles between an autograd.Function's ctx and its node, which refcounting
+        # alone never breaks. Waiting for the generational collector does not work here: it triggers
+        # on container allocation counts, and a handful of multi-GiB tensors barely move that
+        # counter, so they can sit on the device for the rest of the pass. Collecting per microbatch
+        # bounds the garbage to one microbatch.
+        gc.collect()
+
         # Get the batch.
         batch = get_batch(
             data_iterator,


### PR DESCRIPTION
## Problem

`forward_only` runs under `no_grad`, so a microbatch's activations are unreachable the moment its
outputs are collected. A good share of them is not freed anyway.

The reason is a reference cycle: an `autograd.Function`'s `ctx` and its graph node hold each other,
so refcounting can never drop either, and only the cyclic collector can. CPython's generational
collector triggers on **container allocation counts** — a handful of multi-GiB tensors barely move
that counter, so they can sit on the device for the rest of the pass and, at long context, across
the training step that follows.

Snapshot replay of the log-prob pass on a 4-layer DeepSeek-V4 at 128K put its peak at 69.3 GiB with
roughly a third of that already dead.

## What this does

`gc.collect()` once per microbatch in `forward_only`, which bounds the garbage to one microbatch
instead of letting it accumulate across the pass, and `clear_memory()` when `compute_log_prob`
returns, which releases the last one before the training step — the actual peak of the rollout.

## Cost

One full collection per microbatch of a pass that already costs seconds per microbatch. Measured on
the same configuration, step time did not regress: the collections cost less than moving the extra
memory does.

## Verification

Replayed peak of the log-prob pass: 69.3 → 45.8 GiB. Log-probs are unchanged — this frees memory,
it does not touch arithmetic.

## End-to-end measurement

8x MI308X, 4-layer DeepSeek-V4-Flash, 131072-token input, `CP=8`/`TP=1`, three iterations, backward
pinned to the fused kernel so the two runs are comparable:

| | peak allocated / rank | peak reserved / rank |
|---|---:|---:|
| without this and the recomputed-backward collector | 84.82 GiB | 123.46 GiB |
| with both | **46.77 GiB** | **57.15 GiB** |

The two collectors were measured together because they address the same cycle on the two passes
that dominate a step. Pinning the backward matters for the comparison: left on `auto` it is chosen
from free device memory at call time, and a run where the `topk=128` layers took the reference path
reported 86.32 GiB for reasons that have nothing to do with this change.
