### PR TITLE
fix colocate lora duplicated cpu param backup by keeping TMS only

### DIFF
--- a/miles/backends/megatron_utils/actor.py
+++ b/miles/backends/megatron_utils/actor.py
@@ -272,7 +272,7 @@ class MegatronTrainRayActor(TrainRayActor):
                     self.args,
                     self.model,
                     convert_to_global_name=args.megatron_to_hf_mode == "raw",
-                    read_tms_backup=True,
+                    translate_gpu_to_cpu=True,
                 )
             )
         else:

--- a/miles/backends/megatron_utils/actor.py
+++ b/miles/backends/megatron_utils/actor.py
@@ -375,10 +375,11 @@ class MegatronTrainRayActor(TrainRayActor):
     def _weight_sync_reads_tms_backup(self) -> bool:
         """Under colocated LoRA the frozen base already has a memory-saver host backup; a
         pinned "actor" copy of it would duplicate the whole base per rank. Model switching
-        still needs the real backups."""
+        still needs the real backups, and a disk offload target leaves no host backup to read."""
         return (
             self.args.colocate
             and is_lora_enabled(self.args)
+            and self.args.offload_train_target == "cpu"
             and not (self.with_ref or self.with_opd_teacher or self.args.keep_old_actor)
         )
 

--- a/miles/backends/megatron_utils/actor.py
+++ b/miles/backends/megatron_utils/actor.py
@@ -266,10 +266,21 @@ class MegatronTrainRayActor(TrainRayActor):
                 update_weight_cls = UpdateWeightFromDiskDelta
             else:
                 update_weight_cls = UpdateWeightP2P
+        if self._weight_sync_reads_tms_backup:
+            weights_getter = lambda: dict(  # noqa: E731
+                named_params_and_buffers(
+                    self.args,
+                    self.model,
+                    convert_to_global_name=args.megatron_to_hf_mode == "raw",
+                    read_tms_backup=True,
+                )
+            )
+        else:
+            weights_getter = lambda: self.weights_backuper.get("actor")  # noqa: E731
         self.weight_updater = update_weight_cls(
             self.args,
             self.model,
-            weights_getter=lambda: self.weights_backuper.get("actor"),
+            weights_getter=weights_getter,
             model_name=type(self.hf_config).__name__.lower() if self.args.model_name is None else self.args.model_name,
             quantization_config=getattr(self.hf_config, "quantization_config", None),
             is_lora=lora_rollout_enabled(args),
@@ -361,8 +372,21 @@ class MegatronTrainRayActor(TrainRayActor):
         print_memory("after wake_up model")
 
     @property
+    def _weight_sync_reads_tms_backup(self) -> bool:
+        """Under colocated LoRA the frozen base already has a memory-saver host backup; a
+        pinned "actor" copy of it would duplicate the whole base per rank. Model switching
+        still needs the real backups."""
+        return (
+            self.args.colocate
+            and is_lora_enabled(self.args)
+            and not (self.with_ref or self.with_opd_teacher or self.args.keep_old_actor)
+        )
+
+    @property
     def _enable_weight_backup(self) -> bool:
         """Weight backup is only needed for CPU-side model switching or colocated tensor weight sync."""
+        if self._weight_sync_reads_tms_backup:
+            return False
         return self.with_ref or self.with_opd_teacher or self.args.keep_old_actor or self.args.colocate
 
     def _switch_model(self, target_tag: str) -> None:
@@ -676,13 +700,15 @@ class MegatronTrainRayActor(TrainRayActor):
             for adapter in adapters_to_load:
                 self.loaded_adapters[adapter.name] = adapter
                 self._multi_lora_pending_push.add(adapter.name)
-            self.weights_backuper.backup("actor")
+            if self._enable_weight_backup:
+                self.weights_backuper.backup("actor")
         if adapters_to_clean_up:
             _cleanup_adapters(self.args, self.model, self.optimizer, adapters_to_clean_up)
             for adapter in adapters_to_clean_up:
                 self.loaded_adapters.pop(adapter.name, None)
                 self._multi_lora_pending_push.discard(adapter.name)
-            self.weights_backuper.backup("actor")
+            if self._enable_weight_backup:
+                self.weights_backuper.backup("actor")
 
         # Deregistered before ever being loaded: nothing to save or clear.
         if is_first_replica_megatron_main_rank():

--- a/miles/backends/megatron_utils/update_weight/common.py
+++ b/miles/backends/megatron_utils/update_weight/common.py
@@ -285,10 +285,25 @@ def named_params_and_buffers(
     args: Namespace,
     model: Sequence[torch.nn.Module],
     convert_to_global_name: bool = True,
+    read_tms_backup: bool = False,
 ) -> Iterator[tuple[str, torch.Tensor]]:
     if convert_to_global_name:
-        return _named_params_and_buffers_global(args, model)
-    return _named_params_and_buffers_vanilla(model)
+        named_tensors = _named_params_and_buffers_global(args, model)
+    else:
+        named_tensors = _named_params_and_buffers_vanilla(model)
+    if read_tms_backup:
+        named_tensors = ((name, _tms_backup_or_live(tensor)) for name, tensor in named_tensors)
+    return named_tensors
+
+
+def _tms_backup_or_live(tensor: torch.Tensor) -> torch.Tensor:
+    """The memory-saver host backup while the tensor is paused, the live tensor otherwise."""
+    from torch_memory_saver import torch_memory_saver
+
+    # zero_copy aliases the pinned backup; the default clone() would build a second host copy per call
+    if (cpu_tensor := torch_memory_saver.get_cpu_backup(tensor, zero_copy=True)) is not None:
+        return cpu_tensor
+    return tensor
 
 
 def _named_params_and_buffers_vanilla(model: Sequence[torch.nn.Module]) -> Iterator[tuple[str, torch.Tensor]]:

--- a/miles/backends/megatron_utils/update_weight/common.py
+++ b/miles/backends/megatron_utils/update_weight/common.py
@@ -285,23 +285,26 @@ def named_params_and_buffers(
     args: Namespace,
     model: Sequence[torch.nn.Module],
     convert_to_global_name: bool = True,
-    read_tms_backup: bool = False,
+    translate_gpu_to_cpu: bool = False,
 ) -> Iterator[tuple[str, torch.Tensor]]:
     if convert_to_global_name:
-        named_tensors = _named_params_and_buffers_global(args, model)
+        ans = _named_params_and_buffers_global(args, model)
     else:
-        named_tensors = _named_params_and_buffers_vanilla(model)
-    if read_tms_backup:
-        named_tensors = ((name, _tms_backup_or_live(tensor)) for name, tensor in named_tensors)
-    return named_tensors
+        ans = _named_params_and_buffers_vanilla(model)
+
+    if translate_gpu_to_cpu:
+        ans = ((name, _maybe_get_cpu_backup(tensor)) for name, tensor in ans)
+
+    return ans
 
 
-def _tms_backup_or_live(tensor: torch.Tensor) -> torch.Tensor:
+def _maybe_get_cpu_backup(x: torch.Tensor):
     from torch_memory_saver import torch_memory_saver
 
-    if (cpu_tensor := torch_memory_saver.get_cpu_backup(tensor, zero_copy=True)) is not None:
+    if (cpu_tensor := torch_memory_saver.get_cpu_backup(x, zero_copy=True)) is not None:
         return cpu_tensor
-    return tensor
+
+    return x
 
 
 def _named_params_and_buffers_vanilla(model: Sequence[torch.nn.Module]) -> Iterator[tuple[str, torch.Tensor]]:

--- a/miles/backends/megatron_utils/update_weight/common.py
+++ b/miles/backends/megatron_utils/update_weight/common.py
@@ -297,7 +297,6 @@ def named_params_and_buffers(
 
 
 def _tms_backup_or_live(tensor: torch.Tensor) -> torch.Tensor:
-    # lazy: the hosted CPU CI imports this module without torch_memory_saver installed
     from torch_memory_saver import torch_memory_saver
 
     if (cpu_tensor := torch_memory_saver.get_cpu_backup(tensor, zero_copy=True)) is not None:

--- a/miles/backends/megatron_utils/update_weight/common.py
+++ b/miles/backends/megatron_utils/update_weight/common.py
@@ -10,6 +10,7 @@ import torch
 import torch.distributed as dist
 from megatron.core.transformer.transformer_layer import get_transformer_layer_offset
 from ray.actor import ActorHandle
+from torch_memory_saver import torch_memory_saver
 
 from miles.backends.megatron_utils.misc_utils import strip_param_name_prefix
 from miles.backends.training_utils.parallel import get_parallel_state
@@ -297,10 +298,6 @@ def named_params_and_buffers(
 
 
 def _tms_backup_or_live(tensor: torch.Tensor) -> torch.Tensor:
-    """The memory-saver host backup while the tensor is paused, the live tensor otherwise."""
-    from torch_memory_saver import torch_memory_saver
-
-    # zero_copy aliases the pinned backup; the default clone() would build a second host copy per call
     if (cpu_tensor := torch_memory_saver.get_cpu_backup(tensor, zero_copy=True)) is not None:
         return cpu_tensor
     return tensor

--- a/miles/backends/megatron_utils/update_weight/common.py
+++ b/miles/backends/megatron_utils/update_weight/common.py
@@ -10,7 +10,6 @@ import torch
 import torch.distributed as dist
 from megatron.core.transformer.transformer_layer import get_transformer_layer_offset
 from ray.actor import ActorHandle
-from torch_memory_saver import torch_memory_saver
 
 from miles.backends.megatron_utils.misc_utils import strip_param_name_prefix
 from miles.backends.training_utils.parallel import get_parallel_state
@@ -298,6 +297,9 @@ def named_params_and_buffers(
 
 
 def _tms_backup_or_live(tensor: torch.Tensor) -> torch.Tensor:
+    # lazy: the hosted CPU CI imports this module without torch_memory_saver installed
+    from torch_memory_saver import torch_memory_saver
+
     if (cpu_tensor := torch_memory_saver.get_cpu_backup(tensor, zero_copy=True)) is not None:
         return cpu_tensor
     return tensor


### PR DESCRIPTION
Partially recovered from https://github.com/radixark/miles/pull/2223

We use TMS for the lora base weight because SGLang needs to store a backup copy of the parameters during lora training. This means the CPU is already occupied during training, so we must ensure that during SGLang inference, the CPU only has the training backup, and during training, it only has the inference backup. Therefore, we cannot use the full parameter's pin memory way.


## Validation
A/B on one 8xH200 node (devbox `ym-wu-eff2`), `scripts/run_qwen3_5_35b_a3b_lora.py train` (Qwen3.5-35B-A3B, TP2/EP8, colocate, `--lora-base-cpu-backup`, gsm8k), origin/main `9f62cba24` vs this branch (`a543a74a6`; `actor.py` identical to the PR head). Host memory sampled every 5 s (`free` + per-process RSS); `[CPU memory] after_offload_train` from the miles log. Expected saving: 8 ranks x 5.65B params x 2 B = **90 GB**.

| phase | main | this PR | delta |
|---|---|---|---|
| trainer awake (training), node `used` | 323.6 GB | 226.7 GB | **-96.9 GB** |
| trainer awake, RSS per trainer rank | 16.2 GB | 4.1 GB | -12.1 GB |
| trainer asleep (rollout), node `used` | ~351 GB | ~252-257 GB | **~-95 GB** |
| trainer asleep, RSS per trainer rank | 28.1 GB | 16.3 GB | -11.8 GB |
| `after_offload_train` (rollout 0 / 1) | 442.9 / 436.7 GB | 342.0 / 338.5 GB | -101 / -98 GB |

The saving matches the pinned actor copy (11.3 GB/rank bf16 plus host-allocator rounding) in both phases; sglang scheduler RSS is unchanged (13.4 GB paused / 4.9 GB resident), so the engine side is untouched. Per-rank RSS dropping by one base copy while the trainer is awake is direct evidence that `_enable_weight_backup` was off and no pinned copy was built.
