### PR TITLE
openenv tb2 recipe: pin mcp below 2 in the server layer

### DIFF
--- a/examples/experimental/openenv/tb2_sandbox_recipe.py
+++ b/examples/experimental/openenv/tb2_sandbox_recipe.py
@@ -384,7 +384,11 @@ def server_layer_commands(task_dir: Path) -> list[str]:
         # package: local fixes (canonical evaluate, TB2_COMMAND_TIMEOUT_S)
         # ship with the image. Deps (openenv, camel-ai, ...) come from PyPI.
         f"mkdir -p /opt/src && echo {_env_src_tar_b64()} | base64 -d | tar xz -C /opt/src",
-        "/opt/uv/uv pip install --python /opt/envserver/bin/python /opt/src/tbench2_env_src uvicorn gradio",
+        # mcp is pinned below 2: camel-ai constrains only mcp>=1.3, mcp 2.0
+        # (2026-07-28) dropped the `from mcp.server import FastMCP` re-export
+        # its TerminalToolkit imports, and every episode then fails with
+        # "camel-ai (TerminalToolkit) is required for TB2".
+        "/opt/uv/uv pip install --python /opt/envserver/bin/python /opt/src/tbench2_env_src uvicorn gradio 'mcp<2'",
         # Task directory for reset(task_id) via TB2_TASKS_DIR (pinned-SHA
         # GitHub tarball; see _task_layer_command).
         _task_layer_command(task_dir),


### PR DESCRIPTION
Freshly baked TB2 images fail every episode with `camel-ai (TerminalToolkit) is required for TB2`. The real error inside the image is `ImportError: cannot import name 'FastMCP' from 'mcp.server'`: camel-ai constrains only `mcp>=1.3`, and mcp 2.0 (2026-07-28) dropped that re-export. Anything baked before late July still works, which is why this only shows up on new bakes.

One constraint in the server layer: `mcp<2`. The template alias hashes the recipe commands, so the pin re-bakes every task image on first use and the already-broken templates are simply never referenced again. Verified in a baked sandbox on the dev sandbox-service cluster — the import fails as resolved today, works with 1.29.1 (what `<2` resolves to) — and `scan_golden.py` then scores 1.0 on `fix-git` and `adaptive-rejection-sampler`, both freshly baked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
