### PR TITLE
Share one process cleanup across the agentic launchers

### DIFF
--- a/examples/experimental/nemo-gym/run.py
+++ b/examples/experimental/nemo-gym/run.py
@@ -12,8 +12,6 @@ Usage:
 """
 
 import os
-import subprocess
-import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
@@ -56,19 +54,6 @@ class ScriptArgs(U.ExecuteTrainConfig):
     # host cannot resolve the trainer's hostname (e.g. it dials back over a
     # tailnet).
     router_external_host: str = os.environ.get("MILES_ROUTER_EXTERNAL_HOST", "")
-
-
-def cleanup():
-    """Kill old Ray jobs and stale processes to free GPU resources."""
-    my_pid = os.getpid()
-    ppid = os.getppid()
-    exclude = f"grep -v '^{my_pid}$' | grep -v '^{ppid}$'"
-    for t in ["sglang", "train.py", "MegatronTrain"]:
-        subprocess.run(
-            f"pgrep -f '{t}' | {exclude} | xargs -r kill 2>/dev/null || true",
-            shell=True,
-        )
-    time.sleep(5)
 
 
 def prepare(args: ScriptArgs):
@@ -198,7 +183,7 @@ def execute(args: ScriptArgs):
 
 @U.dataclass_cli
 def main(args: ScriptArgs):
-    cleanup()
+    U.cleanup_stale_processes()
     if not args.skip_prepare:
         prepare(args)
     execute(args)

--- a/examples/experimental/openenv/openenv_launch_common.py
+++ b/examples/experimental/openenv/openenv_launch_common.py
@@ -10,8 +10,6 @@ perf/sglang/misc profile and its ``ScriptArgs`` defaults.
 """
 
 import os
-import subprocess
-import time
 from pathlib import Path
 from typing import Protocol
 
@@ -48,22 +46,6 @@ class LaunchArgs(Protocol):
     use_prometheus: bool
     prometheus_port: int
     prometheus_run_name: str
-
-
-def cleanup() -> None:
-    """Kill old Ray jobs and stale processes to free GPU resources."""
-    my_pid = os.getpid()
-    ppid = os.getppid()
-    print(f"Cleanup starting (pid={my_pid}, ppid={ppid})")
-    targets = ["sglang", "train.py", "MegatronTrain"]
-    exclude = f"grep -v '^{my_pid}$' | grep -v '^{ppid}$'"
-    for t in targets:
-        subprocess.run(
-            f"pgrep -f '{t}' | {exclude} | xargs -r kill 2>/dev/null || true",
-            shell=True,
-        )
-    time.sleep(5)
-    print(f"Cleanup complete (pid={my_pid}) — old processes killed.")
 
 
 def rollout_args(args: LaunchArgs) -> str:

--- a/examples/experimental/openenv/run-openenv-tbench2.py
+++ b/examples/experimental/openenv/run-openenv-tbench2.py
@@ -231,7 +231,7 @@ def execute(args: ScriptArgs):
 
 @U.dataclass_cli
 def main(args: ScriptArgs):
-    C.cleanup()
+    U.cleanup_stale_processes()
     if not args.skip_prepare:
         prepare(args)
     execute(args)

