### PR TITLE
smoke: manual golden episodes on real sandbox APIs

### DIFF
--- a/scripts/sandbox_smoke/README.md
+++ b/scripts/sandbox_smoke/README.md
@@ -1,0 +1,43 @@
+# Sandbox smoke: golden episodes on real sandbox APIs
+
+`run.py` runs one (connector, backend, agent, benchmark) combination against
+the real platform; PASS iff the verifier returns reward 1.0. With the default
+agent `golden` — the task's own reference solution, executed by the
+connector's own mechanism — no GPU, no model and no session server are
+involved, so what a run proves is exactly the platform round trip: image
+build, sandbox create, exec, verifier, teardown. The offline unit and
+contract tests cannot see that layer; the GPU e2e suite covers the layers
+above it (harness, session server, training).
+
+| flag | values | notes |
+| --- | --- | --- |
+| `--connector` | `harbor`, (`openenv` next) | which integration carries the episode |
+| `--backend` | `e2b`, `daytona`, `modal`, ... | passed through; the connector validates |
+| `--agent` | `golden` (default), or a harness name | a harness needs `--base-url`: a live session-server URL for full token fidelity, or any OpenAI-compatible endpoint when only the harness↔sandbox plumbing is under test — but never a third-party model API, which cannot sit behind the session server and so proves nothing about the training path |
+| `--benchmark` | `tb2` (default) | Terminal-Bench-2, cloned on first use; `TB2_TASKS_DIR` points at an existing checkout, `--task` overrides the preset `fix-git` instance |
+
+TB2 task directories are native Harbor tasks carrying prebuilt official
+images, so a checkout is directly usable and no image is built from a
+Dockerfile here. (If you point `--tasks-dir` at a Dockerfile-built task set
+instead, note that E2B Cloud builds templates as a non-root user, so `RUN`
+layers needing root fail there.)
+
+```bash
+pip install "harbor[e2b] @ git+https://github.com/harbor-framework/harbor@harbor-miles-v0.20.0"
+export E2B_API_KEY=e2b_...            # or a self-hosted E2B-compatible endpoint:
+# export E2B_API_URL=http://<server>:8000 E2B_SANDBOX_URL=http://<server>:8000
+python scripts/sandbox_smoke/run.py --connector harbor --backend e2b
+```
+
+Other backends follow the same key-file contract (`DAYTONA_API_KEY` /
+`~/.config/daytona/api_key`, ...; see `miles/rollout/agentic/credentials.py`).
+
+Run it from any machine holding the provider key — deliberately not a
+scheduled workflow, so no sandbox credential lives in repository secrets.
+
+## Exercised so far
+
+| connector | backend | agent | task | last run |
+| --- | --- | --- | --- | --- |
+| harbor | e2b | golden | tb2/fix-git | 2026-09-02 PASS |
+| harbor | daytona | golden | tb2/fix-git | 2026-09-02 PASS |

--- a/scripts/sandbox_smoke/README.md
+++ b/scripts/sandbox_smoke/README.md
@@ -23,7 +23,8 @@ instead, note that E2B Cloud builds templates as a non-root user, so `RUN`
 layers needing root fail there.)
 
 ```bash
-pip install "harbor[e2b] @ git+https://github.com/harbor-framework/harbor@harbor-miles-v0.20.0"
+# uv, not pip: the branch carries a uv-workspace dependency pip cannot resolve
+uv pip install "harbor[e2b] @ git+https://github.com/harbor-framework/harbor@harbor-miles-v0.20.0"
 mkdir -p ~/.config/e2b && echo e2b_... > ~/.config/e2b/api_key
 # the key FILE, not an exported var: this is the credential path training uses,
 # so a smoke run exercises it too (E2B_API_KEY in the env would shadow it)

--- a/scripts/sandbox_smoke/README.md
+++ b/scripts/sandbox_smoke/README.md
@@ -24,7 +24,10 @@ layers needing root fail there.)
 
 ```bash
 pip install "harbor[e2b] @ git+https://github.com/harbor-framework/harbor@harbor-miles-v0.20.0"
