### PR TITLE
Bump sglang to v0.5.19

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,12 +11,12 @@
 # release for the current arch picked from TARGETARCH — WHEELS_TAG_X86 on amd64,
 # WHEELS_TAG_ARM64 on arm64 (cu12-x86 overrides WHEELS_TAG_X86).
 
-ARG SGLANG_IMAGE_TAG=v0.5.18
+ARG SGLANG_IMAGE_TAG=v0.5.19
 FROM lmsysorg/sglang:${SGLANG_IMAGE_TAG} AS sglang
 
 # ======================================== Arguments =============================================
 
-ARG SGLANG_BRANCH=sglang-miles
+ARG SGLANG_BRANCH=sglang-miles-v0.5.19
 ARG SGLANG_COMMIT=""
 
 ARG MEGATRON_REPO=radixark/Megatron-LM
@@ -197,6 +197,9 @@ RUN rm -rf /root/.cache/pip /root/flash-attention
 # file. Force it, then re-apply the same rewrite: the tree we just checked out carries
 # the cu13 markers, and sglang's editable install makes them visible to every later pip
 # resolve, which would drag cu13 packages onto a cu12 image.
+# The base image ships the Rust extension modules prebuilt (SGLANG_RUST_BUILD_MODE=never);
+# re-installing must not rebuild them, which needs the torch link path only the upstream
+# build stage has.
 RUN cd /sgl-workspace/sglang && \
     git fetch origin ${SGLANG_BRANCH} && \
     if [ -n "${SGLANG_COMMIT}" ]; then \
@@ -209,7 +212,7 @@ RUN cd /sgl-workspace/sglang && \
       sed -i 's/flashinfer_python\[cu13\]/flashinfer_python[cu12]/' python/pyproject.toml && \
       sed -i 's/nvidia-cutlass-dsl\[cu13\]/nvidia-cutlass-dsl/' python/pyproject.toml; \
     fi && \
-    pip install -e "python[all]" --no-deps
+    SGLANG_BUILD_RUST_EXTS=none pip install -e "python[all]" --no-deps
 
 # =========================== Mooncake structured object store wheel ===========================
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,7 +16,7 @@ FROM lmsysorg/sglang:${SGLANG_IMAGE_TAG} AS sglang
 
 # ======================================== Arguments =============================================
 
-ARG SGLANG_BRANCH=sglang-miles-v0.5.19
+ARG SGLANG_BRANCH=sglang-miles
 ARG SGLANG_COMMIT=""
 
 ARG MEGATRON_REPO=radixark/Megatron-LM

--- a/docker/build.py
+++ b/docker/build.py
@@ -46,7 +46,7 @@ VARIANTS = {
         "tag_postfix": "-cu12",
         "build_args": {
             "ENABLE_CUDA_13": "0",
-            "SGLANG_IMAGE_TAG": "v0.5.18-cu129",
+            "SGLANG_IMAGE_TAG": "v0.5.19-cu129",
             "WHEELS_TAG_X86": "cu129-x86_64",
         },
     },

--- a/miles/backends/sglang_utils/server_args_utils.py
+++ b/miles/backends/sglang_utils/server_args_utils.py
@@ -1,6 +1,7 @@
 import argparse
 
 from sglang.srt.server_args import ServerArgs
+from sglang.srt.utils import get_device
 
 from miles.utils.workers.argv_utils import render_cli_argv
 
