### PR TITLE
perf(megatron): optionally collect reference cycles after each recomputed backward

### DIFF
--- a/miles/backends/megatron_utils/actor.py
+++ b/miles/backends/megatron_utils/actor.py
@@ -56,6 +56,7 @@ from .initialize import init, is_first_replica_megatron_main_rank
 from .lora_utils import is_lora_enabled, lora_rollout_enabled
 from .model import TrainStepOutcome, forward_only, initialize_model_and_optimizer, save, train
 from .parallel import verify_megatron_parallel_state
+from .recompute_gc import enable_recompute_backward_gc
 from .replay_utils import register_replay_list_moe
 from .update_weight.common import named_params_and_buffers
 from .update_weight.update_weight_from_distributed.broadcast import UpdateWeightFromDistributed
@@ -99,6 +100,7 @@ class MegatronTrainRayActor(TrainRayActor):
         indep_dp_info: IndepDPInfo,
     ) -> int | None:
         monkey_patch_torch_dist()
+        enable_recompute_backward_gc()
 
         super().init(args, role, with_ref, with_opd_teacher=with_opd_teacher)
 

--- a/miles/backends/megatron_utils/recompute_gc.py
+++ b/miles/backends/megatron_utils/recompute_gc.py
@@ -1,0 +1,85 @@
+"""Collect reference cycles after each recomputed backward.
+
+Full activation recomputation is supposed to keep one layer's activations alive at a time. It does
+not, and the reason is the same one that affects the log-prob pass: an ``autograd.Function``'s
+``ctx`` and its graph node reference each other, so refcounting cannot free either, and CPython's
+generational collector triggers on *container allocation counts* -- a handful of multi-GiB tensors
+barely move that counter.
+
+Measured on a 4-layer DeepSeek-V4 at 128K with ``recompute_granularity=full``, bucketing the blocks
+live at the memory peak by age: ~15 GiB had been allocated 10-60 s earlier, spanning two to ten
+completed layer backwards. Tracing when they were finally released showed 12 GiB freed in one go
+69.9 s *after* the peak -- not gradual reclamation, one outer boundary letting go at once.
+
+Collecting explicitly at the end of each checkpointed backward moves that release to peak +0.6 s
+and takes ~19 GiB off the peak at CP=8. Step time does not regress; the collections cost less than
+moving the extra memory.
+
+Off unless ``MILES_RECOMPUTE_BACKWARD_GC_GEN`` is set to a generation:
+
+  * ``2`` (recommended) collects everything.
+  * ``1`` measured bit-identical to 2, in peak and in step time.
+  * ``0`` is WORSE THAN NOT COLLECTING. A cycle is only collectable when every object in it lies in
+    a scanned generation, and surviving gen-0 objects get promoted; the tensors that were missed
+    once because the cycle held one older object then leave ``collect(0)``'s view permanently.
+
+This lives in Miles rather than in Megatron-LM because the image should not carry a patched
+Megatron: the wrapper is applied to whatever ``megatron.core`` is installed. Doing it from the
+outside is equivalent to doing it inside ``CheckpointFunction.backward`` -- the frame, and with it
+every local naming an activation, is already gone by the time the wrapper regains control.
+"""
+
+from __future__ import annotations
+
+import gc
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+_ENV = "MILES_RECOMPUTE_BACKWARD_GC_GEN"
+_installed = False
+
+
+def recompute_backward_gc_generation() -> int:
+    """Which GC generation to collect after a checkpointed backward; negative disables."""
+    try:
+        return int(os.environ.get(_ENV, "-1"))
+    except ValueError:
+        logger.warning(f"{_ENV} is not an integer; treating it as disabled")
+        return -1
+
+
+def enable_recompute_backward_gc() -> bool:
+    """Wrap ``CheckpointFunction.backward`` to collect cycles when it returns.
+
+    Idempotent, and a no-op unless the environment asks for it. Returns whether the wrapper is
+    installed.
+    """
+    global _installed
+    if _installed:
+        return True
+
+    generation = recompute_backward_gc_generation()
+    if generation < 0:
+        return False
+    if generation == 0:
+        logger.warning(
+            f"{_ENV}=0 promotes surviving objects out of the only generation it scans, which "
+            f"delays the collection it is trying to force. Use 1 or 2."
+        )
+
+    from megatron.core.tensor_parallel.random import CheckpointFunction
+
+    # Accessing a staticmethod through the class yields the plain function.
+    original = CheckpointFunction.backward
+
+    def backward(ctx, *args):
+        grads = original(ctx, *args)
+        gc.collect(generation)
+        return grads
+
+    CheckpointFunction.backward = staticmethod(backward)
+    _installed = True
+    logger.info(f"recomputed backward will gc.collect({generation}) on return ({_ENV})")
+    return True

