### PR TITLE
feat(megatron): reset optimizer state by optimizer class

### DIFF
--- a/miles/backends/megatron_utils/model.py
+++ b/miles/backends/megatron_utils/model.py
@@ -28,6 +28,7 @@ from megatron.training.training import get_model
 from miles.backends.megatron_utils.ft.indep_dp import allreduce_grads_and_losses_across_replicas
 from miles.backends.megatron_utils.ft.types import TrainStepOutcome
 from miles.backends.megatron_utils.local_weight_checksum import dump_local_weight_checksums
+from miles.backends.megatron_utils.optimizer_state_reset import reset_optimizer_states
 from miles.utils.audit_utils.witness.allocator import WitnessInfo
 from miles.utils.audit_utils.witness.module import witness_dump_and_clear_stale
 from miles.utils.dumper_utils import DumperMegatronUtil, DumperPhase
@@ -746,16 +747,11 @@ def train(
 
     if args.reset_optimizer_states and not disable_optimizer:
         if is_first_replica_megatron_main_rank():
-            print("Reset optimizer states")
-        for chained_optimizer in optimizer.chained_optimizers:
-            for group in chained_optimizer.optimizer.param_groups:
-                if "step" in group:
-                    group["step"] = 0
-            for state in chained_optimizer.optimizer.state.values():
-                if "exp_avg" in state:
-                    state["exp_avg"].zero_()
-                if "exp_avg_sq" in state:
-                    state["exp_avg_sq"].zero_()
+            logger.info("Reset optimizer states")
+        reset_optimizer_states(
+            args.optimizer,
+            [chained_optimizer.optimizer for chained_optimizer in optimizer.chained_optimizers],
+        )
 
     if args.manual_gc:
         # Disable the default garbage collector and perform the collection manually.

--- a/miles/backends/megatron_utils/model.py
+++ b/miles/backends/megatron_utils/model.py
@@ -748,10 +748,7 @@ def train(
     if args.reset_optimizer_states and not disable_optimizer:
         if is_first_replica_megatron_main_rank():
             logger.info("Reset optimizer states")
-        reset_optimizer_states(
-            args.optimizer,
-            [chained_optimizer.optimizer for chained_optimizer in optimizer.chained_optimizers],
-        )
+        reset_optimizer_states(optimizer)
 
     if args.manual_gc:
         # Disable the default garbage collector and perform the collection manually.

--- a/miles/backends/megatron_utils/optimizer_state_reset.py
+++ b/miles/backends/megatron_utils/optimizer_state_reset.py
@@ -1,97 +1,61 @@
-"""Fail-closed optimizer-state reset helpers for Megatron training."""
+"""Reset optimizer history for --reset-optimizer-states, failing closed on state it does not know."""
 
-from collections.abc import MutableMapping, Sequence
-from typing import Any
+from collections.abc import Iterator
 
 import torch
-from megatron.core.optimizer import Adam as MegatronAdam
-from megatron.core.optimizer import CPUAdam
-from megatron.core.optimizer.cpu_offloading.hybrid_optimizer import HybridDeviceOptimizer
+from megatron.core.optimizer import Adam, CPUAdam
 from megatron.core.optimizer.emerging_optimizers import TensorParallelMuon
 
 
-def _zero_step(container: MutableMapping[str, Any]) -> None:
-    if "step" not in container:
-        return
+class UnsupportedOptimizerState(RuntimeError):
+    """An optimizer or state key this module has no schema for; teach _history_keys rather than guessing."""
 
-    step = container["step"]
+
+def reset_optimizer_states(optimizer) -> None:
+    for leaf in _leaves(optimizer):
+        _reset(leaf, _history_keys(leaf))
+
+
+def _leaves(optimizer) -> Iterator[torch.optim.Optimizer]:
+    """Descend Megatron's wrappers to the torch optimizers that own the state."""
+    if optimizer is None:
+        return
+    for children in ("chained_optimizers", "sub_optimizers"):
+        if hasattr(optimizer, children):
+            for child in getattr(optimizer, children):
+                yield from _leaves(child)
+            return
+    if hasattr(optimizer, "optimizer"):
+        yield from _leaves(optimizer.optimizer)
+    else:
+        yield optimizer
+
+
+def _history_keys(optimizer) -> frozenset[str]:
+    if isinstance(optimizer, TensorParallelMuon):
+        return frozenset({"momentum_buffer"})
+    if isinstance(optimizer, (Adam, CPUAdam)):
+        return frozenset({"exp_avg", "exp_avg_sq"})
+    raise UnsupportedOptimizerState(f"no reset schema for {type(optimizer).__name__}")
+
+
+def _reset(optimizer, history: frozenset[str]) -> None:
+    for group in optimizer.param_groups:
+        _reset_step(group)
+    for state in optimizer.state.values():
+        unknown = set(state) - history - {"step", "master_param"}
+        if unknown:
+            raise UnsupportedOptimizerState(f"unknown state keys {sorted(unknown)} on {type(optimizer).__name__}")
+        _reset_step(state)
+        for key in history & set(state):
+            state[key].zero_()
+
+
+def _reset_step(container) -> None:
+    step = container.get("step")
     if isinstance(step, torch.Tensor):
         step.zero_()
     elif isinstance(step, (int, float)):
         container["step"] = 0
-    else:
-        raise TypeError(f"Unsupported optimizer step type: {type(step).__name__}")
-
-
-def _zero_tensor(state: MutableMapping[str, Any], key: str) -> None:
-    value = state.get(key)
-    if not isinstance(value, torch.Tensor):
-        raise TypeError(f"Expected tensor optimizer state {key!r}, got {type(value).__name__}")
-    value.zero_()
-
-
-def _reset_adam_state(optimizer: torch.optim.Optimizer) -> None:
-    # Some Adam implementations store the step inside optimizer.param_groups.
-    for group in optimizer.param_groups:
-        _zero_step(group)
-
-    for state in optimizer.state.values():
-        unexpected_keys = set(state) - {"step", "exp_avg", "exp_avg_sq", "master_param"}
-        if unexpected_keys:
-            raise RuntimeError(f"Unsupported Adam optimizer state keys: {sorted(unexpected_keys)}")
-
-        has_exp_avg = "exp_avg" in state
-        has_exp_avg_sq = "exp_avg_sq" in state
-
-        # Both moments may be absent before a parameter's first optimizer step or for frozen parameters.
-        if has_exp_avg != has_exp_avg_sq:
-            raise RuntimeError(f"Incomplete Adam optimizer state: {sorted(state)}")
-
-        # This is a no-op for implementations that store the step only in param_groups.
-        _zero_step(state)
-
-        if has_exp_avg:
-            _zero_tensor(state, "exp_avg")
-            _zero_tensor(state, "exp_avg_sq")
-
-
-def _reset_muon_state(optimizer: TensorParallelMuon) -> None:
-    for state in optimizer.state.values():
-        unexpected_keys = set(state) - {"momentum_buffer"}
-        if unexpected_keys:
-            raise RuntimeError(f"Unsupported Muon optimizer state keys: {sorted(unexpected_keys)}")
-        if "momentum_buffer" in state:
-            _zero_tensor(state, "momentum_buffer")
-
-
-def _reset_supported_adam_state(optimizer: torch.optim.Optimizer) -> None:
-    if isinstance(optimizer, HybridDeviceOptimizer):
-        if optimizer.gpu_optimizer is not None:
-            raise TypeError("HybridDeviceOptimizer with a GPU child optimizer is not supported")
-        if not optimizer.cpu_optimizers:
-            raise TypeError("HybridDeviceOptimizer has no CPU child optimizers")
-        for child_optimizer in optimizer.cpu_optimizers:
-            if not isinstance(child_optimizer, CPUAdam):
-                raise TypeError(f"HybridDeviceOptimizer wraps unsupported CPU optimizer {type(child_optimizer).__name__}")
-    elif not isinstance(optimizer, (MegatronAdam, CPUAdam)):
-        raise TypeError(f"Unsupported Adam optimizer implementation: {type(optimizer).__name__}. When adding support for a new optimizer, update _reset_adam_state() for its state schema")
-
-    _reset_adam_state(optimizer)
-
-
-def reset_optimizer_states(optimizer_name: str, optimizers: Sequence[torch.optim.Optimizer]) -> None:
-    """Reset all history for a supported optimizer, failing on unknown implementations or state."""
-    if optimizer_name == "adam":
-        for optimizer in optimizers:
-            _reset_supported_adam_state(optimizer)
-        return
-
-    if optimizer_name == "dist_muon":
-        for optimizer in optimizers:
-            if isinstance(optimizer, TensorParallelMuon):
-                _reset_muon_state(optimizer)
-            else:
-                _reset_supported_adam_state(optimizer)
-        return
-
-    raise NotImplementedError(f"--reset-optimizer-states does not support optimizer {optimizer_name!r}")
+    elif step is not None:
+        raise UnsupportedOptimizerState(f"unsupported step type {type(step).__name__}")

--- a/miles/backends/megatron_utils/optimizer_state_reset.py
+++ b/miles/backends/megatron_utils/optimizer_state_reset.py
@@ -1,0 +1,97 @@
+"""Fail-closed optimizer-state reset helpers for Megatron training."""
+
+from collections.abc import MutableMapping, Sequence
+from typing import Any
+
+import torch
+from megatron.core.optimizer import Adam as MegatronAdam
+from megatron.core.optimizer import CPUAdam
+from megatron.core.optimizer.cpu_offloading.hybrid_optimizer import HybridDeviceOptimizer
+from megatron.core.optimizer.emerging_optimizers import TensorParallelMuon
+
+
+def _zero_step(container: MutableMapping[str, Any]) -> None:
+    if "step" not in container:
+        return
+
+    step = container["step"]
+    if isinstance(step, torch.Tensor):
+        step.zero_()
+    elif isinstance(step, (int, float)):
+        container["step"] = 0
+    else:
+        raise TypeError(f"Unsupported optimizer step type: {type(step).__name__}")
+
+
+def _zero_tensor(state: MutableMapping[str, Any], key: str) -> None:
+    value = state.get(key)
+    if not isinstance(value, torch.Tensor):
+        raise TypeError(f"Expected tensor optimizer state {key!r}, got {type(value).__name__}")
+    value.zero_()
+
+
+def _reset_adam_state(optimizer: torch.optim.Optimizer) -> None:
+    # Some Adam implementations store the step inside optimizer.param_groups.
+    for group in optimizer.param_groups:
+        _zero_step(group)
+
+    for state in optimizer.state.values():
+        unexpected_keys = set(state) - {"step", "exp_avg", "exp_avg_sq", "master_param"}
+        if unexpected_keys:
+            raise RuntimeError(f"Unsupported Adam optimizer state keys: {sorted(unexpected_keys)}")
+
+        has_exp_avg = "exp_avg" in state
+        has_exp_avg_sq = "exp_avg_sq" in state
+
+        # Both moments may be absent before a parameter's first optimizer step or for frozen parameters.
+        if has_exp_avg != has_exp_avg_sq:
+            raise RuntimeError(f"Incomplete Adam optimizer state: {sorted(state)}")
+
+        # This is a no-op for implementations that store the step only in param_groups.
+        _zero_step(state)
+
+        if has_exp_avg:
+            _zero_tensor(state, "exp_avg")
+            _zero_tensor(state, "exp_avg_sq")
+
+
+def _reset_muon_state(optimizer: TensorParallelMuon) -> None:
+    for state in optimizer.state.values():
+        unexpected_keys = set(state) - {"momentum_buffer"}
+        if unexpected_keys:
+            raise RuntimeError(f"Unsupported Muon optimizer state keys: {sorted(unexpected_keys)}")
+        if "momentum_buffer" in state:
+            _zero_tensor(state, "momentum_buffer")
+
+
+def _reset_supported_adam_state(optimizer: torch.optim.Optimizer) -> None:
+    if isinstance(optimizer, HybridDeviceOptimizer):
+        if optimizer.gpu_optimizer is not None:
+            raise TypeError("HybridDeviceOptimizer with a GPU child optimizer is not supported")
+        if not optimizer.cpu_optimizers:
+            raise TypeError("HybridDeviceOptimizer has no CPU child optimizers")
+        for child_optimizer in optimizer.cpu_optimizers:
+            if not isinstance(child_optimizer, CPUAdam):
+                raise TypeError(f"HybridDeviceOptimizer wraps unsupported CPU optimizer {type(child_optimizer).__name__}")
+    elif not isinstance(optimizer, (MegatronAdam, CPUAdam)):
+        raise TypeError(f"Unsupported Adam optimizer implementation: {type(optimizer).__name__}. When adding support for a new optimizer, update _reset_adam_state() for its state schema")
+
+    _reset_adam_state(optimizer)
+
+
+def reset_optimizer_states(optimizer_name: str, optimizers: Sequence[torch.optim.Optimizer]) -> None:
+    """Reset all history for a supported optimizer, failing on unknown implementations or state."""
+    if optimizer_name == "adam":
+        for optimizer in optimizers:
+            _reset_supported_adam_state(optimizer)
+        return
+
+    if optimizer_name == "dist_muon":
+        for optimizer in optimizers:
+            if isinstance(optimizer, TensorParallelMuon):
+                _reset_muon_state(optimizer)
+            else:
+                _reset_supported_adam_state(optimizer)
+        return
+
+    raise NotImplementedError(f"--reset-optimizer-states does not support optimizer {optimizer_name!r}")

--- a/miles/backends/megatron_utils/optimizer_state_reset.py
+++ b/miles/backends/megatron_utils/optimizer_state_reset.py
@@ -1,10 +1,13 @@
-"""Reset optimizer history for --reset-optimizer-states, failing closed on state it does not know."""
+"""Reset optimizer history for --reset-optimizer-states, failing closed on state it does not know.
+
+The Muon classes are imported where they are matched: Megatron builds without
+``emerging_optimizers`` (the NPU pin) still run Adam.
+"""
 
 from collections.abc import Iterator
 
 import torch
 from megatron.core.optimizer import Adam, CPUAdam
-from megatron.core.optimizer.emerging_optimizers import TensorParallelMuon
 
 
 class UnsupportedOptimizerState(RuntimeError):
@@ -32,10 +35,14 @@ def _leaves(optimizer) -> Iterator[torch.optim.Optimizer]:
 
 
 def _history_keys(optimizer) -> frozenset[str]:
-    if isinstance(optimizer, TensorParallelMuon):
-        return frozenset({"momentum_buffer"})
     if isinstance(optimizer, (Adam, CPUAdam)):
         return frozenset({"exp_avg", "exp_avg_sq"})
+    from megatron.core.optimizer.emerging_optimizers import TensorParallelAdaptiveMuon, TensorParallelMuon
+
+    if isinstance(optimizer, TensorParallelAdaptiveMuon):
+        return frozenset({"momentum_buffer", "moment2_buffer"})
+    if isinstance(optimizer, TensorParallelMuon):
+        return frozenset({"momentum_buffer"})
     raise UnsupportedOptimizerState(f"no reset schema for {type(optimizer).__name__}")
 
 

--- a/tests/fast/backends/megatron_utils/test_model_initialize.py
+++ b/tests/fast/backends/megatron_utils/test_model_initialize.py
@@ -77,9 +77,12 @@ def _mock_megatron_environment():
             {
                 "OptimizerConfig": _DummyOptimizerConfig,
                 "get_megatron_optimizer": MagicMock(),
+                "Adam": _DummyOptimizer,
+                "CPUAdam": _DummyOptimizer,
             },
             is_package=True,
         )
+        _stub_module("megatron.core.optimizer.emerging_optimizers", {"TensorParallelMuon": _DummyOptimizer})
         _stub_module("megatron.core.optimizer.muon", {"get_megatron_muon_optimizer": MagicMock()})
         _stub_module("megatron.core.optimizer.distrib_optimizer", {"DistributedOptimizer": _DummyDistributedOptimizer})
         _stub_module(
@@ -94,7 +97,7 @@ def _mock_megatron_environment():
         _stub_module("megatron.core.pipeline_parallel", {"get_forward_backward_func": MagicMock()})
         _stub_module("megatron.core.transformer", is_package=True)
         _stub_module("megatron.core.transformer.utils", {"sharded_state_dict_default": MagicMock()})
-        _stub_module("megatron.core.utils", {"get_model_config": MagicMock()})
+        _stub_module("megatron.core.utils", {"get_model_config": MagicMock(), "unwrap_model": MagicMock()})
         _stub_module("megatron.core.config", {"set_experimental_flag": MagicMock()})
         _stub_module("megatron.core.num_microbatches_calculator", {"init_num_microbatches_calculator": MagicMock()})
         _stub_module("megatron.training", is_package=True)
@@ -130,7 +133,13 @@ def _mock_megatron_environment():
                 "_setup_lora_model_via_bridge": MagicMock(),
             },
         )
