### PR TITLE
refactor(rollout): rename shared filter output

### DIFF
--- a/docs/diffusion/user-guide/customization.md
+++ b/docs/diffusion/user-guide/customization.md
@@ -177,7 +177,7 @@ Per-group filter after scoring (DAPO-style). Stock:
 
 ```python
 def filter_function(args, samples: list[Sample], **kwargs):
-    # return DynamicFilterOutput(keep=..., reason=...) or a bool
+    # return FilterOutput(keep=..., reason=...) or a bool
     ...
 ```
 

--- a/docs/user-guide/customization.md
+++ b/docs/user-guide/customization.md
@@ -161,8 +161,8 @@ Hook to normalize rewards differently from the default GRPO normalization.
 Per-group filter; runs after scoring, before queueing for training.
 
 ```python
-def filter_function(args, samples: list[Sample], **kwargs) -> DynamicFilterOutput:
-    return DynamicFilterOutput(keep=True, reason=None)
+def filter_function(args, samples: list[Sample], **kwargs) -> FilterOutput:
+    return FilterOutput(keep=True, reason=None)
 ```
 
 **Stock implementation:** `miles.rollout.filter_hub.dynamic_sampling_filters.check_reward_nonzero_std`.

--- a/miles/rollout/filter_hub/base_types.py
+++ b/miles/rollout/filter_hub/base_types.py
@@ -3,20 +3,23 @@ from dataclasses import dataclass
 
 
 @dataclass
-class DynamicFilterOutput:
+class FilterOutput:
     keep: bool
     reason: str | None = None
 
 
+DynamicFilterOutput = FilterOutput
+
+
 def call_dynamic_filter(fn, *args, **kwargs):
     if fn is None:
-        return DynamicFilterOutput(keep=True)
+        return FilterOutput(keep=True)
 
     output = fn(*args, **kwargs)
 
     # compatibility for legacy version
-    if not isinstance(output, DynamicFilterOutput):
-        output = DynamicFilterOutput(keep=output)
+    if not isinstance(output, FilterOutput):
+        output = FilterOutput(keep=output)
 
     return output
 

--- a/miles/rollout/filter_hub/dynamic_sampling_filters.py
+++ b/miles/rollout/filter_hub/dynamic_sampling_filters.py
@@ -1,6 +1,6 @@
 import torch
 
-from miles.rollout.filter_hub.base_types import DynamicFilterOutput
+from miles.rollout.filter_hub.base_types import FilterOutput
 from miles.utils.types import Sample
 
 __all__ = ["check_reward_nonzero_std", "check_no_aborted"]
@@ -18,7 +18,7 @@ def _flatten_samples(samples: list[Sample | list[Sample]]):
 def check_reward_nonzero_std(args, samples: list[Sample | list[Sample]], **kwargs):
     rewards = [sample.get_reward_value(args) for sample in _flatten_samples(samples)]
     keep = torch.tensor(rewards, dtype=torch.float64).std() > 1e-8
-    return DynamicFilterOutput(
+    return FilterOutput(
         keep=keep,
         reason=None if keep else f"zero_std_{round(rewards[0], 1)}",
     )
@@ -27,5 +27,5 @@ def check_reward_nonzero_std(args, samples: list[Sample | list[Sample]], **kwarg
 def check_no_aborted(args, samples: list[Sample | list[Sample]], **kwargs):
     """Reject entire group if any sample was aborted (e.g. env timeout, Docker crash)."""
     if any(s.status == Sample.Status.ABORTED for s in _flatten_samples(samples)):
-        return DynamicFilterOutput(keep=False, reason="group_has_aborted")
-    return DynamicFilterOutput(keep=True)
+        return FilterOutput(keep=False, reason="group_has_aborted")
+    return FilterOutput(keep=True)

--- a/tests/fast/rollout/inference_rollout/integration/utils.py
+++ b/tests/fast/rollout/inference_rollout/integration/utils.py
@@ -7,7 +7,7 @@ from miles.rollout.base_types import (
     RolloutFnOutput,
     RolloutFnTrainInput,
 )
-from miles.rollout.filter_hub.base_types import DynamicFilterOutput
+from miles.rollout.filter_hub.base_types import FilterOutput
 from miles.rollout.inference_rollout.compatibility import call_rollout_function, load_rollout_function
 from miles.utils.types import Sample, WeightVersionsPerCall
 
@@ -85,5 +85,5 @@ def load_and_call_train(args, data_source):
 def filter_by_reward(args, samples, **kwargs):
     reward = samples[0].reward if not isinstance(samples[0], list) else samples[0][0].reward
     if reward == 1:
-        return DynamicFilterOutput(keep=True)
-    return DynamicFilterOutput(keep=False, reason="reward_zero")
+        return FilterOutput(keep=True)
+    return FilterOutput(keep=False, reason="reward_zero")

--- a/tests/fast/rollout/test_filters.py
+++ b/tests/fast/rollout/test_filters.py
@@ -1,0 +1,9 @@
+from tests.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=20, suite="stage-a-cpu", labels=[])
+
+from miles.rollout.filter_hub.base_types import DynamicFilterOutput, FilterOutput
+
+
+def test_dynamic_filter_output_is_a_compatibility_alias():
+    assert DynamicFilterOutput is FilterOutput

--- a/tests/fast/rollout/test_fully_async_rollout.py
+++ b/tests/fast/rollout/test_fully_async_rollout.py
@@ -12,7 +12,7 @@ import pytest
 import miles.rollout.fully_async_data_buffer as data_buffer
 import miles.rollout.fully_async_rollout as fully_async
 from miles.rollout.base_types import BaseRolloutFn, RolloutFnConstructorInput, RolloutFnEvalInput, RolloutFnTrainInput
-from miles.rollout.filter_hub.base_types import DynamicFilterOutput
+from miles.rollout.filter_hub.base_types import FilterOutput
 from miles.utils.types import Sample, WeightVersionSpan, WeightVersionsPerCall
 
 N_SAMPLES_PER_PROMPT = 2
@@ -347,7 +347,7 @@ async def test_nested_group_recycles_the_flat_prompt_group(monkeypatch):
 
 def reject_group_1(args, group, **kwargs):
     keep = group[0].group_index != 1
-    return DynamicFilterOutput(keep=keep, reason=None if keep else "rejected")
+    return FilterOutput(keep=keep, reason=None if keep else "rejected")
 
 
 async def test_dynamic_filter_drops_group_without_recycling(monkeypatch):


### PR DESCRIPTION
## Summary
Rename the shared rollout filter result from `DynamicFilterOutput` to `FilterOutput`.

## Motivation
Common predicates and configured dynamic filters return the same result type, so `DynamicFilterOutput` describes the wrong ownership boundary. `FilterOutput` is now the primary name while the old import remains compatible.

## Before / After
- **Before / After:** The same dataclass and call flow use the ownership-neutral name `FilterOutput`.
- **What moved where:** Production code, tests, integration helpers, and documentation migrate to `FilterOutput`.
- **Compatibility:** `DynamicFilterOutput` remains an exact alias of `FilterOutput`; old imports and `isinstance` behavior continue to work.

## Behavior Preservation
- Focused filter and fully-async suite on `58bad6e94431c4cf3a2236f3fdcf11b06f67a64a`: 24 passed.
- Alias identity, legacy bool normalization, and the existing call flow remain covered.

## Verification
- Ruff `0.14.7`, isort `5.13.2`, Black `24.3.0`, `py_compile`, and `git diff --check` passed.

## Review Focus
- `base_types.py`: `DynamicFilterOutput is FilterOutput` remains true.
- No common-filter ownership or missing-reward behavior enters this layer.
