### PR TITLE
test(dist): cover the reloadable process-group destroy/reload cycle

### DIFF
--- a/tests/fast/utils/test_reloadable_process_group.py
+++ b/tests/fast/utils/test_reloadable_process_group.py
@@ -1,0 +1,93 @@
+"""Tests for reloadable_process_group: the destroy/reload cycle colocate runs on every step.
+
+The reload path has caused repeated multi-node hangs (#384, #574), and the fix that made
+reload replay the original ``new_group`` contract (#1594) landed without a regression test.
+These run on CPU: the monkey patch only skips groups whose *arguments* name gloo, so a
+group created with the default backend on a gloo world is wrapped like any NCCL group.
+"""
+
+from datetime import timedelta
+
+import torch
+import torch.distributed as dist
+from tests.fast.dist_utils import init_gloo, run_multiprocess
+
+from miles.utils.reloadable_process_group import (
+    ReloadableProcessGroup,
+    destroy_process_groups,
+    monkey_patch_torch_dist,
+    reload_process_groups,
+)
+
+_TIMEOUT = timedelta(seconds=1234)
+
+
+def _worker_reload_replays_new_group_args(rank: int, world_size: int, port: int) -> None:
+    """Reload must rebuild the group from the original new_group args, not a hardcoded pair.
+
+    Before #1594 the reload hardcoded ``(ranks, backend="nccl")``, silently dropping timeout,
+    pg_options and group_desc. On a CPU world that regression surfaces as a hard failure:
+    the rebuilt group claims an NCCL backend and the next collective raises.
+    """
+    init_gloo(rank, world_size, port=port)
+    try:
+        monkey_patch_torch_dist()
+        group = dist.new_group(ranks=[0, 1], timeout=_TIMEOUT, group_desc="reload_probe")
+        assert isinstance(group, ReloadableProcessGroup)
+        assert group.inner_kwargs["timeout"] == _TIMEOUT
+        assert group.inner_kwargs["group_desc"] == "reload_probe"
+
+        tensor = torch.ones(4)
+        dist.all_reduce(tensor, group=group)
+        assert tensor.sum().item() == 4.0 * world_size
+
+        destroy_process_groups()
+        reload_process_groups()
+
+        tensor = torch.ones(4)
+        dist.all_reduce(tensor, group=group)
+        assert tensor.sum().item() == 4.0 * world_size
+    finally:
+        dist.destroy_process_group()
+
+
+def _worker_gloo_group_is_not_wrapped(rank: int, world_size: int, port: int) -> None:
+    """A group that explicitly asks for gloo is returned unwrapped, by either arg style."""
+    init_gloo(rank, world_size, port=port)
+    try:
+        monkey_patch_torch_dist()
+        assert not isinstance(dist.new_group(ranks=[0, 1], backend="gloo"), ReloadableProcessGroup)
+        assert not isinstance(dist.new_group([0, 1], _TIMEOUT, "gloo"), ReloadableProcessGroup)
+    finally:
+        dist.destroy_process_group()
+
+
+def _worker_single_rank_group_is_not_wrapped(rank: int, world_size: int, port: int) -> None:
+    """A one-rank group has nothing to rebuild, so it is returned unwrapped."""
+    init_gloo(rank, world_size, port=port)
+    try:
+        monkey_patch_torch_dist()
+        assert not isinstance(dist.new_group(ranks=[0]), ReloadableProcessGroup)
+    finally:
+        dist.destroy_process_group()
+
+
+class TestReloadableProcessGroup:
+    def test_reload_replays_new_group_args(self) -> None:
+        run_multiprocess(_worker_reload_replays_new_group_args)
+
+    def test_gloo_group_is_not_wrapped(self) -> None:
+        run_multiprocess(_worker_gloo_group_is_not_wrapped)
+
+    def test_single_rank_group_is_not_wrapped(self) -> None:
+        run_multiprocess(_worker_single_rank_group_is_not_wrapped)
+
+
+class TestCleanupWithoutGroups:
+    """Cleanup must tolerate a process that never registered a group (#354: single-GPU runs)."""
+
+    def test_destroy_is_a_noop(self) -> None:
+        destroy_process_groups()
+
+    def test_reload_is_a_noop(self) -> None:
+        reload_process_groups()


### PR DESCRIPTION
## Why

`miles/utils/reloadable_process_group.py` is the machinery colocate runs on every rollout→train switch: `sleep()` destroys every wrapped process group, `wake_up()` rebuilds them. It has been behind several multi-node hangs (#384, #574; the same phase is reported in THUDM/slime#1487), and the fix in #1594 — replay the original `new_group` args on reload instead of a hardcoded `(ranks, backend="nccl")` — landed without a regression test. There is currently no `tests/fast/utils/test_reloadable_process_group.py`.

Before #1594 the rebuild silently dropped `timeout`, `pg_options` and `group_desc`. In practice that meant `--distributed-timeout-minutes 120` stopped applying after the first offload cycle and every rebuilt group fell back to the 10-minute default — which is exactly the "ignores the timeout flag, dies at 600 s" shape those reports describe.

## What

Adds `tests/fast/utils/test_reloadable_process_group.py` (CPU suite, auto-registered in `stage-a-cpu`, no GPU or `run-ci-*` label needed):

- `test_reload_replays_new_group_args` — a group created with `timeout=` and `group_desc=` is wrapped, `inner_kwargs` carries both, and a collective still works after `destroy_process_groups()` + `reload_process_groups()`.
- `test_gloo_group_is_not_wrapped` — explicit gloo (keyword or positional) is returned unwrapped.
- `test_single_rank_group_is_not_wrapped` — one-rank groups are returned unwrapped.
- `TestCleanupWithoutGroups` — `destroy_process_groups()` / `reload_process_groups()` are no-ops in a process that never registered a group (#354).

It runs on CPU because the monkey patch only skips groups whose *arguments* name gloo; a group created with the default backend on a gloo world is wrapped like any NCCL group. That also makes the pre-#1594 behaviour a hard failure rather than a silent one: the rebuilt group claims an NCCL backend and the next collective raises `No backend type associated with device type cpu`.

## Verification

Same file run against both versions of `reloadable_process_group.py`, torch 2.11, gloo, 2 processes:

| `reloadable_process_group.py` | result |
|---|---|
| `main` (with #1594) | `5 passed` |
| pre-#1594 | `1 failed, 4 passed` — `test_reload_replays_new_group_args`, at `assert group.inner_kwargs["timeout"] == _TIMEOUT` |

`pre-commit` hooks (ruff 0.14.7, autoflake, isort 5.13.2, black 24.3.0 @ 119) leave the file unchanged.

Not touched here: the reload path still has no synchronization point after the rebuild loop; that is #705's proposal and is left to that discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
