### PR TITLE
[dockerfile] Track radixark/Megatron-Bridge@bridge in the CUDA Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -165,10 +165,7 @@ RUN pip install "git+https://github.com/NVIDIA-NeMo/Emerging-Optimizers.git@v0.3
 RUN TMS_CUDA_MAJOR=$(python3 -c "import torch; print(torch.version.cuda.split('.')[0])") \
     pip install git+https://github.com/fzyzcjy/torch_memory_saver.git@f05a8754daf68238d54e4cf31cb3ba866684bbaf --no-cache-dir --force-reinstall
 RUN pip install "nvidia-modelopt[torch]>=0.37.0" --no-build-isolation
-# radixark/Megatron-Bridge#24 (TE 2.17 grouped-linear contract), merged to @bridge.
-# Pinned by SHA, not branch: buildkit caches this layer on the instruction text, so a
-# branch that moves leaves the old revision baked into the image with nothing to show it.
-RUN pip install git+https://github.com/radixark/Megatron-Bridge.git@7f0fb3456f8ffe47599b5fd167b454605d85f932 --no-deps --no-build-isolation
+RUN pip install git+https://github.com/radixark/Megatron-Bridge.git@bridge --no-deps --no-build-isolation
 RUN pip install megatron-energon --no-deps
 RUN pip install multi-storage-client --no-deps
 


### PR DESCRIPTION
## What this changes

`docker/Dockerfile` installed `radixark/Megatron-Bridge` pinned to `7f0fb345` (radixark/Megatron-Bridge#24, 2026-07-26). This points the install at the `bridge` branch instead and removes the SHA-pin comment block above it.

## Why

- `bridge` is 16 commits past that pin: the multi-LoRA redesign (#26), recompute and expert-DDP grad routing (#27), ROCm TE grouped-linear fields (#28), the grouped-MM alignment fallback (#32), the GLM-5 sparse-MLA NaN fix (#31), and seeded slot init (#34). The CUDA image currently has none of them.
- `docker/Dockerfile.rocm` already installs `@bridge`; this makes the two images consistent.

## Note

buildkit keys this layer on the instruction text, so a later move of `bridge` does not by itself invalidate a cached layer. A rebuild with `--no-cache` (or any change to that `RUN` line) picks up the new head.
