### PR TITLE
fix(ray): use IP literal for SGLang router bind address

### DIFF
--- a/miles/backends/sglang_utils/router_args_utils.py
+++ b/miles/backends/sglang_utils/router_args_utils.py
@@ -1,9 +1,15 @@
 import argparse
+import ipaddress
+import logging
+import socket
 from collections.abc import Mapping
 
 from sglang_router.launch_router import RouterArgs
 
+from miles.utils.http_utils import MILES_HOST_IP_ENV, _wrap_ipv6
 from miles.utils.workers.argv_utils import render_cli_argv
+
+logger = logging.getLogger(__name__)
 
 _ROUTER_DEST_PREFIX = "router_"
 
@@ -32,6 +38,49 @@ def compute_sglang_router_args(
         router_args["pd_disaggregation"] = True
 
     return router_args
+
+
+def compute_sglang_router_bind_host(host: str) -> str:
+    """The ``--host`` sglang_router can bind for a worker advertised as ``host``.
+
+    The router parses ``host:port`` as a socket address, so it takes an IPv4 literal or a bracketed IPv6
+    literal and nothing else. The worker manager may advertise a placed node under a hostname (Ray on Slurm
+    reports nodes that way, and so may ``MILES_HOST_IP``); that name stays the connect-side address and is
+    resolved here only for the router's own listening socket.
+    """
+    if _is_ip_literal(host):
+        return _wrap_ipv6(host)
+
+    try:
+        infos = socket.getaddrinfo(host, None, type=socket.SOCK_STREAM)
+    except socket.gaierror as e:
+        raise RuntimeError(_unresolvable_bind_host_message(host, reason=str(e))) from e
+    candidates = list(dict.fromkeys(info[4][0] for info in infos))
+    if not candidates:
+        raise RuntimeError(_unresolvable_bind_host_message(host, reason="the resolver returned no address"))
+    if len(candidates) > 1:
+        logger.warning(
+            f"The sglang router's advertised host {host!r} resolves to {candidates}; binding the first resolver "
+            f"candidate {candidates[0]!r}. Configure {MILES_HOST_IP_ENV} or Ray's --node-ip-address as a specific "
+            f"IP literal if deterministic interface selection is required."
+        )
+    return _wrap_ipv6(candidates[0])
+
+
+def _is_ip_literal(host: str) -> bool:
+    try:
+        ipaddress.ip_address(host.strip("[]"))
+        return True
+    except ValueError:
+        return False
+
+
+def _unresolvable_bind_host_message(host: str, *, reason: str) -> str:
+    return (
+        f"Cannot bind the sglang router on {host!r}: {reason}. sglang_router needs an IP literal for --host, "
+        f"so configure {MILES_HOST_IP_ENV} on that node, or Ray's --node-ip-address, as a specific IP literal "
+        f"(another hostname would fail the same way)."
+    )
 
 
 def router_args_to_argv(router_args: Mapping[str, object]) -> list[str]:

--- a/miles/ray/specs/inference.py
+++ b/miles/ray/specs/inference.py
@@ -2,7 +2,11 @@ import logging
 import os
 import shlex
 
-from miles.backends.sglang_utils.router_args_utils import compute_sglang_router_args, router_args_to_argv
+from miles.backends.sglang_utils.router_args_utils import (
+    compute_sglang_router_args,
+    compute_sglang_router_bind_host,
+    router_args_to_argv,
+)
 from miles.backends.sglang_utils.sglang_config import ModelConfig, ServerGroupConfig, resolve_sglang_config
 from miles.backends.sglang_utils.sglang_engine import compute_engine_launch_cmd
 from miles.ray.utils import NOSET_VISIBLE_DEVICES_ENV_VARS_LIST
@@ -44,7 +48,8 @@ def _compute_spec_router(args, model_idx: int, model_cfg: ModelConfig) -> Comman
         else:
             router_args = compute_sglang_router_args(
                 args,
-                host=primary.host,
+                # peers keep reaching the router by primary.host; only its listening socket needs the literal
+                host=compute_sglang_router_bind_host(primary.host),
                 port=primary.port,
                 prometheus_port=ctx.self_addrs["prometheus"].port,
                 has_pd_disaggregation=model_cfg.has_pd_disaggregation,

--- a/tests/fast/backends/sglang_utils/test_router_args_utils.py
+++ b/tests/fast/backends/sglang_utils/test_router_args_utils.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import argparse
+import logging
+import socket
 from argparse import Namespace
 
 import pytest
@@ -8,6 +10,7 @@ from sglang_router.launch_router import RouterArgs
 
 from miles.backends.sglang_utils.router_args_utils import (
     compute_sglang_router_args,
+    compute_sglang_router_bind_host,
     parse_router_args_argv,
     router_args_to_argv,
 )
@@ -248,3 +251,33 @@ def _make_non_default_raw_scalar(*, action: argparse.Action) -> object:
         return action.default + 1.0 if isinstance(action.default, float) else 1.0
 
     return "other-sweep-value" if action.default == "sweep-value" else "sweep-value"
+
+
+def _addrinfo_rows(*ips: str) -> list[tuple]:
+    return [(socket.AF_INET, socket.SOCK_STREAM, socket.IPPROTO_TCP, "", (ip, 0)) for ip in ips]
+
+
+class TestComputeSglangRouterBindHost:
+    def test_a_bare_ipv6_literal_is_bracketed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The router rejects ``::1:port``; only ``[::1]:port`` parses as a socket address."""
+        monkeypatch.setattr(socket, "getaddrinfo", lambda *a, **k: pytest.fail("literals are not resolved"))
+
+        assert compute_sglang_router_bind_host("fd00::1") == "[fd00::1]"
+        assert compute_sglang_router_bind_host("[fd00::1]") == "[fd00::1]"
+        assert compute_sglang_router_bind_host("10.0.0.7") == "10.0.0.7"
+
+    def test_repeated_resolver_rows_are_one_candidate(self, monkeypatch: pytest.MonkeyPatch, caplog) -> None:
+        """Resolvers often list one address once per protocol; that is not an ambiguous name."""
+        monkeypatch.setattr(socket, "getaddrinfo", lambda *a, **k: _addrinfo_rows("10.20.30.40", "10.20.30.40"))
+
+        with caplog.at_level(logging.WARNING):
+            assert compute_sglang_router_bind_host("worker-01.cluster.internal") == "10.20.30.40"
+
+        assert not [r for r in caplog.records if "resolves to" in r.message]
+
+    def test_a_name_without_addresses_is_reported_with_a_remedy(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """An empty answer is as unusable as a failed lookup and must name the host and the override."""
+        monkeypatch.setattr(socket, "getaddrinfo", lambda *a, **k: [])
+
+        with pytest.raises(RuntimeError, match=r"worker-01\.cluster\.internal.*MILES_HOST_IP"):
+            compute_sglang_router_bind_host("worker-01.cluster.internal")

--- a/tests/fast/ray/specs/test_inference.py
+++ b/tests/fast/ray/specs/test_inference.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import ipaddress
+import logging
 import shlex
+import socket
 import sys
 from argparse import Namespace
 
@@ -43,18 +46,64 @@ def _make_model_cfg(*worker_types: str) -> ModelConfig:
     return ModelConfig(name="default", model_path=None, server_groups=groups, update_weights=True)
 
 
-def _make_router_ctx(*, port: int = 20000, prometheus_port: int = 4001) -> LaunchCommandContext:
+def _make_router_ctx(
+    *, host: str = "127.0.0.1", port: int = 20000, prometheus_port: int = 4001
+) -> LaunchCommandContext:
     return LaunchCommandContext(
         cell_index=0,
         worker_in_cell_index=0,
         self_addrs=dict(
-            primary=HostAndPort(host="127.0.0.1", port=port),
-            prometheus=HostAndPort(host="127.0.0.1", port=prometheus_port),
+            primary=HostAndPort(host=host, port=port),
+            prometheus=HostAndPort(host=host, port=prometheus_port),
         ),
         pool_addrs={},
         gpu_ids=[],
         local_gpu_ids=[],
     )
+
+
+_ADVERTISED_HOSTNAME = "worker-01.cluster.internal"
+_RESOLVED_IP = "10.20.30.40"
+
+
+def _addrinfo(ip: str, port: int | None) -> tuple:
+    """One getaddrinfo() row for ``ip``, in the shape the real resolver returns."""
+    if ipaddress.ip_address(ip).version == 6:
+        return (socket.AF_INET6, socket.SOCK_STREAM, socket.IPPROTO_TCP, "", (ip, port or 0, 0, 0))
+    return (socket.AF_INET, socket.SOCK_STREAM, socket.IPPROTO_TCP, "", (ip, port or 0))
+
+
+class _FakeResolver:
+    """Answers getaddrinfo() from a fixed table so no test touches real DNS or the machine's own addresses."""
+
+    def __init__(self) -> None:
+        self.answers: dict[str, list[str]] = {}
+        self.queries: list[str] = []
+
+    def __call__(self, host, port, family=0, type=0, proto=0, flags=0):  # noqa: A002
+        self.queries.append(host)
+        if host not in self.answers:
+            raise socket.gaierror(socket.EAI_NONAME, "Name or service not known")
+        return [_addrinfo(ip, port) for ip in self.answers[host]]
+
+
+@pytest.fixture
+def fake_resolver(monkeypatch: pytest.MonkeyPatch) -> _FakeResolver:
+    resolver = _FakeResolver()
+    monkeypatch.setattr(socket, "getaddrinfo", resolver)
+    return resolver
+
+
+def _sgl_router_argv(ctx: LaunchCommandContext) -> list[str]:
+    args = make_args(use_miles_router=False, sglang_router_ip=None, sglang_router_port=None)
+    spec = _compute_spec_router(args, model_idx=0, model_cfg=_make_model_cfg("regular"))
+    argv = shlex.split(spec.launch_command(ctx))
+    assert argv[1:3] == ["-m", "sglang_router.launch_router"]
+    return argv
+
+
+def _sgl_router_bind_host(argv: list[str]) -> str:
+    return argv[argv.index("--host") + 1]
 
 
 class TestRouterPortPinning:
@@ -136,6 +185,93 @@ class TestComputeSpecRouterLaunchCommand:
         assert config.host == "127.0.0.1"
         assert config.port == 20000
         assert config.max_connections == 100
+
+
+class TestSglRouterBindHost:
+    """sglang_router parses ``--host:--port`` as a socket address, so it needs an IP literal even though the
+    worker manager may legitimately advertise the placed node under a hostname (Ray on Slurm does)."""
+
+    def test_a_hostname_stays_advertised_while_the_router_binds_the_ip_it_resolves_to(self, fake_resolver):
+        """The launch context keeps the hostname for its peers; only the bind flag carries the resolved IP literal."""
+        fake_resolver.answers[_ADVERTISED_HOSTNAME] = [_RESOLVED_IP]
+        ctx = _make_router_ctx(host=_ADVERTISED_HOSTNAME)
+
+        argv = _sgl_router_argv(ctx)
+
+        assert _sgl_router_bind_host(argv) == _RESOLVED_IP
+        assert argv[argv.index("--port") + 1] == "20000"
+        assert ctx.self_addrs["primary"].host == _ADVERTISED_HOSTNAME
+        assert ctx.self_addrs["primary"].addr == f"http://{_ADVERTISED_HOSTNAME}:20000"
+        assert fake_resolver.queries == [_ADVERTISED_HOSTNAME]
+
+    def test_an_ipv4_literal_is_bound_as_given_without_a_lookup(self, fake_resolver):
+        """An address that already satisfies the router is never sent through the resolver."""
+        argv = _sgl_router_argv(_make_router_ctx(host="10.0.0.7"))
+
+        assert _sgl_router_bind_host(argv) == "10.0.0.7"
+        assert fake_resolver.queries == []
+
+    def test_a_bracketed_ipv6_literal_is_bound_as_given_without_a_lookup(self, fake_resolver):
+        """The manager advertises IPv6 nodes bracketed, which is the only IPv6 form the router accepts."""
+        argv = _sgl_router_argv(_make_router_ctx(host="[fd00::1]"))
+
+        assert _sgl_router_bind_host(argv) == "[fd00::1]"
+        assert parse_router_args_argv(argv[3:]).host == "[fd00::1]"
+        assert fake_resolver.queries == []
+
+    def test_a_hostname_resolving_to_ipv6_is_bound_bracketed(self, fake_resolver):
+        """The resolver hands back bare IPv6 addresses; the router only parses the bracketed form."""
+        fake_resolver.answers[_ADVERTISED_HOSTNAME] = ["fd00::1"]
+
+        argv = _sgl_router_argv(_make_router_ctx(host=_ADVERTISED_HOSTNAME))
+
+        assert _sgl_router_bind_host(argv) == "[fd00::1]"
+
+    def test_a_multi_address_hostname_binds_the_first_candidate_and_reports_the_ambiguity(self, fake_resolver, caplog):
+        """A multi-address hostname uses the first resolver candidate and reports the ambiguity."""
+        fake_resolver.answers[_ADVERTISED_HOSTNAME] = [_RESOLVED_IP, "fd00::40"]
+
+        with caplog.at_level(logging.WARNING):
+            argv = _sgl_router_argv(_make_router_ctx(host=_ADVERTISED_HOSTNAME))
+
+        assert _sgl_router_bind_host(argv) == _RESOLVED_IP
+        assert any(_RESOLVED_IP in r.message and "fd00::40" in r.message for r in caplog.records)
+
+    def test_an_unresolvable_hostname_fails_before_the_router_is_launched(self, fake_resolver):
+        """A name nobody can resolve must not reach the router, whose own failure names neither host nor remedy."""
+        ctx = _make_router_ctx(host="nowhere.invalid")
+
+        with pytest.raises(RuntimeError, match=r"nowhere\.invalid.*MILES_HOST_IP"):
+            _sgl_router_argv(ctx)
+
+    def test_the_miles_router_and_the_session_server_keep_the_advertised_hostname(self, fake_resolver):
+        """Only the sglang router needs a literal; the python servers bind hostnames and peers connect by them."""
+        args = make_args(
+            use_miles_router=True,
+            sglang_router_ip=None,
+            sglang_router_port=None,
+            miles_router_max_connections=100,
+            miles_router_timeout=None,
+            miles_router_health_check_failure_threshold=3,
+            rollout_health_check_interval=10.0,
+        )
+        spec = _compute_spec_router(args, model_idx=0, model_cfg=_make_model_cfg("regular"))
+        argv = shlex.split(spec.launch_command(_make_router_ctx(host=_ADVERTISED_HOSTNAME)))
+        assert parse_config_argv(MilesRouterConfig, argv[3:]).host == _ADVERTISED_HOSTNAME
+
+        session_ctx = LaunchCommandContext(
+            cell_index=0,
+            worker_in_cell_index=0,
+            self_addrs=dict(primary=HostAndPort(host=_ADVERTISED_HOSTNAME, port=5006)),
+            pool_addrs={compute_router_pool_id(0): [dict(primary=HostAndPort(host=_ADVERTISED_HOSTNAME, port=3000))]},
+            gpu_ids=[],
+            local_gpu_ids=[],
+        )
+        argv = shlex.split(spec_session_server(_make_session_server_args()).launch_command(session_ctx))
+        config = parse_config_argv(SessionServerConfig, argv[3:])
+        assert config.backend_url == f"http://{_ADVERTISED_HOSTNAME}:3000"
+        assert config.host == _ADVERTISED_HOSTNAME
+        assert fake_resolver.queries == []
 
 
 class TestComputeSpecSessionServer:


### PR DESCRIPTION
## Motivation

The worker manager advertises each placed worker under Ray's node address (`NodeProbeMixin._get_node_ip()`, i.e. `MILES_HOST_IP` or `ray._private.services.get_node_ip_address()`). On Slurm-managed clusters that address is the node's hostname. Every connect-side consumer handles that fine (engine HTTP base URLs, `dist_init_addr`, the session server's backend URL, `wait_tcp_ready`), but `sglang_router` parses `--host:--port` as a Rust `SocketAddr`, which only accepts an IP literal. The router exits with `Invalid address: invalid socket address syntax` before binding and the whole run dies with `Server at <hostname>:<port> not ready after 120s`.

Reproduced CPU-only with `sglang-router` 0.3.2: `--host <hostname>` and `--host ::1` both fail that way, `--host 127.0.0.1` and `--host [::1]` bind.

There is no separate IP-typed value to carry from the placement layer: the probed node address *is* what Ray was started with, and the existing tests pin that `MILES_HOST_IP` may be a non-numeric name. So the fix stays on the router's bind side.

## Changes

- `compute_sglang_router_bind_host(host)` in `router_args_utils.py` turns the advertised host into what the router can bind: IP literals pass through unchanged (IPv6 stays bracketed, the only form the router parses), a hostname is resolved with `socket.getaddrinfo()` over both address families, an unresolvable name raises a `RuntimeError` naming the host and the `MILES_HOST_IP` / `--node-ip-address` remedies instead of letting the router die on bind, and a name that resolves to several addresses binds the first resolver candidate and logs the full candidate list.
- `_compute_spec_router()` passes that bind host to `compute_sglang_router_args(host=...)`. `primary.host` is still what the launch context advertises; the miles router, session server and engine launch paths are untouched.
- Regression tests in `tests/fast/ray/specs/test_inference.py` render the real launch command with a fake resolver (no DNS, no dependency on the machine's addresses): hostname advertised + resolved IP bound, IPv4 literal and bracketed IPv6 literal unchanged and never resolved, hostname resolving to IPv6 bound bracketed, multi-address warning, unresolvable-name error, and the miles router / session server keeping the hostname. Unit tests in `test_router_args_utils.py` cover bare-IPv6 bracketing, duplicate resolver rows and an empty resolver answer.

## Validation

- `tests/fast/ray/specs/test_inference.py::TestSglRouterBindHost` fails on current `main` for the intended reason (`--host worker-01.cluster.internal` instead of `10.20.30.40`) and passes with the fix.
- `pytest tests/fast/ray/specs tests/fast/backends/sglang_utils tests/fast/ray/rollout/test_engine_addressing.py tests/fast/ray/rollout/test_server_cell_addressing.py tests/fast/ray/rollout/test_router_manager.py tests/fast/utils/test_misc.py tests/fast/utils/workers`: 2014 passed, 5 xfailed.
- `pre-commit run --files <changed files>`: ruff, autoflake, isort, black all pass. `git diff --check` clean.
- Original-environment validation: the issue reporter validated this exact commit on the original Slurm-managed aarch64 GB200 NVL and GB300 NVL environments. Four end-to-end runs passed on the first attempt with Ray still advertising the node hostname and without `MILES_HOST_IP` or `--sglang-router-ip` workarounds. Engines registered, rollout became ready, and all runs completed five GRPO steps. The original `invalid socket address syntax` and readiness-timeout signatures did not recur. See the reporter's validation comment below.

## Scope

- Connect-side hostname behaviour is unchanged: `HostAndPort.host`, `addr`, `dist_init_addr` and the session server backend URL still carry the advertised hostname.
- Miles addresses are not globally normalized; the literal is derived only where the SGLang router's listening socket needs it.
- Resolution is performed when the router launch command is rendered, so the selected bind address reflects the manager's resolver view of the advertised hostname.
- No GPU is needed for the local regression; this is control-plane addressing logic. The original Slurm GB200/GB300 environment has now also passed end-to-end validation on this exact commit.

Fixes #3133