-export E2B_API_KEY=e2b_...            # or a self-hosted E2B-compatible endpoint:
+mkdir -p ~/.config/e2b && echo e2b_... > ~/.config/e2b/api_key
+# the key FILE, not an exported var: this is the credential path training uses,
+# so a smoke run exercises it too (E2B_API_KEY in the env would shadow it)
+# self-hosted E2B-compatible endpoint instead of E2B Cloud:
 # export E2B_API_URL=http://<server>:8000 E2B_SANDBOX_URL=http://<server>:8000
 python scripts/sandbox_smoke/run.py --connector harbor --backend e2b
 ```

--- a/scripts/sandbox_smoke/run.py
+++ b/scripts/sandbox_smoke/run.py
@@ -1,0 +1,154 @@
+"""Golden smoke of one (connector, backend, agent, benchmark) combination on the real sandbox API.
+
+PASS iff the verifier returns reward 1.0. What a run proves, the axes,
+credentials, and how to choose what to run: README.md next to this file.
+"""
+
+import argparse
+import asyncio
+import os
+import shutil
+import subprocess
+import sys
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+REPO = Path(__file__).resolve().parents[2]
+
+# The whole smoke should finish in minutes; a hung platform call must not eat
+# hours. Overridable (AGENT_TRIAL_TIMEOUT) for slow first-time template builds.
+_DEFAULT_TRIAL_TIMEOUT_S = "1200"
+
+# The connector-neutral name for "execute the task's own reference solution".
+GOLDEN = "golden"
+
+
+@dataclass(frozen=True)
+class Benchmark:
+    tasks_dir: Callable[[], Path]  # resolved lazily: may fetch on first use
+    smoke_task: str  # the instance a smoke run uses when --task is not given
+
+
+_TB2_REPO = "https://github.com/laude-institute/terminal-bench-2.git"
+
+
+def _tb2_tasks_dir() -> Path:
+    """A Terminal-Bench-2 checkout: TB2_TASKS_DIR if set, else a cached shallow clone.
+
+    TB2 task directories are native Harbor tasks (instruction.md, task.toml
+    with a prebuilt official docker_image, tests/, solution/), so a checkout
+    is directly usable as HARBOR_TASKS_DIR -- no preparation step.
+    """
+    env = os.environ.get("TB2_TASKS_DIR", "").strip()
+    if env:
+        return Path(env)
+    cache = Path.home() / ".cache" / "miles-sandbox-smoke" / "terminal-bench-2"
+    if not (cache / "fix-git").is_dir():
+        print(f"sandbox-smoke: cloning {_TB2_REPO} -> {cache}", flush=True)
+        cache.parent.mkdir(parents=True, exist_ok=True)
+        # clone into a scratch dir and rename into place, so an interrupted
+        # clone leaves nothing at the final path to block the next run
+        scratch = cache.with_name(cache.name + ".partial")
+        shutil.rmtree(cache, ignore_errors=True)
+        shutil.rmtree(scratch, ignore_errors=True)
+        subprocess.run(["git", "clone", "--depth", "1", _TB2_REPO, str(scratch)], check=True)
+        scratch.rename(cache)
+    return cache
+
+
+BENCHMARKS: dict[str, Benchmark] = {
+    # fix-git: small, easy, the task our golden runs have always used.
+    "tb2": Benchmark(tasks_dir=_tb2_tasks_dir, smoke_task="fix-git"),
+}
+
+
+async def _run_harbor(tasks_dir: Path, task: str, *, backend: str, agent: str, base_url: str) -> dict[str, Any]:
+    """One trial through examples/experimental/harbor/harbor_agent_function."""
+    sys.path.insert(0, str(REPO))  # for miles.rollout.agentic; no PYTHONPATH needed
+    sys.path.insert(0, str(REPO / "examples" / "experimental" / "harbor"))
+    try:
+        import harbor  # noqa: F401 -- probed eagerly: harbor_agent_function defers its harbor imports
+        import harbor_agent_function as haf
+    except ImportError as e:
+        raise SystemExit(
+            f"{e}\nharbor is not importable in this environment; the install line is in {Path(__file__).parent / 'README.md'}"
+        ) from e
+
+    if agent == GOLDEN:
+        agent = "oracle"  # harbor's solution-executing agent
+    os.environ["HARBOR_TASKS_DIR"] = str(tasks_dir)
+    os.environ["HARBOR_ENV_TYPE"] = backend
+    os.environ.setdefault("AGENT_TRIAL_TIMEOUT", _DEFAULT_TRIAL_TIMEOUT_S)
+    return await haf.run(
+        base_url=base_url,
+        prompt=[],
+        request_kwargs={},
+        metadata={"instance_id": task, "agent_name": agent},
+    )
+
+
+def _run_openenv(tasks_dir: Path, task: str, *, backend: str, agent: str, base_url: str) -> Any:
+    raise NotImplementedError(
+        "the openenv connector is not wired into this driver yet; its golden episode "
+        "lives in examples/experimental/openenv/scan_golden.py until then"
+    )
+
+
+# connector name -> (tasks_dir, task, backend=, agent=, base_url=) -> result dict
+CONNECTORS: dict[str, Callable[..., Any]] = {
+    "harbor": _run_harbor,
+    "openenv": _run_openenv,
+}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--connector", required=True, choices=sorted(CONNECTORS))
+    parser.add_argument(
+        "--backend", required=True, help="sandbox platform, passed through to the connector (e2b, daytona, modal, ...)"
+    )
+    parser.add_argument(
+        "--agent",
+        default=GOLDEN,
+        help=f"{GOLDEN!r} (default, no model needed) or a real harness name (needs --base-url)",
+    )
+    parser.add_argument("--benchmark", default="tb2", choices=sorted(BENCHMARKS))
+    parser.add_argument(
+        "--base-url", default="", help="OpenAI-compatible endpoint; required for any agent other than the golden one"
+    )
+    parser.add_argument("--task", default="", help="override the benchmark's preset smoke instance")
+    parser.add_argument("--tasks-dir", type=Path, default=None, help="override the benchmark's task directory")
+    args = parser.parse_args()
+
+    if args.agent != GOLDEN and not args.base_url:
+        parser.error(
+            f"--agent {args.agent} is a real harness and needs --base-url (only {GOLDEN!r} runs without a model)"
+        )
+    base_url = args.base_url or "http://smoke.invalid/sessions/smoke"  # the golden agent never calls it
+    benchmark = BENCHMARKS[args.benchmark]
+    tasks_dir = args.tasks_dir if args.tasks_dir is not None else benchmark.tasks_dir()
+    task = args.task or benchmark.smoke_task
+
+    print(
+        f"sandbox-smoke: connector={args.connector} backend={args.backend} agent={args.agent} "
+        f"benchmark={args.benchmark} task={task}",
+        flush=True,
+    )
+    result = asyncio.run(
+        CONNECTORS[args.connector](tasks_dir, task, backend=args.backend, agent=args.agent, base_url=base_url)
+    )
+    print(f"sandbox-smoke: result={result}", flush=True)
+
+    reward = float(result.get("reward", 0.0))
+    exit_status = result.get("exit_status", "")
+    if reward == 1.0 and exit_status == "Submitted":
+        print("sandbox-smoke: PASS", flush=True)
+        return 0
+    print(f"sandbox-smoke: FAIL (reward={reward}, exit_status={exit_status!r})", flush=True)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/fast/scripts/test_sandbox_smoke.py
+++ b/tests/fast/scripts/test_sandbox_smoke.py
@@ -1,0 +1,53 @@
+"""Offline checks of the sandbox-smoke harness: the registry's shape and the
+axis wiring. The real run needs a sandbox credential and is invoked manually
+(see scripts/sandbox_smoke/README.md)."""
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+RUN_PY = REPO_ROOT / "scripts" / "sandbox_smoke" / "run.py"
+
+
+@pytest.fixture(scope="module")
+def smoke() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("sandbox_smoke_run", RUN_PY)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_connectors_are_callables(smoke):
+    assert "harbor" in smoke.CONNECTORS
+    for name, runner in smoke.CONNECTORS.items():
+        assert callable(runner), name
+
+
+def test_golden_run_wires_all_axes_through(smoke, monkeypatch, tmp_path):
+    """connector/backend/agent/task all reach the runner; the golden default needs no endpoint."""
+    seen = {}
+
+    async def fake_runner(tasks_dir, task, *, backend, agent, base_url):
+        seen.update(tasks_dir=tasks_dir, task=task, backend=backend, agent=agent, base_url=base_url)
+        return {"reward": 1.0, "exit_status": "Submitted"}
+
+    monkeypatch.setitem(smoke.CONNECTORS, "harbor", fake_runner)
+    monkeypatch.setenv("TB2_TASKS_DIR", str(tmp_path))  # the env var wins over the cached clone
+    monkeypatch.setattr("sys.argv", ["run.py", "--connector", "harbor", "--backend", "daytona"])
+    assert smoke.main() == 0
+    # the benchmark preset filled in the task; the golden default reaches the connector untranslated
+    assert seen["backend"] == "daytona" and seen["task"] == "fix-git" and seen["agent"] == smoke.GOLDEN
+    assert seen["tasks_dir"] == tmp_path
+
+
+def test_a_real_harness_requires_a_model_endpoint(smoke, monkeypatch, capsys):
+    monkeypatch.setattr(
+        "sys.argv", ["run.py", "--connector", "harbor", "--backend", "e2b", "--agent", "mini-swe-agent"]
+    )
+    with pytest.raises(SystemExit) as excinfo:
+        smoke.main()
+    assert excinfo.value.code == 2
+    assert "--base-url" in capsys.readouterr().err


### PR DESCRIPTION
## Purpose

A manually-run smoke that proves the **real sandbox platform round trip** (image resolve, sandbox create, exec, verifier, teardown) — the layer the offline unit/contract tests cannot see. No GPU, no model: the default agent is `golden`, the task's own reference solution executed by the connector's own mechanism.

## What it adds

- `scripts/sandbox_smoke/run.py` — one CLI over four orthogonal axes: `--connector` (harbor; openenv next) × `--backend` (pass-through: e2b/daytona/modal/…) × `--agent` (`golden` default; a harness needs `--base-url`) × `--benchmark` (`tb2` default). Any combination the connectors can express is invocable; which subset to run is the caller's policy.
- Benchmark = **Terminal-Bench-2, cloned on first use** (`TB2_TASKS_DIR` overrides; preset task `fix-git`). TB2 task dirs are native Harbor tasks with prebuilt official images, so nothing is vendored in-repo and no image is built from a Dockerfile.
- Offline tests for the registry shape and the axis wiring (`tests/fast/scripts/test_sandbox_smoke.py`).

## Behavior change

None to training code. New script + tests only. Deliberately **not** a scheduled workflow: runs from any machine holding the provider key, so no sandbox credential enters repository secrets.

## Validated on the real platform

| connector | backend | agent | task | result |
| --- | --- | --- | --- | --- |
| harbor | e2b | golden | tb2/fix-git | PASS |
| harbor | daytona | golden | tb2/fix-git | PASS |
