### PR TITLE
feat(ci): grant label commands permission

### DIFF
--- a/.github/workflows/policies/comment-command-access.json
+++ b/.github/workflows/policies/comment-command-access.json
@@ -7,7 +7,12 @@
         {"id": 82826991, "login": "zyzshishui"},
         {"id": 59716405, "login": "nanjiangwill"},
         {"id": 101526713, "login": "xiuhu17"},
-        {"id": 106564213, "login": "zianglih"}
+        {"id": 106564213, "login": "zianglih"},
+        {"id": 185285563, "login": "lawrence-harmonic"},
+        {"id": 295988875, "login": "ilyasher-harmonic"},
+        {"id": 258897383, "login": "vedant-harmonic"},
+        {"id": 109944218, "login": "JessicaJiang-123"},
+        {"id": 214322989, "login": "XinyuJiangCMU"}
       ]
     },
     "repo_write_access": {

--- a/tests/ci/test/test_comment_ci_command.py
+++ b/tests/ci/test/test_comment_ci_command.py
@@ -577,7 +577,19 @@ def test_checked_in_policy_exposes_exact_labels_and_access_groups():
     }
     assert loaded["groups"]["add_label_access"] == {
         "repository_permissions": WRITE_PERMISSIONS,
-        "user_ids": frozenset({82826991, 59716405, 101526713, 106564213}),
+        "user_ids": frozenset(
+            {
+                82826991,
+                59716405,
+                101526713,
+                106564213,
+                185285563,
+                295988875,
+                258897383,
+                109944218,
+                214322989,
+            }
+        ),
         "author_associations": frozenset(),
     }
     assert loaded["groups"]["repo_write_access"] == {


### PR DESCRIPTION
## Summary
Allow contributors to trigger approved CI labels.
