### PR TITLE
refactor(rollout): centralize common group filters

### DIFF
--- a/miles/rollout/filter_hub/base_types.py
+++ b/miles/rollout/filter_hub/base_types.py
@@ -1,5 +1,8 @@
 from collections import defaultdict
+from collections.abc import Iterator
 from dataclasses import dataclass
+
+from miles.utils.types import Sample
 
 
 @dataclass
@@ -11,11 +14,19 @@ class FilterOutput:
 DynamicFilterOutput = FilterOutput
 
 
-def call_dynamic_filter(fn, *args, **kwargs):
+def iter_samples(group: list[Sample | list[Sample]]) -> Iterator[Sample]:
+    for sample in group:
+        if isinstance(sample, list):
+            yield from sample
+        else:
+            yield sample
+
+
+def call_dynamic_filter(fn, args, samples: list[Sample | list[Sample]], **kwargs):
     if fn is None:
         return FilterOutput(keep=True)
 
-    output = fn(*args, **kwargs)
+    output = fn(args, samples, **kwargs)
 
     # compatibility for legacy version
     if not isinstance(output, FilterOutput):

--- a/miles/rollout/filter_hub/common_filters.py
+++ b/miles/rollout/filter_hub/common_filters.py
@@ -1,5 +1,7 @@
 from argparse import Namespace
 
+import torch
+
 from miles.rollout.filter_hub.base_types import FilterOutput, iter_samples
 from miles.utils.types import Sample
 
@@ -11,6 +13,15 @@ def check_no_aborted(args: Namespace, samples: Group, **kwargs) -> FilterOutput:
     if any(sample.status == Sample.Status.ABORTED for sample in iter_samples(samples)):
         return FilterOutput(keep=False, reason="group_has_aborted")
     return FilterOutput(keep=True)
+
+
+def check_reward_nonzero_std(args, samples: list[Sample | list[Sample]], **kwargs):
+    rewards = [sample.get_reward_value(args) for sample in iter_samples(samples)]
+    keep = torch.tensor(rewards, dtype=torch.float64).std() > 1e-8
+    return FilterOutput(
+        keep=keep,
+        reason=None if keep else f"zero_std_{round(rewards[0], 1)}",
+    )
 
 
 def group_staleness(group: Group, current_version: int | None) -> int | None:

--- a/miles/rollout/filter_hub/common_filters.py
+++ b/miles/rollout/filter_hub/common_filters.py
@@ -1,0 +1,21 @@
+from argparse import Namespace
+
+from miles.rollout.filter_hub.base_types import FilterOutput, iter_samples
+from miles.utils.types import Sample
+
+Group = list[Sample | list[Sample]]
+
+
+def check_no_aborted(args: Namespace, samples: Group, **kwargs) -> FilterOutput:
+    """Reject entire group if any sample was aborted (e.g. env timeout, Docker crash)."""
+    if any(sample.status == Sample.Status.ABORTED for sample in iter_samples(samples)):
+        return FilterOutput(keep=False, reason="group_has_aborted")
+    return FilterOutput(keep=True)
+
+
+def group_staleness(group: Group, current_version: int | None) -> int | None:
+    versions = [version for sample in iter_samples(group) if (version := sample.oldest_weight_version) is not None]
+    oldest = min(versions) if versions else None
+    if oldest is None or current_version is None:
+        return None
+    return current_version - oldest

--- a/miles/rollout/filter_hub/common_filters.py
+++ b/miles/rollout/filter_hub/common_filters.py
@@ -8,14 +8,14 @@ from miles.utils.types import Sample
 Group = list[Sample | list[Sample]]
 
 
-def check_no_aborted(args: Namespace, samples: Group, **kwargs) -> FilterOutput:
+def apply_aborted_filter(args: Namespace, samples: Group, **kwargs) -> FilterOutput:
     """Reject entire group if any sample was aborted (e.g. env timeout, Docker crash)."""
     if any(sample.status == Sample.Status.ABORTED for sample in iter_samples(samples)):
         return FilterOutput(keep=False, reason="group_has_aborted")
     return FilterOutput(keep=True)
 
 
