### PR TITLE
Tolerate missing optional SGLang Anthropic helpers

### DIFF
--- a/miles/rollout/session/anthropic_adapter.py
+++ b/miles/rollout/session/anthropic_adapter.py
@@ -3,9 +3,13 @@
 import json
 
 from pydantic import ValidationError
-from sglang.srt.entrypoints.anthropic import utils as anthropic_utils
 from sglang.srt.entrypoints.anthropic.protocol import AnthropicMessagesRequest, is_server_tool
 from starlette.responses import Response
+
+try:
+    from sglang.srt.entrypoints.anthropic import utils as anthropic_utils
+except ImportError:
+    anthropic_utils = None
 
 from miles.rollout.session.core import JSON_MEDIA_TYPE, _render_json
 

--- a/miles/rollout/session/anthropic_adapter.py
+++ b/miles/rollout/session/anthropic_adapter.py
@@ -3,15 +3,23 @@
 import json
 
 from pydantic import ValidationError
-from sglang.srt.entrypoints.anthropic.protocol import AnthropicMessagesRequest, is_server_tool
 from starlette.responses import Response
 
 try:
     from sglang.srt.entrypoints.anthropic import utils as anthropic_utils
+    from sglang.srt.entrypoints.anthropic.protocol import AnthropicMessagesRequest, is_server_tool
 except ImportError:
     anthropic_utils = None
+    AnthropicMessagesRequest = None
+    is_server_tool = None
 
 from miles.rollout.session.core import JSON_MEDIA_TYPE, _render_json
+
+
+def anthropic_adapter_available() -> bool:
+    """Whether the optional SGLang Anthropic helpers this adapter needs exist."""
+    return anthropic_utils is not None and AnthropicMessagesRequest is not None
+
 
 # Preserve end-to-end error metadata; drop headers tied to the replaced body.
 _ANTHROPIC_ERROR_HEADER_ALLOWLIST = ("www-authenticate", "retry-after", "x-request-id")

--- a/miles/rollout/session/sessions.py
+++ b/miles/rollout/session/sessions.py
@@ -9,11 +9,17 @@ import logging
 
 from fastapi import Request
 from fastapi.responses import JSONResponse
-from sglang.srt.entrypoints.anthropic import utils as anthropic_utils
-from sglang.srt.entrypoints.anthropic.serving import convert_response, convert_to_chat_completion_request
 from sglang.srt.entrypoints.openai.protocol import ChatCompletionResponse
 from sglang.srt.parser.template_detection import detect_inline_system_support
 from starlette.responses import Response
