### PR TITLE
[PPO] Support the critic under --megatron-to-hf-mode bridge

### DIFF
--- a/docs/advanced/lora.md
+++ b/docs/advanced/lora.md
@@ -177,9 +177,9 @@ alternative aligned-expert path.
 - **Losses and algorithms.** LoRA wraps the actor model independently of the
   policy loss. The maintained RL recipes use critic-free estimators such as
   GRPO. The SFT loss path can use the same adapter hooks, although the repository
-  does not yet have a dedicated LoRA-SFT E2E test. Shared actor/critic PPO is not
-  supported by the general Bridge LoRA path because the critic path rejects
-  Bridge mode.
+  does not yet have a dedicated LoRA-SFT E2E test. Shared actor/critic PPO with
+  Bridge LoRA is untested: the critic is always built as a full model without
+  adapters.
 - **Checkpoints.** miles saves native per-rank adapter shards and
   optimizer/scheduler state. Exact resume expects the same TP/PP topology. It
   also attempts a best-effort HF PEFT `adapter_model.bin` plus
@@ -374,7 +374,8 @@ dataset-driven driver.
   is model-specific to Inkling. General native coverage is pending PR #1792.
 - **Remote transport:** NCCL broadcast only, with PP1. P2P/RDMA and disk-delta
   reject LoRA.
-- **PPO:** shared actor/critic PPO is incompatible with general Bridge LoRA.
+- **PPO:** shared actor/critic PPO with Bridge LoRA is untested; the critic never
+  gets adapters.
 - **Resume:** miles adapter shards are resumable with the matching parallel
   topology. Direct HF PEFT import into the Bridge model is not yet implemented;
   native Inkling has a custom importer.

--- a/docs/examples/ppo.md
+++ b/docs/examples/ppo.md
@@ -69,8 +69,9 @@ These are enforced at argument validation, so you get an error rather than a sil
   (`--no-offload-train` is accepted but warns, and is meant for offload debugging only); and when
   you scale, you only ever change the actor's placement — the actor world size is
   `--actor-num-nodes` × `--actor-num-gpus-per-node`, and `TP × PP × CP` must divide it.
-* **Megatron only.** PPO raises with any other train backend, and is unsupported with
-  `--megatron-to-hf-mode bridge`.
+* **Megatron only.** PPO raises with any other train backend. Both `--megatron-to-hf-mode raw`
+  and `bridge` are supported; in bridge mode the critic's value head is freshly initialized rather
+  than loaded from the HF checkpoint, since it has no HF counterpart.
 * **`--kl-coef` must be 0.** Reward-level KL is rejected because the critic trains *before* the
   actor and never sees ref log probs, so its value targets would silently exclude the KL penalty
   applied to the actor's rewards. Use loss-level `--use-kl-loss` / `--kl-loss-coef` instead.

--- a/examples/ppo/README.md
+++ b/examples/ppo/README.md
@@ -66,8 +66,9 @@ These are enforced at argument validation, so you get an error rather than a sil
   (`--no-offload-train` is accepted but warns, and is meant for offload debugging only); and when
   you scale, you only ever change the actor's placement — the actor world size is
   `--actor-num-nodes` × `--actor-num-gpus-per-node`, and `TP × PP × CP` must divide it.
-* **Megatron only.** PPO raises with any other train backend, and is unsupported with
-  `--megatron-to-hf-mode bridge`.
+* **Megatron only.** PPO raises with any other train backend. Both `--megatron-to-hf-mode raw`
+  and `bridge` are supported; in bridge mode the critic's value head is freshly initialized rather
+  than loaded from the HF checkpoint, since it has no HF counterpart.
 * **`--kl-coef` must be 0.** Reward-level KL is rejected because the critic trains *before* the
   actor and never sees ref log probs, so its value targets would silently exclude the KL penalty
   applied to the actor's rewards. Use loss-level `--use-kl-loss` / `--kl-loss-coef` instead.

--- a/miles/backends/megatron_utils/checkpoint.py
+++ b/miles/backends/megatron_utils/checkpoint.py
@@ -1,9 +1,11 @@
 import logging
 import os
 import re
+from contextlib import contextmanager
 from pathlib import Path
 
 import torch.distributed as dist
