### PR TITLE
Remove redundant inkling atomic update groups

### DIFF
--- a/miles/backends/megatron_utils/megatron_to_hf/inkling.py
+++ b/miles/backends/megatron_utils/megatron_to_hf/inkling.py
@@ -206,28 +206,3 @@ def convert_inkling_to_hf(args, name, param):
             return [(hp + "mlp.shared_experts.shared_w2_weight", torch.stack(out, dim=0))]
 
     raise ValueError(f"convert_inkling_to_hf: unhandled param name {name!r} (rest={rest!r})")
-
-
-def get_inkling_atomic_update_groups(args):
-    """Keep each accumulated group in one weight-sync bucket so the accumulator completes before flush."""
-    from ..update_weight.common import AtomicUpdateGroup
-
-    ns = _text_cfg(args)["n_shared_experts"]
-
-    groups = []
-    for which in ("linear_fc1", "linear_fc2"):
-        groups.append(
-            AtomicUpdateGroup(
-                key=f"inkling_shared_{which}",
-                suffixes=tuple(f".mlp.shared_experts.experts.{e}.{which}.weight" for e in range(ns)),
-                optional=True,
-            )
-        )
-    groups.append(
-        AtomicUpdateGroup(
-            key="inkling_gate",
-            suffixes=(".mlp.router.weight", ".mlp.router.shared_gate"),
-            optional=True,
-        )
-    )
-    return groups

--- a/miles/backends/megatron_utils/update_weight/common.py
+++ b/miles/backends/megatron_utils/update_weight/common.py
@@ -22,11 +22,10 @@ logger = logging.getLogger(__name__)
 class AtomicUpdateGroup:
     key: str
     suffixes: tuple[str, ...]
-    optional: bool = False
 
 
 def get_atomic_update_groups(args, model_name) -> list[AtomicUpdateGroup]:
-    model_groups = _get_model_atomic_update_groups(args, model_name)
+    model_groups = _get_model_atomic_update_groups(model_name)
     if model_groups:
         return model_groups
     return _get_q_lora_atomic_update_groups(args)
@@ -47,12 +46,8 @@ def _get_q_lora_atomic_update_groups(args) -> list[AtomicUpdateGroup]:
     ]
 
 
-def _get_model_atomic_update_groups(args, model_name) -> list[AtomicUpdateGroup]:
+def _get_model_atomic_update_groups(model_name) -> list[AtomicUpdateGroup]:
     model_name = model_name.lower()
-    if "inkling" in model_name:
-        from ..megatron_to_hf.inkling import get_inkling_atomic_update_groups
-
-        return get_inkling_atomic_update_groups(args)
     if "deepseekv4" in model_name:
         from ..megatron_to_hf.deepseekv4 import get_deepseek_v4_atomic_update_groups
 
@@ -108,7 +103,7 @@ def get_named_update_units(param_names: Sequence[str], atomic_update_groups) -> 
 
     for group in atomic_update_groups:
         assert (
-            group.optional or group.key in matched_group_keys
+            group.key in matched_group_keys
         ), f"Atomic update group {group.key} references no params matching suffixes {group.suffixes}"
 
     for (prefix, key), names in pending_groups.items():


### PR DESCRIPTION
## Motivation

`get_inkling_atomic_update_groups` is correctness-redundant since day 0 (#1683):

- The inkling converter accumulates shared-expert / router-gate pieces in a **module-global** `_PieceAccumulator` (`inkling.py:48`) that survives weight-sync bucket boundaries. If a group's pieces split across buckets, the accumulator simply completes in a later bucket.
- What it emits is a **single stacked HF tensor** (`shared_w13_weight` / `shared_w2_weight` / fused router gate), so the engine always receives the fused weight in one load call — sglang (whose inkling model has expected the stacked form since sgl-project/sglang#31681) never sees partial pieces.

So the groups only pinned emission timing, and they were the sole reason for the `optional=` escape hatch in the completeness assert.

## Modifications

- Delete `get_inkling_atomic_update_groups` and its dispatch branch.
- Revert `AtomicUpdateGroup` to required-only groups (drop `optional`, restore the strict completeness assert), and drop the now-unused `args` param of `_get_model_atomic_update_groups`.

Behavior for inkling after this change: `get_atomic_update_groups` falls through to the q_lora fallback, which returns `[]` because `args.q_lora_rank is None`.

## Validation

- `test_inkling_small_4layer_ci.py` (full) and `test_inkling_small_4layer_lora_ci.py` both pass on this branch with `check_weight_update_equal` (and `check_lora_weight_equal`) on; the per-tensor equality lists include `shared_experts.w13_weight`, `shared_experts.w2_weight` and `mlp.gate.weight`, i.e. exactly the tensors the deleted groups covered. Each sync ran 53 buckets.
- Those runs do not distinguish fixed from unfixed: nothing in the logs shows a deleted group's members straddling a bucket boundary, and the pre-change code passes them too. The correctness argument is the accumulator (`_ACC.put` returns `None` until all pieces arrive, is module-global, and holds the piece references across buckets).
- Not executed: an inkling run with a small `--update-weight-buffer-size` that forces every group across bucket boundaries.
- The dsv4 failures in `stage-c-4-gpu-h200 (0)/(1)` are main-wide (Megatron `miles-main` lacks the DeepSeek-V4 config fields; fixed by radixark/Megatron-LM#93), and the mi350 failure is the ROCm image's sglang lacking the Inkling model.