@@ -8,6 +9,7 @@ _ALWAYS_RENDER_FIELDS = ("trust_remote_code", "model_path", "host", "port", "dev
 
 
 def server_args_to_argv(server_args_dict: dict) -> list[str]:
+    server_args_dict = {**server_args_dict, "device": _explicit_device(server_args_dict.get("device"))}
     return render_cli_argv(
         server_args_dict,
         expected_obj=ServerArgs(**server_args_dict),
@@ -25,3 +27,7 @@ def _make_cli_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser()
     ServerArgs.add_cli_args(parser)
     return parser
+
+
+def _explicit_device(device: str | None) -> str:
+    return (device or get_device()).split(":")[0]

--- a/miles/backends/training_utils/weight_update/protocols/p2p.py
+++ b/miles/backends/training_utils/weight_update/protocols/p2p.py
@@ -210,9 +210,9 @@ class UpdateWeightP2P(WeightTransferProtocol):
             rl_quant_profile=server_args.rl_quant_profile,
         )
         server_args_module.set_global_server_args_for_scheduler(server_args)
-        initialize_moe_config(server_args)
-        initialize_fp8_gemm_config(server_args)
-        initialize_fp4_gemm_config(server_args)
+        initialize_moe_config()
+        initialize_fp8_gemm_config()
+        initialize_fp4_gemm_config()
 
         # Monkey-patch the loader-level post_load_weights to no-op BEFORE get_model,
         # because get_model() calls post_load_weights() internally (loader.py:1310)

--- a/tests/e2e/long/test_qwen3_0.6B_verifiers.py
+++ b/tests/e2e/long/test_qwen3_0.6B_verifiers.py
@@ -1,6 +1,7 @@
 import math
 import os
 import shutil
+import site
 import sys
 from collections import Counter
 from pathlib import Path
@@ -31,7 +32,8 @@ CODE_GOLF_DIR = RUN_DIR / "environments" / "code_golf_v1"
 def prepare():
     U.exec_command_cpu(f"mkdir -p {MODEL_DIR} {RUN_DIR}")
     U.exec_command_cpu(f"hf download Qwen/{MODEL_NAME} --local-dir {MODEL_DIR}/{MODEL_NAME}")
-    U.exec_command_cpu(f"uv venv --clear --python {sys.executable} --system-site-packages {VERIFIERS_VENV}")
+    U.exec_command_cpu(f"uv venv --clear --seed --python {sys.executable} --system-site-packages {VERIFIERS_VENV}")
+    (VERIFIERS_SITE_PACKAGES / "launcher-site.pth").write_text("\n".join(site.getsitepackages()) + "\n")
     U.exec_command_cpu(
         f"{VERIFIERS_VENV}/bin/python -m pip install "
         f"-r {U.repo_base_dir}/examples/experimental/verifiers/requirements.txt"

--- a/tests/fast/backends/sglang_utils/test_server_args_utils.py
+++ b/tests/fast/backends/sglang_utils/test_server_args_utils.py
@@ -26,6 +26,9 @@ _FIELDS_WITHOUT_A_RENDERABLE_CLI: dict[str, str] = {
     "_speculative_draft_quantization_explicitly_set": (
         "Derived inside __post_init__ and declared Arg(no_cli=True); sglang registers no CLI option for it."
     ),
+    "grpc_worker_threads": (
+        "Env-only (SGLANG_GRPC_WORKER_THREADS) and declared Arg(no_cli=True); sglang registers no CLI option for it."
+    ),
     "cuda_graph_config": (
         "The CLI parses a validated per-phase JSON object while ServerArgs holds a CudaGraphConfig "
         "instance, so no generically rendered token parses back to the same value."
@@ -67,9 +70,13 @@ def _server_args(
 
 
 def _assert_roundtrips(server_args_dict: dict) -> None:
-    """Every field the launched process ends up with matches what miles asked for."""
+    """Every field the launched process ends up with matches what miles asked for.
+
+    ``device`` is the one field miles fills in before rendering, so an unset input is
+    compared against the accelerator the argv carries."""
     parsed = parse_server_args_argv(server_args_to_argv(server_args_dict))
-    wanted = ServerArgs(**server_args_dict)
+    device = server_args_dict.get("device") or parsed.device
+    wanted = ServerArgs(**{**server_args_dict, "device": device})
     differing = [
         field.name
         for field in dataclasses.fields(wanted)
@@ -93,7 +100,7 @@ class TestServerArgsToArgv:
 
     def test_an_unspecified_device_renders_the_auto_detected_accelerator(self, monkeypatch):
         """An unset device renders the accelerator chosen by ServerArgs instead of the text None."""
-        monkeypatch.setattr("sglang.srt.server_args.get_device", lambda: "cuda")
+        monkeypatch.setattr("miles.backends.sglang_utils.server_args_utils.get_device", lambda: "cuda")
         server_args = _server_args(sglang_overrides={"device": None})
         argv = server_args_to_argv(server_args)
 
@@ -130,8 +137,9 @@ class TestServerArgsToArgv:
         assert server_args["dtype"] == "float16"
         _assert_roundtrips(server_args)
 
-    def test_dp_attention_defaults_are_normalized_exactly_once(self):
-        """Raw DP inputs are compared before ServerArgs applies interacting defaults."""
+    def test_dp_attention_inputs_are_passed_through_raw(self):
+        """sglang applies the interacting DP-attention defaults when the engine resolves its
+        arguments, so the boundary carries the raw inputs unchanged."""
         server_args = _server_args(
             args=_args(
                 rollout_num_gpus_per_engine=2,
@@ -148,8 +156,8 @@ class TestServerArgsToArgv:
 
         assert "--schedule-conservativeness" not in argv
         assert argv[argv.index("--chunked-prefill-size") + 1] == "4096"
-        assert parsed.schedule_conservativeness == expected.schedule_conservativeness == 0.3
-        assert parsed.chunked_prefill_size == expected.chunked_prefill_size == 2048
+        assert parsed.schedule_conservativeness == expected.schedule_conservativeness == 1.0
+        assert parsed.chunked_prefill_size == expected.chunked_prefill_size == 4096
         _assert_roundtrips(server_args)
 
     def test_sglang_overrides_roundtrip(self):


### PR DESCRIPTION
Rebases the `sglang-miles` stack onto `v0.5.19` and repoints the miles images at it.

## sglang side

`sglang-miles-v0.5.19` = 53 commits on `v0.5.19`, replayed from `sglang-miles` (the v0.5.18 stack, 55 commits; frozen as `sglang-miles-v0.5.18-final`). 794 upstream commits of drift; 12 of the 55 picks conflicted.

**Dropped (already in v0.5.19):**
- `[40/40] Give SWAKVPool a get_v_head_dim` — upstream now has the same method with the same `start_layer` semantics.
- `Cherry pick #35708 (#36760)` (weight-version spans / gated launch) — `weight_versions.py`, `gated_launch.py` and their tests are byte-identical in the tag.

**Notable conflict decisions.** v0.5.19 restructured `ServerArgs`: field resolution moved out of `__post_init__` into `arg_groups/*_hook.py` (`declare_resolution` / `resolving_view`), every field carries an `NS(...)` namespace marker, and the layers read a `force_native` flag and `publish_role()` guard instead of `rl_on_policy_target` directly. Our behaviour was re-expressed on those shapes rather than transplanting the old structure:

- *True on-policy* (`[1/35]`): the deterministic-inference handler edits (`true_on_policy_contract`, `enable_prefill_only_deterministic_inference`, the flashinfer allreduce-fusion disable) live in `arg_groups/attention_hook.handle_deterministic_inference` via `declare_resolution`; the two new fields are `NS("exec.deterministic")`. `RotaryEmbedding._force_native` and `Qwen3LLMModel.use_hf_deepstack_order` now key off `is_true_on_policy_enabled()` (upstream's `publish_role()` guard kept); the mrope axis-map refactor and the deepstack-order gating are upstream's, which already cover our intent. The decode CUDA-graph capture keeps upstream's shared capture stream, wrapped in our prefill-only deterministic patch.
- *MoE-LoRA* (`[11/35]`): upstream's `base_layer.runner` replaces the `quant_method.runner` / `scheme.runner` probing; the DP-attention idle-forward split on `is_moe_lora` is kept on top of upstream's `lora_manager is not None` guard.
- *LoRA upsert* (`[13/35]`): `_create_lora_adapter_from_tensors` still stages the adapter; upstream's new `warn_if_adapter_targets_embeddings` runs before it is returned.
- *Weight-update sessions* (`[16/35]`, streamed LoRA): our fan-out over `get_model_runners(selector)` kept; upstream's `record_weight_version_after_update` added to every success path.
- *Abort by rid prefix* (`[21/35]`): merged with upstream's `AbortReq.weight_versions` field and `get_serving().tokenizer_worker_num`.
- *RDT/NIXL weight sync* (`[36/37]`): `needs_engine_info_bootstrap()` / `registers_parallelism_config()` re-added on the resolved view; `_handle_rdt_weight_sync` became `serving_hook.handle_rdt_weight_sync` in the pipeline; the engine keeps upstream's placement-group parameter path while `RayEngine` keeps our contextvar.
- *Anthropic conversion utils*: re-extracted from v0.5.19's `_convert_to_chat_completion_request`, which gained native reasoning-history support (`supports_native_reasoning_history`), so the module-level `convert_to_chat_completion_request` now takes that callback too. Miles imports these (`miles/rollout/session`).

Post-pick repairs: `get_disagg().disaggregation_mode` in the retraction loop (`[3/35]`), the `is_true_on_policy_enabled` import in `qwen3_vl`. `ruff` F821/F401 is zero across every file the stack touches; each commit passed pre-commit individually (isort/black/ruff amendments folded in).

## miles side

- `docker/Dockerfile`: `SGLANG_IMAGE_TAG=v0.5.19`, `SGLANG_BRANCH=sglang-miles` (sgl-project's `sglang-miles` now points at a8e5c632fe, the `sglang-miles-v0.5.19` head; the v0.5.18 tip is kept as `sglang-miles-v0.5.18-final`). The editable install now runs with `SGLANG_BUILD_RUST_EXTS=none`: v0.5.19's `pip install -e` invokes setuptools-rust and tries to relink `rust/mem-cache` against torch, which fails outside upstream's build stage; the base image already ships the extension modules prebuilt and runs with `SGLANG_RUST_BUILD_MODE=never`. The stack touches nothing under `rust/`.
- `docker/build.py`: release variant pinned to `v0.5.19-cu129`.
- The cu12 `pyproject.toml` rewrite block was re-checked against v0.5.19's upstream Dockerfile — the three sed patterns and the three markers are unchanged.


## Validation

- `tests/fast/backends/sglang_utils` and `tests/fast/utils/workers` pass against the v0.5.19 tree (563 passed).
- Two-node H200 devbox built from this Dockerfile, all labels: the first pass surfaced the `--device None` round-trip failure (second commit here) and the Qwen3.5 `rotary_emb.axis_map` weight-check failure (`sglang-miles-v0.5.19` @a8e5c632fe flags the buffer `_skip_weight_check` like the sincos tables); `test_qwen3_5_35b_a3b_r3` passes with it. The other 8-GPU failures were the FT family, which fails identically on main's daily run (33887858726).
- `stage-c-8-gpu-h100 (1)` failed `test_qwen3_30B_A3B_p2p`: v0.5.19 made `initialize_moe_config` / `initialize_fp8_gemm_config` / `initialize_fp4_gemm_config` no-argument readers of the published runtime context, so the P2P CPU replica setup raised `TypeError`; third commit here drops the arguments (the legacy `set_global_server_args_for_scheduler` shim publishes and resolves the record).
- With the broader label set (`run-ci-image`, `fsdp`, `eval`) three more jobs went red: `test_qwen3_0.6B_verifiers` is a real image-layout consequence — the v0.5.19 image runs Python from the `/opt/sglang` virtualenv, so the test's `uv venv --system-site-packages` inherited the bare base interpreter (no pip, no sglang deps); the fourth commit seeds the venv and points a `.pth` at the launcher's site-packages. `test_deepseek_v4_flash_4layer_megatron_impl_ci` (CUDA OOM on GPU 2 with a foreign process holding 16 GiB) and `test_qwen36` (session verifier saw an empty event list on one sample) both passed in this PR's first run and are recurring flakes on main (`megatron_impl` failed on main's 09-01 and 09-02 runs).
- Re-runs: `test_nemotron3` (one TITO special-token mismatch of 3%, never seen on main in 8 runs) passed on rerun, and `test_qwen3_0.6B_verifiers` passes with the venv fix (179 s, whole partition 6/6). `test_deepseek_v4_flash_4layer_megatron_impl_ci` OOMs at the first training step in three consecutive attempts (trainer at 114 GiB next to the sleeping engine's 16 GiB, TMS 3 GiB margin, 6.6 GiB request); engine memory (`avail mem` trace, residual after release) is byte-for-byte the same as main's passing run, and the test passed in this PR's first run and fails intermittently on main (09-01, 09-02), rollout lengths are identical (256 tokens every run) and the PR image was not rebuilt in between, so this is a pre-existing borderline test rather than a bump regression; it passed on the fourth attempt and the whole partition (10/10) is green.
- Final state (run 34023500701 on 8ed26e326 with labels run-ci-image/fsdp/eval/megatron/model-scripts/sglang/weight-update/lora): every CUDA stage green; the only red check is `stage-c-4-gpu-mi350 (0)` / `test_inkling_small_4layer_ci`, identical to main's latest ROCm run.
- This PR's CI (labels run-ci-megatron / model-scripts / sglang / weight-update / lora): every CUDA stage passes — `stage-c-8-gpu-h200` (0,1), `stage-c-8-gpu-h100` (0,1), `stage-c-4-gpu-h200` (0,1,2), `stage-c-2-gpu-h200` (0,1), `stage-b-2-gpu-h200` — plus `stage-c-4-gpu-mi350 (1)` (Qwen3.5 MTP R3 on ROCm). The one red job, `stage-c-4-gpu-mi350 (0)`, fails `test_inkling_small_4layer_ci` exactly as main's latest ROCm run does (33887975054). On the devbox the 4-GPU H200 suite was also replayed up to `test_inkling_small_4layer_lora_ci` (9 files) with no bump-related failure before the node ran out of ephemeral storage.