-        _stub_module("miles.backends.megatron_utils.model_provider", {"get_model_provider_func": MagicMock()})
+        _stub_module(
+            "miles.backends.megatron_utils.model_provider",
+            {
+                "get_model_provider_func": MagicMock(),
+                "LinearForLastLayer": _DummyModel,
+            },
+        )
         yield
     finally:
         sys.modules.clear()

--- a/tests/fast/backends/megatron_utils/test_optimizer_state_reset.py
+++ b/tests/fast/backends/megatron_utils/test_optimizer_state_reset.py
@@ -1,0 +1,118 @@
+"""reset_optimizer_states must reach every leaf optimizer under Megatron's wrappers and clear its
+history by class, not by the --optimizer string (which Megatron rewrites before training starts)."""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+from megatron.core.optimizer.emerging_optimizers import TensorParallelMuon
+
+from miles.backends.megatron_utils.optimizer_state_reset import UnsupportedOptimizerState, reset_optimizer_states
+
+
+def stepped_adamw(*shapes):
+    params = [torch.nn.Parameter(torch.ones(*shape)) for shape in shapes]
+    for param in params:
+        param.grad = torch.ones_like(param)
+    optimizer = torch.optim.AdamW(params, lr=1e-3)
+    optimizer.step()
+    return optimizer
+
+
+class GroupStepAdamW(torch.optim.AdamW):
+    """Shaped like TE FusedAdam: the step clock lives in param_groups, not in state."""
+
+    def step(self, closure=None):
+        super().step(closure)
+        for group in self.param_groups:
+            group["step"] = 50
+        for state in self.state.values():
+            del state["step"]
+
+
+def muon_with_momentum(*shapes):
+    optimizer = TensorParallelMuon.__new__(TensorParallelMuon)
+    optimizer.param_groups = [{"params": [torch.nn.Parameter(torch.ones(*shape)) for shape in shapes]}]
+    optimizer.state = {p: {"momentum_buffer": torch.ones_like(p)} for p in optimizer.param_groups[0]["params"]}
+    return optimizer
+
+
+def wrap(leaf):
+    return SimpleNamespace(optimizer=leaf)
+
+
+def chain(*children):
+    return SimpleNamespace(chained_optimizers=list(children))
+
+
+def assert_adam_reset(optimizer):
+    for group in optimizer.param_groups:
+        if "step" in group:
+            assert group["step"] == 0
+    for state in optimizer.state.values():
+        assert not state["exp_avg"].any()
+        assert not state["exp_avg_sq"].any()
+        if "step" in state:
+            assert state["step"] == 0
+
+
+def test_layer_wise_muon_tree_resets_both_leaves():
+    muon, adam = muon_with_momentum((4, 4)), stepped_adamw((4,))
+    # dist_muon: LayerWiseDistributedOptimizer(ChainedOptimizer) holding Float16 wrappers of Muon + Adam,
+    # itself a child of the top-level ChainedOptimizer
+    reset_optimizer_states(chain(chain(wrap(muon), wrap(adam))))
+
+    assert all(not state["momentum_buffer"].any() for state in muon.state.values())
+    assert_adam_reset(adam)
+
+
+def test_hybrid_device_optimizer_resets_cpu_and_gpu_children():
+    cpu_child, gpu_child = stepped_adamw((4,)), GroupStepAdamW([torch.nn.Parameter(torch.ones(4))], lr=1e-3)
+    gpu_child.param_groups[0]["params"][0].grad = torch.ones(4)
+    gpu_child.step()
+    hybrid = SimpleNamespace(sub_optimizers=[cpu_child, gpu_child], state={}, param_groups=[])
+
+    reset_optimizer_states(chain(wrap(hybrid)))
+
+    assert_adam_reset(cpu_child)
+    assert_adam_reset(gpu_child)
+
+
+def test_tensor_valued_group_step_resets_in_place():
+    adam = stepped_adamw((4,))
+    clock = torch.tensor(50)
+    adam.param_groups[0]["step"] = clock
+
+    reset_optimizer_states(chain(wrap(adam)))
+
+    assert clock.item() == 0
+
+
+def test_wrapper_without_an_optimizer_is_skipped():
+    adam = stepped_adamw((4,))
+    reset_optimizer_states(chain(wrap(None), wrap(adam)))
+    assert_adam_reset(adam)
+
+
+def test_reset_before_the_first_step_is_a_no_op():
+    reset_optimizer_states(chain(wrap(torch.optim.AdamW([torch.nn.Parameter(torch.ones(4))], lr=1e-3))))
+
+
+def test_unknown_adam_state_key_is_rejected():
+    adam = stepped_adamw((4,))
+    next(iter(adam.state.values()))["max_exp_avg_sq"] = torch.ones(4)
+    with pytest.raises(UnsupportedOptimizerState, match="max_exp_avg_sq"):
+        reset_optimizer_states(chain(wrap(adam)))
+
+
+def test_unknown_muon_state_key_is_rejected():
+    muon = muon_with_momentum((4, 4))
+    next(iter(muon.state.values()))["moment2_buffer"] = torch.ones(4, 4)
+    with pytest.raises(UnsupportedOptimizerState, match="moment2_buffer"):
+        reset_optimizer_states(chain(wrap(muon)))
+
+
+def test_unknown_optimizer_class_is_rejected():
+    sgd = torch.optim.SGD([torch.nn.Parameter(torch.ones(4))], lr=1e-3, momentum=0.9)
+    with pytest.raises(UnsupportedOptimizerState, match="SGD"):
+        reset_optimizer_states(chain(wrap(sgd)))

