### PR TITLE
fix(verifiers): cap renderers before pool API removal

### DIFF
--- a/examples/experimental/verifiers/requirements.txt
+++ b/examples/experimental/verifiers/requirements.txt
@@ -1,4 +1,5 @@
 openai-agents<0.5
-renderers>=0.1.8
+# 0.1.11 removes the renderer pool APIs used by Miles and Verifiers 0.2.0.
+renderers>=0.1.8,<0.1.11
 # 0.2.1 requires OpenAI>=2.9, while SGLang pins OpenAI==2.6.1.
 verifiers>=0.2.0,<0.2.1

--- a/examples/experimental/verifiers/verifiers_rollout.py
+++ b/examples/experimental/verifiers/verifiers_rollout.py
@@ -46,6 +46,7 @@ logger = logging.getLogger(__name__)
 _MIN_VERIFIERS_VERSION = Version("0.2.0")
 _MAX_VERIFIERS_VERSION = Version("0.2.1")
 _MIN_RENDERERS_VERSION = Version("0.1.8")
+_MAX_RENDERERS_VERSION = Version("0.1.11")
 _UNSUPPORTED_ERROR_PREFIX = "Miles' Verifiers adapter does not support"
 _CONFIG_ENV_VAR = "VERIFIERS_CONFIG"
 
@@ -79,7 +80,14 @@ def _installed_version(package: str) -> str:
         raise _optional_dependency_error() from error
 
 
-def _check_version(package: str, raw_version: str, minimum: Version, maximum: Version | None = None) -> None:
+def _check_version(
+    package: str,
+    raw_version: str,
+    minimum: Version,
+    maximum: Version | None = None,
+    *,
+    maximum_reason: str | None = None,
+) -> None:
     try:
         installed = Version(raw_version)
     except InvalidVersion as error:
@@ -87,10 +95,10 @@ def _check_version(package: str, raw_version: str, minimum: Version, maximum: Ve
     if installed < minimum:
         raise RuntimeError(f"Verifiers rollouts require {package}>={minimum}; found {installed}.")
     if maximum is not None and installed >= maximum:
-        raise RuntimeError(
-            f"Verifiers rollouts require {package}>={minimum},<{maximum}; found {installed}. "
-            "Verifiers 0.2.1 requires OpenAI>=2.9, while SGLang 0.5.15 pins OpenAI==2.6.1."
-        )
+        message = f"Verifiers rollouts require {package}>={minimum},<{maximum}; found {installed}."
+        if maximum_reason is not None:
+            message += f" {maximum_reason}"
+        raise RuntimeError(message)
 
 
 def _import_verifiers():
@@ -101,8 +109,15 @@ def _import_verifiers():
         _installed_version("verifiers"),
         _MIN_VERIFIERS_VERSION,
         _MAX_VERIFIERS_VERSION,
+        maximum_reason="Verifiers 0.2.1 requires OpenAI>=2.9, while SGLang 0.5.15 pins OpenAI==2.6.1.",
     )
-    _check_version("renderers", _installed_version("renderers"), _MIN_RENDERERS_VERSION)
+    _check_version(
+        "renderers",
+        _installed_version("renderers"),
+        _MIN_RENDERERS_VERSION,
+        _MAX_RENDERERS_VERSION,
+        maximum_reason="Renderers 0.1.11 removes the renderer pool APIs used by Miles and Verifiers 0.2.0.",
+    )
     try:
         from verifiers.v1 import EnvConfig, Environment, ModelContext, SamplingConfig
         from verifiers.v1.clients.train import TrainClient

--- a/tests/fast/examples/experimental/verifiers/test_verifiers_rollout.py
+++ b/tests/fast/examples/experimental/verifiers/test_verifiers_rollout.py
@@ -5,7 +5,6 @@ from contextlib import asynccontextmanager
 from types import SimpleNamespace
 
 import pytest
-from packaging.version import Version
 
 if sys.version_info < (3, 11):
     pytest.skip("Verifiers requires Python 3.11+", allow_module_level=True)