--- a/examples/swe-agent-harbor-docker/run-glm47-flash-agentic-async.py
+++ b/examples/swe-agent-harbor-docker/run-glm47-flash-agentic-async.py
@@ -24,8 +24,6 @@ Usage:
 """
 
 import os
-import subprocess
-import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
@@ -101,26 +99,6 @@ class ScriptArgs(U.ExecuteTrainConfig):
     use_prometheus: bool = True
     prometheus_port: int = 9090
     prometheus_run_name: str = "glm47-flash-swe-async"
-
-
-def cleanup():
-    """Kill old Ray jobs and stale processes to free GPU resources."""
-    my_pid = os.getpid()
-    ppid = os.getppid()
-    print(f"Cleanup starting (pid={my_pid}, ppid={ppid})")
-    targets = ["sglang", "train.py", "train_async.py", "MegatronTrain"]
-    exclude = f"grep -v '^{my_pid}$' | grep -v '^{ppid}$'"
-    for t in targets:
-        # Bracket-wrap the first char so the pgrep pattern doesn't match its
-        # own shell/subprocess command line (which literally contains the
-        # bracketed pattern and thus fails the regex).
-        pattern = f"[{t[0]}]{t[1:]}"
-        subprocess.run(
-            f"pgrep -f '{pattern}' | {exclude} | xargs -r kill 2>/dev/null || true",
-            shell=True,
-        )
-    time.sleep(5)
-    print(f"Cleanup complete (pid={my_pid}) — old processes killed.")
 
 
 def prepare(args: ScriptArgs):
@@ -372,7 +350,7 @@ def execute(args: ScriptArgs):
 
 @U.dataclass_cli
 def main(args: ScriptArgs):
-    cleanup()
+    U.cleanup_stale_processes(("sglang", "train.py", "train_async.py", "MegatronTrain"))
     if not args.skip_prepare:
         prepare(args)
     execute(args)

--- a/examples/swe-agent-harbor-docker/run.py
+++ b/examples/swe-agent-harbor-docker/run.py
@@ -10,8 +10,6 @@ Usage:
 
 import os
 import socket
-import subprocess
-import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
@@ -68,22 +66,6 @@ class ScriptArgs(U.ExecuteTrainConfig):
     use_prometheus: bool = True
     prometheus_port: int = 9090
     prometheus_run_name: str = "glm47-flash-swe-tito"
-
-
-def cleanup():
-    """Kill old Ray jobs and stale processes to free GPU resources."""
-    my_pid = os.getpid()
-    ppid = os.getppid()
-    print(f"Cleanup starting (pid={my_pid}, ppid={ppid})")
-    targets = ["sglang", "train.py", "MegatronTrain"]
-    exclude = f"grep -v '^{my_pid}$' | grep -v '^{ppid}$'"
-    for t in targets:
-        subprocess.run(
-            f"pgrep -f '{t}' | {exclude} | xargs -r kill 2>/dev/null || true",
-            shell=True,
-        )
-    time.sleep(5)
-    print(f"Cleanup complete (pid={my_pid}) — old processes killed.")
 
 
 def prepare(args: ScriptArgs):
@@ -253,7 +235,7 @@ def execute(args: ScriptArgs):
 
 @U.dataclass_cli
 def main(args: ScriptArgs):
-    cleanup()
+    U.cleanup_stale_processes()
     if not args.skip_prepare:
         prepare(args)
     execute(args)

--- a/examples/swe-agent-harbor-docker/run_glm52_lora_tb2_daytona.py
+++ b/examples/swe-agent-harbor-docker/run_glm52_lora_tb2_daytona.py
@@ -33,8 +33,6 @@ Usage (4 nodes x 8 H200, ray already running):
 """
 
 import os
-import subprocess
-import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
@@ -137,26 +135,6 @@ class ScriptArgs(U.ExecuteTrainConfig):
     use_prometheus: bool = True
     prometheus_port: int = 9091
     prometheus_run_name: str = "glm52-lora-tb2-daytona"
-
-
-def cleanup():
-    """Kill old Ray jobs and stale processes to free GPU resources."""
-    my_pid = os.getpid()
-    ppid = os.getppid()
-    print(f"Cleanup starting (pid={my_pid}, ppid={ppid})")
-    targets = ["sglang", "train.py", "MegatronTrain"]
-    exclude = f"grep -v '^{my_pid}$' | grep -v '^{ppid}$'"
-    for t in targets:
-        # Bracket-wrap the first char so the pgrep pattern doesn't match its
-        # own shell/subprocess command line (which literally contains the
-        # bracketed pattern and thus fails the regex).
-        pattern = f"[{t[0]}]{t[1:]}"
-        subprocess.run(
-            f"pgrep -f '{pattern}' | {exclude} | xargs -r kill 2>/dev/null || true",
-            shell=True,
-        )
-    time.sleep(5)
-    print(f"Cleanup complete (pid={my_pid}) — old processes killed.")
 
 
 def _parallel_args(args: ScriptArgs) -> str:
@@ -430,7 +408,7 @@ def execute(args: ScriptArgs):
 
 @U.dataclass_cli
 def main(args: ScriptArgs):
-    cleanup()
+    U.cleanup_stale_processes()
     execute(args)
 
 

--- a/miles/utils/external_utils/command_utils.py
+++ b/miles/utils/external_utils/command_utils.py
@@ -10,7 +10,10 @@ import os
 import platform
 import random
 import shlex
+import signal
 import socket
+import subprocess
+import time
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from functools import partial
@@ -113,6 +116,37 @@ def ssh_start_ray_workers(
         '--node-ip-address $worker_ip --disable-usage-stats" & '
         "done; wait"
     )