--- a/tests/fast/backends/megatron_utils/test_optimizer_state_reset.py
+++ b/tests/fast/backends/megatron_utils/test_optimizer_state_reset.py
@@ -1,11 +1,12 @@
 """reset_optimizer_states must reach every leaf optimizer under Megatron's wrappers and clear its
 history by class, not by the --optimizer string (which Megatron rewrites before training starts)."""
 
+import sys
 from types import SimpleNamespace
 
 import pytest
 import torch
-from megatron.core.optimizer.emerging_optimizers import TensorParallelMuon
+from megatron.core.optimizer.emerging_optimizers import TensorParallelAdaptiveMuon, TensorParallelMuon
 
 from miles.backends.megatron_utils.optimizer_state_reset import UnsupportedOptimizerState, reset_optimizer_states
 
@@ -30,10 +31,10 @@ class GroupStepAdamW(torch.optim.AdamW):
             del state["step"]
 
 
-def muon_with_momentum(*shapes):
-    optimizer = TensorParallelMuon.__new__(TensorParallelMuon)
+def muon_with_momentum(*shapes, cls=TensorParallelMuon, buffers=("momentum_buffer",)):
+    optimizer = cls.__new__(cls)
     optimizer.param_groups = [{"params": [torch.nn.Parameter(torch.ones(*shape)) for shape in shapes]}]