+from megatron.core.utils import unwrap_model
 
 # TODO: may need to copy those 2 functions and do refactoring.
 from megatron.training.checkpointing import load_checkpoint as _load_checkpoint_megatron
@@ -14,6 +16,7 @@ from miles.utils import megatron_bridge_utils
 from miles_plugins.models.deepseek_v4.arguments import assert_checkpoint_is_current, is_dsv4_model
 
 from .lora_utils import is_lora_enabled, is_lora_model, load_lora_adapter, save_lora_checkpoint
+from .model_provider import LinearForLastLayer
 
 try:
     # Here we patch out the `validate_non_overlapping_shards_metadata` in both functions
@@ -179,13 +182,30 @@ def _is_megatron_checkpoint(path: str | Path) -> bool:
     )
 
 
+@contextmanager
+def _hide_critic_value_head_from_hf_load(ddp_model):
+    value_heads = [
+        (chunk, name, head)
+        for chunk in unwrap_model(ddp_model)
+        for name, head in chunk.named_children()
+        if isinstance(head, LinearForLastLayer)
+    ]
+    for chunk, name, _ in value_heads:
+        delattr(chunk, name)
+    try:
+        yield
+    finally:
+        for chunk, name, head in value_heads:
+            setattr(chunk, name, head)
+
+
 def _load_checkpoint_hf(ddp_model, optimizer, args, load_path: str):
     assert args.megatron_to_hf_mode == "bridge", "Only bridge mode is supported for loading HF checkpoint"
     from megatron.bridge import AutoBridge
 
     logger.info(f"Load checkpoint from HuggingFace model into Megatron (path={load_path})")
 
-    with megatron_bridge_utils.patch_megatron_model(ddp_model):
+    with megatron_bridge_utils.patch_megatron_model(ddp_model), _hide_critic_value_head_from_hf_load(ddp_model):
         bridge = AutoBridge.from_hf_pretrained(load_path, trust_remote_code=True)
         bridge.load_hf_weights(ddp_model)
 

