### PR TITLE
skip processor load when multimodal_keys is not set

### DIFF
--- a/miles/rollout/data_source.py
+++ b/miles/rollout/data_source.py
@@ -60,7 +60,7 @@ class RolloutDataSource(DataSource):
             tokenizer = load_tokenizer(
                 args.hf_checkpoint, chat_template_path=args.chat_template_path, trust_remote_code=True
             )
-            processor = load_processor(args.hf_checkpoint, trust_remote_code=True)
+            processor = load_processor(args.hf_checkpoint, trust_remote_code=True) if args.multimodal_keys else None
 
             # TODO move (during the refactor)
             if (d := args.dump_details) is not None:


### PR DESCRIPTION
 ### Background

Qwen3.8-27B is a multimodal (vision-language) model, so _RolloutDataSource_ unconditionally loaded a HuggingFace _AutoProcessor_ for it. The processor is only needed to turn multimodal prompts (message lists
  carrying images/videos) into model inputs. On the SWE-bench Pro eval the model is used purely as a text coder — prompts are plain strings and there is no image/video content — so the processor serves no
  purpose there.

 ### Issue Description

  With the processor always loaded, a text-only SWE-bench Pro run enters the multimodal code path in miles/utils/data.py, which requires the prompt to be a list. Because SWE-bench Pro prompts are strings, the rollout actor crashes at startup:

`  AssertionError: prompt must be a list when processor is not None, got <class 'str'> 
`
 Since the eval passes no --multimodal-keys, if the processor is  absent  this multimodal path is skipped entirely.

 ### Code fix summary

  Load the processor only when multimodal input is actually configured (--multimodal-keys set); otherwise leave it None