### PR TITLE
[1/2] Dense Qwen TOP: forward

### DIFF
--- a/miles/backends/fsdp_utils/adaptations/specs/qwen3.py
+++ b/miles/backends/fsdp_utils/adaptations/specs/qwen3.py
@@ -4,7 +4,7 @@ from dataclasses import replace
 
 import torch
 
-from miles.true_on_policy.contracts import QWEN3_DENSE_TRUE_ON_POLICY_V1
+from miles.true_on_policy.contracts import TRUE_ON_POLICY_V1
 
 from ..class_patches import ModelInstancePatchHook, register_model_instance_patch
 from ..precision import PrecisionPolicyHook, register_precision_policy
@@ -18,15 +18,15 @@ def _uses_formal_contract(hf_config, args) -> bool:
     return (
         _is_qwen3(hf_config)
         and getattr(args, "true_on_policy_mode", False)
-        and getattr(args, "sglang_true_on_policy_contract", None) == QWEN3_DENSE_TRUE_ON_POLICY_V1.name
+        and getattr(args, "sglang_true_on_policy_contract", None) == TRUE_ON_POLICY_V1.name
     )
 
 
 def _resolve_precision(base_policy, hf_config, args):
     if getattr(args, "fp16", False):
-        raise ValueError(f"{QWEN3_DENSE_TRUE_ON_POLICY_V1.name} requires bf16 training")
+        raise ValueError(f"{TRUE_ON_POLICY_V1.name} requires bf16 training")
     if not base_policy.keep_fp32_master:
-        raise ValueError(f"{QWEN3_DENSE_TRUE_ON_POLICY_V1.name} requires fp32 master weights")
+        raise ValueError(f"{TRUE_ON_POLICY_V1.name} requires fp32 master weights")
     return replace(
         base_policy,
         param_dtype=torch.float32,

--- a/miles/backends/megatron_utils/arguments.py
+++ b/miles/backends/megatron_utils/arguments.py
@@ -12,10 +12,12 @@ logger = logging.getLogger(__name__)
 
 
 def set_default_megatron_args(args):
-    if getattr(args, "true_on_policy_mode", False):
+    if getattr(args, "true_on_policy_mode", False) and not getattr(args, "true_on_policy_contract", None):
         raise NotImplementedError(
-            "--true-on-policy-mode is not supported on the megatron backend with this Megatron "
-            "version; support lands in a follow-up PR. Use --train-backend fsdp for true-on-policy."
+            "--true-on-policy-mode on the megatron backend requires --true-on-policy-contract "
+            "naming a program (see miles_plugins/top/program.py), which also selects the "
+            "matching --spec. The unprogrammed path is the fsdp backend's, reached by "
+            "hand-assembling --true-on-policy-mode with --sglang-true-on-policy-contract."
         )
     # Muon currently owns its sharding path, and Megatron's distributed optimizer
     # only supports Adam-family optimizers.

--- a/miles/backends/training_utils/loss_hub/logit_processors.py
+++ b/miles/backends/training_utils/loss_hub/logit_processors.py
@@ -219,6 +219,17 @@ def get_log_probs_and_entropy(
         sample. If `with_entropy` is True, also includes "entropy" key with
         a list of `[R]` tensors.
     """
+    if args.true_on_policy_mode:
+        if (
+            args.rollout_temperature != 1.0
+            or getattr(args, "rollout_top_k", -1) not in (-1, 1 << 30)
+            or getattr(args, "rollout_top_p", 1.0) != 1.0
+            or rollout_sampling_mask is not None
+        ):
+            raise ValueError(
+                "true-on-policy supports only temperature=1 and unfiltered, unmodified "
+                "full-vocabulary sampling; sampling-mask replay is not supported"
+            )
     assert non_loss_data
     if rollout_sampling_mask is not None:
         for sample_index, (sampling_mask, response_length) in enumerate(

--- a/miles/rollout/generate_utils/prefill_logprobs.py
+++ b/miles/rollout/generate_utils/prefill_logprobs.py
@@ -38,7 +38,7 @@ def _build_prefill_scoring_payload(
         "sampling_params": {
             **dict(sampling_params),
             "max_new_tokens": 0,
-            "temperature": 0,
+            "temperature": 1.0,
             "skip_special_tokens": False,
         },
         "return_logprob": True,

--- a/miles/true_on_policy/__init__.py
+++ b/miles/true_on_policy/__init__.py
@@ -8,17 +8,18 @@ from .config import (
     apply_true_on_policy_script_defaults,
     build_true_on_policy_launch_plan,
 )
-from .contracts import QWEN3_DENSE_TRUE_ON_POLICY_V1, TrueOnPolicyContract, get_true_on_policy_contract
+from .contracts import TRUE_ON_POLICY_V1, get_true_on_policy_contract
+from .schema import TrueOnPolicyContractSchema
 from .model_profiles import TrueOnPolicyModelProfile, get_megatron_model_type, get_true_on_policy_model_profile
 
 __all__ = [
     "TrueOnPolicyLaunchPlan",
     "TrueOnPolicyArgList",
     "TrueOnPolicyKernelPolicy",
-    "TrueOnPolicyContract",
+    "TrueOnPolicyContractSchema",
     "TrueOnPolicyModelProfile",
     "TrueOnPolicyParallelLayout",
-    "QWEN3_DENSE_TRUE_ON_POLICY_V1",
+    "TRUE_ON_POLICY_V1",
     "apply_true_on_policy_script_defaults",
     "build_true_on_policy_launch_plan",
     "get_true_on_policy_contract",

--- a/miles/true_on_policy/config.py
+++ b/miles/true_on_policy/config.py
@@ -5,12 +5,12 @@ import shlex
 from dataclasses import dataclass, field
 from typing import Any, Literal
 
-from .contracts import TrueOnPolicyContract, get_true_on_policy_contract
+from .contracts import get_true_on_policy_contract
+from .schema import TrueOnPolicyContractSchema
 from .model_profiles import TrueOnPolicyModelProfile, get_true_on_policy_model_profile
 
 
-OnPolicyTarget = Literal["fsdp", "fsdp_tp"]
-TrainBackend = Literal["fsdp", "megatron"]
+TrainBackend = Literal["megatron"]
 
 
 @dataclass(frozen=True)
@@ -36,14 +36,69 @@ class TrueOnPolicyParallelLayout:
     train_context_parallel_size: int
     train_pipeline_parallel_size: int
     rollout_num_gpus_per_engine: int
+    # CP IS TWO ORTHOGONAL AXES, and conflating them made CP unreachable for DSA families once.
+    #   train_cp_comm_type  -> how ATTENTION communicates: "a2a" is Ulysses, "all_gather" is the
+    #                          DSA gather-per-chunk scheme, and "p2p" is ring. None means
+    #                          megatron's own default, ["p2p"] -- the one scheme that can never
+    #                          be bitwise against a cp=1 rollout.
+    #   train_allgather_cp  -> miles' SEQUENCE LAYOUT: contiguous chunks per rank (True) vs the
+    #                          zigzag ring layout (False). Independent of the comm type above.
+    train_cp_comm_type: str | None = None
+    train_allgather_cp: bool = False
+    # EP is stated on BOTH sides because the degrees may legitimately differ: the combine is
+    # per-slot at the token owner, so it references no rank and no contributor count. A
+    # per-CONTRIBUTOR fold would not be degree-invariant -- that distinction is the reason an
+    # earlier ep=4-vs-ep=2 measurement read 0.03125 and the current one reads 0.0.
+    train_expert_parallel_size: int = 1
+    rollout_expert_parallel_size: int = 1
+    rollout_data_parallel_size: int = 1
 
     @property
     def uses_train_tp(self) -> bool:
         return self.train_tensor_parallel_size > 1
 
     @property
-    def uses_ulysses_cp(self) -> bool:
+    def uses_train_cp(self) -> bool:
         return self.train_context_parallel_size > 1
+
+    @property
+    def train_cp_attention_scheme(self) -> str:
+        """Derived from the comm type, never from the degree. THREE schemes, not two:
+
+        * "ulysses"  (a2a)          -- transport by heads, no reduction. The only exact one.
+        * "allgather"               -- megatron's LOCAL attention implements this and only this, but
+                                       with EAGER attention (a full materialized softmax), which is
+                                       a different kernel from the rollout's FA3.
+        * "ring"     (p2p/a2a+p2p)  -- merges chunks with an online softmax: a different reduction
+                                       from the rollout's single call.
+
+        "all_gather" is NOT a flavour of "ring" and must not be folded into it: it adds no
+        reduction at all, it runs a different kernel on this code path.
+        """
+        if self.train_cp_comm_type == "a2a":
+            return "ulysses"
+        if self.train_cp_comm_type == "all_gather":
+            return "allgather"
+        return "ring"
+
+    @property
+    def train_cp_sequence_layout(self) -> str:
+        return "allgather" if self.train_allgather_cp else "zigzag"
+
+    @property
+    def required_cp_layout(self) -> str:
+        """The `supported_train_layouts` key this CP scheme needs.
+
+        Derived from the scheme rather than fixed at "ulysses_cp" for any cp>1, so a profile can
+        say "supports CP, but not that flavour". Fixing it would make CP unreachable for every
+        family whose supported flavour is allgather rather than Ulysses.
+        """
+        return f"{self.train_cp_attention_scheme}_cp"
+
+    @property
+    def uses_ulysses_cp(self) -> bool:
+        """Kept for callers that only ask "is this the Ulysses program"; not a CP-degree test."""
+        return self.uses_train_cp and self.train_cp_attention_scheme == "ulysses"
 
     @property
     def uses_train_pp(self) -> bool:
@@ -53,52 +108,66 @@ class TrueOnPolicyParallelLayout:
     def uses_rollout_tp(self) -> bool:
         return self.rollout_num_gpus_per_engine > 1
 
+    @property
+    def uses_train_ep(self) -> bool:
+        return self.train_expert_parallel_size > 1
+
+    @property
+    def uses_rollout_ep(self) -> bool:
+        return self.rollout_expert_parallel_size > 1
+
+    @property
+    def rollout_moe_tensor_parallel_size(self) -> int:
+        """What sglang gives the EXPERTS once EP and DP have taken their share of the engine.
+
+        sglang derives `moe_tp = gpus_per_engine // ep // dp`, so an engine wider than its EP
+        degree silently puts the remainder into MoE tensor parallelism. Invisible while every
+        rung had gpus_per_engine == ep; CP is the first axis to consume world size WITHOUT
+        consuming EP degree, which is what made it reachable.
+        """
+        consumed = self.rollout_expert_parallel_size * self.rollout_data_parallel_size
+        if consumed <= 0:
+            return 1
+        return max(1, self.rollout_num_gpus_per_engine // consumed)
+
+    @property
+    def uses_rollout_moe_tp(self) -> bool:
+        return self.rollout_moe_tensor_parallel_size > 1
+
 
 @dataclass(frozen=True)
 class TrueOnPolicyKernelPolicy:
     """Kernel/runtime switches required to keep SGLang and Megatron aligned."""
 
-    contract: TrueOnPolicyContract
-    deterministic_inference: bool
-    deterministic_training: bool
+    contract: TrueOnPolicyContractSchema
     sglang_attention_backend: str
-    megatron_uses_sglang_backend: bool
-    disable_rope_fusion: bool
-    disable_bias_swiglu_fusion: bool
-    batch_invariant_mode: bool
-    tp_invariant_row_linear: bool
-    deterministic_tp_allreduce: bool
 
     def build_sglang_args(self) -> TrueOnPolicyArgList:
-        values = [
-            "--sglang-true-on-policy-contract",
-            self.contract.name,
-            "--sglang-attention-backend",
-            self.sglang_attention_backend,
-        ]
-        if self.deterministic_inference:
-            values.insert(0, "--sglang-enable-deterministic-inference")
-        return TrueOnPolicyArgList(tuple(values))
+        return TrueOnPolicyArgList(
+            (
+                "--sglang-enable-deterministic-inference",
+                "--sglang-true-on-policy-contract",
+                self.contract.name,
+                "--sglang-attention-backend",
+                self.sglang_attention_backend,
+            )
+        )
 
     def build_megatron_args(self) -> TrueOnPolicyArgList:
-        values: list[str] = []
-        if self.megatron_uses_sglang_backend:
-            values.extend(
-                [
-                    "--true-on-policy-contract",
-                    self.contract.name,
-                    "--transformer-impl",
-                    "local",
-                    "--use-cpu-initialization",
-                ]
+        return TrueOnPolicyArgList(
+            (
+                "--true-on-policy-contract",
+                self.contract.name,
+                "--spec",
+                "miles_plugins.top.spec",
+                "get_top_spec",
+                "--transformer-impl",
+                "local",
+                "--use-cpu-initialization",
+                "--batch-invariant-mode",
+                "--no-bias-swiglu-fusion",
             )
-        if self.batch_invariant_mode:
-            values.append("--batch-invariant-mode")
-        if self.disable_bias_swiglu_fusion:
-            values.append("--no-bias-swiglu-fusion")
-        if self.disable_rope_fusion:
-            values.append("--no-rope-fusion")
-        return TrueOnPolicyArgList(tuple(values))
+        )
 
     def build_env_vars(self) -> dict[str, str]:
         return {
@@ -114,14 +183,12 @@ class TrueOnPolicyLaunchPlan:
 
     enabled: bool
     model_profile: TrueOnPolicyModelProfile | None = None
-    contract: TrueOnPolicyContract | None = None
+    contract: TrueOnPolicyContractSchema | None = None
     train_backend: TrainBackend | None = None
-    sglang_target: OnPolicyTarget | None = None
     parallel_layout: TrueOnPolicyParallelLayout | None = None
     kernel_policy: TrueOnPolicyKernelPolicy | None = None
     sglang_args: TrueOnPolicyArgList = field(default_factory=TrueOnPolicyArgList)
     megatron_args: TrueOnPolicyArgList = field(default_factory=TrueOnPolicyArgList)
-    fsdp_args: TrueOnPolicyArgList = field(default_factory=TrueOnPolicyArgList)
     miles_args: TrueOnPolicyArgList = field(default_factory=TrueOnPolicyArgList)
     env_vars: dict[str, str] = field(default_factory=dict)
 
@@ -130,7 +197,6 @@ class TrueOnPolicyLaunchPlan:
         return (
             self.sglang_args.as_cli_string()
             + self.megatron_args.as_cli_string()
-            + self.fsdp_args.as_cli_string()
             + self.miles_args.as_cli_string()
         )
 
@@ -146,6 +212,11 @@ class TrueOnPolicyConfig:
     context_parallel_size: int
     pipeline_model_parallel_size: int
     rollout_num_gpus_per_engine: int
+    cp_comm_type: str | None = None
+    allgather_cp: bool = False
+    expert_model_parallel_size: int = 1
+    sglang_ep_size: int = 1
+    sglang_dp_size: int = 1
     contract_override: str | None = None
 
     @property
@@ -155,19 +226,15 @@ class TrueOnPolicyConfig:
             train_context_parallel_size=self.context_parallel_size,
             train_pipeline_parallel_size=self.pipeline_model_parallel_size,
             rollout_num_gpus_per_engine=self.rollout_num_gpus_per_engine,
+            train_cp_comm_type=self.cp_comm_type,
+            train_allgather_cp=self.allgather_cp,
+            train_expert_parallel_size=self.expert_model_parallel_size,
+            rollout_expert_parallel_size=self.sglang_ep_size,
+            rollout_data_parallel_size=self.sglang_dp_size,
         )
 
     @property
-    def requires_tp_invariant_rollout(self) -> bool:
-        layout = self.parallel_layout
-        return layout.uses_train_tp or layout.uses_rollout_tp
-
-    @property
-    def sglang_target(self) -> OnPolicyTarget:
-        return "fsdp_tp" if self.requires_tp_invariant_rollout else "fsdp"
-
-    @property
-    def contract(self) -> TrueOnPolicyContract:
+    def contract(self) -> TrueOnPolicyContractSchema:
         if self.contract_override is not None:
             return get_true_on_policy_contract(self.contract_override)
         return self.model_profile.contract
@@ -176,65 +243,164 @@ class TrueOnPolicyConfig:
         if not self.enabled:
             return
         layout = self.parallel_layout
-        if self.contract.model_family != self.model_profile.family:
+        if self.train_backend != "megatron":
             raise ValueError(
-                f"Contract {self.contract.name!r} is for {self.contract.model_family}, "
-                f"but model profile is {self.model_profile.family}"
+                f"true-on-policy supports the megatron backend only, got {self.train_backend!r}"
             )
-        if self.train_backend == "megatron" and not self.model_profile.supports_megatron:
-            raise ValueError(f"{self.model_profile.family} does not support Megatron true-on-policy")
-        if self.train_backend == "fsdp" and not self.model_profile.supports_fsdp:
-            raise ValueError(f"{self.model_profile.family} does not support FSDP true-on-policy")
-        if layout.uses_ulysses_cp and not self.model_profile.supports_ulysses_cp:
-            raise ValueError(f"{self.model_profile.family} does not support Ulysses CP true-on-policy")
+        if layout.uses_train_cp:
+            # AXIS 1 -- the attention comm. Ring is refused for EVERY family: it merges attention
+            # chunks with an online softmax, a different number of rescales than the rollout's one
+            # call, and each rescale rounds -- no declaration can make that bitwise. Refused by
+            # NAME rather than left to read as unsupported-model.
+            scheme = layout.train_cp_attention_scheme
+            if scheme == "ring":
+                got = layout.train_cp_comm_type or 'megatron default ["p2p"]'
+                raise ValueError(
+                    f"true-on-policy cannot run ring CP; got {got}. Ring merges attention chunks "
+                    "with an online softmax, a different reduction from the rollout's single call, "
+                    "so it cannot be bitwise at any degree. Declare a2a (Ulysses) or all_gather, "
+                    "whichever scheme the family supports. Note the scheme lives in THIS contract, "
+                    "not in megatron's --cp-comm-type alone: under --transformer-impl local "
+                    "megatron's own attention has its own comm-type restrictions, and TOP "
+                    "substitutes the attention module."
+                )
+            # Ulysses and allgather are both exact schemes -- WHICH is exact depends on what the
+            # family's attention actually runs, so the answer is the profile's, not a blanket
+            # rule. Ulysses moves heads with a2a and adds no arithmetic; it is the scheme for a
+            # family whose delegated kernel is FA3 over the full sequence. Allgather replicates
+            # KV across the group and adds no arithmetic either; it is the scheme for a family
+            # whose spec-substituted attention gathers its own KV and runs the delegated kernel
+            # per chunk (glm_moe_dsa). What allgather is NOT exact for is megatron's own local
+            # DotProductAttention, which implements it with EAGER attention -- which is why the
+            # qwen families do not declare it, not why nobody may.
+            required = layout.required_cp_layout
+            if required not in self.model_profile.supported_train_layouts:
+                raise ValueError(
+                    f"{self.model_profile.family} does not support "
+                    f"{layout.train_cp_attention_scheme}-CP true-on-policy (needs {required!r} in "
+                    f"supported_train_layouts; it has "
+                    f"{list(self.model_profile.supported_train_layouts)})."
+                )
+            # AXIS 2 -- the sequence layout, independent of the comm type. A family whose
+            # index/kv sharing gathers over the CP group needs contiguous chunks; the zigzag ring
+            # layout breaks those gathers.
+            if scheme == "ulysses" and layout.train_allgather_cp:
+                raise ValueError(
+                    "true-on-policy Ulysses CP requires per-sequence zigzag shards; "
+                    "--allgather-cp produces contiguous shards that TopAttention cannot restore."
+                )
+            if self.model_profile.requires_allgather_cp and not layout.train_allgather_cp:
+                raise ValueError(
+                    f"{self.model_profile.family} requires --allgather-cp at cp>1: it gathers over "
+                    "the CP group in the contiguous-chunk layout and the zigzag ring layout is not "
+                    f"supported. Got the {layout.train_cp_sequence_layout} layout."
+                )
         if layout.uses_train_pp and "pp" not in self.model_profile.supported_train_layouts:
             raise ValueError(f"{self.model_profile.family} does not support PP true-on-policy")
-        if self.sglang_target == "fsdp_tp" and not self.model_profile.supports_tp_invariant:
-            raise ValueError(f"{self.model_profile.family} does not support TP-invariant true-on-policy")
+        if layout.uses_train_tp and not self.model_profile.supports_train_tensor_parallel:
+            raise ValueError(
+                f"{self.model_profile.family} does not support trainer tensor parallelism "
+                "under true-on-policy"
+            )
+        if layout.uses_rollout_tp and not self.model_profile.supports_rollout_tensor_parallel:
+            raise ValueError(
+                f"{self.model_profile.family} does not support rollout tensor parallelism "
+                "under true-on-policy"
+            )
+        # EP CLAUSE 1 -- the degree itself. A dense family has no expert path to make invariant.
+        if (layout.uses_train_ep or layout.uses_rollout_ep) and not self.model_profile.supports_expert_parallel:
+            raise ValueError(
+                f"{self.model_profile.family} does not support expert-parallel true-on-policy "
+                f"(needs 'ep' in supported_train_layouts; it has "
+                f"{list(self.model_profile.supported_train_layouts)})."
+            )
+        # EP CLAUSE 2 -- what EP LEAVES OVER, and it applies ONLY to families that have experts.
+        # On a dense model the same leftover IS ordinary rollout tensor parallelism, which is
+        # supported and measured to zero at tp=4; reading it as MoE-TP refused every dense engine
+        # wider than one GPU. Refused here rather than as TopMoELayer's raise deep in the forward,
+        # because the fix is a launch-time one: size the engine to ep*dp. The e2e harness works
+        # around this by hand; a production launcher never goes through that harness.
+        if self.model_profile.supports_expert_parallel and layout.uses_rollout_moe_tp:
+            raise ValueError(
+                f"true-on-policy refuses MoE tensor parallelism on the rollout: an engine of "
+                f"{layout.rollout_num_gpus_per_engine} GPUs at ep="
+                f"{layout.rollout_expert_parallel_size} dp={layout.rollout_data_parallel_size} "
+                f"leaves moe_tp={layout.rollout_moe_tensor_parallel_size}, which splits the "
+                f"experts' K dimension across ranks so the trainer cannot call one fused kernel. "
+                f"Size the engine to ep*dp."
+            )
 
     def build_kernel_policy(self) -> TrueOnPolicyKernelPolicy:
         return TrueOnPolicyKernelPolicy(
             contract=self.contract,
-            **self.contract.kernel_policy_kwargs_for(
-                train_backend=self.train_backend,
-                sglang_target=self.sglang_target,
-            ),
+            sglang_attention_backend=self.model_profile.sglang_attention_backend,
         )
 
     def build_launch_plan(self) -> TrueOnPolicyLaunchPlan:
         self.validate()
         kernel_policy = self.build_kernel_policy()
-        miles_args = TrueOnPolicyArgList(
-            (
-                "--deterministic-mode",
-                "--true-on-policy-mode",
-                "--recompute-logprobs-via-prefill",
-            )
-        )
-
-        if self.train_backend == "megatron":
-            megatron_args = kernel_policy.build_megatron_args()
-            fsdp_args = TrueOnPolicyArgList()
-        elif self.train_backend == "fsdp":
-            megatron_args = TrueOnPolicyArgList()
-            fsdp_args = TrueOnPolicyArgList(("--attn-implementation", self.contract.fsdp_attention_implementation))
-        else:
-            raise NotImplementedError(f"Unsupported true-on-policy train backend: {self.train_backend}")
+        # NEVER emit --recompute-logprobs-via-prefill here. The gate must score the logprobs the
+        # rollout's DECODE actually produced — the distribution RL samples from. A prefill
+        # recompute substitutes a different execution (batch shape, kernels, cuda-graph path) and
+        # masks every decode-only gap, so a zero under it certifies the wrong program. The flag
+        # stays a manual, per-investigation opt-in; the FSDP plan already refuses it.
+        miles_values = [
+            "--deterministic-mode",
+            "--true-on-policy-mode",
+        ]
+        layout = self.parallel_layout
+        if layout.uses_train_cp:
+            # Emit it: megatron's parser DEFAULTS --cp-comm-type to ["p2p"]
+            # (megatron/training/arguments.py) and forwards it to the config, so an unemitted
+            # declaration silently selects ring -- the one scheme that can never be bitwise.
+            # TopAttention asserts it at the seam, so a wrong value fails loud rather than running
+            # a different program.
+            #
+            # This requires the megatron-side change that moved the local-attention CP restriction
+            # out of TransformerConfig.__post_init__ and into DotProductAttention.__init__. Config
+            # validation cannot know that `--spec` substituted the core attention module, so it
+            # rejected a2a for an implementation TOP does not use. Without that change this emission
+            # fails at config validation -- which is the correct loud failure, not a silent one.
+            #
+            # The VALIDATED comm type, not a constant. validate() has already refused ring and
+            # checked the scheme against the profile by the time a plan exists, so this emission is
+            # the accepted declaration: a2a for a ulysses family, all_gather for an allgather one.
+            # A constant here overrides the recipe's flag silently -- megatron's parser keeps the
+            # LAST occurrence -- which is how an allgather family ended up building its attention
+            # submodule with a2a and dying on DotProductAttention's own assert.
+            miles_values += ["--cp-comm-type", layout.train_cp_comm_type]
+            if layout.train_allgather_cp:
+                miles_values.append("--allgather-cp")
+        miles_args = TrueOnPolicyArgList(tuple(miles_values))
 
         return TrueOnPolicyLaunchPlan(
             enabled=True,
             model_profile=self.model_profile,
             contract=self.contract,
             train_backend=self.train_backend,
-            sglang_target=self.sglang_target,
             parallel_layout=self.parallel_layout,
             kernel_policy=kernel_policy,
             sglang_args=kernel_policy.build_sglang_args(),
-            megatron_args=megatron_args,
-            fsdp_args=fsdp_args,
+            megatron_args=kernel_policy.build_megatron_args(),
             miles_args=miles_args,
             env_vars=kernel_policy.build_env_vars(),
         )
+
+
+def _normalize_cp_comm_type(value: Any) -> str | None:
+    """Megatron accepts a str or a per-layer list; the contract only reasons about one scheme."""
+    if value is None:
+        return None
+    if isinstance(value, (list, tuple)):
+        distinct = {str(v) for v in value}
+        if len(distinct) != 1:
+            raise ValueError(
+                f"true-on-policy needs ONE cp_comm_type for the whole model; got per-layer "
+                f"{list(value)!r}. A per-layer mix is a per-layer contract, which the schema "
+                f"cannot express yet."
+            )
+        return distinct.pop()
+    return str(value)
 
 
 def _get_required_int(args: Any, name: str) -> int:
@@ -257,6 +423,12 @@ def build_true_on_policy_config(args: Any) -> TrueOnPolicyConfig | None:
         context_parallel_size=_get_required_int(args, "context_parallel_size"),
         pipeline_model_parallel_size=_get_required_int(args, "pipeline_model_parallel_size"),
         rollout_num_gpus_per_engine=_get_required_int(args, "rollout_num_gpus_per_engine"),
+        cp_comm_type=_normalize_cp_comm_type(getattr(args, "cp_comm_type", None)),
+        allgather_cp=bool(getattr(args, "allgather_cp", False)),
+        # Defaulted, not required: these reach validate() from callers that predate the axis.
+        expert_model_parallel_size=int(getattr(args, "expert_model_parallel_size", None) or 1),
+        sglang_ep_size=int(getattr(args, "sglang_ep_size", None) or 1),
+        sglang_dp_size=int(getattr(args, "sglang_dp_size", None) or 1),
         contract_override=getattr(args, "true_on_policy_contract", None),
     )
 
@@ -275,5 +447,5 @@ def apply_true_on_policy_script_defaults(args: Any) -> None:
         return
 
     config.validate()
-    if args.train_backend == "megatron" and config.model_profile.disable_megatron_sequence_parallel:
+    if config.model_profile.disable_megatron_sequence_parallel:
         args.use_sequence_parallel = False

--- a/miles/true_on_policy/contracts.py
+++ b/miles/true_on_policy/contracts.py
@@ -1,83 +1,15 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from .schema import TRUE_ON_POLICY_V1_SCHEMA, TrueOnPolicyContractSchema
 
-from .schema import (
-    QWEN3_DENSE_TRUE_ON_POLICY_V1_SCHEMA,
-    KernelContract,
-    LogprobContract,
-    ModelFamily,
-    TrueOnPolicyContractName,
-    TrueOnPolicyContractSchema,
-)
-
-
-@dataclass(frozen=True)
-class TrueOnPolicyContract:
-    """Internal parity contract selected by Miles and implemented by each backend."""
-
-    schema: TrueOnPolicyContractSchema
-
-    @property
-    def name(self) -> TrueOnPolicyContractName:
-        return self.schema.name
-
-    @property
-    def model_family(self) -> ModelFamily:
-        return self.schema.model_family
-
-    @property
-    def required_kernel_contracts(self) -> tuple[KernelContract, ...]:
-        return self.schema.required_kernel_contracts
-
-    @property
-    def logprob_contract(self) -> LogprobContract:
-        return self.schema.logprob_contract
-
-    @property
-    def sglang_attention_backend(self) -> str:
-        return self.schema.sglang_attention_backend
-
-    @property
-    def fsdp_attention_implementation(self) -> str:
-        return self.schema.fsdp_attention_implementation
-
-    @property
-    def disable_megatron_sequence_parallel(self) -> bool:
-        return self.schema.disable_megatron_sequence_parallel
-
-    def kernel_policy_kwargs_for(
-        self,
-        *,
-        train_backend: str,
-        sglang_target: str,
-    ) -> dict[str, object]:
-        uses_megatron = train_backend == "megatron"
-        uses_tp_invariant_rollout = sglang_target == "fsdp_tp"
-        return {
-            "deterministic_inference": True,
-            "deterministic_training": True,
-            "sglang_attention_backend": self.sglang_attention_backend,
-            "megatron_uses_sglang_backend": uses_megatron,
-            "disable_rope_fusion": uses_megatron,
-            "disable_bias_swiglu_fusion": uses_megatron,
-            "batch_invariant_mode": uses_megatron,
-            "tp_invariant_row_linear": uses_tp_invariant_rollout,
-            "deterministic_tp_allreduce": uses_tp_invariant_rollout,
-        }
-
-
-QWEN3_DENSE_TRUE_ON_POLICY_V1 = TrueOnPolicyContract(
-    schema=QWEN3_DENSE_TRUE_ON_POLICY_V1_SCHEMA,
-)
-
+TRUE_ON_POLICY_V1 = TRUE_ON_POLICY_V1_SCHEMA
 
 _CONTRACT_BY_NAME = {
-    QWEN3_DENSE_TRUE_ON_POLICY_V1.name: QWEN3_DENSE_TRUE_ON_POLICY_V1,
+    TRUE_ON_POLICY_V1.name: TRUE_ON_POLICY_V1,
 }
 
 
-def get_true_on_policy_contract(name: str) -> TrueOnPolicyContract:
+def get_true_on_policy_contract(name: str) -> TrueOnPolicyContractSchema:
     try:
         return _CONTRACT_BY_NAME[name]
     except KeyError as exc:

--- a/miles/true_on_policy/model_profiles.py
+++ b/miles/true_on_policy/model_profiles.py
@@ -2,7 +2,12 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from .contracts import QWEN3_DENSE_TRUE_ON_POLICY_V1, LogprobContract, ModelFamily, TrueOnPolicyContract
+from typing import Literal
+
+from .contracts import TRUE_ON_POLICY_V1
+from .schema import TrueOnPolicyContractSchema
+
+ModelFamily = Literal["qwen3_dense"]
 
 ParallelLayout = str
 
@@ -14,27 +19,10 @@ class TrueOnPolicyModelProfile:
     family: ModelFamily
     model_names: tuple[str, ...]
     megatron_model_types: dict[str, str]
+    sglang_attention_backend: str
     supported_train_layouts: tuple[ParallelLayout, ...]
     supported_rollout_layouts: tuple[ParallelLayout, ...]
-    contract: TrueOnPolicyContract
-    supports_megatron: bool = True
-    supports_fsdp: bool = True
-
-    @property
-    def required_kernel_contracts(self):
-        return self.contract.required_kernel_contracts
-
-    @property
-    def logprob_contract(self) -> LogprobContract:
-        return self.contract.logprob_contract
-
-    @property
-    def sglang_attention_backend(self) -> str:
-        return self.contract.sglang_attention_backend
-
-    @property
-    def fsdp_attention_implementation(self) -> str:
-        return self.contract.fsdp_attention_implementation
+    contract: TrueOnPolicyContractSchema
 
     @property
     def disable_megatron_sequence_parallel(self) -> bool:
@@ -45,8 +33,26 @@ class TrueOnPolicyModelProfile:
         return "ulysses_cp" in self.supported_train_layouts
 
     @property
-    def supports_tp_invariant(self) -> bool:
-        return "tp" in self.supported_train_layouts or "tp" in self.supported_rollout_layouts
+    def requires_allgather_cp(self) -> bool:
+        """Does this family's CP need miles' contiguous-chunk sequence layout?
+
+        The SECOND CP axis, orthogonal to the attention comm type. Families whose attention shares
+        index/kv across the CP group (DSA) gather in the contiguous layout and break under zigzag;
+        Ulysses instead requires per-sequence zigzag shards, enforced by config validation.
+        """
+        return "allgather_cp" in self.supported_train_layouts
+
+    @property
+    def supports_train_tensor_parallel(self) -> bool:
+        return "tp" in self.supported_train_layouts
+
+    @property
+    def supports_rollout_tensor_parallel(self) -> bool:
+        return "tp" in self.supported_rollout_layouts
+
+    @property
+    def supports_expert_parallel(self) -> bool:
+        return "ep" in self.supported_train_layouts or "ep" in self.supported_rollout_layouts
 
     def megatron_model_type_for(self, model_name: str) -> str:
         try:
@@ -67,6 +73,7 @@ QWEN3_DENSE_PROFILE = TrueOnPolicyModelProfile(
         "Qwen3-4B-Base",
         "Qwen3-4B-Instruct-2507",
     ),
+    sglang_attention_backend="fa3",
     megatron_model_types={
         "Qwen3-0.6B": "qwen3-0.6B",
         "Qwen3-4B": "qwen3-4B",
@@ -75,7 +82,7 @@ QWEN3_DENSE_PROFILE = TrueOnPolicyModelProfile(
     },
     supported_train_layouts=("dp", "tp", "pp", "ulysses_cp"),
     supported_rollout_layouts=("dp", "tp"),
-    contract=QWEN3_DENSE_TRUE_ON_POLICY_V1,
+    contract=TRUE_ON_POLICY_V1,
 )
 
 

--- a/miles/true_on_policy/schema.py
+++ b/miles/true_on_policy/schema.py
@@ -3,32 +3,22 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Literal
 
-
-TrueOnPolicyContractName = Literal["qwen3_dense_true_on_policy_v1"]
-ModelFamily = Literal["qwen3_dense", "qwen3_moe", "qwen3_next"]
-KernelContract = Literal["qwen3_dense_sglang_math"]
-LogprobContract = Literal["sglang_prefill"]
+TrueOnPolicyContractName = Literal["true_on_policy_v1"]
 
 
 @dataclass(frozen=True)
 class TrueOnPolicyContractSchema:
-    """Declarative cross-repo identity for a true-on-policy parity contract."""
+    """Cross-repo identity of a true-on-policy program version.
+
+    Names a version of the numerical program, not a model. Model-specific facts (attention
+    backend, which roles bind) live where they are consumed.
+    """
 
     name: TrueOnPolicyContractName
-    model_family: ModelFamily
-    required_kernel_contracts: tuple[KernelContract, ...]
-    logprob_contract: LogprobContract
-    sglang_attention_backend: str
-    fsdp_attention_implementation: str
     disable_megatron_sequence_parallel: bool
 
 
-QWEN3_DENSE_TRUE_ON_POLICY_V1_SCHEMA = TrueOnPolicyContractSchema(
-    name="qwen3_dense_true_on_policy_v1",
-    model_family="qwen3_dense",
-    required_kernel_contracts=("qwen3_dense_sglang_math",),
-    logprob_contract="sglang_prefill",
-    sglang_attention_backend="fa3",
-    fsdp_attention_implementation="flash_attention_3",
+TRUE_ON_POLICY_V1_SCHEMA = TrueOnPolicyContractSchema(
+    name="true_on_policy_v1",
     disable_megatron_sequence_parallel=True,
 )

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -343,6 +343,15 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 help="Whether to enable true-on-policy mode.",
             )
             parser.add_argument(
+                "--true-on-policy-contract",
+                type=str,
+                default=None,
+                help=(
+                    "Name of the numerical program both engines resolve their op "
+                    "implementations from (see miles_plugins/top/program.py)."
+                ),
+            )
+            parser.add_argument(
                 "--recompute-logprobs-via-prefill",
                 action="store_true",
                 default=False,

--- a/miles_plugins/top/README.md
+++ b/miles_plugins/top/README.md
@@ -1,0 +1,82 @@
+# Qwen3 dense true-on-policy: forward review
+
+The Megatron TOP spec runs the dense Qwen forward with the same numerical
+operations as SGLang. `--true-on-policy` on the Qwen launcher selects the versioned
+`true_on_policy_v1` contract, the local Megatron spec, FA3, batch-invariant matmul,
+and native unfused-bias SwiGLU. It uses decode-produced log probabilities; it does
+not enable prefill rescoring.
+
+This is a **draft for forward review**, not a merge-ready training qualification.
+Autograd implementations accompany the delegated modules, but backward, optimizer
+behavior, and learning are outside this review. MoE and GLM programs are not
+registered or bound here. The high-level launcher supports Megatron only; raw
+FSDP launch callers are updated for the versioned contract name.
+
+## Manual review order
+
+| Order | Code | What to check |
+|---|---|---|
+| 1 | `miles/true_on_policy/{schema,contracts,model_profiles,config}.py`; `program.py` | One dense program at every admitted TP degree; explicit Ulysses CP; sequence-parallel and unsupported sampling refusals; no implicit prefill replay. |
+| 2 | `spec.py`; `residual_norm.py` | Preserve stock TransformerLayer forward. Carry `[branch, residual]` without an early BF16 addition. Clone both buffers before SGLang's mutating add+norm kernel. Require `2H` pipeline transport and a pair at every nonfirst residual site. |
+| 3 | `ops.py`; `install.py`; `spec.py:TopRowParallelLinear` | Delegate row matmul and fixed-tree TP reduction; verify the SGLang contract rejects unsupported K dimensions before a fallback is reachable. Review forward methods in this pass. |
+| 4 | `rope.py`; `install.py` | Enforce fused TE RoPE at construction and the actual attention call site; pass the real CP group size/rank for packed sequences. |
+| 5 | `attention.py`; `cp_layout.py` | FA3 varlen with the fixed split policy; explicit process group; global packed lengths; restore zigzag token order around Ulysses collectives. |
+| 6 | `miles/backends/training_utils/loss_hub/logit_processors.py`; `miles/rollout/generate_utils/prefill_logprobs.py` | Identity-only scoring contract; reject temperature/filter/mask changes. Optional prefill scoring sends temperature 1.0. LM-head producer changes belong to the SGLang prerequisite. |
+
+Tests beside these changes cover launch admission, role binding, residual ownership,
+fused RoPE, CP layout bookkeeping, and GPU kernel premises. Synthetic CP/KV tests
+are not a claim that every topology has passed the full-model gate.
+
+## Cross-repository prerequisites
+
+The default dependency pins are not sufficient for this draft. Companion PRs and
+final dependency pins remain to be prepared before merge.
+
+- **Megatron:** validated source was `c6449f0b23be397449f21c0967c5fc90785e55ea`
+  plus forward patches in `model_parallel_config.py`,
+  `pipeline_parallel/{schedules,p2p_communication}.py`, and
+  `transformer/{transformer_layer,transformer_config,dot_product_attention}.py`.
+  These provide the `pipeline_hidden_size` transport width, PP communication
+  ordering, residual lifetime through BDA, and CP admission at the selected
+  attention implementation. File paths are relative to `megatron/core/`.
+- **SGLang:** validated source was `774d7d2d878c58162404847a04dc88e5d85dfcf4`
+  plus LM-head/logit-buffer and sampling patches. The LM-head change spans
+  `layers/logits_processor.py`, `model_executor/graph_shared_output.py`, three
+  `model_executor/runner/` files, two speculative draft-extend graph runners, and
+  `true_on_policy/{config,__init__}.py`; sampling admission also changes
+  `sampling/sampling_params.py`, `managers/tokenizer_manager.py`, and
+  `entrypoints/http_server.py`. Paths are relative to `python/sglang/srt/`.
+  The source pin also supplies the unconditional versioned numerical contract,
+  stock RMSNorm dispatch, TP-invariant row operations, and deterministic reduction.
+  Speculative producer coverage is a buffer-contract requirement, not a claim of
+  speculative end-to-end qualification.
+
+## Existing forward evidence and limits
+
+A frozen development snapshot was tested on four H200s on 2026-09-07 with the
+full 36-layer Qwen3-4B, BF16, frozen weights, identity sampling, CUDA graphs through
+batch 8, and prefill chunk size 1,024. Training and rollout offloading were disabled.
+
+| Trainer TP × CP × PP | Rollout TP | Unique response scores | Maximum absolute difference |
+|---|---|---|---|
+| 4 × 1 × 1 | 4 | 1,024 | 0 |
+| 2 × 2 × 1 | 2, two engines | 1,024 | 0 |
+| 1 × 2 × 2 | 4 | 1,024 | 0 |
+
+Each run produced eight responses of 128 tokens. An audit compared original
+HTTP-returned scores with trainer scores, checked complete per-sample CP ownership,
+and avoided double-counting TP replicas. These are selected-token score results,
+not full-vocabulary or all-hidden-state equality. Twenty live HTTP sampling
+contract checks also passed on that snapshot.
+
+**This extracted branch has not been GPU-revalidated.** The earlier snapshot
+included changes outside this draft, so the table is supporting development
+evidence rather than a test result for this PR. Before merge, land/pin the companion
+changes, rerun the full-model forward matrix on the extracted revisions, and review
+backward separately. CP4, other hardware, offloading, and speculative decoding are
+not covered by this full-model matrix.
+
+Local extraction checks: 25 configuration/CP tests passed on Python 3.12. Three
+binding/RoPE test modules were skipped without Torch/Megatron; launcher tests could
+not run without Ray. GPU and sampling integration suites have not run on this
+branch. Python syntax and whitespace checks passed.

--- a/miles_plugins/top/attention.py
+++ b/miles_plugins/top/attention.py
@@ -1,0 +1,136 @@
+"""Attention bound to the rollout's kernel.
+
+No autograd Function needed: FA3's varlen entry point has a backward. Unsupported paths refuse.
+"""
+
+from __future__ import annotations
+
+import torch
+from megatron.core.transformer.enums import AttnMaskType
+from megatron.core.transformer.module import MegatronModule
+from megatron.core.utils import divide
+
+try:
+    from flash_attn_interface import flash_attn_varlen_func as _fa3_varlen
+except ImportError:  # pragma: no cover
+    try:
+        from flash_attn_3.flash_attn_interface import flash_attn_varlen_func as _fa3_varlen
+    except ImportError:
+        _fa3_varlen = None
+
+
+class TopAttention(MegatronModule):
+    """core_attention that runs FA3 varlen -- the kernel the rollout is pinned to."""
+
+    def __init__(self, config, layer_number, attn_mask_type, attention_type,
+                 softmax_scale=None, cp_comm_type=None, model_comm_pgs=None,
+                 pg_collection=None, **kwargs):
+        super().__init__(config=config)
+        if _fa3_varlen is None:
+            raise RuntimeError(
+                "[top] FA3 not importable; the program pins attention to fa3 and the trainer "
+                "cannot honour it. Install flash_attn_interface or change the program."
+            )
+        self.cp_size = config.context_parallel_size
+        if self.cp_size > 1:
+            # CP lives AT this seam: TE handles it inside TEDotProductAttention and megatron's local
+            # DotProductAttention handles it inside its own forward, so nothing above us transposes.
+            # Only Ulysses (a2a) can be bitwise -- ring merges chunks with an online softmax, which
+            # is a different reduction from the rollout's single call. The contract refuses ring, so
+            # by here the comm type is a2a; assert rather than trust.
+            cp_comm_type = cp_comm_type if cp_comm_type is not None else config.cp_comm_type
+            if isinstance(cp_comm_type, (list, tuple)):
+                cp_comm_type = cp_comm_type[layer_number - 1]
+            if cp_comm_type != "a2a":
+                raise NotImplementedError(
+                    f"[top] context parallelism needs cp_comm_type='a2a' (Ulysses); got "
+                    f"{cp_comm_type!r}. Ring/p2p cannot be bitwise against a cp=1 rollout."
+                )
+            from miles_plugins.top.cp_layout import UlyssesCPLayout
+
+            if pg_collection is None:
+                # Compatibility for callers predating Megatron's explicit process groups.
+                from megatron.core import parallel_state
+
+                cp_group = parallel_state.get_context_parallel_group()
+            else:
+                cp_group = pg_collection.cp
+            if cp_group.size() != self.cp_size:
+                raise ValueError("[top] CP process-group size does not match context_parallel_size")
+            self.cp_layout = UlyssesCPLayout(cp_group, self.cp_size)
+        else:
+            self.cp_layout = None
+        self.config = config
+        self.layer_number = max(1, layer_number)
+        self.attn_mask_type = attn_mask_type
+        kv = config.kv_channels
+        self.head_dim = kv
+        self.softmax_scale = softmax_scale if softmax_scale is not None else kv ** -0.5
+        tp = getattr(config, "tensor_model_parallel_size", 1)
+        self.heads_per_partition = divide(config.num_attention_heads, tp)
+
+    def forward(self, query, key, value, attention_mask, attn_mask_type=None,
+                attention_bias=None, packed_seq_params=None, **kwargs):
+        if attention_bias is not None:
+            raise NotImplementedError("[top] attention_bias not supported")
+        mask_type = attn_mask_type or self.attn_mask_type
+        if mask_type not in (None, AttnMaskType.causal):
+            raise NotImplementedError(f"[top] only causal attention; got {mask_type}")
+
+        if self.cp_size > 1 and packed_seq_params is None:
+            raise NotImplementedError(
+                "[top] context parallelism requires packed_seq_params: the CP transforms need the "
+                "GLOBAL cu_seqlens, and the unpacked path derives cu_seqlens from the LOCAL shard "
+                "length, which would silently describe the wrong sequence."
+            )
+
+        if packed_seq_params is not None:
+            cu_q = packed_seq_params.cu_seqlens_q.to(torch.int32)
+            cu_k = packed_seq_params.cu_seqlens_kv.to(torch.int32)
+            max_q = int(packed_seq_params.max_seqlen_q)
+            max_k = int(packed_seq_params.max_seqlen_kv)
+            q, k, v = (t.squeeze(1) if t.dim() == 4 else t for t in (query, key, value))
+        else:
+            s, b, h, d = query.shape
+            sk = key.shape[0]
+            q = query.transpose(0, 1).reshape(b * s, h, d)
+            k = key.transpose(0, 1).reshape(b * sk, key.shape[2], d)
+            v = value.transpose(0, 1).reshape(b * sk, value.shape[2], d)
+            cu_q = torch.arange(0, (b + 1) * s, s, device=query.device, dtype=torch.int32)
+            cu_k = torch.arange(0, (b + 1) * sk, sk, device=query.device, dtype=torch.int32)
+            max_q, max_k = s, sk
+
+        local_tokens, q_heads = q.shape[0], q.shape[-2]
+        if self.cp_size > 1:
+            from miles_plugins.top.cp_layout import replicate_kv_heads_for_cp
+
+            # Under GQA the KV tensors carry num_query_groups heads, which would cap cp at that
+            # count. Replicating lifts the bound to num_q_heads and changes no arithmetic: every
+            # replicated head holds the same values.
+            k = replicate_kv_heads_for_cp(k, self.cp_size)
+            v = replicate_kv_heads_for_cp(v, self.cp_size)
+            q = self.cp_layout.sequence_to_head_parallel(q, cu_q)
+            k = self.cp_layout.sequence_to_head_parallel(k, cu_k)
+            v = self.cp_layout.sequence_to_head_parallel(v, cu_k)
+
+        # num_splits is PINNED, not inherited. sglang pins it to 1 under
+        # enable_deterministic_inference; FA3's library default happens to be 1 too, so the trainer
+        # matches by accident rather than declaration. Under the heuristic (0) a shard's
+        # per-row output can differ from the full call's, so CP would break silently.
+        out = _fa3_varlen(q, k, v, cu_q, cu_k, max_q, max_k,
+                          causal=True, softmax_scale=self.softmax_scale, num_splits=1)
+        if isinstance(out, tuple):
+            out = out[0]
+
+        if self.cp_size > 1:
+            out = self.cp_layout.head_to_sequence_parallel(out, cu_q, local_tokens, q_heads)
+
+        from miles_plugins.top.spec import _canon_dump
+
+        if packed_seq_params is not None:
+            res = out.reshape(out.shape[0], -1)
+        else:
+            s, b = query.shape[0], query.shape[1]
+            res = out.reshape(b, s, -1).transpose(0, 1).contiguous()
+        _canon_dump("top_attn_core_out", res)
+        return res

--- a/miles_plugins/top/cp_layout.py
+++ b/miles_plugins/top/cp_layout.py
@@ -1,0 +1,142 @@
+"""Ulysses CP: transform between megatron's local sequence shards and FA3's head shards.
+
+Two conceptual transforms, implemented as four forward all-to-alls per attention call: one each
+for Q, K, V, and output. The permutations preserve values; replicated KV gradients are summed
+in backward, so this is not a claim of CP1-bitwise gradients. Forward parity also requires FA3's
+per-row output is invariant to how many heads share the call, which is measured in
+`tests/fast-gpu/test_top_attention_shape_invariance.py` (bitwise at cp 2/4/8 with num_splits pinned
+to 1, including the KV-replicated case).
+
+THE CP CEILING IS NOT `num_kv_heads`. Asserting `num_heads % cp_size == 0` here would carry that
+ceiling: under GQA the KV tensors have `num_query_groups` heads, and at tp>1 the bound is
+`num_query_groups / tp`, so a four-group model is capped at cp=1 whenever tp=4. Replicating the KV
+heads lifts it to `num_q_heads / tp` and changes no arithmetic, which is what XoRL does
+(`repeat_kv`, n_repeat = ulysses_size // num_kv_heads).
+"""
+
+from __future__ import annotations
+
+import torch
+from torch import Tensor
+
+from megatron.core.tensor_parallel.mappings import all_to_all
+
+
+def replicate_kv_heads_for_cp(x: Tensor, cp_size: int) -> Tensor:
+    """Repeat KV heads so `cp_size` ranks can each own at least one.
+
+    A no-op when the head count already divides cp_size. Repeats along the head dim so that head
+    group g serves cp ranks [g*n, (g+1)*n) -- matching how FA3 maps a query head to its KV group,
+    so each rank's post-a2a slice still pairs the right q heads with the right kv head.
+    """
+    num_heads = x.shape[-2]
+    if num_heads >= cp_size:
+        return x
+    if cp_size % num_heads != 0:
+        raise ValueError(
+            f"[top] Ulysses CP needs cp_size ({cp_size}) to be a multiple of the KV head count "
+            f"({num_heads}) to replicate; got a remainder. Pick a cp_size that divides or is "
+            f"divisible by the KV head count."
+        )
+    return x.repeat_interleave(cp_size // num_heads, dim=-2)
+
+
+class UlyssesCPLayout:
+    """Sequence-shard <-> head-shard transforms over one CP group."""
+
+    def __init__(self, cp_group, cp_size: int) -> None:
+        self.cp_group = cp_group
+        self.cp_size = cp_size
+
+    def local_packed_lengths(self, cu_seqlens: Tensor, local_tokens: int) -> list[int]:
+        """Per-packed-sequence LOCAL lengths, from the GLOBAL cu_seqlens megatron passes in."""
+        global_lengths = (cu_seqlens[1:] - cu_seqlens[:-1]).tolist()
+        local_lengths = []
+        for length in global_lengths:
+            if length % self.cp_size != 0:
+                raise ValueError(
+                    f"[top] Ulysses CP requires padded sequence lengths divisible by cp_size; "
+                    f"got length={length}, cp_size={self.cp_size}. The collator pads to "
+                    f"2*cp_size for the zigzag layout -- check it ran."
+                )
+            local_lengths.append(length // self.cp_size)
+        if sum(local_lengths) != local_tokens:
+            raise ValueError(
+                f"[top] packed cu_seqlens do not match the local CP shard: "
+                f"sum(local_lengths)={sum(local_lengths)}, local_tokens={local_tokens}. The "
+                f"cu_seqlens handed to attention must be GLOBAL, not per-rank."
+            )
+        return local_lengths
+
+    def sequence_to_head_parallel(self, x: Tensor, cu_seqlens: Tensor) -> Tensor:
+        """local zigzag sequence shard, all heads -> full sequence, head shard."""
+        local_tokens, num_heads, head_dim = x.shape
+        if num_heads % self.cp_size != 0:
+            raise ValueError(
+                f"[top] Ulysses CP needs num_heads ({num_heads}) divisible by cp_size "
+                f"({self.cp_size}); replicate KV heads first via replicate_kv_heads_for_cp."
+            )
+        local_lengths = self.local_packed_lengths(cu_seqlens, local_tokens)
+
+        x = x.reshape(local_tokens, 1, num_heads * head_dim)
+        hidden_per_rank = x.shape[-1] // self.cp_size
+        rank_ordered = torch.cat(
+            torch.split(x.reshape(local_tokens, -1), hidden_per_rank, dim=1), dim=0
+        )
+        rank_ordered = all_to_all(self.cp_group, rank_ordered)
+        rank_ordered = rank_ordered.reshape(local_tokens * self.cp_size, 1, hidden_per_rank)
+
+        # Undo the zigzag: front-half chunks in rank order, back-half in REVERSE rank order, so the
+        # result is in natural token order. FA3 then sees an ordinary full-length sequence.
+        sequential = []
+        for seq_index, local_length in enumerate(local_lengths):
+            if local_length % 2 != 0:
+                raise ValueError(
+                    f"[top] Ulysses CP expects two equal zigzag chunks per rank; got "
+                    f"local_length={local_length}."
+                )
+            chunk = local_length // 2
+            seq_offset = sum(local_lengths[:seq_index])
+            for source_rank in range(self.cp_size):
+                start = source_rank * local_tokens + seq_offset
+                sequential.append(rank_ordered[start : start + chunk])
+            for source_rank in range(self.cp_size - 1, -1, -1):
+                start = source_rank * local_tokens + seq_offset + chunk
+                sequential.append(rank_ordered[start : start + chunk])
+
+        x = torch.cat(sequential, dim=0)
+        return x.view(local_tokens * self.cp_size, num_heads // self.cp_size, head_dim)
+
+    def head_to_sequence_parallel(
+        self, x: Tensor, cu_seqlens: Tensor, local_tokens: int, num_heads: int
+    ) -> Tensor:
+        """full sequence, head shard -> local zigzag sequence shard, all heads."""
+        global_tokens, heads_per_cp_rank, head_dim = x.shape
+        if global_tokens != local_tokens * self.cp_size:
+            raise ValueError(
+                f"[top] unexpected Ulysses global token count: {global_tokens} vs "
+                f"{local_tokens * self.cp_size}"
+            )
+        if heads_per_cp_rank * self.cp_size != num_heads:
+            raise ValueError(
+                f"[top] unexpected Ulysses head shard: {heads_per_cp_rank} * {self.cp_size} "
+                f"!= {num_heads}"
+            )
+        local_lengths = self.local_packed_lengths(cu_seqlens, local_tokens)
+
+        x = x.reshape(global_tokens, 1, heads_per_cp_rank * head_dim)
+        rank_ordered: list[list[Tensor]] = [[] for _ in range(self.cp_size)]
+        seq_start = 0
+        for local_length in local_lengths:
+            chunk = local_length // 2
+            chunks = torch.split(x[seq_start : seq_start + local_length * self.cp_size], chunk, dim=0)
+            assert len(chunks) == 2 * self.cp_size
+            for rank in range(self.cp_size):
+                rank_ordered[rank].append(chunks[rank])
+                rank_ordered[rank].append(chunks[2 * self.cp_size - rank - 1])
+            seq_start += local_length * self.cp_size
+
+        stacked = torch.cat([torch.cat(parts, dim=0) for parts in rank_ordered], dim=0)
+        stacked = all_to_all(self.cp_group, stacked.reshape(global_tokens, -1))
+        output = torch.cat(torch.split(stacked, local_tokens, dim=0), dim=-1)
+        return output.view(local_tokens, num_heads, head_dim)

--- a/miles_plugins/top/install.py
+++ b/miles_plugins/top/install.py
@@ -1,0 +1,45 @@
+"""Patches for ops with no seam. Each one named, guarded, and asserted to have applied."""
+
+from __future__ import annotations
+
+_INSTALLED: dict[str, bool] = {}
+
+
+def install_tree_tp_reduce() -> bool:
+    """Route row-parallel linears' all-reduce through sglang's deterministic tree.
+
+    The reduce is in RowParallelLinear.forward, not _forward_impl, so there is no seam to bind.
+    """
+    if _INSTALLED.get("tree_tp_reduce"):
+        return True
+    from megatron.core.tensor_parallel import layers as _layers
+
+    from miles_plugins.top.ops import tree_reduce_from_tp_region
+
+    if not hasattr(_layers, "reduce_from_tensor_model_parallel_region"):
+        raise RuntimeError("[top] tree-reduce patch: symbol missing; megatron changed shape")
+    _layers.reduce_from_tensor_model_parallel_region = tree_reduce_from_tp_region
+    _INSTALLED["tree_tp_reduce"] = True
+    return True
+
+
+def installed() -> dict[str, bool]:
+    return dict(_INSTALLED)
+
+
+def install_fused_rope() -> bool:
+    """Bind the function SelfAttention actually calls, without replacing its forward."""
+    from megatron.core.models.common.embeddings import rope_utils
+    from megatron.core.transformer import attention
+
+    from miles_plugins.top.rope import apply_fused_rope
+
+    current = getattr(attention, "apply_rotary_pos_emb", None)
+    if current is not apply_fused_rope:
+        if current is None or current is not rope_utils.apply_rotary_pos_emb:
+            raise RuntimeError("[top] fused-RoPE patch: unexpected SelfAttention call site")
+        attention.apply_rotary_pos_emb = apply_fused_rope
+    if attention.apply_rotary_pos_emb is not apply_fused_rope:
+        raise RuntimeError("[top] fused-RoPE patch did not bind SelfAttention")
+    _INSTALLED["fused_rope"] = True
+    return True

--- a/miles_plugins/top/kernels/rms_norm_backward.py
+++ b/miles_plugins/top/kernels/rms_norm_backward.py
@@ -1,0 +1,92 @@
+"""Analytic RMSNorm adjoint with fixed-order, tiled weight-gradient reduction.
+
+Reconstruct the FP32 residual sum from its operands, not the rounded output.
+The weight partials are 1/32 of an activation-sized FP32 temporary; no atomics.
+"""
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _input_grad(X, R, W, DY, DR, DX, INV, H: tl.constexpr, EPS: tl.constexpr,
+                HAS_R: tl.constexpr, HAS_DY: tl.constexpr, HAS_DR: tl.constexpr,
+                BLOCK: tl.constexpr):
+    row = tl.program_id(0)
+    cols = tl.arange(0, BLOCK)
+    mask = cols < H
+    z = tl.load(X + row * H + cols, mask, 0).to(tl.float32)
+    if HAS_R:
+        z += tl.load(R + row * H + cols, mask, 0).to(tl.float32)
+    inv = tl.rsqrt(tl.sum(z * z, 0) / H + EPS)
+    tl.store(INV + row, inv)
+    grad = tl.full((BLOCK,), 0, tl.float32)
+    if HAS_DY:
+        dy = tl.load(DY + row * H + cols, mask, 0).to(tl.float32)
+        w = tl.load(W + cols, mask, 0).to(tl.float32)
+        u = dy * w
+        grad = inv * (u - z * (inv * inv / H) * tl.sum(u * z, 0))
+    if HAS_DR:
+        grad += tl.load(DR + row * H + cols, mask, 0).to(tl.float32)
+    tl.store(DX + row * H + cols, grad, mask)
+
+
+@triton.jit
+def _weight_partials(X, R, DY, INV, PARTIAL, M: tl.constexpr, H: tl.constexpr,
+                     HAS_R: tl.constexpr, ROWS: tl.constexpr, COLS: tl.constexpr):
+    rows = tl.program_id(0) * ROWS + tl.arange(0, ROWS)
+    cols = tl.program_id(1) * COLS + tl.arange(0, COLS)
+    offsets = rows[:, None] * H + cols[None, :]
+    mask = (rows[:, None] < M) & (cols[None, :] < H)
+    z = tl.load(X + offsets, mask, 0).to(tl.float32)
+    if HAS_R:
+        z += tl.load(R + offsets, mask, 0).to(tl.float32)
+    dy = tl.load(DY + offsets, mask, 0).to(tl.float32)
+    inv = tl.load(INV + rows, rows < M, 0)
+    dw = tl.sum(dy * z * inv[:, None], axis=0)
+    tl.store(PARTIAL + tl.program_id(0) * H + cols, dw, cols < H)
+
+
+@triton.jit
+def _weight_reduce(PARTIAL, DW, H: tl.constexpr, N: tl.constexpr,
+                   BLOCK_N: tl.constexpr, COLS: tl.constexpr):
+    rows = tl.arange(0, BLOCK_N)
+    cols = tl.program_id(0) * COLS + tl.arange(0, COLS)
+    acc = tl.full((BLOCK_N, COLS), 0, tl.float32)
+    for start in range(tl.cdiv(N, BLOCK_N)):
+        r = rows + start * BLOCK_N
+        acc += tl.load(PARTIAL + r[:, None] * H + cols[None, :],
+                       (r[:, None] < N) & (cols[None, :] < H), 0)
+    tl.store(DW + cols, tl.sum(acc, axis=0), cols < H)
+
+
+def rms_norm_backward(x, weight, eps, grad_output, *, residual=None, grad_residual=None):
+    """Return dx, dr, dw using the usual floating-point analytic adjoint."""
+    x = x.contiguous()
+    residual = residual.contiguous() if residual is not None else None
+    dy = grad_output.contiguous() if grad_output is not None else None
+    dr = grad_residual.contiguous() if grad_residual is not None else None
+    h = x.shape[-1]
+    rows = x.numel() // h
+    dx = torch.empty_like(x)
+    dw = torch.zeros_like(weight)
+    if rows == 0:
+        return dx, dx if residual is not None else None, dw
+    inv = torch.empty(rows, device=x.device, dtype=torch.float32)
+    _input_grad[(rows,)](
+        x, residual, weight, dy, dr, dx, inv, h, eps,
+        residual is not None, dy is not None, dr is not None,
+        triton.next_power_of_2(h), enable_fp_fusion=False,
+    )
+    if dy is not None:
+        groups = triton.cdiv(rows, 32)
+        partial = torch.empty((groups, h), device=x.device, dtype=torch.float32)
+        _weight_partials[(groups, triton.cdiv(h, 128))](
+            x, residual, dy, inv, partial, rows, h, residual is not None,
+            32, 128, enable_fp_fusion=False,
+        )
+        _weight_reduce[(triton.cdiv(h, 32),)](
+            partial, dw, h, groups, min(triton.next_power_of_2(groups), 256), 32,
+        )
+    return dx, dx if residual is not None else None, dw

--- a/miles_plugins/top/ops.py
+++ b/miles_plugins/top/ops.py
@@ -1,0 +1,88 @@
+"""Delegating ops: the trainer runs the rollout's op object, with an analytic backward.
+
+Backwards are analytic, never recompute-then-autograd; the rollout has no backward to match.
+"""
+
+from __future__ import annotations
+
+import sglang.srt.tp_invariant_ops as _tp
+import torch
+
+
+class _DelegatedRMSNorm(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, weight, eps, sgl_module):
+        out = sgl_module(x)
+        if isinstance(out, tuple):
+            out = out[0]
+        ctx.save_for_backward(x, weight)
+        ctx.eps = eps
+        return out
+
+    @staticmethod
+    def backward(ctx, grad_out):
+        x, w = ctx.saved_tensors
+        xf, gf, wf = x.float(), grad_out.float(), w.float()
+        h = xf.shape[-1]
+        r = torch.rsqrt(xf.pow(2).mean(dim=-1, keepdim=True) + ctx.eps)
+        gw = gf * wf
+        grad_x = r * gw - (r.pow(3) * xf / h) * (gw * xf).sum(dim=-1, keepdim=True)
+        grad_w = (gf * xf * r).reshape(-1, h).sum(dim=0)
+        return grad_x.to(x.dtype), grad_w.to(w.dtype), None, None
+
+
+def delegated_rms_norm(x, sgl_module, eps):
+    return _DelegatedRMSNorm.apply(x, sgl_module.weight, eps, sgl_module)
+
+
+class _DelegatedTpInvMatmul(torch.autograd.Function):
+    """sglang's TP-invariant matmul. Degree-invariant, so used at every tp including 1."""
+
+    @staticmethod
+    def forward(ctx, x_2d, weight, bias):
+        ctx.save_for_backward(x_2d, weight)
+        ctx.has_bias = bias is not None
+        return _tp.matmul_tp_inv(x_2d, weight.t(), bias=bias)
+
+    @staticmethod
+    def backward(ctx, grad_out):
+        x_2d, weight = ctx.saved_tensors
+        grad_x = grad_out @ weight
+        grad_w = grad_out.t() @ x_2d
+        grad_b = grad_out.sum(dim=0) if ctx.has_bias else None
+
+        # megatron's wgrad-fusion protocol: accumulate into main_grad, return None
+        main_grad = getattr(weight, "main_grad", None)
+        if main_grad is not None:
+            main_grad.add_(grad_w.to(main_grad.dtype))
+            if hasattr(weight, "grad_added_to_main_grad"):
+                weight.grad_added_to_main_grad = True
+            grad_w = None
+        return grad_x, grad_w, grad_b
+
+
+def delegated_tp_inv_linear(x_2d, weight, bias=None):
+    return _DelegatedTpInvMatmul.apply(x_2d, weight, bias)
+
+
+class _TreeReduceFromTPRegion(torch.autograd.Function):
+    """Deterministic TP all-reduce: all-gather the partials, reduce with a fixed local tree.
+
+    An ordinary all-reduce has no counterpart in a tp=1 rollout, which computes the whole sum in
+    one GEMM -- so its order shows up as a divergence on every row linear. Backward is identity,
+    matching megatron's _ReduceFromModelParallelRegion.
+    """
+
+    @staticmethod
+    def forward(ctx, x, group):
+        if group is None or group.size() == 1:
+            return x
+        return _tp.tree_all_reduce_sum(x.contiguous(), device_group=group)
+
+    @staticmethod
+    def backward(ctx, grad_out):
+        return grad_out, None
+
+
+def tree_reduce_from_tp_region(x, group=None):
+    return _TreeReduceFromTPRegion.apply(x, group)

--- a/miles_plugins/top/program.py
+++ b/miles_plugins/top/program.py
@@ -1,0 +1,60 @@
+"""The numerical program, as data. One declaration per model family; both engines resolve from it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Literal
+
+import torch
+
+
+# delegate      trainer runs the rollout's op object
+# match         selected fused implementations agree; no delegated forward is needed
+# batch_invariant  both engines use a batch-invariant reduction proven to agree
+# match_native  they agree only once megatron's conflicting fused path is disabled; the rollout
+#               may still run its own fused kernel
+Verb = Literal["delegate", "match", "batch_invariant", "match_native"]
+
+
+@dataclass(frozen=True)
+class NormParams:
+    """Parameters of sglang's RMSNorm expression."""
+
+    weight_dtype: torch.dtype | None = None
+    override_orig_dtype: torch.dtype | None = None
+    fp32_residual: bool = False
+
+
+@dataclass(frozen=True)
+class Program:
+    name: str
+    norm: dict[str, NormParams] = field(default_factory=dict)
+    ops: dict[str, Verb] = field(default_factory=dict)
+
+
+# bf16 stream, fp32 internal -- what both engines run by default
+QWEN3_DENSE_V1 = Program(
+    name="qwen3-dense/v1",
+    norm={r: NormParams() for r in (
+        "input_layernorm", "pre_mlp_layernorm", "final_layernorm",
+        "q_layernorm", "k_layernorm",
+    )},
+    ops={
+        "norm": "delegate",
+        "row_linear": "delegate",
+        "attention": "delegate",
+        "matmul": "batch_invariant",  # validated for the qualified shapes and runtime
+        "activation": "match_native",
+        "rope": "match",
+    },
+)
+
+
+_BY_NAME = {QWEN3_DENSE_V1.name: QWEN3_DENSE_V1}
+
+def get_program(name: str) -> Program:
+    try:
+        return _BY_NAME[name]
+    except KeyError:
+        raise ValueError(f"[top] unknown program {name!r}; known: {sorted(_BY_NAME)}") from None

--- a/miles_plugins/top/residual_norm.py
+++ b/miles_plugins/top/residual_norm.py
@@ -1,0 +1,89 @@
+"""Stock SGLang residual norm at Megatron's existing norm and BDA seams.
+
+Between seams, [branch, residual] is packed along the last dimension. This is
+transport, not addition: checkpointing and PP see one tensor with both gradient
+paths. Norm returns the ordinary activation/residual pair the layer accepts.
+"""
+
+import torch
+from megatron.core.transformer.transformer_layer import TransformerLayer
+
+from miles_plugins.top.kernels.rms_norm_backward import rms_norm_backward
+
+
+class ResidualTransformerLayer(TransformerLayer):
+    """Keep Megatron's forward; declare the first layer's unique unpaired input."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.input_layernorm.requires_residual_pair = self.layer_number != 1
+
+
+class _StockResidualNorm(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, residual, weight, norm):
+        ctx.set_materialize_grads(False)
+        ctx.save_for_backward(x, residual, weight)
+        ctx.eps = norm.variance_epsilon
+        # The inference kernel mutates both buffers. Never mutate Megatron's
+        # tensors or the operands saved for backward/recomputation.
+        return norm(
+            x.clone(memory_format=torch.contiguous_format),
+            residual.clone(memory_format=torch.contiguous_format),
+        )
+
+    @staticmethod
+    def backward(ctx, grad_output, grad_residual):
+        x, residual, weight = ctx.saved_tensors
+        dx, dr, dw = rms_norm_backward(
+            x, weight, ctx.eps, grad_output,
+            residual=residual, grad_residual=grad_residual,
+        )
+        return dx, dr, dw, None
+
+
+def delegated_residual_norm(x, residual, norm):
+    """BF16 implementation; quantized output requires a separately admitted recipe."""
+    if x.shape != residual.shape or x.dtype != residual.dtype:
+        raise ValueError("[top] residual norm requires equal-shaped, equal-dtype inputs")
+    if x.dtype != torch.bfloat16 or norm.weight.dtype != x.dtype or not x.is_cuda:
+        raise NotImplementedError("[top] stock residual norm currently requires CUDA BF16")
+    if norm.cast_x_before_out_mul or norm.override_orig_dtype is not None:
+        raise NotImplementedError("[top] residual norm requires stock SGLang rounding")
+    return _StockResidualNorm.apply(x, residual, norm.weight, norm)
+
+
+def deferred_residual_add(training, fused):
+    """BDA builder: retain operands instead of prematurely rounding their sum."""
+    return _pack_residual
+
+
+def _pack_residual(output_with_bias, residual, probability):
+    x, bias = output_with_bias
+    if bias is not None or probability != 0:
+        raise NotImplementedError("[top] deferred residual add requires no bias and zero dropout")
+    if x.shape != residual.shape or x.dtype != residual.dtype:
+        raise ValueError("[top] residual operands must have identical shape and dtype")
+    return torch.cat((x, residual), dim=-1)
+
+
+def validate_residual_config(config, *, use_te):
+    """Reject unsupported execution paths before constructing model parameters."""
+    unsupported = {
+        "transformer_engine spec": use_te,
+        "FP8 (recipe not yet admitted)": bool(getattr(config, "fp8", None)),
+        "FP4": bool(getattr(config, "fp4", None)),
+        "FP32 residual": config.fp32_residual_connection,
+        "hidden dropout": config.hidden_dropout != 0,
+        "linear bias": config.add_bias_linear,
+        "hyper connections": getattr(config, "enable_hyper_connections", False),
+        "CPU offload": getattr(config, "cpu_offloading", False),
+        "MTP": bool(getattr(config, "mtp_num_layers", None)),
+        "fused TP inference": getattr(config, "inference_fuse_tp_communication", False),
+    }
+    rejected = [name for name, enabled in unsupported.items() if enabled]
+    if rejected:
+        raise NotImplementedError("[top] stock residual norm does not support: " + ", ".join(rejected))
+    if not hasattr(config, "pipeline_hidden_size"):
+        raise RuntimeError("[top] Megatron needs pipeline_hidden_size support for residual transport")
+    config.pipeline_hidden_size = 2 * config.hidden_size

--- a/miles_plugins/top/rope.py
+++ b/miles_plugins/top/rope.py
@@ -1,0 +1,58 @@
+"""Fused-only RoPE at Megatron SelfAttention's existing function seam."""
+
+
+def enforce_fused_rope(args, config):
+    from megatron.core.extensions import transformer_engine as te
+
+    from miles_plugins.top.install import install_fused_rope
+
+    if getattr(config, "mrope_section", None) is not None:
+        raise NotImplementedError("[top] matched fused RoPE does not admit mRoPE")
+    if getattr(config, "fused_single_qkv_rope", False):
+        raise NotImplementedError("[top] matched RoPE requires the separate TE fused RoPE call")
+    for name in ("fused_apply_rotary_pos_emb", "fused_apply_rotary_pos_emb_thd"):
+        if not callable(getattr(te, name, None)):
+            raise RuntimeError(f"[top] required TE fused RoPE implementation is unavailable: {name}")
+    config.apply_rope_fusion = True
+    args.apply_rope_fusion = True
+    install_fused_rope()
+
+
+def apply_fused_rope(
+    t,
+    freqs,
+    config,
+    cu_seqlens=None,
+    mscale=1.0,
+    cp_group=None,
+    mla_rotary_interleaved=False,
+    inverse=False,
+    mla_output_remove_interleaving=False,
+    max_seqlen=None,
+):
+    """Keep the stock SBHD/THD and CP mapping, but never enter unfused dispatch."""
+    if not config.apply_rope_fusion:
+        raise RuntimeError("[top] fused RoPE was disabled after TOP construction")
+    if (
+        getattr(config, "mrope_section", None) is not None
+        or mscale != 1.0
+        or mla_rotary_interleaved
+        or (mla_rotary_interleaved is None and config.multi_latent_attention)
+        or inverse
+        or mla_output_remove_interleaving
+    ):
+        raise NotImplementedError("[top] requested RoPE expression is not supported by the matched TE fused path")
+    from megatron.core.extensions import transformer_engine as te
+
+    if cu_seqlens is None:
+        return te.fused_apply_rotary_pos_emb(t, freqs, interleaved=config.rotary_interleaved)
+    if cp_group is None:
+        raise RuntimeError("[top] packed fused RoPE requires the caller's CP group")
+    return te.fused_apply_rotary_pos_emb_thd(
+        t,
+        cu_seqlens,
+        freqs,
+        cp_size=cp_group.size(),
+        cp_rank=cp_group.rank(),
+        interleaved=config.rotary_interleaved,
+    )

--- a/miles_plugins/top/spec.py
+++ b/miles_plugins/top/spec.py
@@ -1,0 +1,359 @@
+"""Build a Megatron spec, then bind declared roles onto the program."""
+
+from __future__ import annotations
+
+import functools
+
+import torch
+from megatron.core.transformer.spec_utils import ModuleSpec
+
+from sglang.srt.true_on_policy import should_use_tp_invariant_row_linear
+
+from miles_plugins.top.ops import delegated_rms_norm, delegated_tp_inv_linear
+
+try:
+    from sglang.srt.debug_utils.dumper import dumper as _dumper
+except Exception:  # the dumper is optional; never fail a run over instrumentation
+    _dumper = None
+from miles.true_on_policy.schema import TRUE_ON_POLICY_V1_SCHEMA
+from miles_plugins.top.install import installed as _installed
+from miles_plugins.top.program import QWEN3_DENSE_V1, NormParams
+
+_ACTIVE_PROGRAM = None
+
+
+def active_program():
+    """The program this run resolved to, for code outside the spec that must ask what is declared.
+
+    Model plugins consult this rather than sniffing flags: whether an op is delegated is a property
+    of the declared program, not something to infer from --transformer-impl or a contract name.
+    Returns None before the spec is built (a non-true-on-policy run never sets it).
+    """
+    return _ACTIVE_PROGRAM
+
+
+def _canon_dump(name: str, value) -> None:
+    """Dump under a name shared with sglang's side."""
+    if _dumper is None:
+        return
+    try:
+        _dumper.dump(name, value)
+    except Exception:
+        pass
+
+_NORM_ROLES = (
+    "input_layernorm",
+    "pre_mlp_layernorm",
+    "q_layernorm",
+    "k_layernorm",
+)
+_ROW_LINEAR_ROLES = ("linear_proj", "linear_fc2")
+_ATTENTION_ROLES = ("core_attention",)
+
+
+class TopRMSNorm(torch.nn.Module):
+    """RMSNorm delegating to sglang's dispatch; role differences come from the program."""
+
+    def __init__(self, config, hidden_size, eps=1e-6, role="", **kwargs):
+        super().__init__()
+        from sglang.srt.layers.layernorm import RMSNorm
+
+        p = _ACTIVE_PROGRAM.norm.get(role, NormParams()) if _ACTIVE_PROGRAM else NormParams()
+        self.eps, self.role = eps, role
+        self.hidden_size = hidden_size
+        self.requires_residual_pair = role != "input_layernorm"
+        self._packed_residual = role in ("input_layernorm", "pre_mlp_layernorm", "final_layernorm")
+        if self._packed_residual and getattr(config, "pipeline_hidden_size", None) != 2 * config.hidden_size:
+            raise RuntimeError(f"[top] {role} requires packed residual transport (pipeline_hidden_size=2H)")
+        self._want_fp32_weight = p.weight_dtype is torch.float32
+        sgl = RMSNorm(
+            hidden_size,
+            eps=eps,
+            true_on_policy_weight_dtype=p.weight_dtype,
+            true_on_policy_override_orig_dtype=p.override_orig_dtype,
+            true_on_policy_fp32_residual=p.fp32_residual,
+        )
+        # not a submodule: registering it too would put one tensor under two state_dict keys
+        object.__setattr__(self, "_sgl", sgl)
+        self.weight = sgl.weight
+
+    def _apply(self, fn):
+        # --bf16 casts every parameter; re-float if the program declares fp32
+        super()._apply(fn)
+        if self._want_fp32_weight:
+            self.weight.data = self.weight.data.float()
+            if self.weight.grad is not None:
+                self.weight.grad.data = self.weight.grad.data.float()
+        return self
+
+    def forward(self, x, residual=None, post_residual_addition=None):
+        if self._packed_residual:
+            from miles_plugins.top.residual_norm import delegated_residual_norm
+
+            if residual is not None or post_residual_addition is not None:
+                raise ValueError("[top] packed norm cannot also receive a separate residual")
+            if x.shape[-1] == 2 * self.hidden_size:
+                shape = (*x.shape[:-1], self.hidden_size)
+                branch, residual = x.split(self.hidden_size, dim=-1)
+                out, residual = delegated_residual_norm(
+                    branch.reshape(-1, self.hidden_size),
+                    residual.reshape(-1, self.hidden_size), self._sgl,
+                )
+                out, residual = out.view(shape), residual.view(shape)
+                if self.role == "input_layernorm":
+                    _canon_dump("top_attn_norm_out", out)
+                return out if self.role == "final_layernorm" else (out, residual)
+            if x.shape[-1] != self.hidden_size or self.requires_residual_pair:
+                raise ValueError(f"[top] {self.role} expected a packed residual pair")
+        if residual is not None or post_residual_addition is not None:
+            raise NotImplementedError("[top] standalone norm roles do not take a residual")
+        # sglang's forward_cuda flattens rank>2 without restoring it
+        shape = x.shape
+        flat = x.reshape(-1, shape[-1]) if x.dim() != 2 else x
+        out = delegated_rms_norm(flat, self._sgl, self.eps).view(shape)
+        if self.role == "input_layernorm":
+            _canon_dump("top_attn_norm_out", out)
+        return out
+
+
+class TopRowParallelLinear:
+    """Row-parallel linear whose GEMM is sglang's TP-invariant matmul."""
+
+    _cls = None
+
+    def __new__(cls, *args, **kwargs):
+        return cls._build()(*args, **kwargs)
+
+    @classmethod
+    def _build(cls):
+        if cls._cls is not None:
+            return cls._cls
+        from megatron.core.tensor_parallel.layers import RowParallelLinear
+
+        class _Impl(RowParallelLinear):
+            def __init__(self, *args, role="", **kwargs):
+                self._top_role = role
+                super().__init__(*args, **kwargs)
+
+            def forward(self, *args, **kwargs):
+                out = super().forward(*args, **kwargs)
+                # post-reduce, matching sglang's dump point (not the per-rank partial)
+                if self._top_role == "linear_proj":
+                    _canon_dump("top_attn_out", out[0] if isinstance(out, tuple) else out)
+                return out
+
+            def _forward_impl(self, input, weight, *args, **kwargs):
+                bias = kwargs.pop("bias", None)
+                if kwargs.get("sequence_parallel"):
+                    raise NotImplementedError("[top] delegated row linear + sequence parallel")
+                shape = input.shape
+                x2d = input.reshape(-1, shape[-1])
+                if not should_use_tp_invariant_row_linear(x2d.shape[-1]):
+                    return super()._forward_impl(input, weight, *args, bias=bias, **kwargs)
+                out = delegated_tp_inv_linear(x2d, weight, bias)
+                return out.view(*shape[:-1], out.shape[-1])
+
+        cls._cls = _Impl
+        _Impl.__name__ = "TopRowParallelLinear"
+        return _Impl
+
+
+def _bind_roles(node, roles, cls, stamp, as_spec_param=False):
+    """Bind declared roles by field name."""
+    from megatron.core.transformer.identity_op import IdentityOp
+
+    if isinstance(node, ModuleSpec):
+        if node.submodules is not None:
+            _bind_roles(node.submodules, roles, cls, stamp, as_spec_param)
+        return
+    if not hasattr(node, "__dataclass_fields__"):
+        return
+    for f in node.__dataclass_fields__:
+        v = getattr(node, f)
+        if f in roles:
+            if v is IdentityOp or v is None:
+                continue
+            stamp.append((f, getattr(v, "__name__", str(v)), cls.__name__))
+            setattr(node, f, ModuleSpec(module=cls, params={"role": f}) if as_spec_param else cls)
+        elif isinstance(v, ModuleSpec) or hasattr(v, "__dataclass_fields__"):
+            _bind_roles(v, roles, cls, stamp, as_spec_param)
+        elif isinstance(v, functools.partial):
+            for sub in v.keywords.values():
+                if hasattr(sub, "__dataclass_fields__"):
+                    _bind_roles(sub, roles, cls, stamp, as_spec_param)
+
+
+def _bind_residual_layer(spec: ModuleSpec, stamp: list[tuple[str, str, str]]) -> None:
+    """Bind the one paired add+norm path without replacing family-specific submodules."""
+    from megatron.core.transformer.transformer_layer import TransformerLayer
+
+    from miles_plugins.top.residual_norm import ResidualTransformerLayer, deferred_residual_add
+
+    if spec.module not in (TransformerLayer, ResidualTransformerLayer):
+        raise NotImplementedError(f"[top] residual binding requires stock TransformerLayer, found {spec.module!r}")
+    _bind_roles(spec, _NORM_ROLES, TopRMSNorm, stamp, as_spec_param=True)
+    for role in ("input_layernorm", "pre_mlp_layernorm"):
+        norm = getattr(spec.submodules, role, None)
+        if not isinstance(norm, ModuleSpec) or norm.module is not TopRMSNorm:
+            raise NotImplementedError(f"[top] paired residual layer requires an exposed {role}")
+    spec.module = ResidualTransformerLayer
+    spec.submodules.self_attn_bda = deferred_residual_add
+    spec.submodules.mlp_bda = deferred_residual_add
+    stamp.append(("residual_add", "BF16 add", "packed branch/residual -> stock fused norm"))
+
+
+def _existing_server_args():
+    try:
+        from sglang.srt.server_args import get_global_server_args
+
+        return get_global_server_args()
+    except Exception:
+        return None
+
+
+def _pin_sglang(args) -> str:
+    """Pin the trainer's sglang ops to the rollout's program (dispatch is process-global)."""
+    from sglang.srt.server_args import ServerArgs, set_global_server_args_for_scheduler
+
+    contract = getattr(args, "true_on_policy_contract", None) or TRUE_ON_POLICY_V1_SCHEMA.name
+    existing = _existing_server_args()
+    if existing is not None:
+        found = getattr(existing, "true_on_policy_contract", None)
+        if found != contract:
+            raise RuntimeError(
+                f"[top] sglang already pinned to {found!r}, program wants {contract!r}"
+            )
+        return contract
+    # no tp_size: the program must not vary with topology
+    set_global_server_args_for_scheduler(
+        ServerArgs(model_path=args.hf_checkpoint, enable_deterministic_inference=True,
+                   true_on_policy_contract=contract)
+    )
+    return contract
+
+
+def _enable_batch_invariant(program) -> bool:
+    """Enable megatron's BIK; miles never calls initialize_megatron, so the flag alone is inert."""
+    if program.ops.get("matmul") != "batch_invariant":
+        return False
+    from megatron.core.transformer.custom_layers.batch_invariant_kernels import (
+        enable_batch_invariant_mode,
+        is_batch_invariant_mode_enabled,
+    )
+
+    if not is_batch_invariant_mode_enabled():
+        enable_batch_invariant_mode()
+    return is_batch_invariant_mode_enabled()
+
+
+def _resolved_policy() -> str:
+    """What the kernels dispatch to; a contract name only says what was requested."""
+    try:
+        from sglang.srt.true_on_policy.contracts import resolve_true_on_policy_runtime_policy
+
+        sa = _existing_server_args()
+        p = resolve_true_on_policy_runtime_policy(sa)
+        return (f"tp_size={getattr(sa, 'tp_size', None)} "
+                f"row_linear_inv={p.tp_invariant_row_linear} "
+                f"tree_all_reduce={p.deterministic_tree_all_reduce}")
+    except Exception as e:  # a stamp must never break a run
+        return f"unresolved({type(e).__name__})"
+
+
+def _stamp(args, config, contract, bik, binds) -> None:
+    if torch.distributed.is_initialized() and torch.distributed.get_rank() != 0:
+        return
+    print(f"[top] program={_ACTIVE_PROGRAM.name} sglang_pinned={contract} "
+          f"transformer_impl={getattr(args, 'transformer_impl', None)} "
+          f"tp={config.tensor_model_parallel_size} batch_invariant_applied={bik} "
+          f"installed={_installed()} {_resolved_policy()}", flush=True)
+    for role, was, now in binds:
+        print(f"[top] bind {role}: {was} -> {now}", flush=True)
+
+
+def _hf_model_type(args) -> str | None:
+    """Read the actual model family from the checkpoint configuration."""
+    ckpt = getattr(args, "hf_checkpoint", None)
+    if not ckpt:
+        return None
+    from miles.utils.hf_config import load_hf_config
+
+    return getattr(load_hf_config(ckpt), "model_type", None)
+
+
+def _validate_parallel_scope(args, config) -> None:
+    """Refuse an unsupported topology once, before the model is built.
+
+    The delegated row linear has no sequence-parallel implementation, and the per-call refusal in
+    `_forward_impl` fires mid-forward -- after construction, after the checkpoint load, after the
+    rollout has started. `config.sequence_parallel` is known here, so the same refusal costs
+    seconds instead of minutes and names the flag rather than a kernel argument.
+
+    The per-call check stays: this one reads the config, that one reads what megatron actually
+    passed, and they can disagree.
+    """
+    if getattr(config, "sequence_parallel", False):
+        raise NotImplementedError(
+            "[top] sequence parallelism is not a declared program: the delegated row linear has "
+            "no sequence-parallel implementation. Drop --sequence-parallel."
+        )
+
+
+def get_top_spec(args, config, vp_stage):
+    """--spec entry point."""
+    global _ACTIVE_PROGRAM
+    from megatron.core.models.gpt.gpt_layer_specs import get_gpt_layer_local_spec
+    from megatron.core.transformer.transformer_block import (
+        TransformerBlockSubmodules,
+        get_num_layers_to_build,
+    )
+
+    _validate_parallel_scope(args, config)
+    contract = _pin_sglang(args)
+    from miles_plugins.top.residual_norm import validate_residual_config
+
+    use_te = getattr(args, "transformer_impl", "local") == "transformer_engine"
+    validate_residual_config(config, use_te=use_te)
+    if getattr(args, "num_experts", None) or _hf_model_type(args) != "qwen3":
+        raise NotImplementedError("[top] this program supports Qwen3 dense only")
+    _ACTIVE_PROGRAM = QWEN3_DENSE_V1
+
+    from miles_plugins.top.rope import enforce_fused_rope
+
+    enforce_fused_rope(args, config)
+
+    spec = get_gpt_layer_local_spec(
+        num_experts=args.num_experts,
+        moe_grouped_gemm=args.moe_grouped_gemm,
+        qk_layernorm=args.qk_layernorm,
+        multi_latent_attention=args.multi_latent_attention,
+        normalization=args.normalization,
+        use_kitchen=config.use_kitchen,
+        use_kitchen_attention=config.use_kitchen_attention,
+        kitchen_attention_backend=config.kitchen_attention_backend,
+    )
+
+    stamp: list[tuple[str, str, str]] = [("rope", "configurable dispatch", "TE fused only (enforced)")]
+    _bind_residual_layer(spec, stamp)
+    _bind_roles(spec, _ROW_LINEAR_ROLES, TopRowParallelLinear._build(), stamp, as_spec_param=True)
+    if _ACTIVE_PROGRAM.ops.get("attention") == "delegate":
+        from miles_plugins.top.attention import TopAttention
+
+        _bind_roles(spec, _ATTENTION_ROLES, TopAttention, stamp)
+    bik = _enable_batch_invariant(_ACTIVE_PROGRAM)
+
+    from miles_plugins.top.install import install_tree_tp_reduce
+
+    install_tree_tp_reduce()
+
+    if not stamp:
+        raise RuntimeError("[top] no declared role found in the spec")
+
+    block = TransformerBlockSubmodules(
+        layer_specs=[spec] * get_num_layers_to_build(config, vp_stage=vp_stage),
+        layer_norm=ModuleSpec(module=TopRMSNorm, params={"role": "final_layernorm"}),
+    )
+    stamp.append(("final_layernorm", "LayerNormImpl", TopRMSNorm.__name__))
+
+    _stamp(args, config, contract, bik, stamp)
+    return block

--- a/tests/e2e/fsdp/test_qwen3_4B_fsdp_true_on_policy.py
+++ b/tests/e2e/fsdp/test_qwen3_4B_fsdp_true_on_policy.py
@@ -75,7 +75,7 @@ def execute():
         "--sglang-decode-log-interval 1000 "
         "--sglang-enable-metrics "
         "--sglang-enable-deterministic-inference "
-        "--sglang-true-on-policy-contract qwen3_dense_true_on_policy_v1 "
+        "--sglang-true-on-policy-contract true_on_policy_v1 "
         "--sglang-attention-backend fa3 "
         "--attn-implementation flash_attention_3 "
         "--deterministic-mode "

--- a/tests/fast-gpu/test_top_fused_rope_gpu.py
+++ b/tests/fast-gpu/test_top_fused_rope_gpu.py
@@ -1,0 +1,52 @@
+"""Qwen's enforced SelfAttention RoPE seam matches stock SGLang CUDA."""
+
+from types import SimpleNamespace
+
+import pytest
+
+torch = pytest.importorskip("torch")
+pytest.importorskip("sglang")
+pytest.importorskip("megatron.core")
+if not torch.cuda.is_available():
+    pytest.skip("needs a GPU", allow_module_level=True)
+
+from megatron.core.transformer import attention
+from sglang.kernels.ops.attention.rope import apply_rope_with_cos_sin_cache_inplace
+
+from miles_plugins.top.rope import enforce_fused_rope
+
+
+@pytest.mark.parametrize("packed", [False, True])
+@pytest.mark.parametrize("width", [64, 128])
+@pytest.mark.parametrize("rows", [1, 33, 201])
+def test_enforced_rope_is_exact(packed, width, rows, monkeypatch):
+    from miles_plugins.top import install
+
+    monkeypatch.setattr(attention, "apply_rotary_pos_emb", attention.apply_rotary_pos_emb)
+    monkeypatch.setattr(install, "_INSTALLED", {})
+    config = SimpleNamespace(apply_rope_fusion=False, rotary_interleaved=False, mrope_section=None)
+    enforce_fused_rope(SimpleNamespace(), config)
+    torch.manual_seed(71)
+    x = torch.randn(rows, 4, width, device="cuda", dtype=torch.bfloat16, requires_grad=True)
+    positions = torch.arange(rows, device="cuda")
+    inv_freq = (1.0 / (1000000 ** (torch.arange(0, width, 2).float() / width))).cuda()
+    angles = torch.outer(positions.float(), inv_freq)
+    freqs = torch.cat((angles, angles), dim=-1)[:, None, None, :]
+    cache = torch.cat((angles.cos(), angles.sin()), dim=-1)
+    cu = torch.tensor([0, rows], device="cuda", dtype=torch.int32) if packed else None
+    group = SimpleNamespace(size=lambda: 1, rank=lambda: 0)
+    got = attention.apply_rotary_pos_emb(
+        x if packed else x.unsqueeze(1), freqs, config, cu_seqlens=cu, cp_group=group
+    ).reshape_as(x)
+    rollout = x.detach().clone()
+    key = torch.randn(rows, 1, width, device="cuda", dtype=torch.bfloat16)
+    apply_rope_with_cos_sin_cache_inplace(rollout, key, cache, positions, is_neox=True)
+    assert torch.equal(got, rollout)
+    seed = torch.randn_like(got)
+    got.backward(seed)
+    reference = x.detach().double().requires_grad_(True)
+    cos, sin = cache.double().chunk(2, dim=-1)
+    even, odd = reference.chunk(2, dim=-1)
+    output = torch.cat((even * cos[:, None] - odd * sin[:, None], even * sin[:, None] + odd * cos[:, None]), dim=-1)
+    output.backward(seed.double())
+    torch.testing.assert_close(x.grad.double(), reference.grad, rtol=0.005, atol=0.002)

--- a/tests/fast-gpu/test_top_kernel_premises.py
+++ b/tests/fast-gpu/test_top_kernel_premises.py
@@ -1,0 +1,132 @@
+"""The kernel-level premises true-on-policy parity rests on.
+
+Each of these can break SILENTLY: the run still succeeds, the metric just moves off zero. They are
+not regression tests for fixed bugs -- they are the assumptions that make the delegation valid.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+torch = pytest.importorskip("torch")
+pytest.importorskip("sglang")
+
+if not torch.cuda.is_available():
+    pytest.skip("needs a GPU", allow_module_level=True)
+
+H = 2560
+EPS = 1e-6
+
+
+@pytest.fixture
+def sgl_norm(monkeypatch):
+    from sglang.srt.layers import layernorm
+    from sglang.srt.true_on_policy import config
+
+    monkeypatch.setattr(
+        config,
+        "_get_global_server_args",
+        lambda: SimpleNamespace(true_on_policy_contract="true_on_policy_v1"),
+    )
+
+    def refuse_fallback(*args, **kwargs):
+        raise AssertionError("TOP norm must use stock fused dispatch")
+
+    monkeypatch.setattr(layernorm.RMSNorm, "forward_native", refuse_fallback)
+    monkeypatch.setattr(layernorm, "rms_norm_batch_invariant", refuse_fallback)
+    n = layernorm.RMSNorm(H, eps=EPS).cuda().to(torch.bfloat16)
+    with torch.no_grad():
+        n.weight.copy_(torch.randn(H, device="cuda", dtype=torch.bfloat16) * 0.1 + 1.0)
+    return n
+
+
+def _out(v):
+    return v[0] if isinstance(v, tuple) else v
+
+
+@pytest.mark.parametrize("paired", [False, True])
+def test_both_engines_resolve_the_same_norm(sgl_norm, paired):
+    """The trainer has sglang's batch-invariant mode off and the rollout has it on. Under the
+    contract both must still reach the SAME kernel -- that is what makes the delegation exact,
+    and it is invisible if it breaks: the run succeeds and the metric moves off zero.
+    """
+    from sglang.srt.batch_invariant_ops import (
+        disable_batch_invariant_mode,
+        enable_batch_invariant_mode,
+        is_batch_invariant_mode_enabled,
+    )
+
+    assert not sgl_norm.cast_x_before_out_mul, "TOP must follow stock SGLang rounding"
+    x = torch.randn(207, H, device="cuda", dtype=torch.bfloat16)
+    r = torch.randn_like(x)
+
+    def forward():
+        return sgl_norm.forward_cuda(x.clone(), r.clone()) if paired else sgl_norm.forward_cuda(x.clone())
+
+    was_enabled = is_batch_invariant_mode_enabled()
+    try:
+        disable_batch_invariant_mode()
+        trainer = forward()
+        enable_batch_invariant_mode()
+        rollout = forward()
+        if paired:
+            assert all(torch.equal(a, b) for a, b in zip(trainer, rollout))
+        else:
+            assert torch.equal(trainer, rollout)
+    finally:
+        if not was_enabled:
+            disable_batch_invariant_mode()
+
+
+@pytest.mark.parametrize("role", ["input_layernorm", "pre_mlp_layernorm", "final_layernorm"])
+def test_packed_trainer_norm_matches_rollout_add_norm(sgl_norm, role):
+    """Both engines pass the original operands to fused add+norm, with no early BF16 add."""
+    pytest.importorskip("megatron.core")
+    from miles_plugins.top.spec import TopRMSNorm
+
+    config = SimpleNamespace(hidden_size=H, pipeline_hidden_size=2 * H)
+    trainer_norm = TopRMSNorm(config, H, eps=EPS, role=role).cuda().bfloat16()
+    with torch.no_grad():
+        trainer_norm.weight.copy_(sgl_norm.weight)
+    x = torch.randn(207, H, device="cuda", dtype=torch.bfloat16)
+    r = torch.randn(207, H, device="cuda", dtype=torch.bfloat16)
+
+    rollout_out, rollout_residual = sgl_norm.forward_cuda(x.clone(), r.clone())
+    packed = torch.cat((x, r), dim=-1)
+    trainer = trainer_norm(packed)
+    assert torch.equal(rollout_out, _out(trainer))
+    if role != "final_layernorm":
+        assert torch.equal(rollout_residual, trainer[1])
+    assert torch.equal(packed, torch.cat((x, r), dim=-1))
+
+
+@pytest.mark.parametrize("n_tok", [1, 8, 207])
+def test_norm_is_batch_invariant(sgl_norm, n_tok):
+    """A token's norm must not depend on how many tokens share the launch: the rollout sees
+    prefill, decode and recompute batches; the trainer sees the whole sequence."""
+    big = torch.randn(512, H, device="cuda", dtype=torch.bfloat16)
+    ref = _out(sgl_norm.forward_cuda(big.clone()))
+    got = _out(sgl_norm.forward_cuda(big[:n_tok].clone()))
+    assert torch.equal(ref[:n_tok], got)
+
+
+@pytest.mark.parametrize("splits", [2, 4, 8])
+def test_matmul_tp_inv_is_split_invariant(splits):
+    """The row linear gives each rank a K-slice and sums. That is only equal to the whole GEMM if
+    the kernel is invariant to how K is split -- the premise of the entire row-linear delegation."""
+    from sglang.srt.tp_invariant_ops import matmul_tp_inv
+
+    torch.manual_seed(0)
+    M, K, N = 512, 1024, 512
+    a = torch.randn(M, K, device="cuda", dtype=torch.bfloat16)
+    b = torch.randn(K, N, device="cuda", dtype=torch.bfloat16)
+    full = matmul_tp_inv(a, b)
+    step = K // splits
+    parts = [
+        matmul_tp_inv(a[:, i * step : (i + 1) * step].contiguous(), b[i * step : (i + 1) * step, :].contiguous())
+        for i in range(splits)
+    ]
+    # summed the way the row linear sums them: the fixed pairwise tree, not left-to-right
+    while len(parts) > 1:
+        parts = [parts[i] + parts[i + 1] for i in range(0, len(parts), 2)]
+    assert torch.equal(full, parts[0])

--- a/tests/fast/backends/megatron_utils/test_model_provider_true_on_policy.py
+++ b/tests/fast/backends/megatron_utils/test_model_provider_true_on_policy.py
@@ -44,7 +44,7 @@ def _patch_local_model_provider(monkeypatch):
             hidden_size=2560,
             sequence_parallel=False,
             use_kitchen=False,
-            true_on_policy_contract="qwen3_dense_true_on_policy_v1",
+            true_on_policy_contract="true_on_policy_v1",
             use_kitchen_attention=False,
             kitchen_attention_backend="sdpa",
         )

--- a/tests/fast/backends/test_fsdp_precision.py
+++ b/tests/fast/backends/test_fsdp_precision.py
@@ -14,7 +14,7 @@ from miles.backends.fsdp_utils.adaptations.precision import (
 )
 from miles.backends.fsdp_utils.arguments import load_fsdp_args, parse_fsdp_cli
 from miles.backends.training_utils.data import _rollout_logprob_dtype
-from miles.true_on_policy.contracts import QWEN3_DENSE_TRUE_ON_POLICY_V1
+from miles.true_on_policy.contracts import TRUE_ON_POLICY_V1
 
 
 def test_resolve_precision_policy_uses_independent_fp32_master_switch_and_dtypes():
@@ -61,7 +61,7 @@ def test_qwen3_formal_true_on_policy_resolves_fp32_params_with_bf16_autocast():
         fp16=False,
         keep_fp32_master=True,
         true_on_policy_mode=True,
-        sglang_true_on_policy_contract=QWEN3_DENSE_TRUE_ON_POLICY_V1.name,
+        sglang_true_on_policy_contract=TRUE_ON_POLICY_V1.name,
     )
 
     policy = resolve_precision_policy(SimpleNamespace(model_type="qwen3"), args)
@@ -76,9 +76,9 @@ def test_qwen3_formal_true_on_policy_resolves_fp32_params_with_bf16_autocast():
 @pytest.mark.parametrize(
     ("model_type", "true_on_policy_mode", "contract"),
     [
-        ("qwen3", False, QWEN3_DENSE_TRUE_ON_POLICY_V1.name),
+        ("qwen3", False, TRUE_ON_POLICY_V1.name),
         ("qwen3", True, None),
-        ("qwen3_moe", True, QWEN3_DENSE_TRUE_ON_POLICY_V1.name),
+        ("qwen3_moe", True, TRUE_ON_POLICY_V1.name),
     ],
 )
 def test_qwen3_formal_precision_does_not_leak_to_other_modes(model_type, true_on_policy_mode, contract):
@@ -105,7 +105,7 @@ def test_qwen3_formal_true_on_policy_rejects_fp16():
                 fp16=True,
                 keep_fp32_master=True,
                 true_on_policy_mode=True,
-                sglang_true_on_policy_contract=QWEN3_DENSE_TRUE_ON_POLICY_V1.name,
+                sglang_true_on_policy_contract=TRUE_ON_POLICY_V1.name,
             ),
         )
 
@@ -118,7 +118,7 @@ def test_qwen3_formal_true_on_policy_rejects_disabled_fp32_master():
                 fp16=False,
                 keep_fp32_master=False,
                 true_on_policy_mode=True,
-                sglang_true_on_policy_contract=QWEN3_DENSE_TRUE_ON_POLICY_V1.name,
+                sglang_true_on_policy_contract=TRUE_ON_POLICY_V1.name,
             ),
         )
 
@@ -138,7 +138,7 @@ def test_precision_forward_context_uses_policy_autocast(monkeypatch):
             fp16=False,
             keep_fp32_master=True,
             true_on_policy_mode=True,
-            sglang_true_on_policy_contract=QWEN3_DENSE_TRUE_ON_POLICY_V1.name,
+            sglang_true_on_policy_contract=TRUE_ON_POLICY_V1.name,
         ),
     )
 

--- a/tests/fast/backends/test_fsdp_qwen3_true_on_policy.py
+++ b/tests/fast/backends/test_fsdp_qwen3_true_on_policy.py
@@ -16,7 +16,7 @@ from miles.backends.fsdp_utils.models.qwen3 import (
     apply_qwen3_dense_true_on_policy_patch,
     resolve_qwen3_dense_sync_dtype,
 )
-from miles.true_on_policy.contracts import QWEN3_DENSE_TRUE_ON_POLICY_V1
+from miles.true_on_policy.contracts import TRUE_ON_POLICY_V1
 
 
 def test_qwen3_patch_changes_only_final_norm_and_is_idempotent():
@@ -63,7 +63,7 @@ def test_qwen3_instance_patch_registry_is_contract_gated(monkeypatch):
         lambda model: calls.append(model),
     )
     model = object()
-    formal_contract = QWEN3_DENSE_TRUE_ON_POLICY_V1.name
+    formal_contract = TRUE_ON_POLICY_V1.name
 
     for model_type, true_on_policy_mode, contract, fp16 in [
         ("qwen3", False, formal_contract, False),
@@ -144,7 +144,7 @@ def test_qwen3_formal_sync_preserves_post_update_fp32_values():
             fp16=False,
             keep_fp32_master=True,
             true_on_policy_mode=True,
-            sglang_true_on_policy_contract=QWEN3_DENSE_TRUE_ON_POLICY_V1.name,
+            sglang_true_on_policy_contract=TRUE_ON_POLICY_V1.name,
         ),
     )
     model = apply_fp32_master(model, policy.sync_dtype_resolver)
@@ -173,7 +173,7 @@ def test_qwen3_ref_model_uses_fp32_master_storage(monkeypatch):
         fp16=False,
         keep_fp32_master=True,
         true_on_policy_mode=True,
-        sglang_true_on_policy_contract=QWEN3_DENSE_TRUE_ON_POLICY_V1.name,
+        sglang_true_on_policy_contract=TRUE_ON_POLICY_V1.name,
     )
     actor = object.__new__(actor_module.FSDPTrainRayActor)
     actor.args = args

--- a/tests/fast/backends/training_utils/test_sampling_mask.py
+++ b/tests/fast/backends/training_utils/test_sampling_mask.py
@@ -110,7 +110,7 @@ def test_get_log_probs_and_entropy_applies_per_response_sampling_support(monkeyp
     args = SimpleNamespace(
         qkv_format="thd",
         rollout_temperature=1.0,
-        true_on_policy_mode=True,
+        true_on_policy_mode=False,
         bf16=False,
         fp16=False,
         log_probs_chunk_size=-1,
@@ -219,3 +219,31 @@ def test_zigzag_cp_response_rows_keep_global_response_indices(monkeypatch, cp_ra
     assert list(response_indices) == expected_indices
     assert tokens_chunk.tolist() == [3 + index for index in expected_indices]
     assert logits_chunk.size(0) == len(expected_indices)
+
+
+@pytest.mark.parametrize(
+    "overrides, sampling_mask",
+    [
+        ({"rollout_temperature": 0.7}, None),
+        ({"rollout_top_k": 10}, None),
+        ({"rollout_top_p": 0.9}, None),
+        ({}, [RolloutSamplingMask.from_mask_list([[0]])]),
+    ],
+)
+def test_true_on_policy_rejects_transformed_sampling(overrides, sampling_mask):
+    args = SimpleNamespace(**{
+        "true_on_policy_mode": True,
+        "rollout_temperature": 1.0,
+        "rollout_top_k": -1,
+        "rollout_top_p": 1.0,
+        **overrides,
+    })
+    with pytest.raises(ValueError, match="unfiltered, unmodified"):
+        logit_processors.get_log_probs_and_entropy(
+            torch.zeros(1, 2, 4),
+            args=args,
+            unconcat_tokens=[torch.tensor([0, 1])],
+            total_lengths=[2],
+            response_lengths=[1],
+            rollout_sampling_mask=sampling_mask,
+        )

--- a/tests/fast/rollout/generate_utils/test_prefill_logprobs.py
+++ b/tests/fast/rollout/generate_utils/test_prefill_logprobs.py
@@ -50,7 +50,7 @@ async def test_recompute_rollout_logprobs_via_prefill_uses_response_tail(monkeyp
     assert seen["payload"]["return_logprob"] is True
     assert seen["payload"]["logprob_start_len"] == 2
     assert seen["payload"]["sampling_params"]["max_new_tokens"] == 0
-    assert seen["payload"]["sampling_params"]["temperature"] == 0
+    assert seen["payload"]["sampling_params"]["temperature"] == 1.0
 
 
 @pytest.mark.asyncio

--- a/tests/fast/true_on_policy/test_config.py
+++ b/tests/fast/true_on_policy/test_config.py
@@ -5,7 +5,7 @@ from types import SimpleNamespace
 import pytest
 
 from miles.true_on_policy import (
-    QWEN3_DENSE_TRUE_ON_POLICY_V1,
+    TRUE_ON_POLICY_V1,
     apply_true_on_policy_script_defaults,
     build_true_on_policy_launch_plan,
     get_megatron_model_type,
@@ -26,6 +26,10 @@ def _args(**overrides):
         "sglang_rl_on_policy_target": None,
         "true_on_policy_contract": None,
         "use_sequence_parallel": True,
+        # cp>1 now requires an explicit Ulysses declaration; megatron's default is p2p (ring),
+        # which the contract refuses.
+        "cp_comm_type": "a2a",
+        "allgather_cp": False,
     }
     values.update(overrides)
     return SimpleNamespace(**values)
@@ -33,19 +37,17 @@ def _args(**overrides):
 
 def test_qwen3_dense_profile_resolves_model_names():
     profile = get_true_on_policy_model_profile("Qwen3-4B")
-    contract = get_true_on_policy_contract("qwen3_dense_true_on_policy_v1")
+    contract = get_true_on_policy_contract("true_on_policy_v1")
 
     assert profile.family == "qwen3_dense"
-    assert profile.contract is QWEN3_DENSE_TRUE_ON_POLICY_V1
+    assert profile.contract is TRUE_ON_POLICY_V1
     assert profile.contract is contract
-    assert contract.schema.name == "qwen3_dense_true_on_policy_v1"
-    assert contract.schema.model_family == "qwen3_dense"
+    assert contract.name == "true_on_policy_v1"
     assert profile.supported_train_layouts == ("dp", "tp", "pp", "ulysses_cp")
     assert profile.supported_rollout_layouts == ("dp", "tp")
-    assert profile.required_kernel_contracts == ("qwen3_dense_sglang_math",)
-    assert profile.logprob_contract == "sglang_prefill"
     assert profile.supports_ulysses_cp
-    assert profile.supports_tp_invariant
+    assert profile.supports_train_tensor_parallel
+    assert profile.supports_rollout_tensor_parallel
     assert get_megatron_model_type("Qwen3-4B") == "qwen3-4B"
     assert get_megatron_model_type("Qwen3-4B-Instruct-2507") == "qwen3-4B-Instruct-2507"
 
@@ -56,18 +58,18 @@ def test_unknown_true_on_policy_model_fails_early():
 
 
 @pytest.mark.parametrize(
-    ("tp_size", "rollout_tp_size", "expected_target"),
+    ("tp_size", "rollout_tp_size"),
     [
-        (1, 1, "fsdp"),
-        (2, 1, "fsdp_tp"),
-        (1, 2, "fsdp_tp"),
+        (1, 1),
+        (2, 1),
+        (1, 2),
     ],
 )
-def test_true_on_policy_target_is_derived_from_train_and_rollout_tp(
+def test_launch_plan_does_not_vary_with_tensor_parallel_degree(
     tp_size: int,
     rollout_tp_size: int,
-    expected_target: str,
 ):
+    """The program is declared, not derived from topology: a result at one degree transfers."""
     args = _args(
         tensor_model_parallel_size=tp_size,
         context_parallel_size=1,
@@ -78,19 +80,18 @@ def test_true_on_policy_target_is_derived_from_train_and_rollout_tp(
     plan = build_true_on_policy_launch_plan(args)
 
     assert args.sglang_rl_on_policy_target is None
-    assert plan.sglang_target == expected_target
-    assert plan.contract is QWEN3_DENSE_TRUE_ON_POLICY_V1
+    assert plan.contract is TRUE_ON_POLICY_V1
     assert plan.sglang_args.values == (
         "--sglang-enable-deterministic-inference",
         "--sglang-true-on-policy-contract",
-        "qwen3_dense_true_on_policy_v1",
+        "true_on_policy_v1",
         "--sglang-attention-backend",
         "fa3",
     )
     assert "--sglang-rl-on-policy-target" not in plan.train_args
 
 
-def test_legacy_sglang_target_override_does_not_change_contract_policy():
+def test_legacy_sglang_target_override_is_ignored():
     args = _args(
         tensor_model_parallel_size=2,
         context_parallel_size=1,
@@ -102,9 +103,7 @@ def test_legacy_sglang_target_override_does_not_change_contract_policy():
     plan = build_true_on_policy_launch_plan(args)
 
     assert args.sglang_rl_on_policy_target == "fsdp"
-    assert plan.sglang_target == "fsdp_tp"
     assert plan.kernel_policy is not None
-    assert plan.kernel_policy.tp_invariant_row_linear
     assert "--sglang-rl-on-policy-target" not in plan.train_args
     assert "ROW_LINEAR_ENABLE_INV" not in plan.env_vars
 
@@ -120,14 +119,20 @@ def test_contract_object_owns_miles_kernel_policy_values():
     plan = build_true_on_policy_launch_plan(args)
 
     assert plan.kernel_policy is not None
-    assert plan.kernel_policy.contract is QWEN3_DENSE_TRUE_ON_POLICY_V1
+    assert plan.kernel_policy.contract is TRUE_ON_POLICY_V1
     assert plan.kernel_policy.sglang_attention_backend == "fa3"
-    assert plan.kernel_policy.megatron_uses_sglang_backend
-    assert plan.kernel_policy.disable_rope_fusion
-    assert plan.kernel_policy.disable_bias_swiglu_fusion
-    assert plan.kernel_policy.batch_invariant_mode
-    assert plan.kernel_policy.tp_invariant_row_linear
-    assert plan.kernel_policy.deterministic_tp_allreduce
+    assert plan.kernel_policy.build_megatron_args().values == (
+        "--true-on-policy-contract",
+        "true_on_policy_v1",
+        "--spec",
+        "miles_plugins.top.spec",
+        "get_top_spec",
+        "--transformer-impl",
+        "local",
+        "--use-cpu-initialization",
+        "--batch-invariant-mode",
+        "--no-bias-swiglu-fusion",
+    )
 
 
 def test_megatron_true_on_policy_disables_sequence_parallel_and_enables_backend_flags():
@@ -138,11 +143,12 @@ def test_megatron_true_on_policy_disables_sequence_parallel_and_enables_backend_
 
     assert args.use_sequence_parallel is False
     assert "--use-sglang" not in plan.train_args
-    assert "--true-on-policy-contract qwen3_dense_true_on_policy_v1" in plan.train_args
-    assert "--sglang-true-on-policy-contract qwen3_dense_true_on_policy_v1" in plan.train_args
-    assert "--recompute-logprobs-via-prefill" in plan.train_args
+    assert "--true-on-policy-contract true_on_policy_v1" in plan.train_args
+    assert "--sglang-true-on-policy-contract true_on_policy_v1" in plan.train_args
+    # the gate scores DECODE-produced logprobs; a plan that re-adds the prefill recompute
+    # certifies a different program (and masks every decode-only gap)
+    assert "--recompute-logprobs-via-prefill" not in plan.train_args
     assert "--batch-invariant-mode" in plan.train_args
-    assert "--no-rope-fusion" in plan.train_args
     assert "ROW_LINEAR_ENABLE_INV" not in plan.env_vars
     assert "MEGATRON_USE_DETERMINISTIC_ALLREDUCE" not in plan.env_vars
 
@@ -172,29 +178,32 @@ def test_megatron_tp2_cp4_normal_topology_has_complete_true_on_policy_contract(m
     assert plan.parallel_layout.uses_ulysses_cp
     assert plan.parallel_layout.uses_rollout_tp
     assert plan.kernel_policy is not None
-    assert plan.kernel_policy.tp_invariant_row_linear
-    assert plan.kernel_policy.deterministic_tp_allreduce
     assert plan.sglang_args.values == (
         "--sglang-enable-deterministic-inference",
         "--sglang-true-on-policy-contract",
-        "qwen3_dense_true_on_policy_v1",
+        "true_on_policy_v1",
         "--sglang-attention-backend",
         "fa3",
     )
     assert plan.megatron_args.values == (
         "--true-on-policy-contract",
-        "qwen3_dense_true_on_policy_v1",
+        "true_on_policy_v1",
+        "--spec",
+        "miles_plugins.top.spec",
+        "get_top_spec",
         "--transformer-impl",
         "local",
         "--use-cpu-initialization",
         "--batch-invariant-mode",
         "--no-bias-swiglu-fusion",
-        "--no-rope-fusion",
     )
     assert plan.miles_args.values == (
         "--deterministic-mode",
         "--true-on-policy-mode",
-        "--recompute-logprobs-via-prefill",
+        # emitted because this fixture is cp=4: megatron's parser defaults it to ["p2p"], so an
+        # unemitted declaration would silently select ring
+        "--cp-comm-type",
+        "a2a",
     )
     assert plan.env_vars == {
         "NCCL_ALGO": "Ring",
@@ -210,7 +219,8 @@ def test_true_on_policy_contract_override_is_validated():
         build_true_on_policy_launch_plan(args)
 
 
-def test_fsdp_true_on_policy_uses_fsdp_attention_without_megatron_backend_flags():
+def test_non_megatron_train_backend_is_refused():
+    """Megatron is the true-on-policy backend; another backend must refuse, not lose its flags."""
     args = _args(
         train_backend="fsdp",
         tensor_model_parallel_size=1,
@@ -218,16 +228,8 @@ def test_fsdp_true_on_policy_uses_fsdp_attention_without_megatron_backend_flags(
         rollout_num_gpus_per_engine=1,
     )
 
-    apply_true_on_policy_script_defaults(args)
-    plan = build_true_on_policy_launch_plan(args)
-
-    assert args.use_sequence_parallel is True
-    assert plan.sglang_target == "fsdp"
-    assert plan.fsdp_args.values == ("--attn-implementation", "flash_attention_3")
-    assert plan.megatron_args.values == ()
-    assert "--attn-implementation flash_attention_3" in plan.train_args
-    assert "--use-sglang" not in plan.train_args
-    assert "ROW_LINEAR_ENABLE_INV" not in plan.env_vars
+    with pytest.raises(ValueError, match="megatron backend only"):
+        build_true_on_policy_launch_plan(args)
 
 
 def test_fsdp_e2e_uses_current_true_on_policy_contract(monkeypatch):
@@ -240,7 +242,7 @@ def test_fsdp_e2e_uses_current_true_on_policy_contract(monkeypatch):
     fsdp_e2e.execute()
 
     train_args = captured["train_args"]
-    assert "--sglang-true-on-policy-contract qwen3_dense_true_on_policy_v1" in train_args
+    assert "--sglang-true-on-policy-contract true_on_policy_v1" in train_args
     assert "--recompute-logprobs-via-prefill" not in train_args
     assert "--sglang-rl-on-policy-target" not in train_args
 

--- a/tests/fast/true_on_policy/test_cp_layout_units.py
+++ b/tests/fast/true_on_policy/test_cp_layout_units.py
@@ -1,0 +1,85 @@
+"""The single-process parts of the Ulysses CP layout: KV replication and the length bookkeeping.
+
+The all-to-all round trip needs a real process group and lives in a gloo script; what is testable
+here is the index math around it, which is where the bugs were: the archived version ASSERTED
+`num_heads % cp_size == 0` instead of replicating (carrying the `cp <= num_kv_heads` ceiling), and
+`local_packed_lengths` is the guard that catches a LOCAL cu_seqlens being passed where a GLOBAL one
+is required -- a mistake that would otherwise describe the wrong sequence silently.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from miles_plugins.top.cp_layout import UlyssesCPLayout, replicate_kv_heads_for_cp
+
+HEAD_DIM = 128
+NUM_Q_HEADS = 32
+NUM_KV_HEADS = 4  # synthetic head layout for replication coverage
+
+
+def _kv(num_heads=NUM_KV_HEADS, tokens=8):
+    return torch.arange(tokens * num_heads * HEAD_DIM, dtype=torch.float32).reshape(
+        tokens, num_heads, HEAD_DIM
+    )
+
+
+# --- KV replication: the thing that lifts the cp <= num_kv_heads ceiling ----------------------
+
+@pytest.mark.parametrize("cp_size", [1, 2, 4])
+def test_replication_is_a_noop_when_kv_heads_already_cover_cp(cp_size):
+    x = _kv()
+    assert replicate_kv_heads_for_cp(x, cp_size) is x
+
+
+@pytest.mark.parametrize("cp_size,expected_heads", [(8, 8), (16, 16)])
+def test_replication_expands_kv_heads_past_the_ceiling(cp_size, expected_heads):
+    out = replicate_kv_heads_for_cp(_kv(), cp_size)
+    assert out.shape[-2] == expected_heads
+
+
+def test_replication_repeats_each_group_contiguously():
+    """Group g must serve cp ranks [g*n, (g+1)*n) so the post-a2a q/kv pairing stays correct."""
+    out = replicate_kv_heads_for_cp(_kv(num_heads=2), 4)
+    assert out.shape[-2] == 4
+    torch.testing.assert_close(out[:, 0], out[:, 1])  # both copies of group 0
+    torch.testing.assert_close(out[:, 2], out[:, 3])  # both copies of group 1
+    assert not torch.equal(out[:, 1], out[:, 2])      # ...and the groups stay distinct
+
+
+def test_replication_refuses_a_non_multiple_rather_than_guessing():
+    with pytest.raises(ValueError, match="multiple of the KV head count"):
+        replicate_kv_heads_for_cp(_kv(num_heads=3), 4)
+
+
+def test_a_gqa_model_reaches_cp_8_only_by_replicating():
+    """The concrete bound: 4 KV heads caps Ulysses at cp=4 unless the heads are replicated."""
+    kv = _kv(num_heads=NUM_KV_HEADS)
+    layout = UlyssesCPLayout(cp_group=None, cp_size=8)
+    with pytest.raises(ValueError, match="divisible by cp_size"):
+        layout.sequence_to_head_parallel(kv, torch.tensor([0, 8], dtype=torch.int32))
+    replicated = replicate_kv_heads_for_cp(kv, 8)
+    assert replicated.shape[-2] % 8 == 0
+
+
+# --- length bookkeeping: the GLOBAL-vs-LOCAL cu_seqlens guard ---------------------------------
+
+def test_local_lengths_divide_the_global_ones():
+    layout = UlyssesCPLayout(cp_group=None, cp_size=4)
+    cu = torch.tensor([0, 16, 40], dtype=torch.int32)  # global lengths 16 and 24
+    assert layout.local_packed_lengths(cu, local_tokens=10) == [4, 6]
+
+
+def test_a_length_not_divisible_by_cp_is_refused_and_names_the_collator():
+    layout = UlyssesCPLayout(cp_group=None, cp_size=4)
+    with pytest.raises(ValueError, match="divisible by cp_size"):
+        layout.local_packed_lengths(torch.tensor([0, 18], dtype=torch.int32), local_tokens=4)
+
+
+def test_passing_a_LOCAL_cu_seqlens_is_caught():
+    """The failure this exists for: local cu_seqlens sum to the shard, so lengths/cp are too small."""
+    layout = UlyssesCPLayout(cp_group=None, cp_size=4)
+    local_cu = torch.tensor([0, 16], dtype=torch.int32)  # already per-rank
+    with pytest.raises(ValueError, match="must be GLOBAL"):
+        layout.local_packed_lengths(local_cu, local_tokens=16)

--- a/tests/fast/true_on_policy/test_cp_scheme.py
+++ b/tests/fast/true_on_policy/test_cp_scheme.py
@@ -1,0 +1,149 @@
+"""CP is TWO orthogonal axes, and the contract must check both without conflating either with degree.
+
+    train_cp_comm_type  -> how ATTENTION communicates.   "a2a" = Ulysses, "p2p" = ring.
+    train_allgather_cp  -> miles' SEQUENCE LAYOUT.        contiguous chunks vs the zigzag ring layout.
+
+Two failures this pins, both of which have happened:
+
+1. `uses_ulysses_cp` was once just `context_parallel_size > 1`, so ANY cp>1 was validated against the
+   `ulysses_cp` capability -- making CP unreachable for every DSA family even though the plugin
+   implemented allgather-CP. The profile had no way to say "supports CP, but not that flavour".
+2. `--cp-comm-type a2a` was set on a launcher args object that never reached the training command
+   line. Megatron's own default is `["p2p"]`, so an unemitted default silently selects ring -- the
+   one scheme that can never be bitwise. A default invisible where it matters is not a default.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from miles.true_on_policy.config import build_true_on_policy_config
+from miles.true_on_policy.model_profiles import QWEN3_DENSE_PROFILE
+
+
+def _args(**overrides):
+    values = {
+        "true_on_policy": True,
+        "model_name": "Qwen3-4B",
+        "train_backend": "megatron",
+        "tensor_model_parallel_size": 1,
+        "context_parallel_size": 2,
+        "pipeline_model_parallel_size": 1,
+        "rollout_num_gpus_per_engine": 1,
+        "true_on_policy_contract": None,
+        "cp_comm_type": "a2a",
+        "allgather_cp": False,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+# --- axis 1: the attention comm type ----------------------------------------------------------
+
+def test_ulysses_is_derived_from_the_comm_type_not_the_degree():
+    layout = build_true_on_policy_config(_args(context_parallel_size=4)).parallel_layout
+    assert layout.uses_train_cp
+    assert layout.train_cp_attention_scheme == "ulysses"
+    assert layout.required_cp_layout == "ulysses_cp"
+    assert layout.uses_ulysses_cp
+
+
+def test_cp_degree_one_is_not_a_cp_program_whatever_the_comm_type():
+    for comm in ("a2a", "p2p", None):
+        layout = build_true_on_policy_config(
+            _args(context_parallel_size=1, cp_comm_type=comm)
+        ).parallel_layout
+        assert not layout.uses_train_cp
+        assert not layout.uses_ulysses_cp
+        # and it must VALIDATE -- cp=1 never touches the CP clauses
+        build_true_on_policy_config(_args(context_parallel_size=1, cp_comm_type=comm)).validate()
+
+
+@pytest.mark.parametrize("comm", ["p2p", "a2a+p2p", None])
+def test_ring_is_refused_by_name_including_megatrons_default(comm):
+    config = build_true_on_policy_config(_args(cp_comm_type=comm))
+    assert config.parallel_layout.train_cp_attention_scheme == "ring"
+    with pytest.raises(ValueError, match="online softmax"):
+        config.validate()
+
+
+def test_all_gather_is_its_OWN_scheme_not_ring():
+    """all_gather adds no reduction; it runs megatron's EAGER attention, the wrong KERNEL.
+
+    Folding it into "ring" mislabelled the reason for refusing it.
+    """
+    config = build_true_on_policy_config(_args(cp_comm_type="all_gather"))
+    assert config.parallel_layout.train_cp_attention_scheme == "allgather"
+    with pytest.raises(ValueError, match="does not support allgather-CP"):
+        config.validate()
+
+
+def test_the_refusal_explains_where_the_declaration_LIVES():
+    """megatron's --cp-comm-type cannot carry it: under transformer_impl=local megatron demands
+    all_gather at cp>1 for its own attention, which TOP replaces."""
+    with pytest.raises(ValueError) as exc:
+        build_true_on_policy_config(_args(cp_comm_type=None)).validate()
+    message = str(exc.value)
+    assert "p2p" in message
+    assert "--transformer-impl local" in message
+
+
+def test_per_layer_comm_type_is_refused_unless_uniform():
+    build_true_on_policy_config(_args(cp_comm_type=["a2a", "a2a"])).validate()
+    with pytest.raises(ValueError, match="per-layer"):
+        build_true_on_policy_config(_args(cp_comm_type=["a2a", "p2p"]))
+
+
+# --- axis 2: the sequence layout --------------------------------------------------------------
+
+def test_sequence_layout_is_independent_of_the_comm_type():
+    zig = build_true_on_policy_config(_args(allgather_cp=False)).parallel_layout
+    gather = build_true_on_policy_config(_args(allgather_cp=True)).parallel_layout
+    assert zig.train_cp_sequence_layout == "zigzag"
+    assert gather.train_cp_sequence_layout == "allgather"
+    # Both are Ulysses on axis 1 -- the axes do not constrain each other.
+    assert zig.train_cp_attention_scheme == gather.train_cp_attention_scheme == "ulysses"
+
+
+def test_ulysses_requires_zigzag_layout():
+    assert not QWEN3_DENSE_PROFILE.requires_allgather_cp
+    build_true_on_policy_config(_args(allgather_cp=False)).validate()
+    with pytest.raises(ValueError, match="requires per-sequence zigzag"):
+        build_true_on_policy_config(_args(allgather_cp=True)).validate()
+
+
+def test_a_family_declaring_allgather_cp_refuses_the_zigzag_layout():
+    from dataclasses import replace
+
+    dsa_like = replace(
+        QWEN3_DENSE_PROFILE,
+        supported_train_layouts=QWEN3_DENSE_PROFILE.supported_train_layouts + ("allgather_cp",),
+    )
+    assert dsa_like.requires_allgather_cp
+    config = build_true_on_policy_config(_args(allgather_cp=False, cp_comm_type="all_gather"))
+    strict = type(config)(**{**config.__dict__, "model_profile": dsa_like})
+    with pytest.raises(ValueError, match="allgather-cp"):
+        strict.validate()
+    ok = type(config)(**{**config.__dict__, "model_profile": dsa_like, "allgather_cp": True})
+    ok.validate()
+
+
+# --- the flag must reach the program ----------------------------------------------------------
+
+def test_a2a_is_emitted_because_megatrons_parser_defaults_to_p2p():
+    """An unemitted declaration is not a declaration: megatron's parser defaults this to ["p2p"]
+    and forwards it, so leaving it off silently selects ring."""
+    plan = build_true_on_policy_config(_args(context_parallel_size=2)).build_launch_plan()
+    values = plan.miles_args.values
+    assert "--cp-comm-type" in values
+    assert values[values.index("--cp-comm-type") + 1] == "a2a"
+
+
+def test_nothing_cp_is_emitted_at_cp_1():
+    plan = build_true_on_policy_config(
+        _args(context_parallel_size=1, cp_comm_type=None)
+    ).build_launch_plan()
+    assert "--cp-comm-type" not in plan.miles_args.values
+    assert "--allgather-cp" not in plan.miles_args.values

--- a/tests/fast/true_on_policy/test_run_qwen3_4b.py
+++ b/tests/fast/true_on_policy/test_run_qwen3_4b.py
@@ -31,16 +31,15 @@ def test_qwen3_script_true_on_policy_single_knob_expands_to_megatron_contract(mo
 
     assert "--true-on-policy-mode" in train_args
     assert "--sglang-enable-deterministic-inference" in train_args
-    assert "--sglang-true-on-policy-contract qwen3_dense_true_on_policy_v1" in train_args
+    assert "--sglang-true-on-policy-contract true_on_policy_v1" in train_args
     assert "--sglang-rl-on-policy-target" not in train_args
     assert "--sglang-attention-backend fa3" in train_args
-    assert "--true-on-policy-contract qwen3_dense_true_on_policy_v1" in train_args
-    assert "--recompute-logprobs-via-prefill" in train_args
+    assert "--true-on-policy-contract true_on_policy_v1" in train_args
+    assert "--recompute-logprobs-via-prefill" not in train_args  # gate scores DECODE logprobs
     assert "--load /root/models/Qwen3-4B_torch_dist" in train_args
     assert "--save /root/shared_data/unit-test/checkpoints" in train_args
     assert "--use-sglang" not in train_args
     assert "--batch-invariant-mode" in train_args
-    assert "--no-rope-fusion" in train_args
     assert "--sequence-parallel" not in train_args
     assert "ROW_LINEAR_ENABLE_INV" not in env_vars
     assert "MEGATRON_USE_DETERMINISTIC_ALLREDUCE" not in env_vars
@@ -84,14 +83,13 @@ def test_qwen3_script_true_on_policy_tp2_cp4_normal_topology_contract(monkeypatc
     assert "--rollout-num-gpus-per-engine 8" in train_args
     assert "--load /root/models/Qwen3-4B_torch_dist" in train_args
     assert "--save /root/shared_data/unit-test-tp2-cp4/checkpoints" in train_args
-    assert "--sglang-true-on-policy-contract qwen3_dense_true_on_policy_v1" in train_args
+    assert "--sglang-true-on-policy-contract true_on_policy_v1" in train_args
     assert "--sglang-rl-on-policy-target" not in train_args
     assert "--sglang-attention-backend fa3" in train_args
-    assert "--recompute-logprobs-via-prefill" in train_args
+    assert "--recompute-logprobs-via-prefill" not in train_args  # gate scores DECODE logprobs
     assert "--use-sglang" not in train_args
     assert "--batch-invariant-mode" in train_args
     assert "--no-bias-swiglu-fusion" in train_args
-    assert "--no-rope-fusion" in train_args
     assert "--sequence-parallel" not in train_args
     assert env_vars["NCCL_ALGO"] == "Ring"
     assert env_vars["NVTE_ALLOW_NONDETERMINISTIC_ALGO"] == "0"

--- a/tests/fast/true_on_policy/test_top_fused_rope.py
+++ b/tests/fast/true_on_policy/test_top_fused_rope.py
@@ -1,0 +1,145 @@
+"""Fused RoPE is enforced at construction and at SelfAttention's call site."""
+
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("torch")
+pytest.importorskip("megatron.core")
+
+from megatron.core.extensions import transformer_engine as te
+from megatron.core.models.common.embeddings import rope_utils
+from megatron.core.transformer import attention
+
+from miles_plugins.top import install, spec
+from miles_plugins.top.rope import apply_fused_rope, enforce_fused_rope
+
+
+def _config(**kwargs):
+    return SimpleNamespace(
+        **{
+            "apply_rope_fusion": False,
+            "rotary_interleaved": False,
+            "mrope_section": None,
+            "multi_latent_attention": False,
+            **kwargs,
+        }
+    )
+
+
+@pytest.fixture(autouse=True)
+def restore_patch(monkeypatch):
+    monkeypatch.setattr(attention, "apply_rotary_pos_emb", rope_utils.apply_rotary_pos_emb)
+    monkeypatch.setattr(install, "_INSTALLED", {})
+
+
+@pytest.mark.parametrize("num_experts", [None], ids=["qwen_dense"])
+def test_spec_enforces_fusion_before_building_layers(monkeypatch, num_experts):
+    from megatron.core.models.gpt import gpt_layer_specs
+
+    args = SimpleNamespace(
+        transformer_impl="local",
+        num_experts=num_experts,
+        moe_grouped_gemm=False,
+        qk_layernorm=True,
+        multi_latent_attention=False,
+        normalization="RMSNorm",
+        apply_rope_fusion=False,
+    )
+    config = _config(
+        hidden_size=128,
+        pipeline_hidden_size=None,
+        fp32_residual_connection=False,
+        hidden_dropout=0,
+        add_bias_linear=False,
+        use_kitchen=False,
+        use_kitchen_attention=False,
+        kitchen_attention_backend=None,
+    )
+    monkeypatch.setattr(spec, "_pin_sglang", lambda args: "true_on_policy_v1")
+    monkeypatch.setattr(spec, "_hf_model_type", lambda args: "qwen3_moe" if num_experts else "qwen3")
+    monkeypatch.setattr(spec, "_ACTIVE_PROGRAM", None)
+
+    class ReachedBuilder(Exception):
+        pass
+
+    def build(**kwargs):
+        assert args.apply_rope_fusion is True
+        assert config.apply_rope_fusion is True
+        assert attention.apply_rotary_pos_emb is apply_fused_rope
+        raise ReachedBuilder
+
+    monkeypatch.setattr(gpt_layer_specs, "get_gpt_layer_local_spec", build)
+    with pytest.raises(ReachedBuilder):
+        spec.get_top_spec(args, config, None)
+
+
+def test_patch_is_idempotent_and_asserted(monkeypatch):
+    assert install.install_fused_rope()
+    assert install.install_fused_rope()
+    assert attention.apply_rotary_pos_emb is apply_fused_rope
+    monkeypatch.setattr(attention, "apply_rotary_pos_emb", lambda *a, **kw: None)
+    with pytest.raises(RuntimeError, match="unexpected SelfAttention call site"):
+        install.install_fused_rope()
+
+
+@pytest.mark.parametrize("symbol", ["fused_apply_rotary_pos_emb", "fused_apply_rotary_pos_emb_thd"])
+def test_missing_te_fails_construction(monkeypatch, symbol):
+    monkeypatch.setattr(te, symbol, None)
+    with pytest.raises(RuntimeError, match="required TE fused RoPE implementation is unavailable"):
+        enforce_fused_rope(SimpleNamespace(), _config())
+
+
+@pytest.mark.parametrize("option", [{"mrope_section": [16, 16, 32]}, {"fused_single_qkv_rope": True}])
+def test_unmatched_construction_options_raise(option):
+    with pytest.raises(NotImplementedError):
+        enforce_fused_rope(SimpleNamespace(), _config(**option))
+
+
+def test_disabling_fusion_after_construction_raises():
+    config = _config()
+    enforce_fused_rope(SimpleNamespace(), config)
+    config.apply_rope_fusion = False
+    with pytest.raises(RuntimeError, match="disabled after TOP construction"):
+        attention.apply_rotary_pos_emb(None, None, config)
+
+
+@pytest.mark.parametrize("packed", [False, True])
+@pytest.mark.parametrize(
+    "option",
+    [
+        {"mscale": 1.1},
+        {"mla_rotary_interleaved": True},
+        {"inverse": True},
+        {"mla_output_remove_interleaving": True},
+    ],
+)
+def test_unmatched_runtime_expression_raises(packed, option):
+    with pytest.raises(NotImplementedError, match="not supported by the matched TE fused path"):
+        apply_fused_rope(
+            None, None, _config(apply_rope_fusion=True), cu_seqlens=object() if packed else None, **option
+        )
+
+
+@pytest.mark.parametrize("packed", [False, True])
+def test_fused_failure_is_not_retried_unfused(monkeypatch, packed):
+    def fail(*args, **kwargs):
+        raise RuntimeError("TE failed")
+
+    def refuse(*args, **kwargs):
+        raise AssertionError("must never enter unfused RoPE")
+
+    symbol = "fused_apply_rotary_pos_emb_thd" if packed else "fused_apply_rotary_pos_emb"
+    monkeypatch.setattr(te, symbol, fail)
+    monkeypatch.setattr(rope_utils, "_apply_rotary_pos_emb_bshd", refuse)
+    monkeypatch.setattr(rope_utils, "_apply_rotary_pos_emb_thd", refuse)
+    group = SimpleNamespace(size=lambda: 1, rank=lambda: 0)
+    with pytest.raises(RuntimeError, match="TE failed"):
+        apply_fused_rope(
+            None, None, _config(apply_rope_fusion=True), cu_seqlens=object() if packed else None, cp_group=group
+        )
+
+
+def test_packed_rope_requires_explicit_cp_group():
+    with pytest.raises(RuntimeError, match="caller's CP group"):
+        apply_fused_rope(None, None, _config(apply_rope_fusion=True), cu_seqlens=object())

--- a/tests/fast/true_on_policy/test_top_residual_binding.py
+++ b/tests/fast/true_on_policy/test_top_residual_binding.py
@@ -1,0 +1,112 @@
+"""Residual sites must share one paired path across family-specific specs."""
+
+import copy
+from types import SimpleNamespace
+
+import pytest
+
+torch = pytest.importorskip("torch")
+pytest.importorskip("megatron.core")
+
+from megatron.core.models.gpt.gpt_layer_specs import get_gpt_layer_local_spec
+from megatron.core.transformer.identity_op import IdentityOp
+from megatron.core.transformer.spec_utils import ModuleSpec
+from megatron.core.transformer.transformer_layer import TransformerLayer
+
+from miles_plugins.top import spec as S
+from miles_plugins.top.residual_norm import (
+    ResidualTransformerLayer,
+    deferred_residual_add,
+    validate_residual_config,
+)
+
+
+def _config(**overrides):
+    return SimpleNamespace(**{
+        "hidden_size": 128, "pipeline_hidden_size": None,
+        "fp32_residual_connection": False, "hidden_dropout": 0,
+        "add_bias_linear": False, **overrides,
+    })
+
+
+def _layer():
+    return get_gpt_layer_local_spec(num_experts=None, qk_layernorm=True, normalization="RMSNorm")
+
+
+@pytest.fixture
+def on_policy_server_args(monkeypatch):
+    from sglang.srt.true_on_policy import config
+
+    monkeypatch.setattr(
+        config, "_get_global_server_args",
+        lambda: SimpleNamespace(true_on_policy_contract="true_on_policy_v1"),
+    )
+
+
+def test_residual_binding_preserves_family_submodules():
+    layer = _layer()
+    attention, mlp = layer.submodules.self_attention, layer.submodules.mlp
+    params, key_map = copy.deepcopy(layer.params), copy.deepcopy(layer.submodules.sharded_state_dict_keys_map)
+    stamp = []
+    S._bind_residual_layer(layer, stamp)
+    assert layer.module is ResidualTransformerLayer
+    assert layer.module.forward is TransformerLayer.forward
+    assert layer.submodules.self_attn_bda is deferred_residual_add
+    assert layer.submodules.mlp_bda is deferred_residual_add
+    assert layer.submodules.self_attention is attention
+    assert layer.submodules.mlp is mlp
+    assert layer.params == params
+    assert layer.submodules.sharded_state_dict_keys_map == key_map
+    assert sum(role == "residual_add" for role, _, _ in stamp) == 1
+    for role in ("input_layernorm", "pre_mlp_layernorm"):
+        norm = getattr(layer.submodules, role)
+        assert norm.module is S.TopRMSNorm
+        assert norm.params == {"role": role}
+
+
+@pytest.mark.parametrize("role", ["input_layernorm", "pre_mlp_layernorm"])
+def test_unexposed_residual_norm_is_not_a_fallback(role):
+    layer = _layer()
+    setattr(layer.submodules, role, IdentityOp)
+    with pytest.raises(NotImplementedError, match=role):
+        S._bind_residual_layer(layer, [])
+
+
+def test_custom_layer_forward_is_not_silently_replaced():
+    with pytest.raises(NotImplementedError, match="stock TransformerLayer"):
+        S._bind_residual_layer(ModuleSpec(module=torch.nn.Identity), [])
+
+
+@pytest.mark.parametrize("role", ["input_layernorm", "pre_mlp_layernorm", "final_layernorm"])
+@pytest.mark.parametrize("width", [None, 128, 384])
+def test_residual_roles_require_paired_transport(role, width):
+    with pytest.raises(RuntimeError, match="requires packed residual transport"):
+        S.TopRMSNorm(_config(pipeline_hidden_size=width), 128, role=role)
+
+
+@pytest.mark.parametrize("family", ["qwen3"])
+def test_configuration_is_validated_before_family_builder(monkeypatch, family):
+    monkeypatch.setattr(S, "_pin_sglang", lambda args: "true_on_policy_v1")
+    monkeypatch.setattr(S, "_hf_model_type", lambda args: family)
+    with pytest.raises(NotImplementedError, match="transformer_engine spec"):
+        S.get_top_spec(SimpleNamespace(transformer_impl="transformer_engine"), _config(), None)
+
+
+def test_supported_configuration_sets_transport_width():
+    config = _config()
+    validate_residual_config(config, use_te=False)
+    assert config.pipeline_hidden_size == 256
+
+
+@pytest.mark.parametrize("role", ["pre_mlp_layernorm", "final_layernorm"])
+def test_unpaired_payload_at_residual_site_raises(role, on_policy_server_args):
+    norm = S.TopRMSNorm(_config(pipeline_hidden_size=256), 128, role=role)
+    with pytest.raises(ValueError, match="expected a packed residual pair"):
+        norm(torch.empty(2, 128, dtype=torch.bfloat16))
+
+
+def test_nonfirst_input_norm_requires_a_pair(on_policy_server_args):
+    norm = S.TopRMSNorm(_config(pipeline_hidden_size=256), 128, role="input_layernorm")
+    norm.requires_residual_pair = True
+    with pytest.raises(ValueError, match="expected a packed residual pair"):
+        norm(torch.empty(2, 128, dtype=torch.bfloat16))

--- a/tests/fast/true_on_policy/test_top_spec_binding.py
+++ b/tests/fast/true_on_policy/test_top_spec_binding.py
@@ -1,0 +1,39 @@
+"""Structural role-binding tests for the supported local Qwen dense spec."""
+
+import pytest
+
+torch = pytest.importorskip("torch")
+pytest.importorskip("megatron.core")
+
+from miles_plugins.top import spec as S  # noqa: E402
+
+
+def _local_spec():
+    from megatron.core.models.gpt.gpt_layer_specs import get_gpt_layer_local_spec
+
+    return get_gpt_layer_local_spec(num_experts=None, qk_layernorm=True, normalization="RMSNorm")
+
+
+def _bind_all(layer_spec):
+
+    stamp: list[tuple[str, str, str]] = []
+    S._bind_roles(layer_spec, S._NORM_ROLES, S.TopRMSNorm, stamp, as_spec_param=True)
+    S._bind_roles(
+        layer_spec, S._ROW_LINEAR_ROLES, S.TopRowParallelLinear._build(), stamp,
+        as_spec_param=True,
+    )
+    from miles_plugins.top.attention import TopAttention
+
+    S._bind_roles(layer_spec, S._ATTENTION_ROLES, TopAttention, stamp)
+    return {role for role, _, _ in stamp}
+
+
+def test_local_path_binds_the_unfused_roles():
+    bound = _bind_all(_local_spec())
+    assert {"input_layernorm", "pre_mlp_layernorm"} <= bound, bound
+    assert {"linear_proj", "linear_fc2", "core_attention"} <= bound, bound
+
+
+def test_binding_something_is_mandatory():
+    """A table that matches nothing is worse than no table."""
+    assert _bind_all(_local_spec())


### PR DESCRIPTION
Series: **[1/2] Dense Qwen TOP: forward** (this PR) → **[2/2] Dense Qwen TOP: backward** (planned separate PR, based on this branch). The second PR will contain backward/optimizer fixes and validation. This pass remains forward-only.

Megatron currently rejects true-on-policy mode. This adds a Qwen3 dense numerical program that delegates RMSNorm and row-parallel matmul to SGLang, preserves separate branch/residual operands through the pipeline, enforces fused RoPE, and uses FA3 with Ulysses context parallelism. The launcher selects the program explicitly and compares decode-produced scores without enabling prefill replay.

**Draft: forward review only.** Autograd code is included with the modules, but backward/optimizer correctness and learning are not approved by this pass. MoE and GLM bindings are excluded. The high-level launcher now admits Megatron only; existing raw FSDP callers receive the versioned contract-name migration.

### Manual review order

1. **Contract/admission:** `miles/true_on_policy/`, `miles_plugins/top/program.py`, and the two argument-parser changes. Check supported topology, explicit CP scheme, and disabled sequence parallelism/bias-SwiGLU fusion.
2. **Residual ownership and norm:** `miles_plugins/top/spec.py` and `residual_norm.py`. Check separate operands, private clones before mutating SGLang kernels, first-layer handling, and mandatory `2H` PP payload.
3. **Linear and TP reduction:** `miles_plugins/top/ops.py`, row-linear binding in `spec.py`, and `install.py`. Check the forward numerical path and unsupported-shape refusal supplied by SGLang.
4. **RoPE:** `miles_plugins/top/rope.py` and its install hook. Check fused dispatch and actual CP group/rank propagation.
5. **Attention/CP:** `miles_plugins/top/attention.py` and `cp_layout.py`. Check global sequence lengths, zigzag restoration, head exchange, and fixed FA3 split policy.
6. **Scores/sampling:** `loss_hub/logit_processors.py`, `generate_utils/prefill_logprobs.py`, and their tests. Check identity-only admission and optional prefill request temperature. Review LM-head buffer producers in the SGLang companion change.

The [review guide](https://github.com/radixark/miles/blob/review/qwen-dense-top/miles_plugins/top/README.md) provides file-level questions, prerequisite details, and evidence limits. Tests accompany the implementation, including launch/CP checks, residual-binding guards, fused RoPE and GPU premises. Existing sampling-mask coverage remains active for ordinary scoring; TOP now explicitly rejects mask replay.

### Dependencies and draft exit criteria

- [ ] Prepare and pin the **Megatron companion**: `pipeline_hidden_size` configuration and schedule use, PP communication ordering, residual lifetime through BDA, and local CP restriction moved to the selected attention implementation. Development evidence used `c6449f0b23be397449f21c0967c5fc90785e55ea` plus these uncommitted forward patches.
- [ ] Prepare and pin the **SGLang companion**: unconditional versioned contract/stock norm/TP-invariant operations, producer-complete LM-head logits buffers across eager/graph runners, and identity-only sampling including internal health/warmup requests. Development evidence used `774d7d2d878c58162404847a04dc88e5d85dfcf4` plus the LM-head and sampling patches.
- [ ] Rerun the full-model forward matrix on the extracted PR and final companion revisions. Existing repository dependency pins are insufficient.
- [ ] Review backward/optimizer behavior separately before treating this as merge-ready training support.

### Validation

**This branch:** 25 configuration/CP tests passed on Python 3.12; three Torch/Megatron-dependent binding/RoPE modules skipped. Launcher tests were blocked by missing Ray; GPU and sampling integration tests were not run locally. Changed Python files parse, and `git diff --check` passes. Extraction preserves the numerical forward bodies; the spec is narrowed to dense Qwen and accompanying tests are scoped accordingly.

**Supporting development evidence, not validation of this extracted branch:** full 36-layer Qwen3-4B on four H200s, eight 128-token responses per layout, frozen weights, identity sampling, BF16, graphs through batch 8, prefill chunk 1,024, no offloading:

| Trainer TP × CP × PP | Rollout TP | Unique response scores | Max absolute difference |
|---|---|---|---|
| 4 × 1 × 1 | 4 | 1,024 | 0 |
| 2 × 2 × 1 | 2, two engines | 1,024 | 0 |
| 1 × 2 × 2 | 4 | 1,024 | 0 |

The audit checked original HTTP scores, complete CP ownership, and TP-replica deduplication. Twenty live HTTP sampling checks also passed. These results concern selected-token scores on frozen development snapshots, not all hidden states/full-vocabulary equality, gradient equality, CP4, other hardware, offloading, or speculative decoding.