-    optimizer.state = {p: {"momentum_buffer": torch.ones_like(p)} for p in optimizer.param_groups[0]["params"]}
+    optimizer.state = {p: {name: torch.ones_like(p) for name in buffers} for p in optimizer.param_groups[0]["params"]}
     return optimizer
 
 
@@ -64,6 +65,29 @@ def test_layer_wise_muon_tree_resets_both_leaves():
 
     assert all(not state["momentum_buffer"].any() for state in muon.state.values())
     assert_adam_reset(adam)
+
+
+def test_adaptive_muon_resets_both_moment_buffers():
+    adaptive = muon_with_momentum(
+        (4, 4), cls=TensorParallelAdaptiveMuon, buffers=("momentum_buffer", "moment2_buffer")
+    )
+
+    reset_optimizer_states(chain(wrap(adaptive)))
+
+    for state in adaptive.state.values():
+        assert not state["momentum_buffer"].any()
+        assert not state["moment2_buffer"].any()
+
+
+def test_adam_reset_does_not_need_emerging_optimizers(monkeypatch):
+    monkeypatch.setitem(sys.modules, "megatron.core.optimizer.emerging_optimizers", None)
+    adam = stepped_adamw((4,))
+
+    reset_optimizer_states(chain(wrap(adam)))
+
+    assert_adam_reset(adam)
+    with pytest.raises(ImportError):
+        reset_optimizer_states(chain(wrap(muon_with_momentum((4, 4)))))
 
 
 def test_hybrid_device_optimizer_resets_cpu_and_gpu_children():


