### PR TITLE
fix: make get_async_loop initialization thread-safe

### DIFF
--- a/miles/utils/async_utils.py
+++ b/miles/utils/async_utils.py
@@ -31,12 +31,15 @@ class AsyncLoopThread:
 
 # Create one global instance
 async_loop = None
+_async_loop_init_lock = threading.Lock()
 
 
 def get_async_loop():
     global async_loop
     if async_loop is None:
-        async_loop = AsyncLoopThread()
+        with _async_loop_init_lock:
+            if async_loop is None:
+                async_loop = AsyncLoopThread()
     return async_loop
 
 

--- a/tests/fast/utils/test_async_utils.py
+++ b/tests/fast/utils/test_async_utils.py
@@ -1,10 +1,13 @@
-"""Tests for eager_create_task and AsyncioGatherUtils."""
+"""Tests for eager_create_task, AsyncioGatherUtils, and the get_async_loop singleton."""
 
 import asyncio
 import logging
+import threading
+import time
 
 import pytest
 
+import miles.utils.async_utils as async_utils
 from miles.utils.async_utils import AsyncioGatherUtils, eager_create_task
 
 
@@ -90,6 +93,41 @@ class TestCreateTaskComparison:
             task = asyncio.create_task(compute())
 
         assert await task == {"key": "value"}
+
+
+# ---- get_async_loop ----
+
+
+class TestGetAsyncLoopSingleton:
+    def test_concurrent_first_callers_share_one_loop(self, monkeypatch):
+        """Two threads racing the first call must construct exactly one loop; a
+        primitive bound to a losing loop later raises "bound to a different event loop"."""
+        constructed = []
+        real_init = async_utils.AsyncLoopThread.__init__
+
+        def slow_init(self):
+            constructed.append(self)
+            time.sleep(0.2)  # hold the check-then-act window open
+            real_init(self)
+
+        monkeypatch.setattr(async_utils.AsyncLoopThread, "__init__", slow_init)
+        monkeypatch.setattr(async_utils, "async_loop", None)
+
+        barrier = threading.Barrier(2)
+        results = []
+
+        def call():
+            barrier.wait()
+            results.append(async_utils.get_async_loop())
+
+        threads = [threading.Thread(target=call) for _ in range(2)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert len(constructed) == 1
+        assert results[0] is results[1]
 
 
 # ---- AsyncioGatherUtils ----


### PR DESCRIPTION
`get_async_loop()` initializes its singleton with an unlocked check-then-act. The first two callers in a RolloutManager process are exactly concurrent: `train_async.py` issues the pre-train eval dispatch and `generate.remote(0)` back-to-back, and both paths immediately call `asyncio.to_thread(call_rollout_function, ...)`, so two executor threads hit the first `get_async_loop()` at the same time. When the race fires, two event loops exist; the coroutine that landed on the losing loop binds asyncio primitives (e.g. `GenerateState.generate_fn_semaphore`) there, and any later acquire from the surviving loop raises `RuntimeError: ... is bound to a different event loop`.

Observed on #2823's CI (stage-c-8-gpu-h200): the fully-async **external** eval posture caches `GenerateState` across eval points, so the baseline eval crashed with exactly this error and was reported as `eval/skipped_crashed`. On main this failure mode is silently swallowed by the skip semantics; #2823's new CI gate surfaced it. The symmetric loss (first generate on the orphan loop) would crash training itself on the second rollout.

Fix: double-checked locking around the singleton construction. Test: widen the constructor window and race two threads through a barrier — fails on the unlocked code (two loops constructed), passes with the lock. `tests/fast/utils/test_async_utils.py` 24 passed on an h200 devbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)