### PR TITLE
Scan full responses for repetition metrics

### DIFF
--- a/miles/utils/metric_utils.py
+++ b/miles/utils/metric_utils.py
@@ -1,7 +1,13 @@
 import math
+from collections.abc import Iterator
 from typing import Any, Literal
 
 import numpy as np
+
+
+REPETITION_WINDOW_SIZE_CHARS = 10_000
+REPETITION_WINDOW_STRIDE_CHARS = 5_000
+REPETITION_COMPRESSION_RATIO_THRESHOLD = 10.0
 
 
 def dict_add_prefix(d: dict[str, Any], prefix: str) -> dict[str, Any]:
@@ -107,11 +113,26 @@ def compression_ratio(
     return ratio, savings_pct
 
 
-def has_repetition(text: str):
-    if len(text) > 10000 and compression_ratio(text[-10000:])[0] > 10:
-        return True
-    else:
-        return False
+def _repetition_windows(text: str) -> Iterator[str]:
+    """Yield overlapping windows, including the exact final suffix."""
+    if len(text) < REPETITION_WINDOW_SIZE_CHARS:
+        return
+
+    final_start = len(text) - REPETITION_WINDOW_SIZE_CHARS
+    last_start = -1
+    for start in range(0, final_start + 1, REPETITION_WINDOW_STRIDE_CHARS):
+        yield text[start : start + REPETITION_WINDOW_SIZE_CHARS]
+        last_start = start
+
+    if last_start != final_start:
+        yield text[final_start:]
+
+
+def has_repetition(text: str) -> bool:
+    """Return whether any overlapping window is highly compressible."""
+    return any(
+        compression_ratio(window)[0] > REPETITION_COMPRESSION_RATIO_THRESHOLD for window in _repetition_windows(text)
+    )
 
 
 def compute_rollout_step(args, rollout_id):

--- a/miles/utils/metric_utils.py
+++ b/miles/utils/metric_utils.py
@@ -7,6 +7,12 @@ import numpy as np
 
 REPETITION_WINDOW_SIZE_CHARS = 10_000
 REPETITION_WINDOW_STRIDE_CHARS = 5_000
+# has_repetition runs synchronously on the rollout executor's event loop, so
+# the scan must stay bounded however long a response grows: past ~165k chars
+# the stride widens to keep at most this many windows. Adjacent windows still
+# overlap (stride <= window size) up to ~320k chars, so coverage stays
+# gap-free for any realistic response length.
+REPETITION_MAX_WINDOWS = 32
 REPETITION_COMPRESSION_RATIO_THRESHOLD = 10.0
 
 
@@ -119,8 +125,9 @@ def _repetition_windows(text: str) -> Iterator[str]:
         return
 
     final_start = len(text) - REPETITION_WINDOW_SIZE_CHARS
+    stride = max(REPETITION_WINDOW_STRIDE_CHARS, math.ceil(final_start / (REPETITION_MAX_WINDOWS - 1)))
     last_start = -1
-    for start in range(0, final_start + 1, REPETITION_WINDOW_STRIDE_CHARS):
+    for start in range(0, final_start + 1, stride):
         yield text[start : start + REPETITION_WINDOW_SIZE_CHARS]
         last_start = start
 

--- a/tests/fast/utils/test_metric_utils.py
+++ b/tests/fast/utils/test_metric_utils.py
@@ -1,0 +1,40 @@
+from unittest.mock import Mock
+
+from miles.utils import metric_utils
+
+
+def test_has_repetition_checks_stride_aligned_middle_window(monkeypatch) -> None:
+    text = "a" * 5_000 + "b" * 10_000 + "c" * 5_000
+    compression_ratio = Mock(side_effect=lambda window: (11.0, 0.0) if window == "b" * 10_000 else (1.0, 0.0))
+    monkeypatch.setattr(metric_utils, "compression_ratio", compression_ratio)
+
+    assert metric_utils.has_repetition(text)
+    assert compression_ratio.call_count == 2
+
+
+def test_has_repetition_checks_unaligned_final_window(monkeypatch) -> None:
+    text = "a" * 2_345 + "b" * 10_000
+    final_window = text[-10_000:]
+    compression_ratio = Mock(side_effect=lambda window: (11.0, 0.0) if window == final_window else (1.0, 0.0))
+    monkeypatch.setattr(metric_utils, "compression_ratio", compression_ratio)
+
+    assert metric_utils.has_repetition(text)
+    assert compression_ratio.call_count == 2
+
+
+def test_has_repetition_checks_exactly_ten_thousand_characters() -> None:
+    assert metric_utils.has_repetition("repeat" * 1_666 + "xxxx")
+
+
+def test_has_repetition_ignores_short_text(monkeypatch) -> None:
+    compression_ratio = Mock(return_value=(100.0, 0.0))
+    monkeypatch.setattr(metric_utils, "compression_ratio", compression_ratio)
+
+    assert not metric_utils.has_repetition("x" * 9_999)
+    compression_ratio.assert_not_called()
+
+
+def test_has_repetition_uses_strict_threshold(monkeypatch) -> None:
+    monkeypatch.setattr(metric_utils, "compression_ratio", lambda _: (10.0, 0.0))
+
+    assert not metric_utils.has_repetition("x" * 10_000)

--- a/tests/fast/utils/test_metric_utils.py
+++ b/tests/fast/utils/test_metric_utils.py
@@ -1,3 +1,4 @@
+import hashlib
 from unittest.mock import Mock
 
 from miles.utils import metric_utils
@@ -38,3 +39,33 @@ def test_has_repetition_uses_strict_threshold(monkeypatch) -> None:
     monkeypatch.setattr(metric_utils, "compression_ratio", lambda _: (10.0, 0.0))
 
     assert not metric_utils.has_repetition("x" * 10_000)
+
+
+def test_repetition_window_count_is_bounded_for_very_long_text(monkeypatch) -> None:
+    """The scan runs on the rollout executor's event loop; its cost must not
+    scale with response length."""
+    compression_ratio = Mock(return_value=(1.0, 0.0))
+    monkeypatch.setattr(metric_utils, "compression_ratio", compression_ratio)
+
+    assert not metric_utils.has_repetition("x" * 2_000_000)  # ~400 natural stride windows
+    assert compression_ratio.call_count <= metric_utils.REPETITION_MAX_WINDOWS
+
+
+def test_bounded_windows_keep_first_and_final_coverage() -> None:
+    text = "".join(chr(33 + (i % 90)) for i in range(500_000))
+    windows = list(metric_utils._repetition_windows(text))
+
+    assert len(windows) <= metric_utils.REPETITION_MAX_WINDOWS
+    assert windows[0] == text[: metric_utils.REPETITION_WINDOW_SIZE_CHARS]
+    assert windows[-1] == text[-metric_utils.REPETITION_WINDOW_SIZE_CHARS :]
+
+
+def test_repetition_mid_way_in_a_very_long_response_is_still_caught() -> None:
+    """Up to ~320k chars the widened stride keeps windows overlapping, so a
+    repetitive run longer than one window always lands fully inside some
+    window (real compression, no mocks)."""
+    filler = "".join(hashlib.sha256(str(i).encode()).hexdigest() for i in range(4_300))  # ~275k, low ratio
+    text = filler[:150_000] + "spam" * 6_250 + filler[150_000:]
+
+    assert metric_utils.has_repetition(text)
+    assert not metric_utils.has_repetition(filler)


### PR DESCRIPTION
## Summary

- scan the full response for repetition using overlapping 10,000-character windows with a 5,000-character stride
- preserve coverage of the exact final 10,000-character suffix when it is not stride-aligned
- add focused tests for middle-response repetition, boundary lengths, suffix coverage, and the existing strict compression threshold

## Why

`rollout/repetition_frac` currently checks only the final 10,000 characters of each response. A long response can contain severe repetition earlier and end with non-repetitive text, causing the metric to miss the behavior. Scanning bounded overlapping windows makes the metric represent repetition anywhere in the response while retaining short-circuit evaluation once repetition is found.

## Testing

- `uv run --active --no-sync pytest -q --confcutdir=tests/fast/utils tests/fast/utils/test_metric_utils.py` — 5 passed
- `uv run --active --no-sync pre-commit run --files miles/utils/metric_utils.py tests/fast/utils/test_metric_utils.py` — passed
