### PR TITLE
Dump debug train data once per DP/CP shard instead of on every rank

### DIFF
--- a/miles/backends/training_utils/debug_dump.py
+++ b/miles/backends/training_utils/debug_dump.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import torch
 import torch.distributed as dist
 
+from miles.backends.training_utils.parallel import get_parallel_state
 from miles.utils.types import RolloutBatch
 
 _POLICY_LOSS_DUMP_COUNTER = 0
@@ -23,6 +24,9 @@ def maybe_dump_policy_loss_debug(
 ) -> None:
     dump_dir = getattr(args, "dump_details", None)
     if dump_dir is None:
+        return
+    # TP peers compute the loss on identical data; CP ranks hold distinct token slices
+    if get_parallel_state().tp.rank != 0:
         return
 
     global _POLICY_LOSS_DUMP_COUNTER

--- a/miles/dashboard/dump_reader.py
+++ b/miles/dashboard/dump_reader.py
@@ -873,7 +873,8 @@ class DumpReader:
     def _visible(self, path: Path, rollout_id: int, *, evaluation: bool, now: float) -> bool:
         if now - path.stat().st_mtime > self.MIN_AGE_SECONDS:
             return True
-        return not evaluation and (self.train_dir / f"{rollout_id}_0.pt").exists()
+        # any rank number: with pp > 1 the dumping ranks no longer include global rank 0
+        return not evaluation and any(self.train_dir.glob(f"{rollout_id}_*.pt"))
 
     def _torch_load(self, path: Path, *, mmap: bool = False):
         try:

--- a/miles/utils/train_dump_utils.py
+++ b/miles/utils/train_dump_utils.py
@@ -11,6 +11,9 @@ logger = logging.getLogger(__name__)
 def save_debug_train_data(args, *, rollout_id, rollout_data):
     if args.save_debug_train_data is not None:
         parallel_state = get_parallel_state()
+        # TP peers duplicate the DP shard and only the last PP stage computes the per-token fields
+        if parallel_state.tp.rank != 0 or not parallel_state.is_pp_last_stage:
+            return
         save_debug_train_data_for_rank(
             args,
             rollout_id=rollout_id,

--- a/tests/fast/dashboard/test_dump_reader_join.py
+++ b/tests/fast/dashboard/test_dump_reader_join.py
@@ -30,7 +30,8 @@ def test_fresh_rollout_hidden_until_train_companion_exists(run):
     torch.save(dict(rollout_id=3, samples=[]), fresh)  # mtime = now
     assert 3 not in reader.rollout_ids().train
 
-    (reader.train_dir / "3_0.pt").touch()  # train companion written strictly later
+    # any rank number counts: with pp > 1 global rank 0 does not dump
+    (reader.train_dir / "3_6.pt").touch()  # train companion written strictly later
     assert 3 in reader.rollout_ids().train
 
 

--- a/tests/fast/utils/test_train_dump_utils.py
+++ b/tests/fast/utils/test_train_dump_utils.py
@@ -1,0 +1,45 @@
+"""`save_debug_train_data` must write exactly one file per (dp, cp) shard."""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+import miles.backends.training_utils.parallel as parallel
+from miles.utils import train_dump_utils
+from miles.utils.ft_utils.process_group_utils import GroupInfo
+
+
+def _parallel_state(*, tp_rank: int, is_pp_last_stage: bool) -> parallel.ParallelState:
+    trivial = GroupInfo(rank=0, size=1, group=None)
+    return parallel.ParallelState(
+        intra_dp=trivial,
+        intra_dp_cp=trivial,
+        cp=trivial,
+        tp=GroupInfo(rank=tp_rank, size=2, group=None),
+        pp=trivial,
+        ep=trivial,
+        etp=trivial,
+        indep_dp=trivial,
+        is_pp_last_stage=is_pp_last_stage,
+    )
+
+
+@pytest.mark.parametrize(
+    ("tp_rank", "is_pp_last_stage", "writes"),
+    [(0, True, True), (1, True, False), (0, False, False)],
+    ids=["tp0_last_stage_writes", "tp_peer_skips", "earlier_pp_stage_skips"],
+)
+def test_only_one_rank_per_shard_writes(tmp_path, monkeypatch, tp_rank, is_pp_last_stage, writes):
+    monkeypatch.setattr(
+        parallel, "_parallel_state", _parallel_state(tp_rank=tp_rank, is_pp_last_stage=is_pp_last_stage)
+    )
+    monkeypatch.setattr(torch.distributed, "get_rank", lambda: 5)
+    args = SimpleNamespace(
+        save_debug_train_data=str(tmp_path / "{rollout_id}_{rank}.pt"),
+        qkv_format="thd",
+    )
+
+    train_dump_utils.save_debug_train_data(args, rollout_id=3, rollout_data={"sample_indices": [0]})
+
+    assert (tmp_path / "3_5.pt").exists() == writes


### PR DESCRIPTION
## Problem

With `--dump-details`, every training rank writes its rollout shard to `train_data/{rollout_id}_{rank}.pt`, but the data is only split by DP: TP peers hold identical shards, and only the last PP stage computes the per-token fields (`log_probs`, `entropy`, `advantages`, ...) the dashboard joins on. The dump directory therefore holds `tp_size * pp_size` copies of every shard, and the dashboard reader loads them only to deduplicate them away ("deduplicated across TP-duplicate rank files" in `dump_reader.py`). Long runs fill the disk with data that is never used.

## Change

- `save_debug_train_data` dumps only on `tp.rank == 0` of the last PP stage, keeping every CP rank (each holds a distinct per-token slice the reader reassembles with `assemble_log_prob_from_cp`). Disk usage of `train_data/` drops by `tp_size * pp_size`.
- `maybe_dump_policy_loss_debug` gets the same TP gate: `policy_loss_debug/` files were written per rank per loss call and TP peers compute the loss on identical data.
- `DumpReader._visible` probes for any `{rollout_id}_*.pt` train shard instead of hardcoding `{rollout_id}_0.pt`; with `pp > 1` global rank 0 no longer dumps, and the old probe would only have delayed a fresh step's visibility by `MIN_AGE_SECONDS`.

## Compatibility

No other reader change is needed: `_train_paths` already collects rank files by glob, recorded `cp_rank`/`cp_size` drive CP reassembly, and TP dedup is a `setdefault`. Old all-rank dumps read exactly as before; new dumps are the same format minus the duplicate files. FSDP is unaffected (`tp.size == 1`, `is_pp_last_stage` always true).

## Tests

- New `tests/fast/utils/test_train_dump_utils.py`: only the tp0 / last-PP-stage rank writes a shard file.
- `test_fresh_rollout_hidden_until_train_companion_exists` now uses a non-rank-0 companion file to pin the visibility probe.
- Ran `tests/fast/dashboard/test_dump_reader_join.py test_dump_reader_views.py test_token_point_reads.py test_dashboard_args.py tests/fast/utils/test_train_dump_utils.py` — 63 passed, 2 skipped. Validated on a 4x H200 devbox (Qwen3-4B, 2 rollout steps, `--dump-details`): tp2/pp1/dp2 dumps only ranks {0, 2} and tp2/pp2/dp1 dumps only rank 2 (tp0 of the last PP stage; no global-rank-0 file, exercising the new visibility probe); in both runs `DumpReader.load_joined` reports `train_coverage == 1.0` with every per-token field present and no alignment failures. Not executed: the fastapi/sglang-dependent dashboard suites (no local deps); CI covers them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