### PR DESCRIPTION
Corrected version of #2769, whose commit is kept as the first one here. Three things stop #2769 from working: its `dist_muon` branch can never run, because Megatron's `validate_args` renames the optimizer to `muon` before training starts; it rejects `HybridDeviceOptimizer` at any offload fraction below 1.0 (the AMD DSv4 recipe uses 0.75), which the loop it replaced handled; and its new top-level imports break `test_model_initialize.py` under that file's stub, taking stage-a-cpu and every GPU stage gated on it down.

The reset now dispatches on each leaf optimizer's class and walks `chained_optimizers` / `sub_optimizers` / `.optimizer` recursively, so nested `ChainedOptimizer`s and the GPU child of a partially offloaded optimizer are reached too. The key allowlists stay: `master_param` is the fp32 weights and must not be zeroed.

Verified on an H200 devbox: 13 fast tests pass with the real TE and Muon classes; an A/B against #2769's module raises `NotImplementedError` / `TypeError` where this branch resets; Qwen3-4B end to end with `--optimizer dist_muon` and with `adam --optimizer-cpu-offload --optimizer-offload-fraction 0.75`, both under `--reset-optimizer-states`, shows every moment tensor nonzero before the reset and zero after, and both jobs succeeded.

Follow-up, not here: share `_zero_step` with `multi_lora_utils.zero_optimizer_state_for_adapter`.