+
+try:
+    from sglang.srt.entrypoints.anthropic import utils as anthropic_utils
+    from sglang.srt.entrypoints.anthropic.serving import convert_response, convert_to_chat_completion_request
+except ImportError:
+    anthropic_utils = None
+    convert_response = None
+    convert_to_chat_completion_request = None
 
 from miles.rollout.session.anthropic_adapter import (
     _ANTHROPIC_ERROR_HEADER_ALLOWLIST as _ANTHROPIC_ERROR_HEADER_ALLOWLIST,
@@ -120,6 +126,11 @@ def setup_session_routes(app, backend, config: SessionServerConfig, *, use_addit
     @app.post("/sessions/{session_id}/v1/messages")
     async def anthropic_messages(request: Request, session_id: str):
         """Serve Anthropic Messages through the OpenAI session path."""
+        if anthropic_utils is None or convert_response is None or convert_to_chat_completion_request is None:
+            return JSONResponse(
+                status_code=501,
+                content={"error": "The installed SGLang does not support the Anthropic Messages adapter"},
+            )
         body = await request.body()
         try:
             anthropic_request = _parse_anthropic_request(body)

--- a/miles/rollout/session/sessions.py
+++ b/miles/rollout/session/sessions.py
@@ -38,7 +38,7 @@ from miles.rollout.session.anthropic_adapter import (
 from miles.rollout.session.anthropic_adapter import (
     _validate_anthropic_content_block as _validate_anthropic_content_block,
 )
-from miles.rollout.session.anthropic_adapter import _validate_anthropic_features
+from miles.rollout.session.anthropic_adapter import _validate_anthropic_features, anthropic_adapter_available
 from miles.rollout.session.config import SessionServerConfig
 from miles.rollout.session.core import JSON_MEDIA_TYPE, SessionCore, _render_json
 from miles.rollout.session.errors import SessionError
@@ -126,10 +126,24 @@ def setup_session_routes(app, backend, config: SessionServerConfig, *, use_addit
     @app.post("/sessions/{session_id}/v1/messages")
     async def anthropic_messages(request: Request, session_id: str):
         """Serve Anthropic Messages through the OpenAI session path."""
-        if anthropic_utils is None or convert_response is None or convert_to_chat_completion_request is None:
+        if (
+            anthropic_utils is None
+            or convert_response is None
+            or convert_to_chat_completion_request is None
+            or not anthropic_adapter_available()
+        ):
+            # _anthropic_error_response depends on the very helpers that are
+            # missing, so write the wire envelope out literally: this route
+            # always speaks Anthropic error shapes, 501 included.
             return JSONResponse(
                 status_code=501,
-                content={"error": "The installed SGLang does not support the Anthropic Messages adapter"},
+                content={
+                    "type": "error",
+                    "error": {
+                        "type": "api_error",
+                        "message": "The installed SGLang does not support the Anthropic Messages adapter",
+                    },
+                },
             )
         body = await request.body()
         try:

--- a/tests/fast/router/test_session_anthropic.py
+++ b/tests/fast/router/test_session_anthropic.py
@@ -6,6 +6,8 @@ same commit/skip decisions — clients only ever see Anthropic wire shapes.
 """
 
 import json
+import subprocess
+import sys
 import time
 import uuid
 from concurrent.futures import ThreadPoolExecutor
@@ -116,7 +118,30 @@ def _parse_sse(body: str) -> list[tuple[str, dict]]:
     return events
 
 
+@pytest.mark.parametrize(
+    "missing_module",
+    [
+        "sglang.srt.entrypoints.anthropic.utils",
+        "sglang.srt.entrypoints.anthropic.serving",
+    ],
+)
+def test_sessions_module_imports_without_optional_sglang_anthropic_helpers(missing_module: str) -> None:
+    script = f"import sys\nsys.modules[{missing_module!r}] = None\nfrom miles.rollout.session import sessions\nassert sessions.anthropic_utils is None\nassert sessions.convert_response is None\nassert sessions.convert_to_chat_completion_request is None\n"
+    result = subprocess.run([sys.executable, "-c", script], capture_output=True, text=True, check=False)
+
+    assert result.returncode == 0, result.stderr
+
+
 class TestAnthropicRoute:
+    def test_unavailable_sglang_adapter_returns_501_without_record(self, anthropic_env):
+        session_id = _create_session(anthropic_env.url)
+        with patch.object(sessions_module, "anthropic_utils", None):
+            resp = _post_messages(anthropic_env.url, session_id, _payload([{"role": "user", "content": "hello"}]))
+
+        assert resp.status_code == 501
+        assert resp.json() == {"error": "The installed SGLang does not support the Anthropic Messages adapter"}
+        assert _records(anthropic_env.url, session_id) == []
+
     def test_health_reports_live_intermediate_system_capability(self, anthropic_env):
         body = requests.get(f"{anthropic_env.url}/health", timeout=5.0).json()
         assert body["anthropic_intermediate_system_supported"] is True

--- a/tests/fast/router/test_session_anthropic.py
+++ b/tests/fast/router/test_session_anthropic.py
@@ -121,12 +121,26 @@ def _parse_sse(body: str) -> list[tuple[str, dict]]:
 @pytest.mark.parametrize(
     "missing_module",
     [
+        "sglang.srt.entrypoints.anthropic",
         "sglang.srt.entrypoints.anthropic.utils",
         "sglang.srt.entrypoints.anthropic.serving",
+        "sglang.srt.entrypoints.anthropic.protocol",
     ],
 )
 def test_sessions_module_imports_without_optional_sglang_anthropic_helpers(missing_module: str) -> None:
-    script = f"import sys\nsys.modules[{missing_module!r}] = None\nfrom miles.rollout.session import sessions\nassert sessions.anthropic_utils is None\nassert sessions.convert_response is None\nassert sessions.convert_to_chat_completion_request is None\n"
+    script = (
+        "import sys\n"
+        f"missing = {missing_module!r}\n"
+        "sys.modules[missing] = None\n"
+        "from miles.rollout.session import anthropic_adapter, sessions\n"
+        "if missing.endswith(('.utils', 'anthropic')):\n"
+        "    assert sessions.anthropic_utils is None\n"
+        "if missing.endswith(('.serving', 'anthropic')):\n"
+        "    assert sessions.convert_response is None\n"
+        "    assert sessions.convert_to_chat_completion_request is None\n"
+        "if missing.endswith(('.protocol', 'anthropic')):\n"
+        "    assert anthropic_adapter.anthropic_adapter_available() is False\n"
+    )
     result = subprocess.run([sys.executable, "-c", script], capture_output=True, text=True, check=False)
 
     assert result.returncode == 0, result.stderr
@@ -139,7 +153,13 @@ class TestAnthropicRoute:
             resp = _post_messages(anthropic_env.url, session_id, _payload([{"role": "user", "content": "hello"}]))
 
         assert resp.status_code == 501
-        assert resp.json() == {"error": "The installed SGLang does not support the Anthropic Messages adapter"}
+        assert resp.json() == {
+            "type": "error",
+            "error": {
+                "type": "api_error",
+                "message": "The installed SGLang does not support the Anthropic Messages adapter",
+            },
+        }
         assert _records(anthropic_env.url, session_id) == []
 
     def test_health_reports_live_intermediate_system_capability(self, anthropic_env):


### PR DESCRIPTION
## Summary

- Keep the Miles session server importable when optional SGLang Anthropic helper modules are unavailable.
- Leave OpenAI-compatible and TITO session routes usable.
- Return HTTP 501 from the Anthropic Messages route when that adapter is unavailable.

## Why

SGLang installations can expose the core OpenAI-compatible serving APIs without including every optional Anthropic adapter helper. Miles currently imports those optional helpers when the session server module loads, so a missing helper prevents the entire server from starting—even when the caller only needs an unrelated API. Detecting the optional capability at runtime isolates that limitation to the Anthropic route and keeps the rest of the session interface usable.

## Verification

- Full `tests/fast/router/test_session_anthropic.py`: 46 passed, 1 skipped.
- Focused missing-module probes: 4 passed.
- Ruff check: passed.
- `git diff --check`: passed.