--- a/tests/fast/backends/megatron_utils/test_recompute_backward_gc.py
+++ b/tests/fast/backends/megatron_utils/test_recompute_backward_gc.py
@@ -1,0 +1,73 @@
+"""The checkpointed-backward collector is opt-in, idempotent, and does not change gradients."""
+
+import gc
+
+import pytest
+import torch
+
+from miles.backends.megatron_utils import recompute_gc
+
+
+@pytest.fixture(autouse=True)
+def _uninstalled(monkeypatch):
+    """Each test starts from "not installed" and leaves megatron.core as it found it."""
+    from megatron.core.tensor_parallel.random import CheckpointFunction
+
+    original = CheckpointFunction.backward
+    monkeypatch.setattr(recompute_gc, "_installed", False, raising=False)
+    yield
+    CheckpointFunction.backward = staticmethod(original)
+
+
+def test_disabled_unless_the_environment_asks(monkeypatch):
+    monkeypatch.delenv("MILES_RECOMPUTE_BACKWARD_GC_GEN", raising=False)
+    from megatron.core.tensor_parallel.random import CheckpointFunction
+
+    before = CheckpointFunction.backward
+    assert recompute_gc.enable_recompute_backward_gc() is False
+    assert CheckpointFunction.backward is before
+
+
+def test_installs_once_and_collects_once_per_backward(monkeypatch):
+    monkeypatch.setenv("MILES_RECOMPUTE_BACKWARD_GC_GEN", "2")
+    from megatron.core.tensor_parallel.random import CheckpointFunction, checkpoint
+
+    before = CheckpointFunction.backward
+    assert recompute_gc.enable_recompute_backward_gc() is True
+    installed = CheckpointFunction.backward
+    assert installed is not before
+
+    # Idempotent: a second call must not wrap the wrapper.
+    assert recompute_gc.enable_recompute_backward_gc() is True
+    assert CheckpointFunction.backward is installed
+
+    generations = []
+    real_collect = gc.collect
+    monkeypatch.setattr(gc, "collect", lambda *a: generations.append(a) or real_collect(*a))
+
+    x = torch.randn(4, 4, requires_grad=True)
+    checkpoint(lambda t: (t * 2).sin(), False, x).sum().backward()
+
+    assert generations == [(2,)]
+
+
+def test_gradients_are_unchanged(monkeypatch):
+    monkeypatch.setenv("MILES_RECOMPUTE_BACKWARD_GC_GEN", "2")
+    from megatron.core.tensor_parallel.random import checkpoint
+
+    recompute_gc.enable_recompute_backward_gc()
+
+    x = torch.randn(8, 8, requires_grad=True)
+    reference = x.detach().clone().requires_grad_(True)
+
+    checkpoint(lambda t: (t * 2).sin(), False, x).sum().backward()
+    (reference * 2).sin().sum().backward()
+
+    torch.testing.assert_close(x.grad, reference.grad, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("value", ["-1", "not-a-number"])
+def test_bad_or_negative_values_disable_it(monkeypatch, value):
+    monkeypatch.setenv("MILES_RECOMPUTE_BACKWARD_GC_GEN", value)
+    assert recompute_gc.recompute_backward_gc_generation() == -1
+    assert recompute_gc.enable_recompute_backward_gc() is False


### PR DESCRIPTION
## Problem

Full activation recomputation (`recompute_granularity=full`) is supposed to keep one layer's
activations alive at a time. It does not.

Bucketing the allocator blocks live at the memory peak of a 4-layer DeepSeek-V4 step at 128K by age:

```
age of the block at the peak                GiB    blocks
< 1 s   (the layer being recomputed now)    6.33      27
1-10 s                                      9.45      59
10-60 s                                    14.90      64   <- should be long gone
> 60 s  (alive since the forward)           1.55      23
```

A steady-state step is ~99 s over 16 layer backwards, so "10-60 s ago" spans two to ten *completed*
layer backwards. Tracing when those blocks were actually released showed 12 GiB freed **in one go,
69.9 s after the peak** — not gradual reclamation, one outer boundary letting go at once.

Same cause as the log-prob pass: an `autograd.Function`'s `ctx` and its graph node reference each
other, refcounting cannot break the cycle, and CPython's generational collector fires on container
allocation counts, which a few multi-GiB tensors barely move.

## What this does

Collect explicitly when a checkpointed backward returns. That moves the release to peak + 0.6 s and
takes ~19 GiB off the peak at CP=8, with no step-time regression — the collections cost less than
moving the extra memory.

Off unless `MILES_RECOMPUTE_BACKWARD_GC_GEN` names a generation:

| value | effect |
|---|---|
| `2` | recommended, collects everything |
| `1` | measured bit-identical to 2, in peak and in step time |
| `0` | **worse than not collecting.** A cycle is only collectable when every object in it lies in a scanned generation, and surviving gen-0 objects are promoted out of view. Measured: the 12 GiB moved from peak+69.9 s to peak+48.2 s and never crossed the peak. |
| unset / negative | disabled |

## Why it is a wrapper on `megatron.core` rather than a Megatron-LM change

The natural home for this is `CheckpointFunction.backward` itself. Putting it here instead means a
training image does not have to carry a patched Megatron-LM to get the memory back, and the fix
applies to whatever `megatron.core` is installed.

It is behaviourally the same: by the time the wrapper regains control the original frame is gone,
and with it every local naming an activation, so an explicit `del` inside the method buys nothing
that returning does not.

## Verification

`tests/fast/backends/megatron_utils/test_recompute_backward_gc.py`: disabled unless asked;
installed at most once, however many times it is called; exactly one collection per checkpointed
backward, at the requested generation; gradients bit-identical to the same computation without
checkpointing; a malformed or negative environment value disables it rather than raising.

## End-to-end measurement

8x MI308X, 4-layer DeepSeek-V4-Flash, 131072-token input, `CP=8`/`TP=1`, three iterations, backward
pinned to the fused kernel so the two runs are comparable:

| | peak allocated / rank | peak reserved / rank | step time |
|---|---:|---:|---:|
| without this and the log-prob collector | 84.82 GiB | 123.46 GiB | 135-143 s |
| with both | **46.77 GiB** | **57.15 GiB** | 121-124 s |

Step time improves rather than regresses. The two collectors are measured together because they
address the same cycle on the two passes that dominate a step.