--- a/miles/backends/megatron_utils/model_provider.py
+++ b/miles/backends/megatron_utils/model_provider.py
@@ -167,6 +167,8 @@ def get_model_provider_func(
         bridge = AutoBridge.from_hf_pretrained(args.hf_checkpoint, trust_remote_code=True)
         provider = bridge.to_megatron_provider(load_weights=False)
         _apply_bridge_runtime_config(provider, args)
+        if role == "critic":
+            provider.share_embeddings_and_output_weights = False
         provider.finalize()
 
         def wrapped_bridge_provider(
@@ -183,6 +185,10 @@ def get_model_provider_func(
             if pg_collection is not None:
                 provider._pg_collection = pg_collection
             model = provider.provide(pre_process=pre_process, post_process=post_process, vp_stage=vp_stage)
+            if post_process and role == "critic":
+                model.output_layer = LinearForLastLayer(
+                    input_size=model.config.hidden_size, output_size=1, config=model.config
+                )
             assert not getattr(args, "enable_witness", False), "Witness is not supported yet in this mode"
             # Gemma-4 forward returns (logits, loss_mask); keep logits only.
             _bridge_forward = model.forward

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -3249,9 +3249,6 @@ def miles_validate_args(args):
     if args.use_critic:
         if args.train_backend != "megatron":
             raise ValueError("Shared Actor/Critic PPO requires the Megatron backend")
-        assert (
-            args.megatron_to_hf_mode != "bridge"
-        ), "Critic models are not supported with --megatron-to-hf-mode bridge"
         assert not enable_experimental_ft_trainer(), (
             "Shared Actor/Critic PPO is not supported with MILES_EXPERIMENTAL_FT_TRAINER=1: the v2 "
             "fault-tolerant train group cannot route critic values or lifecycle options yet. "

--- a/tests/fast/utils/test_arguments.py
+++ b/tests/fast/utils/test_arguments.py
@@ -591,7 +591,7 @@ class TestTitoFixedTemplateConfiguration:
         }
 
 
-def test_bridge_mode_rejects_critic(tmp_path):
+def test_bridge_mode_accepts_critic(tmp_path):
     parser = argparse.ArgumentParser()
     get_miles_extra_args_provider()(parser)
     args = parser.parse_args(
@@ -608,11 +608,8 @@ def test_bridge_mode_rejects_critic(tmp_path):
         + REQUIRED_ARGS
     )
 
-    with pytest.raises(
-        AssertionError,
-        match="Critic models are not supported with --megatron-to-hf-mode bridge",
-    ):
-        miles_validate_args(args)
+    miles_validate_args(args)
+    assert args.use_critic is True
 
 
 def test_critic_rejects_experimental_ft_trainer(tmp_path, monkeypatch):


### PR DESCRIPTION
## Why

PPO rejected `--megatron-to-hf-mode bridge` with "Critic models are not supported". The reason was in the bridge model provider: it ignored `role`, so the critic came out as a plain LM (vocab-sized output layer, tied to the embedding per HF `tie_word_embeddings`) instead of a value head, and `get_values` would have gotten `[1, T, vocab]` where it needs `[1, T, 1]`.

The critic never touches the weight-update path (it returns from `init` before `weight_updater` is built and has no `rollout_manager`), so no changes there.

## What

- **Provider** (`model_provider.py`): the bridge branch now does what the raw and custom branches already do for `role == "critic"` — `share_embeddings_and_output_weights = False` on the provider before `finalize()`, and swap `output_layer` for `LinearForLastLayer([hidden, 1])` on post-process stages.
- **HF load** (`checkpoint.py`): the critic's weights come from the HF checkpoint via `bridge.load_hf_weights()`. That walk maps `output_layer.weight` onto `lm_head.weight`; with the `[1, hidden]` head it raises on shape for untied models at TP=1 and takes a negative-pad path in `ColumnParallelMapping.hf_to_megatron` at TP>1 (`allowed_mismatched_params` does not reach that path). `_hide_critic_value_head_from_hf_load` detaches every `LinearForLastLayer` child for the duration of the load — same trick miles already uses with `hide_adapters` for multi-LoRA base loads. The head keeps its fresh init, matching the raw path (tied model → key missing → ignored by `assume_ok_unexpected`).
- Drop the assert in `arguments.py`; flip `test_bridge_mode_rejects_critic` → `test_bridge_mode_accepts_critic`.
- Docs: `examples/ppo/README.md` + regenerated `docs/examples/ppo.md`; `docs/advanced/lora.md` no longer cites the bridge-critic rejection as the reason PPO+Bridge LoRA is unsupported (it is now merely untested — the critic never gets adapters).

## Validation

- `pre-commit run --all-files` clean.
- `pytest tests/fast/utils/test_arguments.py` on an H200 devbox — 156 passed.
- E2E (run on the commit before the final `_hide_critic_value_head_from_hf_load` rewrite from `_modules.pop` to `delattr`/`setattr`; intended behavior-equivalent, **not re-run since**), 3 rollouts each, `tests/e2e/megatron/test_qwen3_4B_ppo.py` args plus `--megatron-to-hf-mode bridge` (HF dirs for `--hf-checkpoint`/`--ref-load`, no torch_dist), 4×H200 colocated:
  - **Qwen3-4B (tied), TP1/PP2/CP2** — exit 0. Critic loaded via the bridge with no `output_layer` mapping/shape warnings; rollout 0 critic-only; `critic-value_loss` 9.81 → 4.90 → 3.43 → 2.93 → 1.51 → 3.40.
  - **Qwen3-8B (untied, `tie_word_embeddings=false`), TP2/PP2** — exit 0. This is the configuration where the unhidden head would have hit the `lm_head.weight` shape path; no warnings, `critic-value_loss` 3.96 → 4.17 → 1.94 → 2.08 → 1.46 → 1.42.

Not executed: the full fast suite (CI covers it); PPO + Bridge LoRA; virtual pipeline (VPP) with a bridge critic.

## Follow-ups not in this PR

- `critic_load` defaults to the actor's `--load`, while `critic_save` is `--save + "_critic"`; on resume the critic therefore loads from the actor's checkpoint dir. Pre-existing, raw and bridge alike.
- `bridge_lora_helpers._make_value_model_hook` constructs `LinearForLastLayer(sequence_parallel=...)`, a kwarg the class does not take; it has no callers.


