### PR TITLE
fix: isolate trainer disk-offload backups by role

### DIFF
--- a/docs/advanced/disk-offload.md
+++ b/docs/advanced/disk-offload.md
@@ -20,9 +20,10 @@ does not fit, and disk offload is the alternative.
 Instead of a pinned host copy, the paused actor is streamed to per-rank files through a
 fixed-size pinned staging buffer, so host memory stays bounded by
 `--offload-train-disk-chunk-mb` regardless of how much is offloaded. Each rank writes to
-its own directory under `--offload-train-disk-dir` (defaults to
-`$SCRATCH/miles_train_offload_<uid>`), the files are overwritten in place every step, and
-they are removed when the actor exits.
+its own `<role>/cell<cell_index>_rank<rank>` directory under `--offload-train-disk-dir` (defaults to
+`$SCRATCH/miles_train_offload_<uid>`). Separating actor and critic roles, cells, and ranks
+prevents one worker's startup cleanup from removing another worker's backups. The files
+are overwritten in place every step and removed when the worker exits.
 
 Point the directory at real node-local NVMe. A tmpfs mount (including `/tmp` on many
 systems) keeps the backup in RAM and defeats the purpose.
@@ -32,8 +33,9 @@ systems) keeps the backup in RAM and defeats the purpose.
 This runs on [torch_memory_saver](https://github.com/fzyzcjy/torch_memory_saver), which
 hooks the allocator, so it does not care what the memory holds — weights, gradient
 buffers and optimizer state all move as one block when the actor is paused, and come back
-on resume. miles' part is choosing the per-rank directory, launching each actor with the
-matching `TMS_DISK_BACKUP_*` environment, and reclaiming the files at startup and exit.
+on resume. miles' part is choosing the role-, cell-, and rank-specific directory,
+launching each actor with the matching `TMS_DISK_BACKUP_*` environment, and reclaiming
+the files at startup and exit.
 
 Because pause and resume happen at phase boundaries, everything is resident again by the
 time the optimizer step runs. If the binding constraint is instead that the optimizer

--- a/miles/backends/megatron_utils/actor.py
+++ b/miles/backends/megatron_utils/actor.py
@@ -75,7 +75,8 @@ def _setup_disk_offload_reclaim(disk_dir: str) -> None:
 
     torch_memory_saver unlinks each backup file as its allocation is freed on a
     graceful teardown, but a SIGKILL'd run leaves stale files behind. The dir is
-    per-rank (see actor_factory), so clearing it wholesale touches nobody else.
+    per-role, cell, and rank (see ray.specs.train), so clearing it wholesale
+    touches nobody else.
     """
     if not disk_dir:
         return

--- a/miles/ray/specs/train.py
+++ b/miles/ray/specs/train.py
@@ -86,7 +86,7 @@ def _compute_spec_trainer(
     return ServeWorkerSpec(
         name=compute_trainer_pool_id(role),
         port_infos=[PortInfo(name=MASTER_PORT_NAME, static_port=9000, mode="master", allow_dynamic=True)],
-        env_var=lambda ctx: compute_trainer_env_vars(args, ctx, fp8_scales=fp8_scales),
+        env_var=lambda ctx: compute_trainer_env_vars(args, ctx, role=role, fp8_scales=fp8_scales),
         scheduling=SchedulingSpec(
             num_cells=num_cells,
             num_workers_per_cell=gpus_per_cell,
@@ -110,7 +110,7 @@ def _compute_spec_trainer(
     )
 
 
-def compute_trainer_env_vars(args, ctx: WorkerLaunchContext, *, fp8_scales: str) -> dict[str, str]:
+def compute_trainer_env_vars(args, ctx: WorkerLaunchContext, *, role: str, fp8_scales: str) -> dict[str, str]:
     env_vars = {
         # because sglang will always set NCCL_CUMEM_ENABLE to 0
         # we need also set it to 0 to prevent nccl error.
@@ -140,8 +140,10 @@ def compute_trainer_env_vars(args, ctx: WorkerLaunchContext, *, fp8_scales: str)
             env_vars["TMS_INIT_ENABLE_CPU_BACKUP"] = "0"
             env_vars["TMS_INIT_ENABLE_DISK_BACKUP"] = "1"
             env_vars["TMS_DISK_BACKUP_CHUNK_MB"] = str(args.offload_train_disk_chunk_mb)
+            # Actor and critic have overlapping cell/rank IDs. Each role's
+            # startup and teardown reclaim must only touch its own backups.
             env_vars["TMS_DISK_BACKUP_DIR"] = os.path.join(
-                args.offload_train_disk_dir, f"cell{ctx.cell_index}_rank{ctx.worker_in_cell_index}"
+                args.offload_train_disk_dir, role, f"cell{ctx.cell_index}_rank{ctx.worker_in_cell_index}"
             )
         else:
             env_vars["TMS_INIT_ENABLE_CPU_BACKUP"] = "1"

--- a/tests/fast/ray/specs/test_train.py
+++ b/tests/fast/ray/specs/test_train.py
@@ -355,7 +355,25 @@ class TestEnvironmentVariables:
         directories = [
             spec.env_var(_make_context(cell_index=1, worker_in_cell_index=i))["TMS_DISK_BACKUP_DIR"] for i in range(2)
         ]
-        assert directories == ["/tmp/offload/cell1_rank0", "/tmp/offload/cell1_rank1"]
+        assert directories == ["/tmp/offload/actor/cell1_rank0", "/tmp/offload/actor/cell1_rank1"]
+
+    def test_disk_offload_isolated_between_actor_and_critic(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Critic startup must not clear an offloaded actor's backup directory."""
+        _install_fake_torch_memory_saver(monkeypatch, MagicMock(return_value=Path("/opt/tms.so")))
+        specs = specs_trainer(_make_args(use_critic=True, offload_train=True, offload_train_target="disk"))
+
+        directories = [spec.env_var(_make_context())["TMS_DISK_BACKUP_DIR"] for spec in specs]
+
+        assert directories == ["/tmp/offload/actor/cell0_rank0", "/tmp/offload/critic/cell0_rank0"]
+
+    def test_disk_offload_isolated_between_cells(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A cell restart must not reclaim another cell's backup at the same rank."""
+        _install_fake_torch_memory_saver(monkeypatch, MagicMock(return_value=Path("/opt/tms.so")))
+        (spec,) = specs_trainer(_make_args(offload_train=True, offload_train_target="disk"))
+
+        directories = [spec.env_var(_make_context(cell_index=i))["TMS_DISK_BACKUP_DIR"] for i in range(2)]
+
+        assert directories == ["/tmp/offload/actor/cell0_rank0", "/tmp/offload/actor/cell1_rank0"]
 
     def test_a_library_without_the_disk_backend_is_rejected(self, monkeypatch):
         """Launching disk offload against a library that cannot write to disk would


### PR DESCRIPTION
## Problem

Actor and critic trainer pools each start their cell and rank numbering at zero. When both use the same disk-offload root, a directory named only by cell and rank can therefore belong to two different workers.

Each worker reclaims stale backup files in its assigned directory at startup and exit. A newly started critic can consequently delete a paused actor's live backups, making the actor unable to restore its offloaded state. The reverse collision is also possible.

## When this can occur

- Both actor and critic trainer pools use disk offloading (`--offload-train --offload-train-target disk`).
- They share a disk-offload root on the same underlying filesystem and have overlapping cell/rank IDs, for example when both roles share a training node.
- One worker starts, restarts, or exits while the other still has live backup files in the formerly shared directory.

CPU-only offloading does not use these files. Identical path strings on separate, node-local filesystems do not by themselves cause a collision; both workers must see the same directory.

## Changes

- Include the trainer role in `TMS_DISK_BACKUP_DIR`: `<root>/<role>/cell<cell_index>_rank<rank>`.
- Pass the role through trainer environment construction.
- Add tests for separation between actor/critic roles, cells, and ranks.
- Update the disk-offload documentation and cleanup contract to match the directory layout.

This isolates workers within a job; independent jobs should still use separate disk-offload roots.

## Validation

The focused suite passes on this branch: **75 passed**.

The new actor/critic isolation check fails against unpatched `main` and passes with this fix.

```bash
python -m pytest -q -o addopts= \
  tests/fast/backends/megatron_utils/test_shared_ppo_lifecycle.py \
  tests/fast/ray/specs/test_train.py \
  tests/fast/ray/test_placement_group_shared_ppo.py
```

All pre-commit checks pass for the changed files. These tests validate worker environment generation and lifecycle behavior; they do not perform a full distributed offload/restore cycle.
