### PR TITLE
fix(rollout): snapshot the global-dataset cursor per rollout

### DIFF
--- a/miles/ray/rollout/rollout_manager.py
+++ b/miles/ray/rollout/rollout_manager.py
@@ -166,6 +166,8 @@ class RolloutManager:
             data_ref = object_store.get_instance().put(value=data, value_spec=ROLLOUT_DATA_VALUE_SPEC)
         else:
             data_ref = split_train_data_by_dp(self.args, data, self.train_parallel_config)
+        if (snapshot := getattr(self.data_source, "snapshot", None)) is not None:
+            snapshot(rollout_id)
         return dict(sample_indices=sample_indices, data_ref=data_ref)
 
     async def eval(

--- a/miles/rollout/data_source.py
+++ b/miles/rollout/data_source.py
@@ -27,6 +27,12 @@ class DataSource(abc.ABC):
         Add samples to the data source
         """
 
+    def snapshot(self, rollout_id):
+        """
+        Snapshot the state of the data source after a successful rollout.
+        """
+        return None
+
     @abc.abstractmethod
     def save(self, rollout_id):
         """
@@ -55,6 +61,7 @@ class RolloutDataSource(DataSource):
         self.sample_offset = 0
         # TODO remove this
         self.metadata = {}
+        self._rollout_state_snapshots = {}
 
         if args.rollout_global_dataset:
             tokenizer = load_tokenizer(
@@ -121,20 +128,44 @@ class RolloutDataSource(DataSource):
     def add_samples(self, samples: list[list[Sample]]):
         raise RuntimeError(f"Cannot add samples to {self.__class__.__name__}. This is a read-only data source.")
 
+    def _live_state(self):
+        return copy.deepcopy(
+            {
+                "sample_offset": self.sample_offset,
+                "epoch_id": self.epoch_id,
+                "sample_group_index": self.sample_group_index,
+                "sample_index": self.sample_index,
+                "metadata": self.metadata,
+            }
+        )
+
+    def snapshot(self, rollout_id):
+        if not self.args.rollout_global_dataset:
+            return
+
+        # The cursor advances while the trainer catches up, so capture it here, not at save time.
+        self._rollout_state_snapshots[rollout_id] = self._live_state()
+
     def save(self, rollout_id):
         if not self.args.rollout_global_dataset:
             return
 
-        state_dict = {
-            "sample_offset": self.sample_offset,
-            "epoch_id": self.epoch_id,
-            "sample_group_index": self.sample_group_index,
-            "sample_index": self.sample_index,
-            "metadata": self.metadata,
-        }
+        if rollout_id in self._rollout_state_snapshots:
+            state_dict = self._rollout_state_snapshots[rollout_id]
+        else:
+            # A save with no generate behind it, e.g. eval-only. The live cursor may sit past
+            # rollout_id, but it beats refusing to write one.
+            logger.warning(f"No data-source snapshot for rollout {rollout_id}; saving the live cursor instead.")
+            state_dict = self._live_state()
         path = os.path.join(self.args.save, f"rollout/global_dataset_state_dict_{rollout_id}.pt")
         os.makedirs(os.path.dirname(path), exist_ok=True)
         torch.save(state_dict, path)
+        for snapshot_rollout_id in [
+            snapshot_rollout_id
+            for snapshot_rollout_id in self._rollout_state_snapshots
+            if snapshot_rollout_id <= rollout_id
+        ]:
+            del self._rollout_state_snapshots[snapshot_rollout_id]
 
     def load(self, rollout_id=None):
         if not self.args.rollout_global_dataset:

--- a/tests/fast/rollout/test_data_source_checkpoint.py
+++ b/tests/fast/rollout/test_data_source_checkpoint.py
@@ -1,0 +1,70 @@
+from argparse import Namespace
+
+import torch
+
+from miles.rollout.data_source import RolloutDataSource
+
+
+def make_source(tmp_path, **overrides):
+    args = {
+        "rollout_global_dataset": True,
+        "load": str(tmp_path / "base-model"),
+        "save": str(tmp_path / "run"),
+        "rollout_shuffle": False,
+    }
+    args.update(overrides)
+
+    source = RolloutDataSource.__new__(RolloutDataSource)
+    source.args = Namespace(**args)
+    source.sample_offset = 0
+    source.epoch_id = 0
+    source.sample_group_index = 0
+    source.sample_index = 0
+    source.metadata = {}
+    source._rollout_state_snapshots = {}
+    return source
+
+
+def test_save_uses_immutable_rollout_snapshot_and_prunes_old_snapshots(tmp_path):
+    source = make_source(tmp_path)
+    source.snapshot(2)
+
+    source.sample_offset = 64
+    source.epoch_id = 2
+    source.sample_group_index = 11
+    source.sample_index = 22
+    source.metadata = {"nested": {"source": "rollout-3"}}
+    source.snapshot(3)
+
+    source.sample_offset = 96
+    source.epoch_id = 3
+    source.sample_group_index = 15
+    source.sample_index = 30
+    source.metadata["nested"]["source"] = "rollout-4"
+    source.snapshot(4)
+
+    source.save(3)
+
+    state = torch.load(
+        tmp_path / "run" / "rollout" / "global_dataset_state_dict_3.pt",
+        weights_only=True,
+    )
+    assert state == {
+        "sample_offset": 64,
+        "epoch_id": 2,
+        "sample_group_index": 11,
+        "sample_index": 22,
+        "metadata": {"nested": {"source": "rollout-3"}},
+    }
+    assert set(source._rollout_state_snapshots) == {4}
+
+def test_save_without_a_matching_snapshot_falls_back_to_the_live_cursor(tmp_path):
+    """An eval-only or externally triggered save has no generate behind it. Writing the live
+    cursor keeps that path working; it used to raise."""
+    source = make_source(tmp_path)
+    source.sample_offset = 16
+
+    source.save(0)
+
+    state = torch.load(tmp_path / "run" / "rollout" / "global_dataset_state_dict_0.pt", weights_only=True)
+    assert state["sample_offset"] == 16

--- a/train.py
+++ b/train.py
@@ -93,11 +93,11 @@ async def train(args):
             if args.use_critic and args.offload_train:
                 await model.offload()
 
+        await rollout_manager.save.remote(rollout_id)
         if (not args.use_critic) or (rollout_id >= args.num_critic_only_steps):
             await save_training_model(actor_model)
         if args.use_critic:
             await save_training_model(critic_model)
-        await rollout_manager.save.remote(rollout_id)
 
     # train loop.
     # note that for async training, one can change the position of the sync operation(ray.get).

--- a/train_async.py
+++ b/train_async.py
@@ -97,10 +97,10 @@ async def train(args):
             rollout_id, args.save_interval, num_rollout_per_epoch, args.num_rollout
         ):
             force_sync = external_save or rollout_id == args.num_rollout - 1
+            await rollout_manager.save.remote(rollout_id)
             await save_training_model(actor_model, rollout_id, force_sync)
             if args.use_critic:
                 await save_training_model(critic_model, rollout_id, force_sync)
-            await rollout_manager.save.remote(rollout_id)
             if external_save:
                 os.remove(args.save_trigger_sentinel)
 


### PR DESCRIPTION
## Problem

`RolloutDataSource.save(rollout_id)` writes whatever the cursor happens to be at save time:

```python
def save(self, rollout_id):
    state_dict = {"sample_offset": self.sample_offset, ...}
    path = os.path.join(self.args.save, f"rollout/global_dataset_state_dict_{rollout_id}.pt")
```

The rollout manager keeps generating while the trainer catches up, so by the time the save runs the cursor can already belong to a later rollout. The file named for `rollout_id` then records a position the run never occupied at `rollout_id`, and resuming from it skips whatever the later rollouts consumed.

On `main`, with rollout 3 ending at offset 64 and rollout 4 having advanced the cursor to 96 before the save:

```
saved in global_dataset_state_dict_3.pt : 96      (expected 64)
```

## Change

Snapshot the cursor where the position is actually known — after `generate` — and have `save()` write the snapshot matching its `rollout_id`, pruning the ones it has passed. Snapshots are deep-copied, so later mutation of `metadata` cannot reach back into an already-captured rollout.

A save with no `generate` behind it — eval-only, or an externally triggered save — has no snapshot to match. That path keeps writing the live cursor and logs a warning, rather than refusing to write a checkpoint.

Both training loops now save the data source before the model, so the two artifacts of one checkpoint are written from the same position.

## Validation

- 2 fast tests in `tests/fast/rollout/test_data_source_checkpoint.py`: snapshot selection and pruning across three rollouts, and the eval-only fallback.
- The reproduction above returns 64 with this branch and 96 on `main`.
