### PR TITLE
ctpo: raw prefix-ratio estimator with a sqrt(t)-scaled clip band

### DIFF
--- a/miles/backends/training_utils/loss_hub/advantages.py
+++ b/miles/backends/training_utils/loss_hub/advantages.py
@@ -50,7 +50,10 @@ def compute_advantages(
         `advantages`: List length `B`; `advantages[i]` has shape `[C_i]`.
         `returns`: List length `B`; `returns[i]` has shape `[C_i]`.
     """
-    if args.advantage_estimator in ["grpo", "gspo"]:
+    # ctpo shares this path deliberately: it changes the importance weight
+    # (prefix product instead of per-token or sequence-mean ratio), not the
+    # credit assignment, so the broadcast group-normalised advantage is the same.
+    if args.advantage_estimator in ["grpo", "gspo", "ctpo"]:
         rewards = torch.tensor(rewards, dtype=torch.float32, device=kl[0].device)
         returns = get_grpo_returns(rewards, kl)
         # TODO: is the copy necessary?

--- a/miles/backends/training_utils/loss_hub/losses.py
+++ b/miles/backends/training_utils/loss_hub/losses.py
@@ -14,6 +14,8 @@ from miles.backends.training_utils.loss_hub.logit_processors import get_log_prob
 from miles.backends.training_utils.loss_hub.math_utils import (
     compute_approx_kl,
     compute_ess_ratio_contribution,
+    compute_ctpo_clip_band,
+    compute_ctpo_prefix_kl,
     compute_gspo_kl,
     compute_opsm_mask,
     compute_policy_loss,
@@ -138,7 +140,7 @@ def policy_loss_function(
     old_log_probs_list = old_log_probs
 
     # Pre-gather log probs if needed by OPSM or GSPO to avoid duplicate gathering
-    need_full_log_probs = args.use_opsm or args.advantage_estimator == "gspo"
+    need_full_log_probs = args.use_opsm or args.advantage_estimator in ("gspo", "ctpo")
 
     full_log_probs = None
     full_old_log_probs = None
@@ -169,9 +171,20 @@ def policy_loss_function(
             loss_masks=batch["loss_masks"],
         )
 
-    # Compute KL divergence (GSPO uses sequence-level KL, others use per-token KL)
+    # Which reduction of the per-token KL becomes the importance weight:
+    # GSPO takes the sequence mean, CTPO the running prefix sum, others the raw
+    # per-token term.
     if args.advantage_estimator == "gspo":
         ppo_kl = compute_gspo_kl(
+            full_log_probs=full_log_probs,
+            full_old_log_probs=full_old_log_probs,
+            local_log_probs=log_probs,
+            loss_masks=batch["loss_masks"],
+        )
+        old_log_probs = torch.cat(old_log_probs, dim=0)
+        log_probs = torch.cat(log_probs, dim=0)
+    elif args.advantage_estimator == "ctpo":
+        ppo_kl = compute_ctpo_prefix_kl(
             full_log_probs=full_log_probs,
             full_old_log_probs=full_old_log_probs,
             local_log_probs=log_probs,
@@ -204,8 +217,17 @@ def policy_loss_function(
         advantages.new_zeros(()),
     )
 
+    # CTPO's band widens as sqrt(t) along the response, so the clip bounds are
+    # per-token tensors rather than scalars; Tensor.clamp is elementwise either way.
+    if args.advantage_estimator == "ctpo":
+        eps_clip, eps_clip_high = compute_ctpo_clip_band(batch["loss_masks"], args.eps_clip, args.eps_clip_high)
+        eps_clip = eps_clip.to(ppo_kl.device)
+        eps_clip_high = eps_clip_high.to(ppo_kl.device)
+    else:
+        eps_clip, eps_clip_high = args.eps_clip, args.eps_clip_high
+
     pg_loss, pg_clipfrac = compute_policy_loss(
-        ppo_kl, advantages, args.eps_clip, args.eps_clip_high, getattr(args, "eps_clip_c", None)
+        ppo_kl, advantages, eps_clip, eps_clip_high, getattr(args, "eps_clip_c", None)
     )
 
     if getattr(args, "dump_details", None) is not None:

--- a/miles/backends/training_utils/loss_hub/math_utils.py
+++ b/miles/backends/training_utils/loss_hub/math_utils.py
@@ -250,14 +250,94 @@ def compute_gspo_kl(
     return ppo_kl
 
 
+def compute_ctpo_prefix_kl(
+    full_log_probs: list[torch.Tensor],
+    full_old_log_probs: list[torch.Tensor],
+    local_log_probs: list[torch.Tensor],
+    loss_masks: list[torch.Tensor],
+) -> torch.Tensor:
+    """Compute CTPO-style running prefix KL, one value per token.
+
+    ``compute_policy_loss`` forms ``ratio = exp(-ppo_kl)``, so returning the running
+    sum of the per-token KL makes the importance weight the prefix product
+    ``rho_{0:t} = prod_{i<=t} rho_i`` -- the raw prefix ratio, with no length
+    normalisation. GSPO's sequence mean and GRPO's per-token term are the two other
+    reductions of the same per-token quantity.
+
+    ``old`` is whatever the caller bound as the behaviour policy; under
+    ``--use-rollout-logprobs`` that is the inference engine's own log prob, so the
+    weight is genuinely ``pi_theta / mu``.
+
+    Masked-out tokens contribute no factor: the running sum carries through them
+    unchanged, and their own positions are zeroed by the caller.
+
+    Args:
+        full_log_probs: Current policy log-probs per sample (full or CP-local).
+        full_old_log_probs: Behaviour policy log-probs per sample.
+        local_log_probs: Local log-probs, for the CP shape check.
+        loss_masks: Loss masks per sample.
+
+    Returns:
+        Concatenated per-token tensor whose value at t is the sum of the per-token
+        KL over the masked tokens up to and including t, restarting at each sample.
+    """
+    ppo_kl = []
+    for log_prob, old_log_prob, local_log_prob, loss_mask in zip(
+        full_log_probs, full_old_log_probs, local_log_probs, loss_masks, strict=False
+    ):
+        if log_prob.shape != local_log_prob.shape:
+            raise NotImplementedError(
+                "ctpo does not support context parallelism yet: a prefix sum is not "
+                "local, so the running total would have to be sliced back to this "
+                "rank's shard. Run with context-parallel size 1."
+            )
+        ppo_kl.append(torch.cumsum((old_log_prob - log_prob) * loss_mask, dim=0))
+    return torch.cat(ppo_kl, dim=0)
+
+
+def compute_ctpo_clip_band(
+    loss_masks: list[torch.Tensor],
+    eps_clip: float,
+    eps_clip_high: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Per-token CTPO clip band, widening as sqrt(t) along the response.
+
+    ``log rho_{0:t}`` is a sum of t token log-ratios, so its spread grows as
+    ``sqrt(t)``. A fixed band would therefore clip an ever-larger share of tokens
+    as the response runs on; scaling the band the same way holds the clip rate
+    roughly constant in t.
+
+    ``t`` counts masked-in tokens and is 1-based, so the first generated token gets
+    the base band and contributes exactly one factor to the prefix product. A
+    leading masked token would otherwise give ``t = 0`` and a zero-width band, so
+    ``t`` is floored at 1; those positions are masked out of the loss regardless.
+
+    Returns:
+        ``(eps_low, eps_high)``, concatenated to match the layout of
+        :func:`compute_ctpo_prefix_kl`.
+    """
+    eps_low, eps_high = [], []
+    for loss_mask in loss_masks:
+        scale = torch.sqrt(torch.cumsum(loss_mask, dim=0).clamp_min(1.0))
+        eps_low.append(eps_clip * scale)
+        eps_high.append(eps_clip_high * scale)
+    return torch.cat(eps_low, dim=0), torch.cat(eps_high, dim=0)
+
+
 @torch.compile(dynamic=True)
 def compute_policy_loss(
     ppo_kl: torch.Tensor,
     advantages: torch.Tensor,
-    eps_clip: float,
-    eps_clip_high: float,
+    eps_clip: float | torch.Tensor,
+    eps_clip_high: float | torch.Tensor,
     eps_clip_c: float | None = None,
 ):
+    """PPO clipped policy loss.
+
+    ``eps_clip`` / ``eps_clip_high`` are scalars for the token- and sequence-ratio
+    estimators, or per-token tensors for CTPO, whose band widens along the
+    response. ``Tensor.clamp`` is elementwise either way.
+    """
     ratio = _safe_exp_neg_ppo_kl(ppo_kl)
     pg_losses1 = -ratio * advantages
     pg_losses2 = -ratio.clamp(1 - eps_clip, 1 + eps_clip_high) * advantages

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -1455,6 +1455,7 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 choices=[
                     "grpo",
                     "gspo",
+                    "ctpo",
                     "reinforce_plus_plus",
                     "reinforce_plus_plus_baseline",
                     "ppo",

--- a/tests/fast/backends/training_utils/loss/test_ctpo.py
+++ b/tests/fast/backends/training_utils/loss/test_ctpo.py
@@ -1,0 +1,198 @@
+"""CTPO: raw prefix-ratio importance weight with a sqrt(t)-scaled clip band.
+
+The importance weight is the prefix product rho_{0:t} = prod_{i<=t} rho_i, where
+rho_i = pi_theta(a_i|s_i) / mu(a_i|s_i) and mu is the inference engine. miles
+carries ppo_kl = old - new and forms ratio = exp(-ppo_kl), so the prefix weight is
+produced by making ppo_kl a running sum rather than a per-token term.
+
+log rho_{0:t} is a t-term random walk, so its spread grows as sqrt(t); the band
+widens the same way, holding the clip rate roughly constant along the response
+instead of clipping nearly everything at large t.
+"""
+
+import math
+
+import pytest
+import torch
+
+from miles.backends.training_utils.loss_hub.math_utils import (
+    compute_ctpo_clip_band,
+    compute_ctpo_prefix_kl,
+)
+
+
+def _kl(old: list[float], new: list[float]) -> torch.Tensor:
+    return torch.tensor(old, dtype=torch.float32), torch.tensor(new, dtype=torch.float32)
+
+
+class TestPrefixRatio:
+    def test_first_token_weight_is_the_local_ratio(self) -> None:
+        """rho_{0:0} == rho_0: the prefix over one factor is that factor."""
+        old, new = _kl([0.0, 0.0, 0.0], [0.5, 0.25, -0.75])
+        mask = torch.ones(3)
+        ppo_kl = compute_ctpo_prefix_kl([new], [old], [new], [mask])
+        assert torch.exp(-ppo_kl)[0].item() == pytest.approx(math.exp(0.5), rel=1e-6)
+
+    def test_weight_is_the_cumulative_product_of_token_ratios(self) -> None:
+        old, new = _kl([0.0, 0.0, 0.0, 0.0], [0.5, 0.25, -0.75, 0.1])
+        mask = torch.ones(4)
+        ratio = torch.exp(-compute_ctpo_prefix_kl([new], [old], [new], [mask]))
+        want = torch.cumprod(torch.exp(new - old), dim=0)
+        assert torch.allclose(ratio, want, atol=1e-6)
+
+    def test_prefix_does_not_bleed_across_samples(self) -> None:
+        """The batch is one flat concatenated tensor; a naive cumsum would run
+        straight through the boundary and corrupt every sample after the first."""
+        old_a, new_a = _kl([0.0, 0.0], [1.0, 1.0])
+        old_b, new_b = _kl([0.0, 0.0], [0.25, 0.25])
+        masks = [torch.ones(2), torch.ones(2)]
+        ppo_kl = compute_ctpo_prefix_kl([new_a, new_b], [old_a, old_b], [new_a, new_b], masks)
+        ratio = torch.exp(-ppo_kl)
+        # sample b restarts at its own first token, unaffected by sample a's +2.0
+        assert ratio[2].item() == pytest.approx(math.exp(0.25), rel=1e-6)
+        assert ratio[3].item() == pytest.approx(math.exp(0.50), rel=1e-6)
+
+    def test_masked_tokens_do_not_contribute_to_the_prefix(self) -> None:
+        old, new = _kl([0.0, 0.0, 0.0], [0.5, 99.0, 0.25])
+        mask = torch.tensor([1.0, 0.0, 1.0])
+        ratio = torch.exp(-compute_ctpo_prefix_kl([new], [old], [new], [mask]))
+        # the masked middle token contributes nothing, so the third token's prefix
+        # is exp(0.5 + 0.25), not exp(0.5 + 99.0 + 0.25)
+        assert ratio[2].item() == pytest.approx(math.exp(0.75), rel=1e-6)
+
+
+class TestClipBand:
+    def test_first_response_token_gets_the_base_band(self) -> None:
+        """t is 1-based, so the first generated token has band [1-eps_lo, 1+eps_hi]."""
+        lo, hi = compute_ctpo_clip_band([torch.ones(3)], 0.025, 0.05)
+        assert lo[0].item() == pytest.approx(0.025, rel=1e-6)
+        assert hi[0].item() == pytest.approx(0.050, rel=1e-6)
+
+    def test_band_scales_with_sqrt_of_position(self) -> None:
+        lo, hi = compute_ctpo_clip_band([torch.ones(4)], 0.025, 0.05)
+        for t in range(1, 5):
+            assert lo[t - 1].item() == pytest.approx(0.025 * math.sqrt(t), rel=1e-6)
+            assert hi[t - 1].item() == pytest.approx(0.050 * math.sqrt(t), rel=1e-6)
+
+    def test_position_counts_only_masked_in_tokens(self) -> None:
+        """A masked token must not advance t, or the band would widen for tokens
+        that contributed no factor to the prefix product."""
+        lo, _ = compute_ctpo_clip_band([torch.tensor([1.0, 0.0, 1.0])], 0.025, 0.05)
+        assert lo[0].item() == pytest.approx(0.025 * math.sqrt(1), rel=1e-6)
+        assert lo[2].item() == pytest.approx(0.025 * math.sqrt(2), rel=1e-6)
+
+    def test_position_restarts_for_each_sample(self) -> None:
+        lo, _ = compute_ctpo_clip_band([torch.ones(2), torch.ones(2)], 0.025, 0.05)
+        assert lo[2].item() == pytest.approx(0.025 * math.sqrt(1), rel=1e-6)
+        assert lo[3].item() == pytest.approx(0.025 * math.sqrt(2), rel=1e-6)
+
+
+class TestBandAppliesElementwise:
+    def test_clamp_uses_each_token_own_band(self) -> None:
+        """compute_policy_loss must clamp per token, not with one scalar band."""
+        from miles.backends.training_utils.loss_hub.math_utils import compute_policy_loss
+
+        # one ratio, four different bands: 1.08 is outside the t=1 band [0.975, 1.05]
+        # and inside the t=4 band [0.95, 1.10]. Deliberately not on an edge, so the
+        # assertion does not turn on a float rounding.
+        ppo_kl = -torch.log(torch.full((4,), 1.08))
+        advantages = torch.ones(4)
+        lo, hi = compute_ctpo_clip_band([torch.ones(4)], 0.025, 0.05)
+        _, clipfrac = compute_policy_loss(ppo_kl, advantages, lo, hi)
+        assert clipfrac[0].item() == 1.0
+        assert clipfrac[3].item() == 0.0
+
+
+class TestDispatch:
+    """The estimator must actually be routed, not fall through to the token path."""
+
+    @staticmethod
+    def _run(estimator: str):
+        import torch.distributed as dist
+
+        from miles.backends.training_utils.cp_utils import get_sum_of_sample_mean
+        from miles.backends.training_utils.loss_hub.losses import policy_loss_function
+        from miles.backends.training_utils.parallel import set_parallel_state
+
+        from .loss_test_utils import deep_clone, make_args, make_batch, make_inputs, make_parallel_state
+
+        set_parallel_state(make_parallel_state())
+        args = make_args(
+            advantage_estimator=estimator,
+            loss_type="policy_loss",
+            use_rollout_logprobs=True,
+            eps_clip=0.025,
+            eps_clip_high=0.05,
+            entropy_coef=0.0,
+            # not in the harness defaults; losses.py reads it unconditionally
+            observe_training_entropy=False,
+        )
+        inputs = make_inputs(
+            seed=7, batch_size=3, prompt_lens=[8, 12, 6], response_lens=[10, 16, 5],
+            vocab_size=64, args=args,
+        )
+        batch = make_batch(inputs, "policy_loss")
+        logits = deep_clone(inputs["policy_logits"])
+        logits.requires_grad_(True)
+        som = get_sum_of_sample_mean(
+            batch["total_lengths"], batch["response_lengths"], batch["loss_masks"],
+            args.calculate_per_token_loss, args.qkv_format, batch.get("max_seq_lens", None),
+        )
+        _, metrics = policy_loss_function(args, batch, logits, som)
+        return metrics
+
+    def test_ctpo_is_accepted_as_an_advantage_estimator(self) -> None:
+        import argparse
+
+        from miles.utils.arguments import get_miles_extra_args_provider
+
+        parser = argparse.ArgumentParser()
+        get_miles_extra_args_provider()(parser)
+        # --rollout-batch-size is required by the miles parser regardless
+        args = parser.parse_args(["--advantage-estimator", "ctpo", "--rollout-batch-size", "64"])
+        assert args.advantage_estimator == "ctpo"
+
+    def test_ctpo_ppo_kl_differs_from_the_token_level_estimator(self) -> None:
+        """A missing branch falls through to `ppo_kl = old - new`, silently making
+        ctpo a synonym for grpo. Prefix sums accumulate, so the reduced ppo_kl must
+        not match the per-token one."""
+        ctpo = self._run("ctpo")["ppo_kl"]
+        grpo = self._run("grpo")["ppo_kl"]
+        assert not torch.allclose(ctpo, grpo), (
+            f"ctpo ppo_kl {ctpo.item()} == grpo {grpo.item()}: the ctpo branch is not being taken"
+        )
+
+
+class TestAdvantageDispatch:
+    """compute_advantages dispatches SEPARATELY from the policy loss.
+
+    A branch added only to policy_loss_function passes every loss test and then
+    raises NotImplementedError at the first optimizer step of a real run.
+    """
+
+    @staticmethod
+    def _advantages(estimator: str):
+        from miles.backends.training_utils.loss_hub.advantages import compute_advantages
+
+        from .loss_test_utils import make_args
+
+        args = make_args(advantage_estimator=estimator)
+        kl = [torch.zeros(4), torch.zeros(3)]
+        return compute_advantages(
+            args,
+            kl=kl,
+            rewards=[1.0, -0.5],
+            log_probs=None,
+            loss_masks=[torch.ones(4), torch.ones(3)],
+            total_lengths=[9, 8],
+            response_lengths=[4, 3],
+        )[0]
+
+    def test_ctpo_is_a_supported_advantage_estimator(self) -> None:
+        self._advantages("ctpo")
+
+    def test_ctpo_advantage_matches_grpo(self) -> None:
+        """CTPO changes the importance weight, not the credit assignment: the
+        broadcast group-normalised advantage is shared with GRPO."""
+        for got, want in zip(self._advantages("ctpo"), self._advantages("grpo"), strict=True):
+            assert torch.allclose(got, want)


### PR DESCRIPTION
CTPO uses the prefix product rho_{0:t} = prod_{i<=t} rho_i as the importance weight -- the alpha=1 endpoint, with no length normalisation. The three estimators are three reductions of the same per-token log-ratio: GRPO keeps the per-token term, GSPO takes the length-normalised sequence mean and broadcasts it, CTPO keeps the running product, so the weight retains per-token credit that a broadcast sequence weight discards.

compute_policy_loss forms ratio = exp(-ppo_kl), so making ppo_kl a running sum over the masked response tokens produces the prefix product directly.

The band scales with sqrt(t) because log rho_{0:t} is a t-term random walk: its spread grows as sqrt(t), so a FIXED band would clip an ever-larger share of tokens as the response runs on. t is the 1-based count of masked-in tokens, so the first generated token gets the base band and contributes exactly one factor.

Notes on the implementation:
- compute_policy_loss needed no signature change. Tensor.clamp is already elementwise, so scalar bands (grpo/gspo) and per-token bands (ctpo) share one path; only the annotations widened.
- need_full_log_probs includes ctpo: a prefix sum is non-local under context parallelism for the same reason GSPO's sequence mean is. CP itself is not supported yet and raises rather than silently computing a per-shard prefix.
- compute_advantages dispatches SEPARATELY from the policy loss. ctpo shares grpo's broadcast group-normalised advantage -- it changes the importance weight, not the credit assignment. A branch added only to the loss passes every loss test and then raises NotImplementedError at the first optimizer step.

Tests cover the prefix product, the band, and both dispatch sites. The load-bearing one is that the prefix does not bleed across samples: ppo_kl is one flat tensor concatenated over the micro-batch, and a naive cumsum would run straight through the boundaries and corrupt every sample after the first while still producing plausible numbers.


(cherry picked from commit 8db6ec4fdf4f5f858b13de0d1addbade7575a166)