@@ -13,9 +12,9 @@ if sys.version_info < (3, 11):
 from examples.experimental.verifiers.verifiers_rollout import (
     MilesSGLangTransport,
     VerifiersRolloutFn,
-    _check_version,
     _config_path,
     _finish_reason,
+    _import_verifiers,
     _load_config_data,
     _make_eval_args,
     _raise_for_unsupported_trace_errors,
@@ -143,9 +142,28 @@ def test_config_loader_rejects_non_toml_formats(tmp_path):
         _load_config_data(path)
 
 
-def test_verifiers_0_2_1_is_rejected_with_compatibility_reason():
+def test_verifiers_0_2_1_is_rejected_with_compatibility_reason(monkeypatch):
+    monkeypatch.setattr(
+        "examples.experimental.verifiers.verifiers_rollout._installed_version",
+        lambda package: {"verifiers": "0.2.1"}[package],
+    )
+
     with pytest.raises(RuntimeError, match="SGLang 0.5.15 pins OpenAI"):
-        _check_version("verifiers", "0.2.1", Version("0.2.0"), Version("0.2.1"))
+        _import_verifiers()
+
+
+def test_renderers_0_1_11_is_rejected_with_compatibility_reason(monkeypatch):
+    versions = {"verifiers": "0.2.0", "renderers": "0.1.11"}
+    monkeypatch.setattr(
+        "examples.experimental.verifiers.verifiers_rollout._installed_version",
+        versions.__getitem__,
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match=r"renderers>=0\.1\.8,<0\.1\.11.*removes the renderer pool APIs",
+    ):
+        _import_verifiers()
 
 
 def test_transport_does_not_treat_aborted_generation_as_complete():


### PR DESCRIPTION
## Summary
Keep Verifiers on pool-compatible Renderers and reject incompatible host installs at startup.

## Symptom & Reproduction
- **Symptom:** `stage-c-2-gpu-h200 (1) / run` [timed out](https://github.com/radixark/miles/actions/runs/33647081842/job/100308489355) at revision `1e3b7a08870952d487c5d14d43d53deab2c24eee` after its venv installed `renderers==0.1.12.dev2`; Renderers 0.1.11 [removed renderer pool APIs](https://github.com/PrimeIntellect-ai/renderers/releases/tag/renderers-v0.1.11).
- **Reproduction:** On Python 3.12, `uv run --no-project --with 'renderers==0.1.12.dev2' --with httpx python -c 'from renderers import RendererPool'` deterministically raises `ImportError: cannot import name 'RendererPool'`.

## Root Cause
1. `renderers>=0.1.8` can resolve a pool-incompatible release.
2. `requirements.txt` constrains only environments that install it.
3. `_import_verifiers()` checks only Renderers' lower bound.
4. `_renderer_pool()` imports removed APIs inside episode execution.
5. `_call_train()` resamples episode exceptions until timeout.

## Fix
Cap the example requirements at `<0.1.11` and enforce the same upper bound in `_import_verifiers()`. This keeps documented and E2E installs compatible while making unmanaged host environments fail during adapter construction with a Renderers-specific diagnosis, before any episode is scheduled. It preserves Verifiers 0.2.0 and OpenAI 2.6.1 and does not attempt an API migration.

## Verification
- `test_renderers_0_1_11_is_rejected_with_compatibility_reason`: passed and proved the exact upper bound plus Renderers-specific startup error.
- `tests/fast/examples/experimental/verifiers/test_verifiers_rollout.py`: 39 passed; 9 optional-dependency cases skipped because the local environment lacks `renderers` and `verifiers`.
- Ruff, Black, and `git diff --check`: passed for both touched Python files at `cdf1571af4a32fd46de35e31770541f96cf0ba8d`.

## Review Focus
- `requirements.txt` and `_MAX_RENDERERS_VERSION`: both use the exclusive 0.1.11 compatibility boundary.
- `_import_verifiers()`: rejects incompatible host packages before `RendererPool` import and resampling while preserving package-specific diagnostics.