+
+
+def cleanup_stale_processes(process_names: tuple[str, ...] = ("sglang", "train.py", "MegatronTrain")) -> None:
+    """Kill old Ray jobs and stale processes to free GPU resources.
+
+    No shell runs the search. Under `shell=True` the spawned shell's own command
+    line is the whole pipeline, search text included, and `pgrep -f` matches full
+    command lines -- so on linux the search finds that shell and signals it
+    (measured: the subprocess returns -15). Exec'ing pgrep directly leaves no
+    such process, since pgrep excludes only itself.
+    """
+    my_pid = os.getpid()
+    ppid = os.getppid()
+    print(f"Cleanup starting (pid={my_pid}, ppid={ppid})")
+    for name in process_names:
+        # An empty pattern matches every process on the host, so this guard is
+        # the difference between reaping stale workers and reaping the machine.
+        assert name, "process name must not be empty"
+        # Exit 1 means "nothing matched", the common case, not an error.
+        found = subprocess.run(["pgrep", "-f", name], capture_output=True, text=True, check=False)
+        for pid in (int(line) for line in found.stdout.split()):
+            if pid in (my_pid, ppid):
+                continue
+            try:
+                os.kill(pid, signal.SIGTERM)
+            except ProcessLookupError:
+                pass  # exited on its own between the scan and the signal
+            except PermissionError:
+                pass  # another user's process that merely matched the name
+    time.sleep(5)
+    print(f"Cleanup complete (pid={my_pid}) — old processes killed.")
 
 
 def hf_download_dataset(full_name: str, data_dir: str = "/root/datasets"):

--- a/tests/fast/utils/test_command_utils.py
+++ b/tests/fast/utils/test_command_utils.py
@@ -2,6 +2,7 @@ import json
 import os
 import platform
 import shlex
+import signal
 import sys
 from types import SimpleNamespace
 
@@ -128,6 +129,73 @@ class TestConvertCheckpoint:
         )
 
         assert "--master-addr" not in commands[0]
+
+
+class TestCleanupStaleProcesses:
+    def _run(self, monkeypatch, found_pids=()):
+        """Stub the scan to report *found_pids*, and record what gets signalled."""
+        monkeypatch.setattr(command_utils.time, "sleep", lambda _seconds: None)
+        scans, killed = [], []
+
+        def fake_pgrep(argv, **kwargs):
+            scans.append(argv)
+            return SimpleNamespace(stdout="".join(f"{pid}\n" for pid in found_pids), returncode=0)
+
+        monkeypatch.setattr(command_utils.subprocess, "run", fake_pgrep)
+        monkeypatch.setattr(command_utils.os, "kill", lambda pid, sig: killed.append((pid, sig)))
+        return scans, killed
+
+    def test_searches_for_each_process_name_without_a_shell(self, monkeypatch):
+        """A shell would hand the search its own process to find: the shell's
+        command line is the whole pipeline, search text included, and `pgrep -f`
+        matches full command lines. Measured on linux, the shell form signals
+        that shell (subprocess returncode -15); exec'ing pgrep leaves nothing
+        to match, since pgrep excludes only itself."""
+        scans, _ = self._run(monkeypatch)
+        command_utils.cleanup_stale_processes()
+        assert scans == [
+            ["pgrep", "-f", "sglang"],
+            ["pgrep", "-f", "train.py"],
+            ["pgrep", "-f", "MegatronTrain"],
+        ]
+
+    def test_terminates_every_process_the_scan_reports(self, monkeypatch):
+        _, killed = self._run(monkeypatch, found_pids=(4321, 4322))
+        command_utils.cleanup_stale_processes(("sglang",))
+        assert killed == [(4321, signal.SIGTERM), (4322, signal.SIGTERM)]
+
+    def test_never_signals_this_process_or_its_parent(self, monkeypatch):
+        """A launcher runs as one of the scanned names, so it matches its own scan."""
+        _, killed = self._run(monkeypatch, found_pids=(os.getpid(), os.getppid(), 4321))
+        command_utils.cleanup_stale_processes(("train.py",))
+        assert killed == [(4321, signal.SIGTERM)]
+
+    def test_a_process_that_exits_before_the_signal_is_not_an_error(self, monkeypatch):
+        """pgrep reports a pid, it exits, the signal lands on nothing: a race that
+        must not abort a launch."""
+        _, killed = self._run(monkeypatch, found_pids=(4321,))
+
+        def already_gone(pid, sig):
+            raise ProcessLookupError(pid)
+
+        monkeypatch.setattr(command_utils.os, "kill", already_gone)
+        command_utils.cleanup_stale_processes(("sglang",))
+        assert killed == []
+
+    def test_a_caller_can_pass_its_own_process_names(self, monkeypatch):
+        """Lets a leg whose worker has a different name reuse this instead of
+        copying it -- the fully-async launcher also has to reap train_async.py."""
+        scans, _ = self._run(monkeypatch)
+        command_utils.cleanup_stale_processes(("sglang", "train_async.py"))
+        assert scans == [["pgrep", "-f", "sglang"], ["pgrep", "-f", "train_async.py"]]
+
+    def test_an_empty_process_name_is_refused(self, monkeypatch):
+        """`pgrep -f ''` matches every process on the host (measured: 5 of 6 on a
+        bare container), so an empty name would reap the machine, not the run."""
+        scans, killed = self._run(monkeypatch, found_pids=(4321,))
+        with pytest.raises(AssertionError, match="must not be empty"):
+            command_utils.cleanup_stale_processes(("",))
+        assert scans == [] and killed == []
 
 
 class TestRsyncSimple:


### PR DESCRIPTION
Towards #3110, which asks which launcher blocks are genuinely shared config and which are experiment snapshots. `cleanup()` is unambiguously the former: it kills leftover processes before a run starts, and nothing about it varies per recipe. This takes that one piece.

## What was there

Five copies, in two flavours:

| launcher | flavour | targets |
| --- | --- | --- |
| `experimental/nemo-gym/run.py` | plain | 3 |
| `experimental/openenv/openenv_launch_common.py` | plain | 3 |
| `swe-agent-harbor-docker/run.py` | plain | 3 |
| `swe-agent-harbor-docker/run-glm47-flash-agentic-async.py` | bracket-wrapped | **4** (`train_async.py` too) |
| `swe-agent-harbor-docker/run_glm52_lora_tb2_daytona.py` | bracket-wrapped | 3 |

The issue describes `cleanup()` as "identical everywhere". It is not, and the difference matters, so a verbatim move was not available.

## Why the plain flavour could not be the survivor

Two of the five rewrite the search pattern (`sglang` -> `[s]glang`) with a comment about the pattern matching its own shell. That is a real defect, not a stylistic tic.

Under `shell=True`, the spawned shell's own command line **is** the whole pipeline, search text included, and `pgrep -f` matches full command lines. So the search finds that shell and signals it.

Measured on linux, with nothing on the host carrying the marker (so any reported pid can only be the shell):

```
old form (shell=True)      -> reported pids: ['108']   <- the shell, matching itself
old form + bracket-wrap    -> reported pids: (none)
new form (no shell)        -> reported pids: (none)
```

and the subprocess returns `-15`, i.e. SIGTERM: it killed its own shell. It does not reproduce on macOS, which is presumably why it went unnoticed.

Copying the plain flavour into the shared helper would therefore have regressed the two launchers that had already fixed this.

**Impact was low, and worth stating plainly:** measured with three real targets, all three still died — `kill` dispatches every pid in one invocation, so the shell's own death lands too late to matter. This is fragility rather than an outage.

## What the shared helper does instead

Rather than carry the bracket trick into shared code, `cleanup_stale_processes` drops the shell: `pgrep` is exec'd directly and the signalling happens in python. There is then no shell to be matched, and `pgrep` excludes only itself.

**This is not a pure move, and the diff should be read as such.** Error handling changes too: `2>/dev/null || true` swallowed everything, including `pgrep` not being installed at all (in which case cleanup silently did nothing, forever). The two failures worth ignoring are now named — `ProcessLookupError` for the scan/signal race, `PermissionError` for another user's process that merely matched the name.

`process_names` is a parameter because the fully-async launcher also has to reap `train_async.py`. That makes an empty name reachable, and `pgrep -f ''` matches every process on the host (measured: 5 of 6 in a bare container), so it is asserted against.

## Tests

`pytest tests/fast/utils/test_command_utils.py` — 82 pass. New coverage: scans each name without a shell, terminates every reported pid, never signals the caller or its parent, tolerates a process exiting mid-race, accepts caller-supplied names, refuses an empty one.

Also verified on linux against real processes, not mocks: terminates a match, leaves an unrelated process alone, survives when the caller's own command line matches the scan (the normal case — a launcher named in its own target list), terminates every match, and no-ops when nothing matches. The self-survival check was mutation-tested: deleting just the pid exclusion makes it fail with `rc=-15`.

Not run: the launchers themselves, which need GPUs.

## Deliberately out of scope

`examples/infra_features/p2p_weight_transfer/run.py` has a similar-looking `pgrep | xargs kill`, but with different semantics (`-x` over interpreter names, `kill -9`). Left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
