### PR TITLE
fix(qwen3.6): annotate packed QKV projection for Muon

### DIFF
--- a/miles_plugins/models/qwen3_5.py
+++ b/miles_plugins/models/qwen3_5.py
@@ -67,6 +67,11 @@ class Qwen3_5GatedDeltaNet(nn.Module):
         projection_size_qkv = self.key_dim * 2 + self.value_dim
         projection_size_z = self.value_dim
         self.in_proj_qkv = nn.Linear(self.hidden_size, projection_size_qkv, bias=False)
+        # Muon orthogonalizes packed QKV projections one component at a time.
+        # This custom projection does not use Megatron's ``linear_qkv`` name,
+        # so attach the split metadata explicitly.
+        self.in_proj_qkv.weight.is_qkv = True
+        self.in_proj_qkv.weight.qkv_split_shapes = (self.key_dim, self.key_dim, self.value_dim)
         self.in_proj_z = nn.Linear(self.hidden_size, projection_size_z, bias=False)
         self.in_proj_b = nn.Linear(self.hidden_size, self.num_v_heads, bias=False)
         self.in_proj_a = nn.Linear(self.hidden_size, self.num_v_heads, bias=False)

--- a/tests/fast/optimizers/test_qwen3_5_muon_metadata.py
+++ b/tests/fast/optimizers/test_qwen3_5_muon_metadata.py
@@ -1,0 +1,30 @@
+import pytest
+import torch
+
+import miles_plugins.models.qwen3_5 as qwen3_5
+
+
+class _FakeConfig:
+    hidden_size = 256
+    linear_num_value_heads = 4
+    linear_num_key_heads = 2
+    linear_key_head_dim = 64
+    linear_value_head_dim = 64
+    linear_conv_kernel_dim = 4
+    hidden_act = "silu"
+    rms_norm_eps = 1e-6
+    dtype = torch.float32
+
+
+def test_qwen3_5_gdn_marks_packed_qkv_for_muon(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(qwen3_5, "ShortConvolution", torch.nn.Identity, raising=False)
+    monkeypatch.setattr(qwen3_5, "FusedRMSNormGated", torch.nn.Identity, raising=False)
+    monkeypatch.setattr(qwen3_5, "get_chunk_gated_delta_rule", lambda _backend: None)
+    monkeypatch.setattr(torch.cuda, "current_device", lambda: 0)
+
+    module = qwen3_5.Qwen3_5GatedDeltaNet(_FakeConfig, layer_idx=0)
+    qkv_weight = module.in_proj_qkv.weight
+
+    assert qkv_weight.is_qkv is True
+    assert qkv_weight.qkv_split_shapes == (module.key_dim, module.key_dim, module.value_dim)
+    assert sum(qkv_weight.qkv_split_shapes) == qkv_weight.shape[0]


### PR DESCRIPTION
## Summary

- mark Qwen3.5/Qwen3.6 GatedDeltaNet's packed QKV projection for Muon
- attach parameter-specific Q, K, and V split sizes because this projection does not use Megatron's standard `linear_qkv` name
- add a CPU regression test for the optimizer metadata

## Why

Megatron automatically recognizes standard `linear_qkv.weight` parameters, but this model uses `linear_attn.in_proj_qkv.weight`. Without explicit metadata, Muon orthogonalizes the packed projection as one matrix instead of splitting Q, K, and V first.

The attributes are ignored by other optimizers, so this does not change Adam training.

## Testing

- `pre-commit run --files miles_plugins/models/qwen3_5.py tests/fast/optimizers/test_qwen3_5_muon_metadata.py`
- `pytest -q --confcutdir=tests/fast/optimizers tests/fast/optimizers/test_qwen3_5_muon_metadata.py`
