### PR TITLE
test: declare the Anthropic intermediate-system expectation for qwen38small

### DIFF
--- a/tests/e2e/sglang/test_session_server_multi_role/test_qwen38small.py
+++ b/tests/e2e/sglang/test_session_server_multi_role/test_qwen38small.py
@@ -17,6 +17,7 @@ CONFIG = ModelConfig(
     mamba_full_memory_ratio=4.59,
     cycles=2,
     tool_call_failure_mode="append_tool",
+    anthropic_intermediate_system_expectation="forbidden",
 )
 
 


### PR DESCRIPTION
## Motivation

`tests/e2e/sglang/test_session_server_multi_role/test_qwen38small.py` fails before its Anthropic pass:

```text
ValueError: Anthropic per-model verification requires an intermediate-system expectation
```

#2711 made `anthropic_intermediate_system_expectation` mandatory whenever `verify_anthropic` is on (the default). #2760 added this config without it, and #2760 merged without any e2e label, so the test never ran. Every sibling config declares one (`required` for qwen3 / nemotron3 / glm47 / inkling, `forbidden` for qwen35 / qwen36 / dsv4, minimax turns `verify_anthropic` off).

## Modifications

Add `anthropic_intermediate_system_expectation="forbidden"` to the qwen38small `ModelConfig`. The agent derives the live capability as `route_supports and "system" in fixed_template_append_roles(tito_model)`; `Qwen38SmallTITOTokenizer` appends only `tool/user/assistant`, the same as Qwen3.5 / Qwen3.6, whose tests declare `forbidden`.

## Validation

Not executed here: the test needs `run-ci-sglang` (2× H200). First observed on radixark/miles#2756 (stage-c-2-gpu-h200 (0)), where the training job succeeded and only this harness check raised.