### PR TITLE
Publish the session servers as one list of instance records

### DIFF
--- a/examples/swe-agent-harbor-docker/swe_agent_function.py
+++ b/examples/swe-agent-harbor-docker/swe_agent_function.py
@@ -140,7 +140,8 @@ async def abort(args) -> None:
     """
     agent_server_url = os.getenv("AGENT_SERVER_URL", os.getenv("SWE_AGENT_URL"))
 
-    instance_ids = set((getattr(args, "session_server_instance_ids", None) or {}).values())
+    instances = getattr(args, "session_server_instances", None) or []
+    instance_ids = {x.instance_id for x in instances if x.instance_id}
     singular = getattr(args, "session_server_instance_id", None)  # back-compat / child path
     if singular:
         instance_ids.add(singular)

--- a/miles/ray/rollout/router_manager.py
+++ b/miles/ray/rollout/router_manager.py
@@ -1,6 +1,7 @@
 import logging
 
 from miles.ray.specs.inference import compute_router_pool_id, compute_session_server_instance_id
+from miles.rollout.session.types import SessionServerInstance
 from miles.utils.http_utils import wait_tcp_ready_async
 from miles.utils.workers.naming import compute_worker_name
 from miles.utils.workers.worker_provider.base import BaseWorkerProvider
@@ -48,18 +49,18 @@ async def wait_session_server_ready(args):
         (await provider.get_addrs(worker_name=compute_worker_name(pool_id="session-server", cell_index=i)))["primary"]
         for i in range(args.session_server_workers)
     ]
-    # The canonical driver-side value; rollout code picks from this list. Instances may sit on
-    # different hosts, so each one is addressed in full rather than by a port under a shared ip.
-    args.session_server_addrs = [f"{x.host}:{x.port}" for x in addrs]
+    # The canonical driver-side value; rollout code picks one instance from this
+    # list per session. Each record carries the full address -- instances may sit
+    # on different hosts -- and the instance id that replaced the per-session
+    # /health probe, so a pick never has to line up with any other structure.
+    args.session_server_instances = [
+        SessionServerInstance(
+            addr=f"{x.host}:{x.port}",
+            instance_id=compute_session_server_instance_id(args, instance_index),
+        )
+        for instance_index, x in enumerate(addrs)
+    ]
 
-    # Spawn all children before waiting on any: each child pays the ~10s
-    # transformers import, so N servers start in ~one import of wall-time.
-    instance_ids: dict[str, str] = {}
-    for instance_index, addr in enumerate(args.session_server_addrs):
-        instance_ids[addr] = compute_session_server_instance_id(args, instance_index)
-    # The per-address map OpenAIEndpointTracer.create reads instance ids from,
-    # replacing the per-session /health probe.
-    args.session_server_instance_ids = instance_ids
     for addr in addrs:
         await wait_tcp_ready_async(addr.host, addr.port, timeout=_SERVER_READY_TIMEOUT_SECS)
-    logger.info(f"Session servers ready at {args.session_server_addrs} ({len(addrs)} instances)")
+    logger.info(f"Session servers ready at {[x.addr for x in args.session_server_instances]} ({len(addrs)} instances)")

--- a/miles/rollout/generate_hub/agentic_tool_call.py
+++ b/miles/rollout/generate_hub/agentic_tool_call.py
@@ -43,8 +43,8 @@ logger = logging.getLogger(__name__)
 
 async def generate(input: GenerateFnInput) -> GenerateFnOutput:
     assert not input.args.partial_rollout, "Partial rollout is not supported"
-    assert getattr(input.args, "session_server_addrs", None), (
-        "agentic_tool_call.generate requires session_server_addrs. "
+    assert getattr(input.args, "session_server_instances", None), (
+        "agentic_tool_call.generate requires session_server_instances. "
         "Pass --use-session-server to start the session server."
     )
     use_v2 = getattr(input.args, "use_session_server", None) == "v2"

--- a/miles/rollout/generate_utils/openai_endpoint_utils.py
+++ b/miles/rollout/generate_utils/openai_endpoint_utils.py
@@ -45,24 +45,22 @@ class OpenAIEndpointTracer:
 
     @staticmethod
     async def create(args: Namespace):
-        session_addrs = getattr(args, "session_server_addrs", None)
-        if not session_addrs:
+        instances = getattr(args, "session_server_instances", None)
+        if not instances:
             raise RuntimeError(
-                "session_server_addrs is not set. Pass --use-session-server to start the session server."
+                "session_server_instances is not set. Pass --use-session-server to start the session server."
             )
         # The only routing decision in the system: pick the owning instance once
         # per session; every later touch of the session reuses this URL.
-        session_addr = random.choice(session_addrs)
-        session_url = f"http://{session_addr}"
-        instance_ids = getattr(args, "session_server_instance_ids", None) or {}
-        session_server_instance_id = instance_ids.get(session_addr)
+        instance = random.choice(instances)
+        session_url = instance.url
         response = await post(f"{session_url}/sessions", {}, action="post")
         session_id = response["session_id"]
         use_v2 = getattr(args, "use_session_server", None) == "v2"
         return OpenAIEndpointTracer(
             router_url=session_url,
             session_id=session_id,
-            session_server_instance_id=session_server_instance_id,
+            session_server_instance_id=instance.instance_id,
             samples_wire_fields=COMPUTED_FIELDS_V2 if use_v2 else COMPUTED_FIELDS,
         )
 

--- a/miles/rollout/session/types.py
+++ b/miles/rollout/session/types.py
@@ -1,5 +1,24 @@
 from pydantic import BaseModel, Field
 
+from miles.utils.pydantic_utils import FrozenStrictBaseModel
+
+
+class SessionServerInstance(FrozenStrictBaseModel):
+    """One session-server instance as the driver published it.
+
+    A pick from ``args.session_server_instances`` returns everything about the
+    instance at once, so nothing has to stay positionally aligned across
+    separate structures.
+    """
+
+    # ``host:port`` the driver dials.
+    addr: str
+    instance_id: str | None = None
+
+    @property
+    def url(self) -> str:
+        return f"http://{self.addr}"
+
 
 class SessionRecord(BaseModel):
     timestamp: float

--- a/tests/fast/fixtures/generation_fixtures.py
+++ b/tests/fast/fixtures/generation_fixtures.py
@@ -9,11 +9,13 @@ from typing import Any
 from unittest.mock import patch
 
 import pytest
+
 from miles.rollout.base_types import GenerateFnInput
 from miles.rollout.inference_rollout.compatibility import load_generate_function
 from miles.rollout.inference_rollout.inference_rollout_common import GenerateState
 from miles.rollout.session.config import compute_session_server_config
 from miles.rollout.session.server import SessionServer
+from miles.rollout.session.types import SessionServerInstance
 from miles.utils.async_utils import run
 from miles.utils.http_utils import find_available_port, init_http_client
 from miles.utils.misc import SingletonMeta
@@ -235,7 +237,7 @@ def with_session_server(
     # Mirror wait_session_server_ready (router_manager.py): the id is minted into the
     # caller's per-port map, where OpenAIEndpointTracer.create reads it from.
     instance_id = f"{args.run_uuid}-0"
-    args.session_server_instance_ids = {f"127.0.0.1:{port}": instance_id}
+    args.session_server_instances = [SessionServerInstance(addr=f"127.0.0.1:{port}", instance_id=instance_id)]
     # Sample assembly runs inside the server, so the R3 decode shape args
     # must reach the server config (set them via args_kwargs BEFORE the
     # server starts; assigning to the driver args afterwards has no effect).
@@ -303,9 +305,8 @@ def generation_env(request, variant):
 
         with cm:
             if is_agentic:
-                # Point session server address to the SessionServer we just started,
-                # mirroring the driver-side contract set by wait_session_server_ready.
-                args.session_server_addrs = [f"127.0.0.1:{server_port}"]
+                # with_session_server already published the driver-side contract
+                # (the instance record, id included); only the mock knobs remain.
                 mock_tools.AGENTIC_MAX_TURNS = args_kwargs.get("generate_max_turns")
                 mock_tools.AGENTIC_RETURN_METADATA = args_kwargs.get("agentic_return_metadata")
             yield GenerateEnv(args=args, mock_server=mock_server)

--- a/tests/fast/fixtures/rollout_fixtures.py
+++ b/tests/fast/fixtures/rollout_fixtures.py
@@ -16,6 +16,7 @@ import requests
 from miles.rollout.data_source import DataSource, RolloutDataSourceWithBuffer
 from miles.rollout.session.config import compute_session_server_config
 from miles.rollout.session.server import SessionServer
+from miles.rollout.session.types import SessionServerInstance
 from miles.router.config import compute_miles_router_config
 from miles.router.router import MilesRouter
 from miles.utils.arguments import parse_args
@@ -116,7 +117,7 @@ def _with_session_server(args: Namespace, backend_url: str) -> Iterator[UvicornT
     server = UvicornThreadServer(session_server.app, host="127.0.0.1", port=port)
     try:
         server.start()
-        args.session_server_addrs = [f"127.0.0.1:{port}"]
+        args.session_server_instances = [SessionServerInstance(addr=f"127.0.0.1:{port}")]
         yield server
     finally:
         server.stop()

--- a/tests/fast/ray/rollout/test_router_manager.py
+++ b/tests/fast/ray/rollout/test_router_manager.py
@@ -8,6 +8,7 @@ import pytest
 from tests.fast.ray.rollout.conftest import make_args
 
 from miles.ray.rollout.router_manager import wait_router_ready, wait_session_server_ready
+from miles.rollout.session.types import SessionServerInstance
 from miles.utils.workers.worker_spec import HostAndPort, NamedHostAndPorts
 
 
@@ -108,8 +109,7 @@ class TestWaitSessionServerReady:
         await wait_session_server_ready(args)
 
         assert created == []
-        assert not hasattr(args, "session_server_addrs")
-        assert not hasattr(args, "session_server_instance_ids")
+        assert not hasattr(args, "session_server_instances")
 
     async def test_enabled_without_hf_checkpoint_raises(self):
         """Enabling the session server without a tokenizer source fails fast."""
@@ -159,11 +159,10 @@ class TestWaitSessionServerReady:
         await wait_session_server_ready(args)
 
         assert requested == ["session-server-0-0", "session-server-1-0"]
-        assert args.session_server_addrs == ["10.0.0.9:5005", "10.0.0.9:5006"]
-        assert args.session_server_instance_ids == {
-            "10.0.0.9:5005": "00112233445566aa-0",
-            "10.0.0.9:5006": "00112233445566aa-1",
-        }
+        assert args.session_server_instances == [
+            SessionServerInstance(addr="10.0.0.9:5005", instance_id="00112233445566aa-0"),
+            SessionServerInstance(addr="10.0.0.9:5006", instance_id="00112233445566aa-1"),
+        ]
         assert waited == [("10.0.0.9", 5005), ("10.0.0.9", 5006)]
 
     async def test_servers_on_different_hosts_are_each_addressed_in_full(self, monkeypatch):
@@ -196,11 +195,10 @@ class TestWaitSessionServerReady:
         )
         await wait_session_server_ready(args)
 
-        assert args.session_server_addrs == ["10.0.0.1:5005", "10.0.0.2:5005"]
-        assert args.session_server_instance_ids == {
-            "10.0.0.1:5005": "00112233445566aa-0",
-            "10.0.0.2:5005": "00112233445566aa-1",
-        }
+        assert args.session_server_instances == [
+            SessionServerInstance(addr="10.0.0.1:5005", instance_id="00112233445566aa-0"),
+            SessionServerInstance(addr="10.0.0.2:5005", instance_id="00112233445566aa-1"),
+        ]
         assert waited == [("10.0.0.1", 5005), ("10.0.0.2", 5005)]
 
     async def test_one_unreachable_instance_fails_the_whole_readiness_wait(self, monkeypatch):

--- a/tests/fast/rollout/generate_hub/test_agentic_v2.py
+++ b/tests/fast/rollout/generate_hub/test_agentic_v2.py
@@ -6,6 +6,7 @@ import miles.rollout.generate_hub.agentic_tool_call as agentic_tool_call
 from miles.ray.rollout.rollout_data_conversion import validate_compact_rollout_ids
 from miles.rollout.base_types import GenerateFnInput
 from miles.rollout.session.samples.codec import SamplesReply
+from miles.rollout.session.types import SessionServerInstance
 from miles.utils.types import Sample
 
 
@@ -29,7 +30,7 @@ class _Tracer:
 
 def _generate_input(**args_kwargs) -> GenerateFnInput:
     args = SimpleNamespace(
-        session_server_addrs=["127.0.0.1:12345"],
+        session_server_instances=[SessionServerInstance(addr="127.0.0.1:12345")],
         custom_agent_function_path="test.fake_agent",
         max_seq_len=None,
         partial_rollout=False,
@@ -127,8 +128,8 @@ _ADDRS_ATTR_ABSENT = object()
 class TestSessionServerAddrsValidation:
     @pytest.mark.asyncio
     @pytest.mark.parametrize("addrs", [_ADDRS_ATTR_ABSENT, None, []], ids=["absent", "none", "empty"])
-    async def test_empty_session_server_addrs_is_rejected(self, monkeypatch, addrs):
-        """generate() raises the documented AssertionError when session_server_addrs is absent, null or empty, without creating a tracer."""
+    async def test_empty_session_server_instances_is_rejected(self, monkeypatch, addrs):
+        """generate() raises the documented AssertionError when session_server_instances is absent, null or empty, without creating a tracer."""
         created_for: list[object] = []
 
         async def fake_create(args):
@@ -140,11 +141,11 @@ class TestSessionServerAddrsValidation:
 
         generate_input = _generate_input()
         if addrs is _ADDRS_ATTR_ABSENT:
-            del generate_input.args.session_server_addrs
+            del generate_input.args.session_server_instances
         else:
-            generate_input.args.session_server_addrs = addrs
+            generate_input.args.session_server_instances = addrs
 
-        with pytest.raises(AssertionError, match="requires session_server_addrs"):
+        with pytest.raises(AssertionError, match="requires session_server_instances"):
             await agentic_tool_call.generate(generate_input)
 
         assert created_for == []

--- a/tests/fast/rollout/generate_hub/test_multi_turn.py
+++ b/tests/fast/rollout/generate_hub/test_multi_turn.py
@@ -11,6 +11,7 @@ import pytest
 from tests.ci.ci_register import register_cpu_ci
 from tests.fast.fixtures.generation_fixtures import GenerateEnv, generation_env, listify, make_sample, run_generate
 
+from miles.rollout.session.types import SessionServerInstance
 from miles.utils.chat_template_utils import TITOTokenizerType, get_tito_tokenizer
 from miles.utils.processing_utils import load_tokenizer
 from miles.utils.test_utils.mock_sglang_server import ProcessResult, ProcessResultMetaInfo
@@ -694,8 +695,8 @@ class TestAgentMetadata:
             mock_tools.AGENTIC_RETURN_METADATA = None
 
         samples = listify(result.sample)
-        (session_server_addr,) = generation_env.args.session_server_addrs
-        session_server_port = int(session_server_addr.rsplit(":", 1)[1])
+        (session_server_instance,) = generation_env.args.session_server_instances
+        session_server_port = int(session_server_instance.addr.rsplit(":", 1)[1])
         expected_session_server_id = f"127.0.0.1:{session_server_port}"
         for s in samples:
             assert s.metadata["session_server_id"] == expected_session_server_id
@@ -773,7 +774,7 @@ class TestAgentNoRecords:
                 extra_argv=noop_argv,
             )
             with with_session_server(mock_server.url, args, port=session_port):
-                args.session_server_addrs = [f"127.0.0.1:{session_port}"]
+                args.session_server_instances = [SessionServerInstance(addr=f"127.0.0.1:{session_port}")]
                 env = GenerateEnv(args=args, mock_server=mock_server)
                 result = _run_generate(agentic_variant, env, make_sample(prompt=TwoTurnStub.PROMPT))
 

--- a/tests/fast/rollout/generate_utils/test_openai_endpoint_utils.py
+++ b/tests/fast/rollout/generate_utils/test_openai_endpoint_utils.py
@@ -17,6 +17,7 @@ import pytest
 import miles.utils.http_utils as http_utils
 from miles.rollout.generate_utils.openai_endpoint_utils import OpenAIEndpointTracer
 from miles.rollout.session.samples.codec import COMPUTED_FIELDS, COMPUTED_FIELDS_V2, encode_samples
+from miles.rollout.session.types import SessionServerInstance
 from miles.utils.http_utils import post_bytes_no_retry
 from miles.utils.types import Sample
 
@@ -34,8 +35,7 @@ async def test_create_reads_session_server_instance_id_from_args(monkeypatch):
     monkeypatch.setattr("miles.rollout.generate_utils.openai_endpoint_utils.post", fake_post)
 
     args = SimpleNamespace(
-        session_server_addrs=["127.0.0.1:12345"],
-        session_server_instance_ids={"127.0.0.1:12345": "server-instance-123"},
+        session_server_instances=[SessionServerInstance(addr="127.0.0.1:12345", instance_id="server-instance-123")],
     )
     tracer = await OpenAIEndpointTracer.create(args)
 
@@ -53,7 +53,7 @@ async def test_create_without_instance_id_on_args(monkeypatch):
 
     monkeypatch.setattr("miles.rollout.generate_utils.openai_endpoint_utils.post", fake_post)
 
-    args = SimpleNamespace(session_server_addrs=["127.0.0.1:12345"])
+    args = SimpleNamespace(session_server_instances=[SessionServerInstance(addr="127.0.0.1:12345")])
     tracer = await OpenAIEndpointTracer.create(args)
 
     assert tracer.session_server_instance_id is None
@@ -80,7 +80,9 @@ async def test_create_distributes_sessions_across_port_range(monkeypatch):
     monkeypatch.setattr("miles.rollout.generate_utils.openai_endpoint_utils.post_bytes_no_retry", fake_post_bytes)
 
     ports = [12345, 12346, 12347, 12348]
-    args = SimpleNamespace(session_server_addrs=[f"127.0.0.1:{port}" for port in ports])
+    args = SimpleNamespace(
+        session_server_instances=[SessionServerInstance(addr=f"127.0.0.1:{port}") for port in ports]
+    )
 
     chosen_ports = set()
     for _ in range(32):
@@ -117,8 +119,10 @@ class TestOpenAIEndpointTracerCreate:
         monkeypatch.setattr("miles.rollout.generate_utils.openai_endpoint_utils.random.choice", lambda addrs: addrs[1])
 
         args = SimpleNamespace(
-            session_server_addrs=["10.0.0.1:5005", "10.0.0.2:5005"],
-            session_server_instance_ids={"10.0.0.1:5005": "instance-a", "10.0.0.2:5005": "instance-b"},
+            session_server_instances=[
+                SessionServerInstance(addr="10.0.0.1:5005", instance_id="instance-a"),
+                SessionServerInstance(addr="10.0.0.2:5005", instance_id="instance-b"),
+            ],
         )
         tracer = await OpenAIEndpointTracer.create(args)
 
@@ -128,9 +132,11 @@ class TestOpenAIEndpointTracerCreate:
         assert tracer.session_server_instance_id == "instance-b"
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("addrs_kwargs", [{}, {"session_server_addrs": None}, {"session_server_addrs": []}])
-    async def test_create_without_session_server_addrs_raises_before_post(self, monkeypatch, addrs_kwargs):
-        """create() raises a RuntimeError pointing at --use-session-server and issues no HTTP request when session_server_addrs is absent, null or empty."""
+    @pytest.mark.parametrize(
+        "addrs_kwargs", [{}, {"session_server_instances": None}, {"session_server_instances": []}]
+    )
+    async def test_create_without_session_server_instances_raises_before_post(self, monkeypatch, addrs_kwargs):
+        """create() raises a RuntimeError pointing at --use-session-server and issues no HTTP request when session_server_instances is absent, null or empty."""
         posted: list[str] = []
 
         async def fake_post(url: str, payload: dict, action: str = "post"):
@@ -139,7 +145,7 @@ class TestOpenAIEndpointTracerCreate:
 
         monkeypatch.setattr("miles.rollout.generate_utils.openai_endpoint_utils.post", fake_post)
 
-        with pytest.raises(RuntimeError, match="session_server_addrs is not set"):
+        with pytest.raises(RuntimeError, match="session_server_instances is not set"):
             await OpenAIEndpointTracer.create(SimpleNamespace(**addrs_kwargs))
 
         assert posted == []
@@ -331,7 +337,9 @@ async def test_create_selects_wire_fields_by_session_server_version(monkeypatch)
     monkeypatch.setattr("miles.rollout.generate_utils.openai_endpoint_utils.post", fake_post)
 
     def args(version):
-        return SimpleNamespace(session_server_addrs=["127.0.0.1:7000"], use_session_server=version)
+        return SimpleNamespace(
+            session_server_instances=[SessionServerInstance(addr="127.0.0.1:7000")], use_session_server=version
+        )
 
     assert (await OpenAIEndpointTracer.create(args(True))).samples_wire_fields == COMPUTED_FIELDS
     assert (await OpenAIEndpointTracer.create(args("v2"))).samples_wire_fields == COMPUTED_FIELDS_V2

--- a/tests/session_parity_utils.py
+++ b/tests/session_parity_utils.py
@@ -24,6 +24,7 @@ from miles.rollout.generate_hub import agentic_tool_call
 from miles.rollout.generate_utils.openai_endpoint_utils import OpenAIEndpointTracer
 from miles.rollout.session.samples.codec import SamplesReply
 from miles.rollout.session.server import SessionServer
+from miles.rollout.session.types import SessionServerInstance
 from miles.utils import http_utils
 from miles.utils.http_utils import find_available_port
 from miles.utils.test_utils.uvicorn_thread_server import UvicornThreadServer
@@ -244,8 +245,7 @@ def _serve_session(*, backend_url: str, hf_checkpoint: str, version: str) -> Ite
         use_rollout_indexer_replay=False,
         pause_generation_mode="retract",
         session_server_ip="127.0.0.1",
-        session_server_addrs=[session_addr],
-        session_server_instance_ids={session_addr: instance_id},
+        session_server_instances=[SessionServerInstance(addr=session_addr, instance_id=instance_id)],
         save_debug_trajectory_data=None,
         custom_agent_function_path="miles.utils.test_utils.session_verify_agent.run_agent",
         partial_rollout=False,


### PR DESCRIPTION
The driver publishes the session servers as two structures that must agree: an address list the tracer picks an index into, and an instance-id dict it then looks the address up in. Nothing enforces that they describe the same fleet — fabricated args in fixtures repeat the same address in both by hand.

Fold them into one list, `args.session_server_instances: list[SessionServerInstance]` (`addr`, `instance_id`). One `random.choice` returns everything about the chosen instance, so there is no alignment to maintain or to get wrong. Purely a representation change; no behavior changes.

This is also the shape #2851 needs: reaching an instance from outside the cluster adds a second address *per instance*, which as separate lists would mean three aligned structures. #2851 rebases onto this and adds a field to the record instead.

## Tests

**E2E smoke — passed (2026-09-04)**, on this stack: two-node ray cluster (8×H200 head + CPU-only second node), each node reporting its own tailnet address via `MILES_NODE_EXTERNAL_IP`; openenv e2b leg against the internal AgentENV sandbox service, GLM-4.7-Flash GRPO. Ray spread the 32 session servers across both nodes; the driver published each instance with its own node's external address; agents dialed those external addresses across nodes — 600+ session calls in the final run, zero `SessionNotFoundError` (3,000+ across all runs); a full train step completed with real rewards from the sandbox verifier (`rollout/raw_reward 0.375`, `train_step outcome=NORMAL valid_step=true`). Every failure along the way was test-rig or sandbox-provider territory (asymmetric node envs, orphaned processes between reruns, AgentENV#12/#15) — no defect surfaced in this stack's code.

Existing coverage carries over mechanically (fixtures and tests fabricate records instead of the list+dict pair). Not executed locally — no torch on this machine; `ruff`, `isort`, `black`, `py_compile` are clean, and the tracer path was exercised directly under python 3.12 (pick returns addr+id together; absent/empty instances still fail loud before any HTTP).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
