### PR TITLE
perf(p2p): make PD publication destination-aware and add DSV4 param mappings

### DIFF
--- a/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/p2p.py
+++ b/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/p2p.py
@@ -33,6 +33,52 @@ from .p2p_transfer_utils import (
 logger = logging.getLogger(__name__)
 
 
+def _parameter_mapper_from_model(model: torch.nn.Module) -> ParameterMapper:
+    """Build a mapper, including mappings that DSV4 keeps local to load_weights."""
+    if getattr(getattr(model, "config", None), "model_type", None) != "deepseek_v4":
+        return ParameterMapper.from_model(model)
+
+    from sglang.srt.layers.moe.fused_moe_triton import FusedMoE
+    from sglang.srt.models.deepseek_v4 import DEEPSEEK_V4_STACKED_PARAMS_MAPPING
+
+    stacked_mapping = list(DEEPSEEK_V4_STACKED_PARAMS_MAPPING)
+    param_names = {name for name, _param in model.named_parameters()}
+    if any(".self_attn.wqkv_a." in name for name in param_names):
+        stacked_mapping.extend(
+            [
+                (".self_attn.wqkv_a.", ".self_attn.wq_a.", 0),
+                (".self_attn.wqkv_a.", ".self_attn.wkv.", 1),
+            ]
+        )
+    stacked_mapping.extend(
+        [
+            (".compressor.wkv_gate.", ".compressor.wkv.", 0),
+            (".compressor.wkv_gate.", ".compressor.wgate.", 1),
+        ]
+    )
+
+    num_routed_experts = model.config.n_routed_experts
+    num_fused_shared_experts = model.num_fused_shared_experts
+    expert_mapping = FusedMoE.make_expert_params_mapping(
+        ckpt_gate_proj_name="gate_proj",
+        ckpt_down_proj_name="down_proj",
+        ckpt_up_proj_name="up_proj",
+        num_experts=num_routed_experts + num_fused_shared_experts,
+    )
+
+    def mutate_weight_preload(name: str) -> str:
+        if num_fused_shared_experts > 0 and "mlp.shared_experts" in name:
+            return name.replace("mlp.shared_experts", f"mlp.experts.{num_routed_experts}")
+        return name
+
+    return ParameterMapper(
+        stacked_params_mapping=stacked_mapping,
+        expert_params_mapping=expert_mapping,
+        num_local_experts=num_routed_experts + num_fused_shared_experts,
+        mutate_weight_preload=mutate_weight_preload,
+    )
+
+
 class UpdateWeightP2P(DistBucketedWeightUpdateMixin):
     """P2P weight transfer using DistBucketedWeightUpdateMixin for bucketed all-gather + HF conversion,
     and a single set of shared CPU pinned buffers for P2P writes.
@@ -192,6 +238,15 @@ class UpdateWeightP2P(DistBucketedWeightUpdateMixin):
         self._connection_stale = False
         self.rollout_engine_lock = rollout_engine_lock
 
+        if engine_gpu_counts is None:
+            engine_gpu_counts = [self.args.rollout_num_gpus_per_engine] * len(rollout_engines)
+        if len(engine_gpu_counts) != len(rollout_engines):
+            raise ValueError(
+                f"P2P engine topology mismatch: {len(engine_gpu_counts)} GPU counts "
+                f"for {len(rollout_engines)} engines"
+            )
+        self.transfer_plan.set_target_topology(engine_gpu_counts)
+
         if self._is_source:
             self._group_name = f"miles-p2p_{self.transfer_plan._gathered_dp_rank}"
             targets = self.transfer_plan.plan_p2p()
@@ -230,7 +285,7 @@ class UpdateWeightP2P(DistBucketedWeightUpdateMixin):
                 )
                 if first_engine_rank:
                     self._shared_params_dict = dict(model_replica.named_parameters())
-                    self._shared_param_mapper = ParameterMapper.from_model(model_replica)
+                    self._shared_param_mapper = _parameter_mapper_from_model(model_replica)
                     first_engine_rank = False
 
                 remote_infos = [
@@ -263,15 +318,15 @@ class UpdateWeightP2P(DistBucketedWeightUpdateMixin):
         initialize_fp8_gemm_config(server_args)
         initialize_fp4_gemm_config(server_args)
 
-        # Monkey-patch the loader-level post_load_weights to no-op BEFORE get_model,
-        # because get_model() calls post_load_weights() internally (loader.py:1310)
-        # which may invoke CUDA-only kernels (e.g., per_tensor_quant_fp8 for FP8 models).
-        # This is safe because the rollout engine runs post_load_weights on its own GPU
-        # after RDMA transfer, at end_weight_update.
+        # This CPU model is only a staging layout: every parameter is overwritten
+        # before publication. Skip dummy initialization and GPU-only post-load work.
+        # The rollout engine runs post_load_weights on its own GPU after transfer.
         from sglang.srt.model_loader import loader as model_loader_module
 
         original_post_load_weights = model_loader_module.post_load_weights
+        original_initialize_dummy_weights = model_loader_module.initialize_dummy_weights
         model_loader_module.post_load_weights = lambda *args, **kwargs: None
+        model_loader_module.initialize_dummy_weights = lambda *args, **kwargs: None
         try:
             with ParallelismContext(parallelism_config):
                 model = get_model(
@@ -281,11 +336,17 @@ class UpdateWeightP2P(DistBucketedWeightUpdateMixin):
                 )
         finally:
             model_loader_module.post_load_weights = original_post_load_weights
+            model_loader_module.initialize_dummy_weights = original_initialize_dummy_weights
 
         # Also patch the instance method for subsequent load_weights() calls
         # (deepseek_weight_loader.py:342 calls self.post_load_weights() at the end).
         if hasattr(model, "post_load_weights"):
             model.post_load_weights = lambda *args, **kwargs: None
+        # DSV4 calls this directly from ``load_weights``. It compiles a CUDA
+        # kernel and needs an initialized TP group, neither of which applies to
+        # the CPU-only staging replica.
+        if hasattr(model, "_prewarm_mhc_pre_kernels"):
+            model._prewarm_mhc_pre_kernels = lambda *args, **kwargs: None
 
         if first_engine_rank:
             for param in model.parameters():

--- a/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/p2p_transfer_utils.py
+++ b/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/p2p_transfer_utils.py
@@ -63,6 +63,21 @@ class RemoteTransferPlan:
         self._rollout_num_gpu_per_engine = args.rollout_num_gpus_per_engine
         self._rollout_engine_count = args.rollout_num_gpus // self._rollout_num_gpu_per_engine
         self._rollout_num_gpus = args.rollout_num_gpus
+        self._engine_gpu_counts = [self._rollout_num_gpu_per_engine] * self._rollout_engine_count
+
+    def set_target_topology(self, engine_gpu_counts: Sequence[int]) -> None:
+        """Use the update-enabled engines reported by the rollout manager.
+
+        ``rollout_num_gpus`` includes every server group in a P/D deployment,
+        while the updater receives only engines belonging to the model marked
+        for weight updates. Deriving targets from the former can therefore
+        produce engine indices that do not exist in ``rollout_engines``.
+        """
+        if not engine_gpu_counts or any(count <= 0 for count in engine_gpu_counts):
+            raise ValueError(f"P2P weight transfer requires positive engine GPU counts: {engine_gpu_counts}")
+        self._engine_gpu_counts = list(engine_gpu_counts)
+        self._rollout_engine_count = len(self._engine_gpu_counts)
+        self._rollout_num_gpus = sum(self._engine_gpu_counts)
 
     def plan_p2p(self) -> list[TransferTaskP2PMeta]:
         """
@@ -88,8 +103,8 @@ class RemoteTransferPlan:
         """
         all_targets = [
             (engine_idx, engine_rank)
-            for engine_idx in range(self._rollout_engine_count)
-            for engine_rank in range(self._rollout_num_gpu_per_engine)
+            for engine_idx, gpu_count in enumerate(self._engine_gpu_counts)
+            for engine_rank in range(gpu_count)
         ]
         assignments = defaultdict(lambda: defaultdict(list))
 

--- a/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/p2p_transfer_utils.py
+++ b/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/p2p_transfer_utils.py
@@ -187,13 +187,16 @@ class P2PTransferManager:
 
     def wait_transfers(self) -> None:
         """Wait for all submitted tasks to complete."""
-        for future in self.transfer_futures:
+        futures, self.transfer_futures = self.transfer_futures, []
+        first_error: Exception | None = None
+        for future in futures:
             try:
                 future.result(timeout=self.transfer_timeout)
-            except Exception as e:
-                logger.error(f"[P2P] Transfer future failed: {e}")
-
-        self.transfer_futures.clear()
+            except Exception as error:
+                if first_error is None:
+                    first_error = error
+        if first_error is not None:
+            raise first_error
 
 
 def create_server_args_from_dict(data_dict: dict) -> ServerArgs:

--- a/tests/fast/backends/megatron_utils/test_p2p_transfer_plan.py
+++ b/tests/fast/backends/megatron_utils/test_p2p_transfer_plan.py
@@ -1,4 +1,5 @@
 import sys
+from concurrent.futures import Future
 from types import ModuleType
 
 mooncake = ModuleType("mooncake")
@@ -8,6 +9,7 @@ sys.modules.setdefault("mooncake", mooncake)
 sys.modules.setdefault("mooncake.engine", mooncake_engine)
 
 from miles.backends.megatron_utils.update_weight.update_weight_from_distributed.p2p_transfer_utils import (
+    P2PTransferManager,
     RemoteTransferPlan,
 )
 
@@ -60,6 +62,22 @@ def test_p2p_plan_rejects_empty_target_topology() -> None:
         assert "positive engine GPU counts" in str(error)
     else:
         raise AssertionError("empty target topology was accepted")
+
+
+def test_p2p_transfer_failure_is_not_silenced() -> None:
+    manager = P2PTransferManager()
+    failed = Future()
+    failed.set_exception(RuntimeError("transfer failed"))
+    manager.transfer_futures.append(failed)
+
+    try:
+        manager.wait_transfers()
+    except RuntimeError as error:
+        assert str(error) == "transfer failed"
+    else:
+        raise AssertionError("transfer failure was silenced")
+
+    assert manager.transfer_futures == []
 
 
 def _plan_for_source(plan: RemoteTransferPlan, source_rank: int):

--- a/tests/fast/backends/megatron_utils/test_p2p_transfer_plan.py
+++ b/tests/fast/backends/megatron_utils/test_p2p_transfer_plan.py
@@ -1,0 +1,67 @@
+import sys
+from types import ModuleType
+
+mooncake = ModuleType("mooncake")
+mooncake_engine = ModuleType("mooncake.engine")
+mooncake_engine.TransferEngine = object
+sys.modules.setdefault("mooncake", mooncake)
+sys.modules.setdefault("mooncake.engine", mooncake_engine)
+
+from miles.backends.megatron_utils.update_weight.update_weight_from_distributed.p2p_transfer_utils import (
+    RemoteTransferPlan,
+)
+
+
+def _plan(*, source_count: int, source_rank: int) -> RemoteTransferPlan:
+    plan = RemoteTransferPlan.__new__(RemoteTransferPlan)
+    plan._pp_rank = 0
+    plan._gathered_dp_size = source_count
+    plan._gathered_dp_rank = source_rank
+    plan._rollout_num_gpu_per_engine = 8
+    plan._rollout_engine_count = 4
+    plan._rollout_num_gpus = 32
+    plan._engine_gpu_counts = [8, 8, 8, 8]
+    return plan
+
+
+def test_p2p_plan_uses_actual_pd_update_engine_topology() -> None:
+    plan = _plan(source_count=8, source_rank=0)
+
+    plan.set_target_topology([8, 8])
+    all_tasks = [task for source_rank in range(8) for task in _plan_for_source(plan, source_rank)]
+
+    assert len(all_tasks) == 16
+    assert {task.engine_ind for task in all_tasks} == {0, 1}
+    assert {task.engine_rank for task in all_tasks} == set(range(8))
+
+
+def test_p2p_plan_supports_heterogeneous_engine_sizes() -> None:
+    plan = _plan(source_count=4, source_rank=0)
+
+    plan.set_target_topology([2, 4])
+    all_tasks = [task for source_rank in range(4) for task in _plan_for_source(plan, source_rank)]
+
+    assert sorted((task.engine_ind, task.engine_rank) for task in all_tasks) == [
+        (0, 0),
+        (0, 1),
+        (1, 0),
+        (1, 1),
+        (1, 2),
+        (1, 3),
+    ]
+
+
+def test_p2p_plan_rejects_empty_target_topology() -> None:
+    plan = _plan(source_count=8, source_rank=0)
+
+    try:
+        plan.set_target_topology([])
+    except ValueError as error:
+        assert "positive engine GPU counts" in str(error)
+    else:
+        raise AssertionError("empty target topology was accepted")
+
+
+def _plan_for_source(plan: RemoteTransferPlan, source_rank: int):
+    plan._gathered_dp_rank = source_rank
+    return plan.plan_p2p()


### PR DESCRIPTION
#### Summary
- derive the P2P transfer plan from the actual update-enabled rollout-engine topology
- add the DeepSeek-V4 parameter mappings needed by the CPU staging replica
- propagate background P2P transfer failures instead of logging and discarding them

#### Commit structure

The changes are intentionally split into two commits:

1. Destination-aware P2P planning and DeepSeek-V4 staging support.
2. Transfer-error propagation. This is isolated because it overlaps conceptually with #1732 and can be dropped independently.


This change lowered our update_weights time from 30s to 7s for DSV4-Flash-FP8
