### PR TITLE
[AMD] Disable inductor max-autotune in ROCm training actors

### DIFF
--- a/miles/ray/specs/train.py
+++ b/miles/ray/specs/train.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 from miles.ray.train_actor import TRAINER_CONCURRENCY_GROUPS, TRAINER_METHOD_CONCURRENCY_GROUPS
 from miles.ray.utils import NOSET_VISIBLE_DEVICES_ENV_VARS_LIST
-from miles.utils.environ import default_fp8_block_scaling_fp32_scales
+from miles.utils.environ import default_fp8_block_scaling_fp32_scales, default_train_inductor_autotune_env
 from miles.utils.ft_utils.indep_dp import create_tcp_store
 from miles.utils.megatron_args_utils import compute_megatron_world_size_except_dp
 from miles.utils.workers.worker_spec import PortInfo, SchedulingSpec, ServeWorkerSpec, WorkerLaunchContext
@@ -82,11 +82,12 @@ def _compute_spec_trainer(
         if (x := os.environ.get("NVTE_FP8_BLOCK_SCALING_FP32_SCALES")) is not None
         else default_fp8_block_scaling_fp32_scales()
     )
+    inductor_env = default_train_inductor_autotune_env()
 
     return ServeWorkerSpec(
         name=compute_trainer_pool_id(role),
         port_infos=[PortInfo(name=MASTER_PORT_NAME, static_port=9000, mode="master", allow_dynamic=True)],
-        env_var=lambda ctx: compute_trainer_env_vars(args, ctx, fp8_scales=fp8_scales),
+        env_var=lambda ctx: compute_trainer_env_vars(args, ctx, fp8_scales=fp8_scales, inductor_env=inductor_env),
         scheduling=SchedulingSpec(
             num_cells=num_cells,
             num_workers_per_cell=gpus_per_cell,
@@ -110,7 +111,9 @@ def _compute_spec_trainer(
     )
 
 
-def compute_trainer_env_vars(args, ctx: WorkerLaunchContext, *, fp8_scales: str) -> dict[str, str]:
+def compute_trainer_env_vars(
+    args, ctx: WorkerLaunchContext, *, fp8_scales: str, inductor_env: dict[str, str]
+) -> dict[str, str]:
     env_vars = {
         # because sglang will always set NCCL_CUMEM_ENABLE to 0
         # we need also set it to 0 to prevent nccl error.
@@ -119,6 +122,7 @@ def compute_trainer_env_vars(args, ctx: WorkerLaunchContext, *, fp8_scales: str)
         "NVSHMEM_DISABLE_NCCL": os.environ.get("NVSHMEM_DISABLE_NCCL", "1"),
         "NVTE_FP8_BLOCK_SCALING_FP32_SCALES": fp8_scales,
         **{name: "1" for name in NOSET_VISIBLE_DEVICES_ENV_VARS_LIST},
+        **inductor_env,
         **args.train_env_vars,
     }
 

--- a/miles/utils/environ.py
+++ b/miles/utils/environ.py
@@ -26,3 +26,18 @@ def default_fp8_block_scaling_fp32_scales() -> str:
         return "1"
     major, _minor = torch.cuda.get_device_capability()
     return "0" if major >= 10 else "1"
+
+
+def default_train_inductor_autotune_env() -> dict[str, str]:
+    """Inductor autotune env for training actors, decided by platform.
+
+    The ROCm image inherits TORCHINDUCTOR_MAX_AUTOTUNE=1 from the sglang base image.
+    With it on, compiled reductions benchmark many launch configs and the two forward
+    passes of one step can pick different ones, so log-probs stop being bitwise identical.
+    """
+    if os.environ.get("MILES_HARDWARE_PLATFORM") != "rocm":
+        return {}
+    return {
+        "TORCHINDUCTOR_MAX_AUTOTUNE": "0",
+        "TORCHINDUCTOR_MAX_AUTOTUNE_POINTWISE": "0",
+    }


### PR DESCRIPTION
Co-authored with: @XinyuJiangCMU 
## What

Fix a flaky ROCm failure in `tests/e2e/fsdp/test_qwen3_0.6B_megatron_fsdp_align.py`.

The step-0 consistency check runs the same batch with the same weights through the log-prob and training paths. On MI355X, `train/ppo_kl` was typically 4.5e-9 to 1.7e-8, exceeding the 1e-9 threshold. The same test reports 0.0 on H200.

## Root cause

The ROCm images enable:

    TORCHINDUCTOR_MAX_AUTOTUNE=1
    TORCHINDUCTOR_MAX_AUTOTUNE_POINTWISE=1

These settings are useful for inference, but training actors inherit them as well.

Megatron's fused vocabulary-parallel cross entropy uses `torch.compile`. The log-prob path runs under `torch.no_grad()`, while the training path runs with gradients, so Inductor compiles them separately.

With max autotune enabled, the two compiled kernels can choose different reduction configurations for `sum(exp(logit - max))`. This changes the reduction order and causes small floating-point differences, which show up as ~1e-8 PPO KL.

Disabling both autotune settings for training makes the two forwards match exactly.

## Fix

- Disable `TORCHINDUCTOR_MAX_AUTOTUNE` and `TORCHINDUCTOR_MAX_AUTOTUNE_POINTWISE` for ROCm training actors by default.
- Keep --train-env-vars as the final override.
- Leave rollout engines unchanged, so sglang ROCm inference still uses autotuning.
- Leave CUDA behavior unchanged.

## Verification

Tested on one MI355X node with `rocm/sgl-dev:miles-rocm720-mi35x-20260829`.

- Replayed the same saved rollout batch six times with cold caches:
    - before: 5/6 failed the PPO KL check
    - after: 6/6 passed with train/ppo_kl = 0.0
- Confirmed training actors use both autotune variables as 0, while the sglang scheduler remains at 1.
- Two full runs of `test_qwen3_0.6B_megatron_fsdp_align.py` passed with fresh rollout data:
    - train/ppo_kl = 0.0
    - train/pg_clipfrac = 0.0
    - grad-norm checks passed

## Notes
ROCm training throughput impact has not been measured. Rollout autotuning remains enabled.