-def check_reward_nonzero_std(args, samples: list[Sample | list[Sample]], **kwargs):
+def apply_reward_nonzero_std_filter(args, samples: list[Sample | list[Sample]], **kwargs):
     rewards = [sample.get_reward_value(args) for sample in iter_samples(samples)]
     keep = torch.tensor(rewards, dtype=torch.float64).std() > 1e-8
     return FilterOutput(

--- a/miles/rollout/filter_hub/dynamic_sampling_filters.py
+++ b/miles/rollout/filter_hub/dynamic_sampling_filters.py
@@ -1,31 +1,16 @@
 import torch
 
-from miles.rollout.filter_hub.base_types import FilterOutput
+from miles.rollout.filter_hub.base_types import FilterOutput, iter_samples
+from miles.rollout.filter_hub.common_filters import check_no_aborted
 from miles.utils.types import Sample
 
 __all__ = ["check_reward_nonzero_std", "check_no_aborted"]
 
 
-def _flatten_samples(samples: list[Sample | list[Sample]]):
-    """Flatten a group whose elements are `Sample` or `list[Sample]` (generate-function dependent)."""
-    for s in samples:
-        if isinstance(s, list):
-            yield from s
-        else:
-            yield s
-
-
 def check_reward_nonzero_std(args, samples: list[Sample | list[Sample]], **kwargs):
-    rewards = [sample.get_reward_value(args) for sample in _flatten_samples(samples)]
+    rewards = [sample.get_reward_value(args) for sample in iter_samples(samples)]
     keep = torch.tensor(rewards, dtype=torch.float64).std() > 1e-8
     return FilterOutput(
         keep=keep,
         reason=None if keep else f"zero_std_{round(rewards[0], 1)}",
     )
-
-
-def check_no_aborted(args, samples: list[Sample | list[Sample]], **kwargs):
-    """Reject entire group if any sample was aborted (e.g. env timeout, Docker crash)."""
-    if any(s.status == Sample.Status.ABORTED for s in _flatten_samples(samples)):
-        return FilterOutput(keep=False, reason="group_has_aborted")
-    return FilterOutput(keep=True)

--- a/miles/rollout/filter_hub/dynamic_sampling_filters.py
+++ b/miles/rollout/filter_hub/dynamic_sampling_filters.py
@@ -1,16 +1,3 @@
-import torch
-
-from miles.rollout.filter_hub.base_types import FilterOutput, iter_samples
-from miles.rollout.filter_hub.common_filters import check_no_aborted
-from miles.utils.types import Sample
+from miles.rollout.filter_hub.common_filters import check_no_aborted, check_reward_nonzero_std
 
 __all__ = ["check_reward_nonzero_std", "check_no_aborted"]
-
-
-def check_reward_nonzero_std(args, samples: list[Sample | list[Sample]], **kwargs):
-    rewards = [sample.get_reward_value(args) for sample in iter_samples(samples)]
-    keep = torch.tensor(rewards, dtype=torch.float64).std() > 1e-8
-    return FilterOutput(
-        keep=keep,
-        reason=None if keep else f"zero_std_{round(rewards[0], 1)}",
-    )

--- a/miles/rollout/filter_hub/dynamic_sampling_filters.py
+++ b/miles/rollout/filter_hub/dynamic_sampling_filters.py
@@ -1,3 +1,4 @@
+# Deprecated compatibility shim retained for existing dynamic filter import paths.
 from miles.rollout.filter_hub.common_filters import check_no_aborted, check_reward_nonzero_std
 
 __all__ = ["check_reward_nonzero_std", "check_no_aborted"]

--- a/miles/rollout/filter_hub/dynamic_sampling_filters.py
+++ b/miles/rollout/filter_hub/dynamic_sampling_filters.py
@@ -1,5 +1,16 @@
-# Deprecated compatibility shim retained for existing dynamic filter import paths.
-from miles.rollout.filter_hub.common_filters import apply_aborted_filter as check_no_aborted
-from miles.rollout.filter_hub.common_filters import apply_reward_nonzero_std_filter as check_reward_nonzero_std
+from typing_extensions import deprecated
+
+from miles.rollout.filter_hub.common_filters import apply_aborted_filter, apply_reward_nonzero_std_filter
+from miles.utils.types import Sample
 
 __all__ = ["check_reward_nonzero_std", "check_no_aborted"]
+
+
+@deprecated("Use miles.rollout.filter_hub.common_filters.apply_reward_nonzero_std_filter", category=None)
+def check_reward_nonzero_std(args, samples: list[Sample | list[Sample]], **kwargs):
+    return apply_reward_nonzero_std_filter(args, samples, **kwargs)
+
+
+@deprecated("Use miles.rollout.filter_hub.common_filters.apply_aborted_filter", category=None)
+def check_no_aborted(args, samples: list[Sample | list[Sample]], **kwargs):
+    return apply_aborted_filter(args, samples, **kwargs)

--- a/miles/rollout/filter_hub/dynamic_sampling_filters.py
+++ b/miles/rollout/filter_hub/dynamic_sampling_filters.py
@@ -1,4 +1,5 @@
 # Deprecated compatibility shim retained for existing dynamic filter import paths.
-from miles.rollout.filter_hub.common_filters import check_no_aborted, check_reward_nonzero_std
+from miles.rollout.filter_hub.common_filters import apply_aborted_filter as check_no_aborted
+from miles.rollout.filter_hub.common_filters import apply_reward_nonzero_std_filter as check_reward_nonzero_std
 
 __all__ = ["check_reward_nonzero_std", "check_no_aborted"]

--- a/miles/rollout/fully_async_data_buffer.py
+++ b/miles/rollout/fully_async_data_buffer.py
@@ -122,7 +122,8 @@ class DefaultDataBuffer(DataBuffer):
     def _preput_filter(self, input: DataBufferInput) -> bool:
         output = check_no_aborted(self._args, input.group)
         if not output.keep:
-            self._handle_aborted(input.prompt_group)
+            self._metric_aborted_groups += 1
+            self._unused_handler_fn(input.prompt_group)
             return False
 
         output = call_dynamic_filter(self._dynamic_filter, self._args, input.group)
@@ -130,10 +131,6 @@ class DefaultDataBuffer(DataBuffer):
             self._metric_gatherer.on_dynamic_filter_drop(reason=output.reason)
             return False
         return True
-
-    def _handle_aborted(self, prompt_group: list[Sample]) -> None:
-        self._metric_aborted_groups += 1
-        self._unused_handler_fn(prompt_group)
 
     async def get(self, current_version: int | None = None, **_) -> DataBufferInput:
         if current_version is not None:
@@ -149,14 +146,11 @@ class DefaultDataBuffer(DataBuffer):
                 if staleness is not None:
                     self._metric_consumed_staleness.append(staleness)
                     if self._args.max_weight_staleness is not None and staleness > self._args.max_weight_staleness:
-                        self._handle_stale(entry.prompt_group, staleness)
+                        logger.info(f"Filtered stale group ({staleness=} > max={self._args.max_weight_staleness})")
+                        self._metric_stale_groups += 1
+                        self._unused_handler_fn(entry.prompt_group)
                         continue
                 return entry
-
-    def _handle_stale(self, prompt_group: list[Sample], staleness: int) -> None:
-        logger.info(f"Filtered stale group ({staleness=} > max={self._args.max_weight_staleness})")
-        self._metric_stale_groups += 1
-        self._unused_handler_fn(prompt_group)
 
     def get_metrics(self) -> dict[str, float]:
         prefix = "rollout/fully_async/"

--- a/miles/rollout/fully_async_data_buffer.py
+++ b/miles/rollout/fully_async_data_buffer.py
@@ -11,10 +11,11 @@ import asyncio
 import logging
 from abc import ABC, abstractmethod
 from argparse import Namespace
-from collections.abc import Callable, Iterator
+from collections.abc import Callable
 from dataclasses import dataclass
 
 from miles.rollout.filter_hub.base_types import MetricGatherer, call_dynamic_filter
+from miles.rollout.filter_hub.common_filters import check_no_aborted, group_staleness
 from miles.utils.function_registry import load_function
 from miles.utils.types import Sample
 
@@ -25,22 +26,8 @@ logger = logging.getLogger(__name__)
 Group = list[Sample | list[Sample]]
 
 
-def iter_samples(group: Group) -> Iterator[Sample]:
-    for item in group:
-        if isinstance(item, list):
-            yield from item
-        else:
-            yield item
-
-
 def first_sample(group: Group) -> Sample:
     return group[0][0] if isinstance(group[0], list) else group[0]
-
-
-def group_oldest_weight_version(group: Group) -> int | None:
-    """Return the minimum weight version across all trajectories and turns in a group."""
-    versions = [v for s in iter_samples(group) if (v := s.oldest_weight_version) is not None]
-    return min(versions) if versions else None
 
 
 @dataclass(frozen=True)
@@ -123,15 +110,7 @@ class DefaultDataBuffer(DataBuffer):
         self._metric_consumed_staleness: list[int] = []
 
     async def put(self, input: DataBufferInput) -> None:
-        # filters at receiving sample: abort filter, dynamic filter
-        if any(s.status == Sample.Status.ABORTED for s in iter_samples(input.group)):
-            self._metric_aborted_groups += 1
-            self._unused_handler_fn(input.prompt_group)
-            return
-        filter_output = call_dynamic_filter(self._dynamic_filter, self._args, input.group)
-        if not filter_output.keep:
-            # Dropped, not recycled: no usable gradient signal.
-            self._metric_gatherer.on_dynamic_filter_drop(reason=filter_output.reason)
+        if not self._preput_filter(input):
             return
 
         async with self._cond:
@@ -139,6 +118,22 @@ class DefaultDataBuffer(DataBuffer):
                 await self._cond.wait()
             self._buffer.append(input)
             self._cond.notify_all()
+
+    def _preput_filter(self, input: DataBufferInput) -> bool:
+        output = check_no_aborted(self._args, input.group)
+        if not output.keep:
+            self._handle_aborted(input.prompt_group)
+            return False
+
+        output = call_dynamic_filter(self._dynamic_filter, self._args, input.group)
+        if not output.keep:
+            self._metric_gatherer.on_dynamic_filter_drop(reason=output.reason)
+            return False
+        return True
+
+    def _handle_aborted(self, prompt_group: list[Sample]) -> None:
+        self._metric_aborted_groups += 1
+        self._unused_handler_fn(prompt_group)
 
     async def get(self, current_version: int | None = None, **_) -> DataBufferInput:
         if current_version is not None:
@@ -150,16 +145,18 @@ class DefaultDataBuffer(DataBuffer):
                 entry = self._buffer.pop(0)
                 self._cond.notify_all()  # wake producers blocked on a full buffer
 
-                # filters at retrieving sample: staleness filter
-                staleness = self._staleness(entry.group, current_version)
-                if staleness is None:
-                    return entry
-                self._metric_consumed_staleness.append(staleness)
-                if self._args.max_weight_staleness is None or staleness <= self._args.max_weight_staleness:
-                    return entry
-                logger.info(f"Filtered stale group ({staleness=} > max={self._args.max_weight_staleness})")
-                self._metric_stale_groups += 1
-                self._unused_handler_fn(entry.prompt_group)
+                staleness = group_staleness(entry.group, current_version)
+                if staleness is not None:
+                    self._metric_consumed_staleness.append(staleness)
+                    if self._args.max_weight_staleness is not None and staleness > self._args.max_weight_staleness:
+                        self._handle_stale(entry.prompt_group, staleness)
+                        continue
+                return entry
+
+    def _handle_stale(self, prompt_group: list[Sample], staleness: int) -> None:
+        logger.info(f"Filtered stale group ({staleness=} > max={self._args.max_weight_staleness})")
+        self._metric_stale_groups += 1
+        self._unused_handler_fn(prompt_group)
 
     def get_metrics(self) -> dict[str, float]:
         prefix = "rollout/fully_async/"
@@ -173,7 +170,7 @@ class DefaultDataBuffer(DataBuffer):
             metrics[f"{prefix}avg_staleness"] = sum(consumed) / len(consumed)
             metrics[f"{prefix}max_staleness"] = max(consumed)
         buffered = [
-            s for entry in self._buffer if (s := self._staleness(entry.group, self._current_version)) is not None
+            s for entry in self._buffer if (s := group_staleness(entry.group, self._current_version)) is not None
         ]
         if buffered:
             metrics[f"{prefix}buffer_avg_staleness"] = sum(buffered) / len(buffered)
@@ -183,10 +180,3 @@ class DefaultDataBuffer(DataBuffer):
         self._metric_consumed_staleness = []
         self._metric_aborted_groups = self._metric_stale_groups = 0
         return metrics
-
-    @staticmethod
-    def _staleness(group: Group, current_version: int | None) -> int | None:
-        oldest = group_oldest_weight_version(group)
-        if oldest is None or current_version is None:
-            return None
-        return current_version - oldest

--- a/miles/rollout/fully_async_data_buffer.py
+++ b/miles/rollout/fully_async_data_buffer.py
@@ -15,7 +15,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 
 from miles.rollout.filter_hub.base_types import MetricGatherer, call_dynamic_filter
-from miles.rollout.filter_hub.common_filters import check_no_aborted, group_staleness
+from miles.rollout.filter_hub.common_filters import apply_aborted_filter, group_staleness
 from miles.utils.function_registry import load_function
 from miles.utils.types import Sample
 
@@ -120,7 +120,7 @@ class DefaultDataBuffer(DataBuffer):
             self._cond.notify_all()
 
     def _preput_filter(self, input: DataBufferInput) -> bool:
-        output = check_no_aborted(self._args, input.group)
+        output = apply_aborted_filter(self._args, input.group)
         if not output.keep:
             self._metric_aborted_groups += 1
             self._unused_handler_fn(input.prompt_group)

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,6 +28,7 @@ tensorboard
 torchft-nightly==2026.4.3; platform_system == "Linux" and platform_machine == "x86_64"
 tqdm
 transformers==5.12.1  # Required by HF-native weight conversion; also avoids SGLang's qwen3_asr collision in 5.13.
+typing_extensions>=4.5
 wandb
 xxhash==3.7.1  # disk-delta weight sync (checksum)
 zstandard==0.25.0  # disk-delta weight sync (codec)

--- a/tests/fast/rollout/test_filters.py
+++ b/tests/fast/rollout/test_filters.py
@@ -5,7 +5,10 @@ register_cpu_ci(est_time=20, suite="stage-a-cpu", labels=[])
 from argparse import Namespace
 
 from miles.rollout.filter_hub.base_types import DynamicFilterOutput, FilterOutput, iter_samples
-from miles.rollout.filter_hub.common_filters import check_no_aborted, group_staleness
+from miles.rollout.filter_hub.common_filters import check_no_aborted, check_reward_nonzero_std, group_staleness
+from miles.rollout.filter_hub.dynamic_sampling_filters import (
+    check_reward_nonzero_std as legacy_check_reward_nonzero_std,
+)
 from miles.utils.types import Sample, WeightVersionSpan, WeightVersionsPerCall
 
 
@@ -27,6 +30,10 @@ def make_sample(
 
 def test_dynamic_filter_output_is_a_compatibility_alias():
     assert DynamicFilterOutput is FilterOutput
+
+
+def test_dynamic_sampling_filters_reexports_common_implementation():
+    assert legacy_check_reward_nonzero_std is check_reward_nonzero_std
 
 
 def test_iter_samples_preserves_flat_and_mixed_nested_order():

--- a/tests/fast/rollout/test_filters.py
+++ b/tests/fast/rollout/test_filters.py
@@ -2,8 +2,55 @@ from tests.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=20, suite="stage-a-cpu", labels=[])
 
-from miles.rollout.filter_hub.base_types import DynamicFilterOutput, FilterOutput
+from argparse import Namespace
+
+from miles.rollout.filter_hub.base_types import DynamicFilterOutput, FilterOutput, iter_samples
+from miles.rollout.filter_hub.common_filters import check_no_aborted, group_staleness
+from miles.utils.types import Sample, WeightVersionSpan, WeightVersionsPerCall
+
+
+def make_sample(
+    *,
+    reward=1.0,
+    status=Sample.Status.COMPLETED,
+    weight_versions=(),
+) -> Sample:
+    return Sample(
+        reward=reward,
+        status=status,
+        weight_versions=[
+            WeightVersionsPerCall(spans=[WeightVersionSpan(version=version, abs_start=0, abs_end=1)])
+            for version in weight_versions
+        ],
+    )
 
 
 def test_dynamic_filter_output_is_a_compatibility_alias():
     assert DynamicFilterOutput is FilterOutput
+
+
+def test_iter_samples_preserves_flat_and_mixed_nested_order():
+    samples = [Sample(index=index) for index in range(4)]
+
+    assert list(iter_samples(samples)) == samples
+    assert list(iter_samples([samples[0], samples[1:3], samples[3]])) == samples
+
+
+def test_common_filter_returns_structured_drop():
+    assert check_no_aborted(
+        Namespace(reward_key=None),
+        [make_sample(status=Sample.Status.ABORTED)],
+        ignored=True,
+    ) == FilterOutput(keep=False, reason="group_has_aborted")
+
+
+def test_group_staleness_uses_oldest_version_across_nested_samples():
+    group = [
+        make_sample(weight_versions=("9",)),
+        [make_sample(weight_versions=("4", "8")), make_sample(weight_versions=())],
+    ]
+
+    assert group_staleness(group, current_version=10) == 6
+    assert group_staleness(group, current_version=None) is None
+    assert group_staleness([make_sample()], current_version=10) is None
+    assert group_staleness([make_sample(weight_versions=("12",))], current_version=10) == -2

--- a/tests/fast/rollout/test_filters.py
+++ b/tests/fast/rollout/test_filters.py
@@ -5,7 +5,12 @@ register_cpu_ci(est_time=20, suite="stage-a-cpu", labels=[])
 from argparse import Namespace
 
 from miles.rollout.filter_hub.base_types import DynamicFilterOutput, FilterOutput, iter_samples
-from miles.rollout.filter_hub.common_filters import check_no_aborted, check_reward_nonzero_std, group_staleness
+from miles.rollout.filter_hub.common_filters import (
+    apply_aborted_filter,
+    apply_reward_nonzero_std_filter,
+    group_staleness,
+)
+from miles.rollout.filter_hub.dynamic_sampling_filters import check_no_aborted as legacy_check_no_aborted
 from miles.rollout.filter_hub.dynamic_sampling_filters import (
     check_reward_nonzero_std as legacy_check_reward_nonzero_std,
 )
@@ -33,7 +38,8 @@ def test_dynamic_filter_output_is_a_compatibility_alias():
 
 
 def test_dynamic_sampling_filters_reexports_common_implementation():
-    assert legacy_check_reward_nonzero_std is check_reward_nonzero_std
+    assert legacy_check_no_aborted is apply_aborted_filter
+    assert legacy_check_reward_nonzero_std is apply_reward_nonzero_std_filter
 
 
 def test_iter_samples_preserves_flat_and_mixed_nested_order():
@@ -44,7 +50,7 @@ def test_iter_samples_preserves_flat_and_mixed_nested_order():
 
 
 def test_common_filter_returns_structured_drop():
-    assert check_no_aborted(
+    assert apply_aborted_filter(
         Namespace(reward_key=None),
         [make_sample(status=Sample.Status.ABORTED)],
         ignored=True,

--- a/tests/fast/rollout/test_filters.py
+++ b/tests/fast/rollout/test_filters.py
@@ -2,18 +2,19 @@ from tests.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=20, suite="stage-a-cpu", labels=[])
 
+import warnings
 from argparse import Namespace
 
+import pytest
+
+from miles.rollout.filter_hub import dynamic_sampling_filters
 from miles.rollout.filter_hub.base_types import DynamicFilterOutput, FilterOutput, iter_samples
 from miles.rollout.filter_hub.common_filters import (
     apply_aborted_filter,
     apply_reward_nonzero_std_filter,
     group_staleness,
 )
-from miles.rollout.filter_hub.dynamic_sampling_filters import check_no_aborted as legacy_check_no_aborted
-from miles.rollout.filter_hub.dynamic_sampling_filters import (
-    check_reward_nonzero_std as legacy_check_reward_nonzero_std,
-)
+from miles.utils.function_registry import load_function
 from miles.utils.types import Sample, WeightVersionSpan, WeightVersionsPerCall
 
 
@@ -37,9 +38,70 @@ def test_dynamic_filter_output_is_a_compatibility_alias():
     assert DynamicFilterOutput is FilterOutput
 
 
-def test_dynamic_sampling_filters_reexports_common_implementation():
-    assert legacy_check_no_aborted is apply_aborted_filter
-    assert legacy_check_reward_nonzero_std is apply_reward_nonzero_std_filter
+@pytest.mark.parametrize(
+    ("legacy_name", "canonical"),
+    [
+        ("check_no_aborted", apply_aborted_filter),
+        ("check_reward_nonzero_std", apply_reward_nonzero_std_filter),
+    ],
+)
+def test_legacy_filters_forward_without_runtime_deprecation_warnings(monkeypatch, legacy_name, canonical):
+    legacy = load_function(f"miles.rollout.filter_hub.dynamic_sampling_filters.{legacy_name}")
+    assert legacy.__name__ == legacy_name
+    assert canonical.__name__ in legacy.__deprecated__
+    assert not hasattr(canonical, "__deprecated__")
+
+    args, samples, extra = Namespace(reward_key=None), [make_sample()], object()
+    result = FilterOutput(keep=False, reason="unchanged")
+
+    def replacement(forwarded_args, forwarded_samples, **kwargs):
+        assert forwarded_args is args
+        assert forwarded_samples is samples
+        assert kwargs == {"extra": extra}
+        return result
+
+    monkeypatch.setattr(dynamic_sampling_filters, canonical.__name__, replacement)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        assert legacy(args, samples, extra=extra) is result
+
+    error = ValueError("filter failed")
+
+    def fail(*args, **kwargs):
+        raise error
+
+    monkeypatch.setattr(dynamic_sampling_filters, canonical.__name__, fail)
+    with pytest.raises(ValueError) as raised:
+        legacy(args=args, samples=samples, extra=extra)
+    assert raised.value is error
+
+
+@pytest.mark.parametrize(
+    ("legacy_name", "samples", "expected"),
+    [
+        ("check_no_aborted", [make_sample()], FilterOutput(keep=True)),
+        (
+            "check_no_aborted",
+            [[make_sample(status=Sample.Status.ABORTED)]],
+            FilterOutput(keep=False, reason="group_has_aborted"),
+        ),
+        (
+            "check_reward_nonzero_std",
+            [make_sample(reward=1.0), make_sample(reward=2.0)],
+            FilterOutput(keep=True),
+        ),
+        (
+            "check_reward_nonzero_std",
+            [[make_sample(reward=1.0), make_sample(reward=1.0)]],
+            FilterOutput(keep=False, reason="zero_std_1.0"),
+        ),
+    ],
+)
+def test_legacy_filters_preserve_structured_results(legacy_name, samples, expected):
+    legacy = load_function(f"miles.rollout.filter_hub.dynamic_sampling_filters.{legacy_name}")
+    result = legacy(Namespace(reward_key=None), samples, ignored=True)
+    assert isinstance(result, DynamicFilterOutput)
+    assert result == expected
 
 
 def test_iter_samples_preserves_flat_and_mixed_nested_order():

--- a/tests/fast/rollout/test_fully_async_rollout.py
+++ b/tests/fast/rollout/test_fully_async_rollout.py
@@ -447,7 +447,7 @@ async def test_buffer_get_skips_groups_stale_at_consumption_time():
     buffer, unused = make_buffer(max_staleness=2)
     stale = make_group(1, weight_versions=["5"])
     await put_group(buffer, stale)
-    await put_group(buffer, make_group(2, weight_versions=["9"]))
+    await put_group(buffer, make_group(2, weight_versions=["8"]))
 
     assert (await buffer.get(current_version=10)).group[0].group_index == 2
     assert unused == [stale]


### PR DESCRIPTION
> **Depends on:** #3095
> Stacked on the parent PR's branch. Review / merge the parent first.

## Summary
Centralize rollout filters with explicit names and deprecated legacy entrypoints.

## Motivation
Stock filters and staleness calculation were spread across filter modules and `DefaultDataBuffer`. Centralizing their implementations and naming `FilterOutput` functions `apply_xxx_filter` makes ownership and call sites clearer while preserving existing CLI/configuration paths and runtime behavior.

## Before / After
- **Before / After:** `common_filters.py` owns aborted validation, reward-variance filtering, and staleness calculation; buffer actions remain in `DefaultDataBuffer`.
- **What moved where:** The stock filters become `apply_aborted_filter` and `apply_reward_nonzero_std_filter`; `group_staleness` remains a numeric helper.
- **Compatibility:** Both old names in `dynamic_sampling_filters.py` remain thin wrappers with their original signatures, returning the canonical result directly.
- **Deprecation:** `typing_extensions.deprecated(..., category=None)` marks only the legacy wrappers without runtime warnings; `typing_extensions>=4.5` is declared directly.
- **Buffer ownership:** Metrics, retry/drop handling, locking, and queue mutation retain their existing order; pre-put validation remains `aborted -> custom`.

## Behavior Preservation
- `test_filters.py` checks old dotted-path loading, structured keep/drop results, argument forwarding, unchanged exceptions, and deprecation metadata; canonical functions remain undecorated.
- Direct buffer probes use both old dotted paths to verify aborted recycling, reward-variance rejection, and valid nested-group enqueue/get; wrapper signatures match the original API in `58bad6e9`.

## Verification
- On `91d2ba61fb1262f889723d3284642a103c986882`, `python -m pytest --confcutdir=tests/fast/rollout tests/fast/rollout/test_filters.py -o addopts= -q`: 10 passed; repository-wide integration fixtures were not loaded.
- Direct buffer compatibility probes passed with deprecation warnings treated as errors.
- Ruff `0.14.7`, isort `5.13.2`, Black `24.3.0`, compilation, and `git diff --check` passed for the changed Python files.
- Full collector integration and GPU CI were not rerun locally.

## Review Focus
- `dynamic_sampling_filters.py`: legacy paths remain callable with unchanged results; only old wrappers carry deprecation metadata.
- `DefaultDataBuffer`: aborted/stale handling and side-effect ordering remain unchanged.
- `common_filters.py`: shared implementation ownership; missing-reward rejection belongs to the dependent PR.
