### PR TITLE
dashboard: pin the anatomy lane to a duplicated index's first leaf

### DIFF
--- a/miles/dashboard/static/views_rollout.js
+++ b/miles/dashboard/static/views_rollout.js
@@ -220,7 +220,11 @@ export async function renderRollout(view, meta, route) {
         createAnatomy({
           lanes: trajectories.lanes,
           consumeTs: trajectories.consume_ts,
-          rowsByIndex: new Map(rows.map((r) => [r.sample_index, r])),
+          // A TITO index can carry several leaves; the lifecycle lane is their
+          // shared execution, so the panel labels and opens the FIRST leaf
+          // (last-one-wins would label one leaf while clicking opened another).
+          // The samples table below reaches every (index, occurrence) row.
+          rowsByIndex: new Map(rows.filter((r) => (r.sample_occurrence ?? 0) === 0).map((r) => [r.sample_index, r])),
           onClickSample: (index) => openTokens({ sample_index: index, sample_occurrence: 0 }),
         }),
       );


### PR DESCRIPTION
## Summary

Follow-up to #2881, addressing the review-bot finding that landed after the merge.

The Trajectories/anatomy panel built `rowsByIndex` as a plain `Map(rows.map(r => [r.sample_index, r]))`. With #2881 merged, a TITO index can carry several summary rows (one per leaf occurrence), and last-one-wins meant the panel labelled a lane with the LAST leaf's reward/turns/versions while clicking the lane always opened occurrence 0's token view — two different leaves.

A lifecycle lane is the shared execution of all leaves of an index (the probes carry no occurrence), so the panel now consistently labels and opens the FIRST leaf, with a comment saying so. Every individual `(index, occurrence)` row remains reachable through the samples table on the same page.

## Validation

- `node --check` passes on the changed module.
- The dashboard frontend has no test harness; the change is a one-line filter plus a comment.