### PR TITLE
fix(optimizer): rematerialize streamed main weights

### DIFF
--- a/miles/backends/megatron_utils/megatron_to_hf/processors/__init__.py
+++ b/miles/backends/megatron_utils/megatron_to_hf/processors/__init__.py
@@ -1,6 +1,7 @@
 from .padding_remover import remove_padding
 from .quantizer_compressed_tensors import quantize_params_compressed_tensors
 from .quantizer_fp8 import quantize_params_fp8
+from .quantizer_mxfp4 import is_routed_expert_param, quantize_params_mxfp4
 from .quantizer_mxfp8 import quantize_params_mxfp8
 from .quantizer_nvfp4 import quantize_params_nvfp4
 
@@ -8,6 +9,7 @@ __all__ = [
     "remove_padding",
     "quantize_param",
     "quantize_params_fp8",
+    "quantize_params_mxfp4",
     "quantize_params_mxfp8",
     "quantize_params_nvfp4",
     "quantize_params_compressed_tensors",
@@ -18,6 +20,8 @@ def quantize_params(args, megatron_name, converted_named_params, quantization_co
     if quantization_config is None:
         return converted_named_params
     elif quantization_config["quant_method"] == "fp8":
+        if getattr(args, "rollout_fp4_experts", False) and is_routed_expert_param(megatron_name):
+            return quantize_params_mxfp4(converted_named_params)
         return quantize_params_fp8(args, megatron_name, converted_named_params, quantization_config)
     elif quantization_config["quant_method"] == "mxfp8":
         return quantize_params_mxfp8(args, megatron_name, converted_named_params, quantization_config)

--- a/miles/backends/megatron_utils/megatron_to_hf/processors/quantizer_mxfp4.py
+++ b/miles/backends/megatron_utils/megatron_to_hf/processors/quantizer_mxfp4.py
@@ -1,0 +1,35 @@
+"""Packed MXFP4 quantization for DeepSeek-V4 routed experts."""
+
+import re
+
+from miles.utils.mxfp4 import mxfp4_quantize
+
+_ROUTED_EXPERT_LINEARS = ("linear_fc1", "linear_fc2")
+
+
+def is_routed_expert_param(megatron_name: str) -> bool:
+    """Whether a Megatron parameter name addresses a routed expert linear."""
+    match = re.search(r"(?:decoder|mtp)\.layers\.\d+\.(.+)", megatron_name)
+    if not match:
+        return False
+    rest = match.group(1).replace("transformer_layer.", "").replace("mtp_model_layer.", "")
+    expert_match = re.match(r"mlp\.experts\.(.+)\.weight\d+", rest)
+    return bool(expert_match) and expert_match.group(1) in _ROUTED_EXPERT_LINEARS
+
+
+def quantize_params_mxfp4(converted_named_params):
+    """Quantize routed-expert weights to packed MXFP4 with UE8M0 block scales."""
+    quantized_named_params = []
+    for converted_name, param in converted_named_params:
+        if converted_name.endswith("_scale"):
+            continue
+        if not converted_name.endswith(".weight"):
+            raise ValueError(f"Expected weight parameter, got {converted_name}")
+        qweight, scale = mxfp4_quantize(param)
+        quantized_named_params.extend(
+            [
+                (converted_name, qweight),
+                (converted_name.replace(".weight", ".weight_scale_inv"), scale),
+            ]
+        )
+    return quantized_named_params

--- a/miles/backends/megatron_utils/model_provider.py
+++ b/miles/backends/megatron_utils/model_provider.py
@@ -89,6 +89,12 @@ def _apply_bridge_runtime_config(provider, args: argparse.Namespace) -> None:
     # the target model. Follow the launched runtime rather than the source file.
     provider.mtp_num_layers = args.mtp_num_layers
 
+    provider.dsv4_mxfp4_qat = getattr(args, "dsv4_mxfp4_qat", False)
+    if provider.dsv4_mxfp4_qat:
+        from miles_plugins.models.deepseek_v4.ops.mxfp4_qat import install_dsv4_mxfp4_qat
+
+        install_dsv4_mxfp4_qat()
+
     # MoE token dispatcher (same-name, always present)
     provider.moe_token_dispatcher_type = args.moe_token_dispatcher_type
 

--- a/miles/backends/megatron_utils/model_provider.py
+++ b/miles/backends/megatron_utils/model_provider.py
@@ -77,6 +77,17 @@ def _apply_bridge_runtime_config(provider, args: argparse.Namespace) -> None:
 
     # attention kernel selection
     provider.attention_backend = args.attention_backend
+    if hasattr(provider, "dsa_kernel_backend"):
+        dsa_kernel_backend = getattr(args, "dsa_kernel_backend", None)
+        if dsa_kernel_backend is None:
+            dsa_kernel_backend = (
+                "cudnn" if getattr(provider, "experimental_attention_variant", None) == "dsv4_hybrid" else "none"
+            )
+        provider.dsa_kernel_backend = dsa_kernel_backend
+
+    # The HF checkpoint can contain an MTP module even when this run trains only
+    # the target model. Follow the launched runtime rather than the source file.
+    provider.mtp_num_layers = args.mtp_num_layers
 
     # MoE token dispatcher (same-name, always present)
     provider.moe_token_dispatcher_type = args.moe_token_dispatcher_type

--- a/miles/backends/megatron_utils/rematerialize_utils.py
+++ b/miles/backends/megatron_utils/rematerialize_utils.py
@@ -49,7 +49,11 @@ def _build_cast_main_to_params_fn(optimizer, *, precision_aware: bool) -> Callab
 
         def cast_mcore():
             for dist_opt in dist_opts:
-                dist_opt._copy_main_params_to_model_params()
+                store = getattr(dist_opt, "_nvme_state_store", None)
+                if store is None:
+                    dist_opt._copy_main_params_to_model_params()
+                else:
+                    store.restore_model_params_from_main()
 
         return cast_mcore
 

--- a/miles/backends/megatron_utils/update_weight/hf_weight_iterator_bridge.py
+++ b/miles/backends/megatron_utils/update_weight/hf_weight_iterator_bridge.py
@@ -2,6 +2,7 @@ import dataclasses
 import itertools
 import json
 import os
+from pathlib import Path
 
 from miles.backends.megatron_utils.update_weight.hf_weight_iterator import (
     MegatronHfWeightIteratorBase,
@@ -21,7 +22,8 @@ class HfWeightIteratorBridge(MegatronHfWeightIteratorBase):
 
         from megatron.bridge import AutoBridge
 
-        self._bridge = AutoBridge.from_hf_pretrained(self.args.hf_checkpoint, trust_remote_code=True)
+        bridge_checkpoint = _select_bridge_checkpoint(self.args)
+        self._bridge = AutoBridge.from_hf_pretrained(bridge_checkpoint, trust_remote_code=True)
 
         if (
             self.quantization_config is not None
@@ -116,6 +118,17 @@ def _load_quantized_param_basenames(hf_checkpoint):
     with open(index_path) as f:
         names = json.load(f)["weight_map"]
     return {n.removesuffix(".weight_packed") for n in names if n.endswith(".weight_packed")}
+
+
+def _select_bridge_checkpoint(args):
+    """Use an HF trainer seed for export mappings when one is available."""
+    for candidate in (getattr(args, "load", None), getattr(args, "ref_load", None)):
+        if candidate is None:
+            continue
+        path = Path(candidate)
+        if (path / "model.safetensors.index.json").is_file() or any(path.glob("*.safetensors")):
+            return candidate
+    return args.hf_checkpoint
 
 
 def _process_conversion_tasks(vanilla_conversion_tasks, new_weight_dict):

--- a/miles/backends/megatron_utils/update_weight/hf_weight_iterator_bridge.py
+++ b/miles/backends/megatron_utils/update_weight/hf_weight_iterator_bridge.py
@@ -8,6 +8,9 @@ from miles.backends.megatron_utils.update_weight.hf_weight_iterator import (
     MegatronHfWeightIteratorBase,
     _iter_mm_tower_units,
 )
+from miles.backends.training_utils.weight_update.hf_weight_iterator.atomic_groups import (
+    get_hf_atomic_update_groups,
+)
 from miles.utils import megatron_bridge_utils
 from miles.utils.lora import is_lora_weight_name
 
@@ -39,6 +42,13 @@ class HfWeightIteratorBridge(MegatronHfWeightIteratorBase):
                     **self.quantization_config,
                     "_miles_quantized_basenames": quantized_basenames,
                 }
+
+    def _hf_atomic_update_groups(self):
+        return get_hf_atomic_update_groups(
+            self.model_name,
+            q_lora_rank=self.args.q_lora_rank,
+            dsv4_checkpoint_layout=True,
+        )
 
     def _iter_hf_param_units(self, weights, *, materialize):
         renamed_megatron_local_weights = {strip_param_name_prefix(k): v for k, v in weights.items()}

--- a/miles/backends/megatron_utils/update_weight/hf_weight_iterator_bridge.py
+++ b/miles/backends/megatron_utils/update_weight/hf_weight_iterator_bridge.py
@@ -8,9 +8,7 @@ from miles.backends.megatron_utils.update_weight.hf_weight_iterator import (
     MegatronHfWeightIteratorBase,
     _iter_mm_tower_units,
 )
-from miles.backends.training_utils.weight_update.hf_weight_iterator.atomic_groups import (
-    get_hf_atomic_update_groups,
-)
+from miles.backends.training_utils.weight_update.hf_weight_iterator.atomic_groups import get_hf_atomic_update_groups
 from miles.utils import megatron_bridge_utils
 from miles.utils.lora import is_lora_weight_name
 

--- a/miles/backends/training_utils/weight_update/hf_weight_iterator/atomic_groups.py
+++ b/miles/backends/training_utils/weight_update/hf_weight_iterator/atomic_groups.py
@@ -53,11 +53,7 @@ def get_hf_atomic_update_groups(
     inside the converter, and its engine-side loads are split-safe."""
     normalized_model_name = model_name.lower().replace("-", "").replace("_", "")
     if "deepseekv4" in normalized_model_name:
-        groups = (
-            _DEEPSEEK_V4_CHECKPOINT_GROUPS
-            if dsv4_checkpoint_layout
-            else _DEEPSEEK_V4_NATIVE_GROUPS
-        )
+        groups = _DEEPSEEK_V4_CHECKPOINT_GROUPS if dsv4_checkpoint_layout else _DEEPSEEK_V4_NATIVE_GROUPS
         return list(groups)
     if "inkling" in normalized_model_name:
         return []

--- a/miles/backends/training_utils/weight_update/hf_weight_iterator/atomic_groups.py
+++ b/miles/backends/training_utils/weight_update/hf_weight_iterator/atomic_groups.py
@@ -6,7 +6,7 @@ from miles.backends.training_utils.weight_update.hf_weight_iterator.bucketing im
 # sglang's deepseek_v4 load_weights cache-and-concats each pair into one engine
 # param (wqkv_a / compressor.wkv_gate / indexer.compressor.wkv_gate) and
 # hard-asserts no half-arrived pair remains at end of call.
-_DEEPSEEK_V4_GROUPS = [
+_DEEPSEEK_V4_NATIVE_GROUPS = [
     AtomicUpdateGroup(key, suffixes)
     for key, suffixes in [
         ("wqkv_a", (".self_attn.wq_a.weight", ".self_attn.wkv.weight")),
@@ -24,13 +24,41 @@ _DEEPSEEK_V4_GROUPS = [
     ]
 ]
 
+_DEEPSEEK_V4_CHECKPOINT_GROUPS = [
+    AtomicUpdateGroup(key, suffixes)
+    for key, suffixes in [
+        ("wqkv_a", (".attn.wq_a.weight", ".attn.wkv.weight")),
+        (
+            "compressor_wkv_gate",
+            (".attn.compressor.wkv.weight", ".attn.compressor.wgate.weight"),
+        ),
+        (
+            "indexer_compressor_wkv_gate",
+            (
+                ".attn.indexer.compressor.wkv.weight",
+                ".attn.indexer.compressor.wgate.weight",
+            ),
+        ),
+    ]
+]
 
-def get_hf_atomic_update_groups(model_name: str, *, q_lora_rank: int | None = None) -> list[AtomicUpdateGroup]:
+
+def get_hf_atomic_update_groups(
+    model_name: str,
+    *,
+    q_lora_rank: int | None = None,
+    dsv4_checkpoint_layout: bool = False,
+) -> list[AtomicUpdateGroup]:
     """Atomic groups for a model. inkling registers none: its fusions happen
     inside the converter, and its engine-side loads are split-safe."""
     normalized_model_name = model_name.lower().replace("-", "").replace("_", "")
     if "deepseekv4" in normalized_model_name:
-        return list(_DEEPSEEK_V4_GROUPS)
+        groups = (
+            _DEEPSEEK_V4_CHECKPOINT_GROUPS
+            if dsv4_checkpoint_layout
+            else _DEEPSEEK_V4_NATIVE_GROUPS
+        )
+        return list(groups)
     if "inkling" in normalized_model_name:
         return []
     if q_lora_rank is not None:

--- a/miles/backends/training_utils/weight_update/hf_weight_iterator/atomic_groups.py
+++ b/miles/backends/training_utils/weight_update/hf_weight_iterator/atomic_groups.py
@@ -28,10 +28,10 @@ _DEEPSEEK_V4_GROUPS = [
 def get_hf_atomic_update_groups(model_name: str, *, q_lora_rank: int | None = None) -> list[AtomicUpdateGroup]:
     """Atomic groups for a model. inkling registers none: its fusions happen
     inside the converter, and its engine-side loads are split-safe."""
-    model_name = model_name.lower()
-    if "deepseekv4" in model_name:
+    normalized_model_name = model_name.lower().replace("-", "").replace("_", "")
+    if "deepseekv4" in normalized_model_name:
         return list(_DEEPSEEK_V4_GROUPS)
-    if "inkling" in model_name:
+    if "inkling" in normalized_model_name:
         return []
     if q_lora_rank is not None:
         # sglang's deepseek family cache-and-concats q_a_proj + kv_a_proj_with_mqa

--- a/miles/backends/training_utils/weight_update/protocols/cuda_ipc.py
+++ b/miles/backends/training_utils/weight_update/protocols/cuda_ipc.py
@@ -186,6 +186,11 @@ class UpdateWeightFromTensor(WeightTransferProtocol):
             if futures_distributed:
                 futures = (futures or []) + futures_distributed
         check_weight_sync_results(async_utils.wait_futures(futures or []), is_lora=False)
+        # Only the gather source receives the engine RPC future, but every rank
+        # owns storage referenced by the gathered CUDA IPC handles. Keep each
+        # producer bucket alive until its consumer has completed the import.
+        if self._ipc_gather_group is not None:
+            dist.barrier(group=self._ipc_gather_group)
         del long_lived_tensors
 
 

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -2216,6 +2216,14 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
             )
             parser.add_argument("--check-weight-update-equal", action="store_true")
             parser.add_argument(
+                "--rollout-fp4-experts",
+                action="store_true",
+                help=(
+                    "The rollout model holds packed MXFP4 routed experts, so online updates must encode "
+                    "those tensors as MXFP4 rather than block-scaled FP8."
+                ),
+            )
+            parser.add_argument(
                 "--check-weight-update-selector",
                 type=str,
                 default="all",

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -230,7 +230,9 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                     "GPU *while the step runs*; --offload-train-target=disk cannot help there.\n"
                     "adam: streams fp32 main params and moments through per-bucket files, one bucket "
                     "resident at a time. Requires the distributed optimizer, excludes "
-                    "--offload-optimizer-states and --optimizer-cpu-offload.\n"
+                    "--offload-optimizer-states and --optimizer-cpu-offload. Colocated CPU trainer "
+                    "offload also requires --rematerialize-param-from-master-weight; the rebuild "
+                    "then streams only the fp32 main params back one bucket at a time.\n"
                     "dist_muon: the disk backend for --chunked-optimizer-state-offload, so pass that "
                     "plus a non-zero --optimizer-state-offload-fraction. --optimizer-cpu-offload is "
                     "Adam-only. This bounds host residency, not the GPU restore window -- for that "
@@ -3458,12 +3460,12 @@ def miles_validate_args(args):
         )
 
     if args.stream_optimizer_state_to_disk:
-        assert args.offload_train_target == "disk" or not args.offload_train, (
-            "--stream-optimizer-state-to-disk with --offload-train requires "
-            "--offload-train-target=disk: a run that cannot hold the optimizer state on GPU for "
-            "the duration of the step will not hold a pinned host copy of the whole actor either. "
-            "Disaggregated runs do not offload the trainer at all, and the target is unused there."
-        )
+        if args.offload_train and args.offload_train_target == "cpu":
+            assert args.rematerialize_param_from_master_weight, (
+                "--stream-optimizer-state-to-disk with CPU trainer offload requires "
+                "--rematerialize-param-from-master-weight: DDP parameter buffers have no CPU "
+                "backup and the streamed fp32 main params must rebuild them before training"
+            )
         assert not args.indep_dp, (
             "--stream-optimizer-state-to-disk does not support --indep-dp: each cell has its own "
             "process group, so torch.distributed.get_rank() restarts at 0 per cell and two cells "

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -406,6 +406,14 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 help="The method to convert megatron weights to hugging face weights for SGLang.",
             )
             parser.add_argument(
+                "--dsv4-mxfp4-qat",
+                action="store_true",
+                help=(
+                    "Fake-quantize DeepSeek V4 routed-expert weights to MXFP4 during Megatron forwards. "
+                    "The trainable parameters and optimizer states retain their configured precision."
+                ),
+            )
+            parser.add_argument(
                 "--dsa-attention-backend",
                 choices=["megatron", "tilelang"],
                 default="tilelang",

--- a/miles/utils/hf_config.py
+++ b/miles/utils/hf_config.py
@@ -38,14 +38,6 @@ _CONFIG_ALIASES: tuple[_HFConfigAlias, ...] = (
         compat_class_name="DeepseekV32Config",
         override_hf_native=True,
     ),
-    _HFConfigAlias(
-        model_type="deepseek_v4",
-        base_module="transformers.models.deepseek_v3.configuration_deepseek_v3",
-        base_class="DeepseekV3Config",
-        compat_class_name="DeepseekV4Config",
-        auto_model_classes=(),
-        override_hf_native=True,
-    ),
 )
 
 _REGISTERED_ALIASES: set[str] = set()

--- a/miles/utils/hf_parameter_names.py
+++ b/miles/utils/hf_parameter_names.py
@@ -1,0 +1,20 @@
+"""Resolve checkpoint tensor names into the Hugging Face model namespace."""
+
+import json
+from collections.abc import Callable
+
+
+def _is_deepseek_v4_native(config_path: str, weight_map: dict[str, str]) -> bool:
+    """Return whether a DeepSeek V4 checkpoint uses release-native names."""
+    with open(config_path, encoding="utf-8") as config_file:
+        architectures = json.load(config_file).get("architectures", [])
+    return "DeepseekV4ForCausalLM" in architectures and "embed.weight" in weight_map
+
+
+def get_param_name_remap(config_path: str, weight_map: dict[str, str]) -> Callable[[str], str]:
+    """Return the checkpoint-to-HF name mapping for a supported checkpoint."""
+    if _is_deepseek_v4_native(config_path, weight_map):
+        from sglang.srt.models.deepseek_v4 import DeepseekV4ForCausalLM
+
+        return DeepseekV4ForCausalLM.remap_weight_name_to_dpsk_hf_format
+    return lambda name: name

--- a/miles/utils/hf_rollout_schema.py
+++ b/miles/utils/hf_rollout_schema.py
@@ -1,0 +1,155 @@
+"""Build metadata-only rollout schemas from Hugging Face checkpoints."""
+
+import json
+import re
+import shutil
+import struct
+from pathlib import Path
+
+from miles.utils.hf_parameter_names import get_param_name_remap
+from miles.utils.mxfp8 import MXFP8_GROUP_SIZE
+
+MXFP8_SKIP_WEIGHT_SUBSTRINGS = (
+    "layernorm",
+    "embed",
+    "router",
+    "mlp.gate.",
+    "norm",
+    "lm_head",
+    "eh_proj",
+    "weights_proj",
+    "head.",
+    "wo_a",
+    "ffn.gate.",
+    "compressor.",
+)
+
+_MXFP8_SOURCE_DTYPES = {"BF16", "F16", "F32", "F8_E4M3", "F8_E4M3FN", "F8_E4M3FNUZ"}
+_SCHEMA_MARKER = ".miles-rollout-schema.json"
+_WEIGHT_INDEX = "model.safetensors.index.json"
+
+
+def _load_json(path: Path) -> dict:
+    with path.open(encoding="utf-8") as json_file:
+        return json.load(json_file)
+
+
+def _read_safetensors_header(path: Path) -> dict[str, dict]:
+    """Read tensor dtype and shape metadata without mapping tensor payloads."""
+    with path.open("rb") as tensor_file:
+        header_size_bytes = tensor_file.read(8)
+        if len(header_size_bytes) != 8:
+            raise ValueError(f"Invalid safetensors header in {path}")
+        header_size = struct.unpack("<Q", header_size_bytes)[0]
+        header = tensor_file.read(header_size)
+        if len(header) != header_size:
+            raise ValueError(f"Truncated safetensors header in {path}")
+    return json.loads(header)
+
+
+def _load_tensor_metadata(source_dir: Path, weight_map: dict[str, str]) -> dict[str, dict]:
+    metadata: dict[str, dict] = {}
+    names_by_shard: dict[str, list[str]] = {}
+    for name, shard in weight_map.items():
+        names_by_shard.setdefault(shard, []).append(name)
+
+    for shard, names in names_by_shard.items():
+        header = _read_safetensors_header(source_dir / shard)
+        for name in names:
+            if name not in header:
+                raise KeyError(f"{name} is listed in {_WEIGHT_INDEX} but missing from {shard}")
+            metadata[name] = header[name]
+    return metadata
+
+
+def _natural_key(value: str) -> list[int | str]:
+    return [int(part) if part.isdigit() else part for part in re.findall(r"\d+|\D+", value)]
+
+
+def _should_use_mxfp8(name: str, metadata: dict, skip_substrings: tuple[str, ...]) -> bool:
+    if not name.endswith(".weight") or any(part in name for part in skip_substrings):
+        return False
+    shape = metadata.get("shape", [])
+    if len(shape) < 2 or shape[-1] % MXFP8_GROUP_SIZE != 0:
+        return False
+    dtype = metadata.get("dtype")
+    if dtype in _MXFP8_SOURCE_DTYPES:
+        return True
+    # Trainer-owned rollout replaces packed source experts with MXFP8 at the
+    # first sync, so reserve the unpacked target layout in the schema.
+    return dtype == "I8" and ".experts." in name
+
+
+def build_mxfp8_quantization_config(
+    source_dir: str | Path,
+    *,
+    extra_high_precision_layers_hf: tuple[str, ...] = (),
+) -> dict:
+    """Derive the SGLang MXFP8 allocation layout from checkpoint headers."""
+    source = Path(source_dir)
+    config_path = source / "config.json"
+    index_path = source / _WEIGHT_INDEX
+    if not config_path.is_file() or not index_path.is_file():
+        raise FileNotFoundError(f"Expected config.json and {_WEIGHT_INDEX} under {source}")
+
+    weight_map = _load_json(index_path)["weight_map"]
+    remap_name = get_param_name_remap(str(config_path), weight_map)
+    tensor_metadata = _load_tensor_metadata(source, weight_map)
+    skip_substrings = (*MXFP8_SKIP_WEIGHT_SUBSTRINGS, *extra_high_precision_layers_hf)
+
+    ignored_modules = set()
+    for source_name, metadata in tensor_metadata.items():
+        if not source_name.endswith(".weight"):
+            continue
+        hf_name = remap_name(source_name)
+        if not _should_use_mxfp8(hf_name, metadata, skip_substrings) and ".experts." not in hf_name:
+            ignored_modules.add(hf_name.removesuffix(".weight"))
+
+    return {
+        "activation_scheme": "dynamic",
+        "fmt": "e4m3",
+        "quant_method": "mxfp8",
+        "weight_block_size": [1, MXFP8_GROUP_SIZE],
+        "scale_fmt": "ue8m0",
+        "modules_to_not_convert": sorted(ignored_modules, key=_natural_key),
+    }
+
+
+def _copy_root_metadata(source: Path, destination: Path) -> None:
+    for source_file in source.iterdir():
+        if not source_file.is_file():
+            continue
+        if source_file.name == _WEIGHT_INDEX or source_file.suffix == ".safetensors":
+            continue
+        shutil.copy2(source_file, destination / source_file.name)
+
+
+def create_mxfp8_rollout_schema(source_dir: str | Path, destination_dir: str | Path) -> Path:
+    """Create a small MXFP8 config/tokenizer directory with no weight payloads."""
+    source = Path(source_dir).resolve()
+    destination = Path(destination_dir).resolve()
+    if source == destination:
+        raise ValueError("The rollout schema destination must differ from the source checkpoint")
+
+    quantization_config = build_mxfp8_quantization_config(source)
+    destination.mkdir(parents=True, exist_ok=True)
+    if any(destination.glob("*.safetensors")):
+        raise ValueError(f"Refusing to use schema directory containing weight payloads: {destination}")
+    _copy_root_metadata(source, destination)
+
+    config = _load_json(source / "config.json")
+    config["quantization_config"] = quantization_config
+    config["expert_dtype"] = "fp8"
+    with (destination / "config.json").open("w", encoding="utf-8") as config_file:
+        json.dump(config, config_file, indent=2)
+        config_file.write("\n")
+
+    marker = {
+        "format": "miles-metadata-only-rollout-schema-v1",
+        "source": str(source),
+        "weight_payloads": False,
+    }
+    with (destination / _SCHEMA_MARKER).open("w", encoding="utf-8") as marker_file:
+        json.dump(marker, marker_file, indent=2)
+        marker_file.write("\n")
+    return destination

--- a/miles/utils/mxfp4.py
+++ b/miles/utils/mxfp4.py
@@ -1,0 +1,35 @@
+"""MXFP4 E2M1 quantization utilities."""
+
+import torch
+
+
+MXFP4_GROUP_SIZE = 32
+E8M0_BIAS = 127
+E2M1_MAX = 6.0
+E2M1_VALUES = (0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0)
+
+# Magnitudes an E2M1 element can take, indexed by its three low bits. The
+# midpoints between them decide which code a value rounds to.
+_E2M1_BOUNDS = torch.tensor([0.25, 0.75, 1.25, 1.75, 2.5, 3.5, 5.0])
+
+
+def mxfp4_quantize(weight: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    """Quantize a tensor to packed MXFP4 with one UE8M0 scale per 32 elements."""
+    weight = weight.contiguous()
+    k = weight.shape[-1]
+    if k % MXFP4_GROUP_SIZE != 0:
+        raise ValueError(f"Last dim {k} must be divisible by {MXFP4_GROUP_SIZE} for MXFP4.")
+
+    blocks = weight.float().reshape(-1, MXFP4_GROUP_SIZE)
+    amax = blocks.abs().amax(dim=-1, keepdim=True)
+    exponent = torch.ceil(torch.log2(amax / E2M1_MAX).clamp(min=-float(E8M0_BIAS)))
+    exponent = torch.where(amax > 0, exponent, torch.full_like(exponent, -float(E8M0_BIAS)))
+
+    scaled = blocks / torch.exp2(exponent)
+    magnitude = (scaled.abs().unsqueeze(-1) > _E2M1_BOUNDS.to(weight.device)).sum(dim=-1)
+    codes = (magnitude + torch.signbit(scaled).to(magnitude.dtype) * 0b1000).to(torch.uint8)
+
+    codes = codes.reshape(*weight.shape[:-1], k)
+    packed = (codes[..., 1::2] << 4) | codes[..., 0::2]
+    scale = (exponent + E8M0_BIAS).to(torch.uint8).reshape(*weight.shape[:-1], k // MXFP4_GROUP_SIZE)
+    return packed.view(torch.int8), scale.view(torch.float8_e8m0fnu)

--- a/miles_plugins/models/deepseek_v4/ops/mxfp4_qat.py
+++ b/miles_plugins/models/deepseek_v4/ops/mxfp4_qat.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from functools import wraps
+
+import torch
+import triton
+import triton.language as tl
+
+from miles.utils.mxfp4 import MXFP4_GROUP_SIZE
+
+_CONFIG_ATTR = "dsv4_mxfp4_qat"
+_PATCH_ATTR = "_miles_dsv4_mxfp4_qat_original_get_weight_tensors"
+_GROUPS_PER_PROGRAM = 8
+
+logger = logging.getLogger(__name__)
+
+
+@triton.jit
+def _mxfp4_quantize_dequantize_kernel(
+    weight_ptr,
+    output_ptr,
+    num_groups,
+    GROUP_SIZE: tl.constexpr,
+    GROUPS_PER_PROGRAM: tl.constexpr,
+):
+    group_offsets = tl.program_id(0) * GROUPS_PER_PROGRAM + tl.arange(0, GROUPS_PER_PROGRAM)
+    value_offsets = tl.arange(0, GROUP_SIZE)
+    offsets = group_offsets[:, None] * GROUP_SIZE + value_offsets[None, :]
+    mask = group_offsets[:, None] < num_groups
+
+    weight = tl.load(weight_ptr + offsets, mask=mask, other=0.0).to(tl.float32)
+    amax = tl.max(tl.abs(weight), axis=1)[:, None]
+    exponent = tl.ceil(tl.log2(amax / 6.0))
+    exponent = tl.maximum(exponent, -127.0)
+    exponent = tl.where(amax > 0.0, exponent, -127.0)
+    scale = tl.exp2(exponent)
+
+    magnitude = tl.abs(weight) / scale
+    code = (magnitude > 0.25).to(tl.int32)
+    code += (magnitude > 0.75).to(tl.int32)
+    code += (magnitude > 1.25).to(tl.int32)
+    code += (magnitude > 1.75).to(tl.int32)
+    code += (magnitude > 2.5).to(tl.int32)
+    code += (magnitude > 3.5).to(tl.int32)
+    code += (magnitude > 5.0).to(tl.int32)
+
+    quantized = tl.where(
+        code == 0,
+        0.0,
+        tl.where(
+            code == 1,
+            0.5,
+            tl.where(
+                code == 2,
+                1.0,
+                tl.where(
+                    code == 3,
+                    1.5,
+                    tl.where(code == 4, 2.0, tl.where(code == 5, 3.0, tl.where(code == 6, 4.0, 6.0))),
+                ),
+            ),
+        ),
+    )
+    quantized = tl.where(weight < 0.0, -quantized, quantized)
+    tl.store(output_ptr + offsets, quantized * scale, mask=mask)
+
+
+def mxfp4_quantize_dequantize(weight: torch.Tensor) -> torch.Tensor:
+    """Round a CUDA tensor to the routed-expert MXFP4 grid."""
+    if not weight.is_cuda:
+        raise ValueError("MXFP4 QAT requires a CUDA weight tensor.")
+    if not weight.is_contiguous():
+        raise ValueError("MXFP4 QAT requires contiguous grouped-expert weights.")
+    if weight.shape[-1] % MXFP4_GROUP_SIZE != 0:
+        raise ValueError(f"Last dim {weight.shape[-1]} must be divisible by {MXFP4_GROUP_SIZE} for MXFP4 QAT.")
+
+    output = torch.empty_like(weight)
+    num_groups = weight.numel() // MXFP4_GROUP_SIZE
+    grid = (triton.cdiv(num_groups, _GROUPS_PER_PROGRAM),)
+    _mxfp4_quantize_dequantize_kernel[grid](
+        weight,
+        output,
+        num_groups,
+        GROUP_SIZE=MXFP4_GROUP_SIZE,
+        GROUPS_PER_PROGRAM=_GROUPS_PER_PROGRAM,
+        num_warps=8,
+    )
+    return output
+
+
+class _MXFP4FakeQuantizeSTE(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, weight: torch.Tensor) -> torch.Tensor:
+        del ctx
+        return mxfp4_quantize_dequantize(weight)
+
+    @staticmethod
+    def backward(ctx, grad_output: torch.Tensor) -> torch.Tensor:
+        del ctx
+        return grad_output
+
+
+def mxfp4_fake_quantize_ste(weight: torch.Tensor) -> torch.Tensor:
+    """Fake-quantize a weight while passing its gradient through unchanged."""
+    output = _MXFP4FakeQuantizeSTE.apply(weight)
+    if hasattr(weight, "main_grad"):
+        output.main_grad = weight.main_grad
+    return output
+
+
+def _wrap_get_weight_tensors(original: Callable) -> Callable:
+    @wraps(original)
+    def get_weight_tensors(module):
+        weights = original(module)
+        if not getattr(module.config, _CONFIG_ATTR, False):
+            return weights
+        return [mxfp4_fake_quantize_ste(weight) for weight in weights]
+
+    return get_weight_tensors
+
+
+def install_dsv4_mxfp4_qat() -> None:
+    """Install the opt-in routed-expert MXFP4 fake-quantization hook."""
+    from megatron.core.extensions.transformer_engine import TEGroupedLinear
+
+    if hasattr(TEGroupedLinear, _PATCH_ATTR):
+        return
+
+    original = TEGroupedLinear._get_weight_tensors
+    setattr(TEGroupedLinear, _PATCH_ATTR, original)
+    TEGroupedLinear._get_weight_tensors = _wrap_get_weight_tensors(original)
+    logger.info("Installed DeepSeek V4 routed-expert MXFP4 QAT hook")

--- a/miles_plugins/optimizers/nvme_stream.py
+++ b/miles_plugins/optimizers/nvme_stream.py
@@ -12,9 +12,10 @@ a store and routes the five entry points that touch optimizer state at it, so
 Megatron carries no NVMe-specific behaviour. The one piece that stays on Megatron's
 side is the pair of checkpoint hooks in ``megatron/training/checkpointing.py``, which
 have to be inside ``save_checkpoint`` / ``load_checkpoint`` to cover every call path;
-they reach this class through four methods:
+they reach this class through five methods:
 
     step()
+    restore_model_params_from_main()
     refresh_main_from_model_params(copy_fn)
     save_to(base_dir)
     load_from(base_dir) -> bool
@@ -239,6 +240,9 @@ class _Bucket:
     def fetch(self) -> int:
         return self._move(SEGMENTS if self.moments_ready else SEGMENTS[:1], to_disk=False)
 
+    def fetch_main(self) -> int:
+        return self._move(SEGMENTS[:1], to_disk=False)
+
     def flush(self, segments=SEGMENTS) -> int:
         moved = self._move(segments, to_disk=True)
         self.moments_ready = self.moments_ready or tuple(segments) == SEGMENTS
@@ -413,6 +417,21 @@ class NVMeOptimizerStateStore:
             f"wrote {written / 1024**3:.1f} GB in {time.monotonic() - started:.1f}s"
         )
         return True
+
+    @torch.no_grad()
+    def restore_model_params_from_main(self) -> None:
+        """Rebuild model-param shards without materializing the full optimizer state."""
+        started = time.monotonic()
+        read = written = 0
+        for bucket in self.buckets:
+            read += bucket.fetch_main()
+            self._copy_main_to_model_params(bucket.entries)
+            written += bucket.flush(segments=SEGMENTS[:1])
+        logger.info(
+            f"NVMe streaming model-param restore: {len(self.buckets)} buckets, "
+            f"read {read / 1024**3:.1f} GB, released {written / 1024**3:.1f} GB "
+            f"in {time.monotonic() - started:.1f}s"
+        )
 
     @torch.no_grad()
     def initialize_main_from_model_params(self) -> int:

--- a/scripts/run_deepseek_v4.py
+++ b/scripts/run_deepseek_v4.py
@@ -76,6 +76,7 @@ _MEGATRON_MODEL_TYPE = {
 _PRO_MODEL_NAMES = ("DeepSeek-V4-Pro-FP8",)
 _MXFP4_MODEL_NAMES = ("DeepSeek-V4-Flash", "DeepSeek-V4-Flash-0731")
 _FLASH_FULL_MODEL_NAMES = ("DeepSeek-V4-Flash", "DeepSeek-V4-Flash-FP8", "DeepSeek-V4-Flash-0731")
+_MXFP4_QAT_MODEL_NAMES = _MXFP4_MODEL_NAMES
 
 _DSV4_TE_PRECISION_CONFIG = """
 configs:
@@ -151,6 +152,7 @@ class ScriptArgs(U.ExecuteTrainConfig):
     train_mxfp8: bool = False
     rollout_mxfp8: bool = False
     rollout_expert_dtype: Literal["auto", "fp4", "fp8"] = "auto"
+    dsv4_mxfp4_qat: bool = False
     # Empty keeps the backend implied by the rollout precision.
     sglang_moe_runner_backend: str = ""
     sglang_fp8_gemm_backend: str = ""
@@ -575,6 +577,10 @@ def _train(args: ScriptArgs):
     trainer_checkpoint = _trainer_checkpoint_path(args)
     rollout_expert_dtype = _resolve_rollout_expert_dtype(args, rollout_checkpoint)
     rollout_fp4_experts = rollout_expert_dtype == "fp4"
+    if args.dsv4_mxfp4_qat:
+        assert args.model_name in _MXFP4_QAT_MODEL_NAMES, "MXFP4 QAT requires a packed-MXFP4 DSV4 checkpoint."
+        assert args.train_mxfp8, "MXFP4 QAT requires the P3 MXFP8 training recipe."
+        assert rollout_fp4_experts, "MXFP4 QAT requires packed MXFP4 routed experts in rollout."
 
     print(f"[checkpoint] trainer initialization ({args.init_model_source}): {trainer_checkpoint}")
     print(f"[checkpoint] rollout layout ({args.rollout_weight_source}): {rollout_checkpoint}")
@@ -582,7 +588,7 @@ def _train(args: ScriptArgs):
     print(
         f"[precision] train_fp8={args.train_fp8}, rollout_fp8={args.rollout_fp8}, "
         f"train_mxfp8={args.train_mxfp8}, rollout_mxfp8={args.rollout_mxfp8}, "
-        f"rollout_expert_dtype={rollout_expert_dtype}"
+        f"rollout_expert_dtype={rollout_expert_dtype}, dsv4_mxfp4_qat={args.dsv4_mxfp4_qat}"
     )
     print(
         f"running on {args.num_nodes} nodes "
@@ -778,6 +784,8 @@ def _train(args: ScriptArgs):
     )
     if rollout_fp4_experts:
         misc_args += "--rollout-fp4-experts "
+    if args.dsv4_mxfp4_qat:
+        misc_args += "--dsv4-mxfp4-qat "
     if args.colocate:
         misc_args += "--colocate "
     else:

--- a/scripts/run_deepseek_v4.py
+++ b/scripts/run_deepseek_v4.py
@@ -747,6 +747,8 @@ def _train(args: ScriptArgs):
         # Colocated multi-engine init can deadlock in the multimem all-gather rendezvous (sgl-project/sglang#36110).
         "SGLANG_DISABLE_MULTIMEM_AG": "1",
     }
+    if args.rollout_weight_source == "trainer":
+        extra_env_vars["MILES_SGLANG_DUMMY_LOAD"] = "1"
     if args.model_name == "DeepSeek-V4-Pro-FP8":
         extra_env_vars["SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK"] = "256"
         extra_env_vars["SGLANG_JIT_DEEPGEMM_PRECOMPILE"] = "0"

--- a/scripts/run_deepseek_v4.py
+++ b/scripts/run_deepseek_v4.py
@@ -2,6 +2,9 @@
 DeepSeek V4 training script.
 
 Supports:
+  - DeepSeek-V4-Flash             Official Preview release from deepseek-ai
+                                  (FP8 attention/shared weights and packed-MXFP4
+                                  routed experts). Supports direct-HF P1-P3.
   - DeepSeek-V4-Flash-FP8         Public FP8 repackage of deepseek-ai/DeepSeek-V4-Flash
                                   (sgl-project/DeepSeek-V4-Flash-FP8, 291B, 43 layers).
                                   Verified full-model profiles: 8 nodes x 8 GPUs on H200
@@ -21,7 +24,13 @@ Usage patterns:
            --model-name DeepSeek-V4-Flash-FP8-4layer \
            --num-nodes 1 --num-gpus-per-node 8
 
-  2. Individual steps (download [-> MXFP4->FP8] -> FP8->BF16 -> BF16->torch_dist -> rsync -> train):
+  2. Direct-HF P1-P3 (no offline weight conversion):
+       python scripts/run_deepseek_v4.py full-train \
+           --model-name DeepSeek-V4-Flash \
+           --init-model-source hf --rollout-weight-source trainer \
+           --no-train-fp8 --train-mxfp8 --no-rollout-fp8 --rollout-mxfp8
+
+  3. Individual converted-checkpoint steps:
        python scripts/run_deepseek_v4.py prepare-download --model-name DeepSeek-V4-Flash-FP8
        python scripts/run_deepseek_v4.py prepare-fp8      --model-name DeepSeek-V4-Flash-0731
        python scripts/run_deepseek_v4.py prepare-single   --model-name DeepSeek-V4-Flash-FP8 \
@@ -34,6 +43,7 @@ Usage patterns:
            --hf-checkpoint /root/models/DeepSeek-V4-Flash-FP8
 """
 
+import json
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Literal
@@ -41,10 +51,12 @@ from typing import Literal
 import typer
 
 import miles.utils.external_utils.command_utils as U
+from miles.utils.hf_rollout_schema import create_mxfp8_rollout_schema
 
 app = typer.Typer()
 
 _DEFAULT_MODEL_ORG = {
+    "DeepSeek-V4-Flash": "deepseek-ai",
     "DeepSeek-V4-Flash-FP8": "sgl-project",
     # 4-layer prune of sgl-project/DeepSeek-V4-Flash-FP8.
     "DeepSeek-V4-Flash-FP8-4layer": "Pinaster",
@@ -54,6 +66,7 @@ _DEFAULT_MODEL_ORG = {
 }
 
 _MEGATRON_MODEL_TYPE = {
+    "DeepSeek-V4-Flash": "deepseek-v4-flash",
     "DeepSeek-V4-Flash-FP8": "deepseek-v4-flash",
     "DeepSeek-V4-Flash-FP8-4layer": "deepseek-v4-flash-4layer",
     "DeepSeek-V4-Pro-FP8": "deepseek-v4-pro",
@@ -61,8 +74,8 @@ _MEGATRON_MODEL_TYPE = {
 }
 
 _PRO_MODEL_NAMES = ("DeepSeek-V4-Pro-FP8",)
-_MXFP4_MODEL_NAMES = ("DeepSeek-V4-Flash-0731",)
-_FLASH_FULL_MODEL_NAMES = ("DeepSeek-V4-Flash-FP8", "DeepSeek-V4-Flash-0731")
+_MXFP4_MODEL_NAMES = ("DeepSeek-V4-Flash", "DeepSeek-V4-Flash-0731")
+_FLASH_FULL_MODEL_NAMES = ("DeepSeek-V4-Flash", "DeepSeek-V4-Flash-FP8", "DeepSeek-V4-Flash-0731")
 
 _DSV4_TE_PRECISION_CONFIG = """
 configs:
@@ -84,6 +97,7 @@ class ScriptArgs(U.ExecuteTrainConfig):
     run_id: str = U.create_run_id()
     model_org: str = ""
     model_name: Literal[
+        "DeepSeek-V4-Flash",
         "DeepSeek-V4-Flash-FP8",
         "DeepSeek-V4-Flash-FP8-4layer",
         "DeepSeek-V4-Pro-FP8",
@@ -94,6 +108,8 @@ class ScriptArgs(U.ExecuteTrainConfig):
     enable_eval: bool = True
 
     hf_checkpoint: str | None = None
+    init_model_source: Literal["torch_dist", "hf"] = "torch_dist"
+    rollout_weight_source: Literal["checkpoint", "trainer"] = "checkpoint"
     data_dir: str = "/root/datasets"
     model_dir: str = "/root/models"
     # Defaults to model_dir. Set explicitly when shared NFS -> per-node local NVMe copy is needed.
@@ -134,6 +150,10 @@ class ScriptArgs(U.ExecuteTrainConfig):
     rollout_fp8: bool = True
     train_mxfp8: bool = False
     rollout_mxfp8: bool = False
+    rollout_expert_dtype: Literal["auto", "fp4", "fp8"] = "auto"
+    # Empty keeps the backend implied by the rollout precision.
+    sglang_moe_runner_backend: str = ""
+    sglang_fp8_gemm_backend: str = ""
     enable_mis: bool = False
 
     # pass any extra sglang/miles/megatron args through `--extra-args '--your-arg'`
@@ -187,12 +207,34 @@ class ScriptArgs(U.ExecuteTrainConfig):
         return f"{self.model_name}-MXFP8"
 
     @property
+    def mxfp8_schema_name(self):
+        return f"{self.mxfp8_name}-schema"
+
+    @property
     def rollout_name(self):
         if self.rollout_mxfp8:
             return self.mxfp8_name
         if self.rollout_fp8:
             return self.fp8_name
         return self.bf16_name
+
+
+def _resolve_rollout_expert_dtype(args: ScriptArgs, rollout_checkpoint: str) -> Literal["fp4", "fp8"]:
+    """Resolve the routed-expert layout shared by SGLang and online sync."""
+    if args.rollout_expert_dtype != "auto":
+        return args.rollout_expert_dtype
+    if args.rollout_mxfp8 or not args.rollout_fp8:
+        return "fp8"
+    if args.model_name not in _MXFP4_MODEL_NAMES:
+        return "fp8"
+
+    config_path = Path(rollout_checkpoint) / "config.json"
+    with config_path.open(encoding="utf-8") as config_file:
+        config = json.load(config_file)
+    expert_dtype = config.get("expert_dtype", "fp8")
+    if expert_dtype not in ("fp4", "fp8"):
+        raise ValueError(f"Unsupported expert_dtype={expert_dtype!r} in {config_path}")
+    return expert_dtype
 
 
 def _download_dataset(args: ScriptArgs):
@@ -208,6 +250,34 @@ def _download_dataset(args: ScriptArgs):
 def _hf_checkpoint_path(args: ScriptArgs) -> str:
     """Resolve hf_checkpoint path: explicit override wins, else {model_dir}/{model_name}."""
     return args.hf_checkpoint or f"{args.model_dir}/{args.model_name}"
+
+
+def _local_hf_checkpoint_path(args: ScriptArgs) -> str:
+    source = Path(_hf_checkpoint_path(args))
+    if args.model_local_dir == args.model_dir:
+        return str(source)
+    return str(Path(args.model_local_dir) / source.name)
+
+
+def _mxfp8_schema_path(args: ScriptArgs, *, local: bool) -> str:
+    root = args.model_local_dir if local else args.model_dir
+    return str(Path(root) / args.mxfp8_schema_name)
+
+
+def _trainer_checkpoint_path(args: ScriptArgs) -> str:
+    if args.init_model_source == "hf":
+        return _local_hf_checkpoint_path(args)
+    return str(Path(args.model_local_dir) / args.torch_dist_name)
+
+
+def _rollout_checkpoint_path(args: ScriptArgs) -> str:
+    if args.rollout_weight_source == "trainer":
+        if args.rollout_mxfp8:
+            return _mxfp8_schema_path(args, local=True)
+        return _local_hf_checkpoint_path(args)
+    if args.rollout_fp8 and args.hf_checkpoint is not None:
+        return _local_hf_checkpoint_path(args)
+    return str(Path(args.model_local_dir) / args.rollout_name)
 
 
 def _ensure_4layer_model_type(args: ScriptArgs):
@@ -297,6 +367,16 @@ def _prepare_mxfp8(args: ScriptArgs):
     )
 
 
+def _prepare_mxfp8_schema(args: ScriptArgs) -> None:
+    if args.rollout_weight_source != "trainer" or not args.rollout_mxfp8:
+        return
+    schema_path = create_mxfp8_rollout_schema(
+        source_dir=_hf_checkpoint_path(args),
+        destination_dir=_mxfp8_schema_path(args, local=False),
+    )
+    print(f"[prepare] MXFP8 metadata-only rollout schema: {schema_path}")
+
+
 @app.command()
 @U.dataclass_cli
 def prepare_mxfp8(args: ScriptArgs):
@@ -373,16 +453,28 @@ def prepare_cp(args: ScriptArgs):
 
 
 def _prepare_cp(args: ScriptArgs):
-    U.rsync_simple(
-        path_src=f"{args.model_dir}/{args.torch_dist_name}",
-        path_dst=f"{args.model_local_dir}/{args.torch_dist_name}",
-        num_nodes=args.num_nodes,
-    )
-    U.rsync_simple(
-        path_src=f"{args.model_dir}/{args.rollout_name}",
-        path_dst=f"{args.model_local_dir}/{args.rollout_name}",
-        num_nodes=args.num_nodes,
-    )
+    copies: list[tuple[str, str]] = []
+    if args.init_model_source == "hf" or args.rollout_weight_source == "trainer":
+        copies.append((_hf_checkpoint_path(args), _local_hf_checkpoint_path(args)))
+    if args.init_model_source == "torch_dist":
+        copies.append(
+            (
+                str(Path(args.model_dir) / args.torch_dist_name),
+                str(Path(args.model_local_dir) / args.torch_dist_name),
+            )
+        )
+    if args.rollout_weight_source == "trainer" and args.rollout_mxfp8:
+        copies.append((_mxfp8_schema_path(args, local=False), _mxfp8_schema_path(args, local=True)))
+    elif args.rollout_weight_source == "checkpoint":
+        copies.append(
+            (
+                str(Path(args.model_dir) / args.rollout_name),
+                str(Path(args.model_local_dir) / args.rollout_name),
+            )
+        )
+
+    for source, destination in dict.fromkeys(copies):
+        U.rsync_simple(path_src=source, path_dst=destination, num_nodes=args.num_nodes)
 
 
 def _get_parallel_config(args: ScriptArgs) -> str:
@@ -476,14 +568,21 @@ def _get_parallel_config(args: ScriptArgs) -> str:
 def _train(args: ScriptArgs):
     if args.train_mxfp8 or args.rollout_mxfp8:
         assert U.GENERATION_HARDWARE[args.hardware] == "Blackwell", "MXFP8 requires Blackwell"
-    if not args.rollout_fp8 or args.hf_checkpoint is None or args.model_name in _MXFP4_MODEL_NAMES:
-        rollout_checkpoint = f"{args.model_local_dir}/{args.rollout_name}"
-        if args.hf_checkpoint != rollout_checkpoint:
-            print(f"[precision] rollout checkpoint: {args.hf_checkpoint} -> {rollout_checkpoint}")
-            args.hf_checkpoint = rollout_checkpoint
+    if args.init_model_source == "hf" and args.dsv4_impl != "megatron":
+        raise ValueError("Direct-HF DeepSeek-V4 training requires --dsv4-impl megatron.")
+
+    rollout_checkpoint = _rollout_checkpoint_path(args)
+    trainer_checkpoint = _trainer_checkpoint_path(args)
+    rollout_expert_dtype = _resolve_rollout_expert_dtype(args, rollout_checkpoint)
+    rollout_fp4_experts = rollout_expert_dtype == "fp4"
+
+    print(f"[checkpoint] trainer initialization ({args.init_model_source}): {trainer_checkpoint}")
+    print(f"[checkpoint] rollout layout ({args.rollout_weight_source}): {rollout_checkpoint}")
+    args.hf_checkpoint = rollout_checkpoint
     print(
         f"[precision] train_fp8={args.train_fp8}, rollout_fp8={args.rollout_fp8}, "
-        f"train_mxfp8={args.train_mxfp8}, rollout_mxfp8={args.rollout_mxfp8}"
+        f"train_mxfp8={args.train_mxfp8}, rollout_mxfp8={args.rollout_mxfp8}, "
+        f"rollout_expert_dtype={rollout_expert_dtype}"
     )
     print(
         f"running on {args.num_nodes} nodes "
@@ -493,7 +592,9 @@ def _train(args: ScriptArgs):
     _ensure_4layer_model_type(args)
 
     load_save_path = f"{args.save_dir}/{args.run_id}/checkpoints"
-    ckpt_args = f"--hf-checkpoint {args.hf_checkpoint} " f"--ref-load {args.model_local_dir}/{args.torch_dist_name} "
+    ckpt_args = f"--hf-checkpoint {rollout_checkpoint} " f"--ref-load {trainer_checkpoint} "
+    if args.init_model_source == "hf":
+        ckpt_args += "--megatron-to-hf-mode bridge "
     if not args.skip_saving:
         ckpt_args += (
             f"--load {load_save_path} " f"--save {load_save_path} " "--save-interval 20 " "--save-retain-interval 20 "
@@ -604,10 +705,14 @@ def _train(args: ScriptArgs):
         sglang_fp8_gemm_backend = "auto"
     if args.rollout_mxfp8:
         sglang_moe_runner_backend = "flashinfer_trtllm_routed"
+    elif rollout_fp4_experts:
+        sglang_moe_runner_backend = "flashinfer_mxfp4"
     elif args.model_name == "DeepSeek-V4-Pro-FP8":
         sglang_moe_runner_backend = "deep_gemm"
     else:
         sglang_moe_runner_backend = "auto"
+    sglang_moe_runner_backend = args.sglang_moe_runner_backend or sglang_moe_runner_backend
+    sglang_fp8_gemm_backend = args.sglang_fp8_gemm_backend or sglang_fp8_gemm_backend
     sglang_args = (
         f"--rollout-num-gpus-per-engine {sglang_world_size} "
         f"--sglang-fp8-gemm-backend {sglang_fp8_gemm_backend} "
@@ -635,7 +740,7 @@ def _train(args: ScriptArgs):
         )
     extra_env_vars = {
         "SGLANG_SKIP_CHECKPOINT_LOAD_CHECK": "1",
-        "SGLANG_DSV4_FP4_EXPERTS": "0",
+        "SGLANG_DSV4_FP4_EXPERTS": "1" if rollout_fp4_experts else "0",
         "SGLANG_HEALTH_CHECK_TIMEOUT": "120",
         "SGLANG_DG_CACHE_DIR_PER_PROCESS": "1",
         "SGLANG_OPT_FP8_WO_A_GEMM": "0",
@@ -669,6 +774,8 @@ def _train(args: ScriptArgs):
         "--rollout-health-check-interval 300 "
         "--rollout-health-check-timeout 300 "
     )
+    if rollout_fp4_experts:
+        misc_args += "--rollout-fp4-experts "
     if args.colocate:
         misc_args += "--colocate "
     else:
@@ -745,48 +852,55 @@ def train(args: ScriptArgs):
     _train(args)
 
 
-@app.command()
-@U.dataclass_cli
-def full_train(args: ScriptArgs):
+def _full_train(args: ScriptArgs) -> None:
     _prepare_download(args)
 
-    if args.model_name in _MXFP4_MODEL_NAMES:
+    needs_converted_rollout = args.rollout_weight_source == "checkpoint" and not args.rollout_fp8
+    needs_bf16 = args.init_model_source == "torch_dist" or needs_converted_rollout
+    if args.model_name in _MXFP4_MODEL_NAMES and needs_bf16:
         fp8_sentinel = Path(f"{args.model_dir}/{args.fp8_name}") / "model.safetensors.index.json"
         if not fp8_sentinel.exists():
             _prepare_fp8(args)
         else:
             print(f"[full_train] Skipping MXFP4->FP8 cast: {fp8_sentinel} already exists.")
 
-    bf16_dir = Path(f"{args.model_dir}/{args.bf16_name}")
-    bf16_sentinel = bf16_dir / "model.safetensors.index.json"
-    if not bf16_sentinel.exists():
-        _prepare_single(args)
-    else:
-        print(f"[full_train] Skipping FP8->BF16 cast: {bf16_sentinel} already exists.")
+    if needs_bf16:
+        bf16_dir = Path(f"{args.model_dir}/{args.bf16_name}")
+        bf16_sentinel = bf16_dir / "model.safetensors.index.json"
+        if not bf16_sentinel.exists():
+            _prepare_single(args)
+        else:
+            print(f"[full_train] Skipping FP8->BF16 cast: {bf16_sentinel} already exists.")
 
-    if args.rollout_mxfp8:
+    if args.rollout_weight_source == "checkpoint" and args.rollout_mxfp8:
         mxfp8_sentinel = Path(f"{args.model_dir}/{args.mxfp8_name}") / "model.safetensors.index.json"
         if not mxfp8_sentinel.exists():
             _prepare_mxfp8(args)
         else:
             print(f"[full_train] Skipping BF16->MXFP8 conversion: {mxfp8_sentinel} already exists.")
 
-    torch_dist_dir = Path(f"{args.model_dir}/{args.torch_dist_name}")
-    torch_dist_sentinel = torch_dist_dir / "latest_checkpointed_iteration.txt"
-    if not torch_dist_sentinel.exists():
-        _prepare_spmd(args)
-    else:
-        print(f"[full_train] Skipping BF16->torch_dist conversion: {torch_dist_sentinel} already exists.")
+    if args.init_model_source == "torch_dist":
+        torch_dist_dir = Path(f"{args.model_dir}/{args.torch_dist_name}")
+        torch_dist_sentinel = torch_dist_dir / "latest_checkpointed_iteration.txt"
+        if not torch_dist_sentinel.exists():
+            _prepare_spmd(args)
+        else:
+            print(f"[full_train] Skipping BF16->torch_dist conversion: {torch_dist_sentinel} already exists.")
+
+    _prepare_mxfp8_schema(args)
 
     if args.model_local_dir != args.model_dir:
         _prepare_cp(args)
     else:
         print(f"[full_train] Skipping rsync: model_local_dir == model_dir ({args.model_dir})")
 
-    if args.hf_checkpoint is None:
-        args.hf_checkpoint = f"{args.model_local_dir}/{args.rollout_name}"
-
     _train(args)
+
+
+@app.command()
+@U.dataclass_cli
+def full_train(args: ScriptArgs):
+    _full_train(args)
 
 
 if __name__ == "__main__":

--- a/tests/fast-gpu/test_dsv4_mxfp4_qat.py
+++ b/tests/fast-gpu/test_dsv4_mxfp4_qat.py
@@ -1,0 +1,89 @@
+from types import SimpleNamespace
+
+import pytest
+import torch
+from tests.ci.ci_register import register_cuda_ci
+
+from miles.utils.mxfp4 import E2M1_VALUES, MXFP4_GROUP_SIZE, mxfp4_quantize
+from miles_plugins.models.deepseek_v4.ops.mxfp4_qat import (
+    _wrap_get_weight_tensors,
+    mxfp4_fake_quantize_ste,
+    mxfp4_quantize_dequantize,
+)
+
+register_cuda_ci(est_time=30, suite="stage-b-2-gpu-h200", labels=["precision"])
+
+
+def _dequantize_reference(packed: torch.Tensor, scale: torch.Tensor) -> torch.Tensor:
+    logical_shape = (*packed.shape[:-1], packed.shape[-1] * 2)
+    codes = packed.view(torch.uint8)
+    nibbles = torch.stack((codes & 0x0F, (codes >> 4) & 0x0F), dim=-1).flatten(-2)
+    table = torch.tensor(E2M1_VALUES + tuple(-value for value in E2M1_VALUES), device=packed.device)
+    values = table[nibbles.long()].reshape(-1, MXFP4_GROUP_SIZE)
+    scale_factor = torch.exp2(scale.view(torch.uint8).float() - 127).reshape(-1, 1)
+    return (values * scale_factor).reshape(logical_shape)
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
+def test_mxfp4_qat_matches_rollout_codec(dtype):
+    torch.manual_seed(0)
+    weight = torch.randn((67, 4 * MXFP4_GROUP_SIZE), device="cuda", dtype=dtype)
+    original = weight.clone()
+
+    actual = mxfp4_quantize_dequantize(weight)
+    packed, scale = mxfp4_quantize(weight)
+    expected = _dequantize_reference(packed, scale).to(dtype)
+
+    assert torch.equal(actual, expected)
+    assert torch.equal(weight, original)
+
+
+@pytest.mark.parametrize(
+    ("linear_name", "shape"),
+    [
+        ("linear_fc1", (6 * MXFP4_GROUP_SIZE, 4 * MXFP4_GROUP_SIZE)),
+        ("linear_fc2", (4 * MXFP4_GROUP_SIZE, 3 * MXFP4_GROUP_SIZE)),
+    ],
+)
+def test_mxfp4_qat_grid_matches_rollout_after_native_layout_conversion(linear_name, shape):
+    torch.manual_seed(1)
+    weight = torch.randn(shape, device="cuda", dtype=torch.bfloat16)
+
+    def convert_native_layout(value):
+        return value.chunk(2, dim=0) if linear_name == "linear_fc1" else (value,)
+
+    qat_converted = convert_native_layout(mxfp4_quantize_dequantize(weight))
+    rollout_converted = convert_native_layout(weight)
+
+    for qat_weight, rollout_weight in zip(qat_converted, rollout_converted, strict=True):
+        packed, scale = mxfp4_quantize(rollout_weight)
+        expected = _dequantize_reference(packed, scale).to(weight.dtype)
+        assert torch.equal(qat_weight, expected)
+
+
+def test_mxfp4_qat_ste_passes_gradient_through_and_preserves_main_grad():
+    weight = torch.randn((4, 2 * MXFP4_GROUP_SIZE), device="cuda", requires_grad=True)
+    weight.main_grad = torch.empty_like(weight)
+    grad = torch.randn_like(weight)
+
+    output = mxfp4_fake_quantize_ste(weight)
+    output.backward(grad)
+
+    assert torch.equal(weight.grad, grad)
+    assert output.main_grad is weight.main_grad
+
+
+def test_grouped_linear_patch_is_config_gated(monkeypatch):
+    weight = torch.randn((2, MXFP4_GROUP_SIZE), device="cuda")
+    module = SimpleNamespace(config=SimpleNamespace(dsv4_mxfp4_qat=False))
+    wrapped = _wrap_get_weight_tensors(lambda _: [weight])
+
+    assert wrapped(module) == [weight]
+
+    sentinel = torch.zeros_like(weight)
+    monkeypatch.setattr(
+        "miles_plugins.models.deepseek_v4.ops.mxfp4_qat.mxfp4_fake_quantize_ste",
+        lambda _: sentinel,
+    )
+    module.config.dsv4_mxfp4_qat = True
+    assert wrapped(module) == [sentinel]

--- a/tests/fast-gpu/test_nvme_optimizer_main_init.py
+++ b/tests/fast-gpu/test_nvme_optimizer_main_init.py
@@ -42,3 +42,41 @@ def test_bucketwise_main_initialization_preserves_bytes_and_releases_cuda_storag
     restored = torch.frombuffer(bytearray(os.pread(bucket.fd, nbytes, 0)), dtype=torch.float32)
     torch.testing.assert_close(restored, model_param.float().cpu(), atol=0, rtol=0)
     os.close(bucket.fd)
+
+
+def test_bucketwise_rematerialization_restores_param_buffer_and_releases_main(tmp_path):
+    param_data = torch.arange(600_000, dtype=torch.float32, device="cuda").to(torch.bfloat16)
+    expected = param_data.clone()
+    model_param = torch.nn.Parameter(param_data)
+    main_param = torch.empty_like(model_param, dtype=torch.float32)
+    _resize(main_param, 0)
+    bucket = _Bucket(
+        str(tmp_path / "bucket.bin"),
+        entries=[_Entry(model_param, main_param, 0)],
+        adam=None,
+        stager=_Stager(1024 * 1024),
+        dtypes={segment: torch.float32 for segment in ("main", "exp_avg", "exp_avg_sq")},
+    )
+    param_range = SimpleNamespace(start=0, end=model_param.numel(), size=model_param.numel())
+    buffer = SimpleNamespace(buckets=[SimpleNamespace(param_data=param_data)])
+    dist_opt = SimpleNamespace(
+        model_fp32_groups=[],
+        shard_fp32_groups=[],
+        model_param_gbuf_map={model_param: (0, 0, 0)},
+        buffers=[buffer],
+        _get_model_param_range_map=lambda _param: {
+            "param": param_range,
+            "gbuf_world_in_bucket": param_range,
+        },
+    )
+    store = object.__new__(NVMeOptimizerStateStore)
+    store.dist_opt = dist_opt
+    store.buckets = [bucket]
+
+    store.initialize_main_from_model_params()
+    param_data.zero_()
+    store.restore_model_params_from_main()
+
+    assert main_param.untyped_storage().nbytes() == 0
+    torch.testing.assert_close(param_data, expected, atol=0, rtol=0)
+    os.close(bucket.fd)

--- a/tests/fast/backends/megatron_utils/test_dsv4_bridge_runtime.py
+++ b/tests/fast/backends/megatron_utils/test_dsv4_bridge_runtime.py
@@ -1,0 +1,64 @@
+from types import SimpleNamespace
+from miles.backends.megatron_utils.model_provider import _apply_bridge_runtime_config
+
+
+def _runtime_args(**overrides):
+    values = {
+        "tensor_model_parallel_size": 1,
+        "pipeline_model_parallel_size": 8,
+        "expert_model_parallel_size": 4,
+        "expert_tensor_parallel_size": 1,
+        "sequence_parallel": False,
+        "context_parallel_size": 1,
+        "calculate_per_token_loss": False,
+        "variable_seq_lengths": True,
+        "attention_softmax_in_fp32": True,
+        "gradient_accumulation_fusion": True,
+        "fp32_residual_connection": False,
+        "deterministic_mode": True,
+        "recompute_granularity": "full",
+        "recompute_method": "uniform",
+        "recompute_num_layers": 1,
+        "recompute_modules": None,
+        "cpu_offloading_num_layers": 0,
+        "distribute_saved_activations": False,
+        "tp_comm_overlap": False,
+        "fp8": "e4m3",
+        "fp8_recipe": "mxfp8",
+        "attention_backend": "auto",
+        "dsa_kernel_backend": "cudnn",
+        "mtp_num_layers": None,
+        "moe_token_dispatcher_type": "alltoall",
+        "decoder_first_pipeline_num_layers": 4,
+        "decoder_last_pipeline_num_layers": 3,
+        "moe_router_bias_update_rate": None,
+        "moe_aux_loss_coeff": None,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def _provider():
+    return SimpleNamespace(
+        dsa_kernel_backend="none",
+        mtp_num_layers=1,
+        experimental_attention_variant="dsv4_hybrid",
+    )
+
+
+def test_bridge_runtime_preserves_native_variant_and_disables_unrequested_mtp():
+    provider = _provider()
+
+    _apply_bridge_runtime_config(provider, _runtime_args())
+
+    assert provider.experimental_attention_variant == "dsv4_hybrid"
+    assert provider.dsa_kernel_backend == "cudnn"
+    assert provider.mtp_num_layers is None
+
+
+def test_bridge_runtime_resolves_native_dsv4_kernel_default():
+    provider = _provider()
+
+    _apply_bridge_runtime_config(provider, _runtime_args(dsa_kernel_backend=None))
+
+    assert provider.dsa_kernel_backend == "cudnn"

--- a/tests/fast/backends/megatron_utils/test_dsv4_bridge_runtime.py
+++ b/tests/fast/backends/megatron_utils/test_dsv4_bridge_runtime.py
@@ -1,4 +1,6 @@
 from types import SimpleNamespace
+from unittest.mock import patch
+
 from miles.backends.megatron_utils.model_provider import _apply_bridge_runtime_config
 
 
@@ -28,6 +30,7 @@ def _runtime_args(**overrides):
         "attention_backend": "auto",
         "dsa_kernel_backend": "cudnn",
         "mtp_num_layers": None,
+        "dsv4_mxfp4_qat": False,
         "moe_token_dispatcher_type": "alltoall",
         "decoder_first_pipeline_num_layers": 4,
         "decoder_last_pipeline_num_layers": 3,
@@ -54,6 +57,7 @@ def test_bridge_runtime_preserves_native_variant_and_disables_unrequested_mtp():
     assert provider.experimental_attention_variant == "dsv4_hybrid"
     assert provider.dsa_kernel_backend == "cudnn"
     assert provider.mtp_num_layers is None
+    assert provider.dsv4_mxfp4_qat is False
 
 
 def test_bridge_runtime_resolves_native_dsv4_kernel_default():
@@ -62,3 +66,13 @@ def test_bridge_runtime_resolves_native_dsv4_kernel_default():
     _apply_bridge_runtime_config(provider, _runtime_args(dsa_kernel_backend=None))
 
     assert provider.dsa_kernel_backend == "cudnn"
+
+
+def test_bridge_runtime_installs_mxfp4_qat_when_enabled():
+    provider = _provider()
+
+    with patch("miles_plugins.models.deepseek_v4.ops.mxfp4_qat.install_dsv4_mxfp4_qat") as install_qat:
+        _apply_bridge_runtime_config(provider, _runtime_args(dsv4_mxfp4_qat=True))
+
+    install_qat.assert_called_once_with()
+    assert provider.dsv4_mxfp4_qat is True

--- a/tests/fast/backends/megatron_utils/test_dsv4_bridge_weight_iterator.py
+++ b/tests/fast/backends/megatron_utils/test_dsv4_bridge_weight_iterator.py
@@ -1,0 +1,36 @@
+from argparse import Namespace
+
+from miles.backends.megatron_utils.update_weight.hf_weight_iterator_bridge import _select_bridge_checkpoint
+
+
+def test_bridge_uses_direct_hf_trainer_seed_for_export_mappings(tmp_path):
+    trainer_seed = tmp_path / "trainer"
+    trainer_seed.mkdir()
+    (trainer_seed / "model.safetensors.index.json").write_text("{}")
+    rollout_schema = tmp_path / "rollout-schema"
+    rollout_schema.mkdir()
+
+    selected = _select_bridge_checkpoint(
+        Namespace(load=str(trainer_seed), ref_load=str(trainer_seed), hf_checkpoint=str(rollout_schema))
+    )
+
+    assert selected == str(trainer_seed)
+
+
+def test_bridge_uses_hf_reference_after_resume(tmp_path):
+    training_checkpoint = tmp_path / "torch-dist"
+    training_checkpoint.mkdir()
+    (training_checkpoint / "latest_checkpointed_iteration.txt").write_text("1")
+    trainer_seed = tmp_path / "trainer"
+    trainer_seed.mkdir()
+    (trainer_seed / "model.safetensors.index.json").write_text("{}")
+
+    selected = _select_bridge_checkpoint(
+        Namespace(
+            load=str(training_checkpoint),
+            ref_load=str(trainer_seed),
+            hf_checkpoint=str(tmp_path / "rollout-schema"),
+        )
+    )
+
+    assert selected == str(trainer_seed)

--- a/tests/fast/backends/megatron_utils/test_lora_hf_weight_iterator.py
+++ b/tests/fast/backends/megatron_utils/test_lora_hf_weight_iterator.py
@@ -49,6 +49,20 @@ class TestHfWeightIteratorFactory:
             iterator = self._create("raw")
             assert isinstance(iterator, HfWeightIteratorDirect)
 
+    def test_dsv4_bridge_uses_checkpoint_layout_atomic_groups(self):
+        from miles.backends.megatron_utils.update_weight.hf_weight_iterator_bridge import HfWeightIteratorBridge
+
+        iterator = object.__new__(HfWeightIteratorBridge)
+        iterator.model_name = "deepseekv4"
+        iterator.args = Namespace(q_lora_rank=None)
+
+        groups = {group.key: group.suffixes for group in iterator._hf_atomic_update_groups()}
+        assert groups["wqkv_a"] == (".attn.wq_a.weight", ".attn.wkv.weight")
+        assert groups["compressor_wkv_gate"] == (
+            ".attn.compressor.wkv.weight",
+            ".attn.compressor.wgate.weight",
+        )
+
     def test_invalid_mode_raises(self):
         with pytest.raises(KeyError):
             self._create("invalid_mode")

--- a/tests/fast/backends/megatron_utils/test_rematerialize_utils.py
+++ b/tests/fast/backends/megatron_utils/test_rematerialize_utils.py
@@ -17,11 +17,34 @@ class _FakeDistOpt:
         self.copied += 1
 
 
+class _FakeNVMeStore:
+    def __init__(self):
+        self.restored = 0
+
+    def restore_model_params_from_main(self):
+        self.restored += 1
+
+
 def test_mcore_cast_calls_every_chained_optimizer():
     dist_opts = [_FakeDistOpt(), _FakeDistOpt()]
     cast = _build_cast_main_to_params_fn(SimpleNamespace(chained_optimizers=dist_opts), precision_aware=False)
     cast()
     assert [opt.copied for opt in dist_opts] == [1, 1]
+
+
+def test_mcore_cast_streams_evicted_main_params_from_nvme():
+    resident = _FakeDistOpt()
+    streamed = _FakeDistOpt()
+    streamed._nvme_state_store = _FakeNVMeStore()
+    cast = _build_cast_main_to_params_fn(
+        SimpleNamespace(chained_optimizers=[resident, streamed]), precision_aware=False
+    )
+
+    cast()
+
+    assert resident.copied == 1
+    assert streamed.copied == 0
+    assert streamed._nvme_state_store.restored == 1
 
 
 def test_hdo_replay_covers_both_fractions():

--- a/tests/fast/backends/training_utils/weight_update/test_atomic_groups.py
+++ b/tests/fast/backends/training_utils/weight_update/test_atomic_groups.py
@@ -1,5 +1,7 @@
 """Unit tests for the HF-namespace atomic group registry."""
 
+import pytest
+
 from tests.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=60, suite="stage-a-cpu", labels=[])
@@ -9,8 +11,17 @@ from miles.backends.training_utils.weight_update.hf_weight_iterator.atomic_group
 
 
 class TestHfAtomicUpdateGroups:
-    def test_deepseekv4_registers_the_three_fused_pairs(self):
-        groups = {g.key: g.suffixes for g in get_hf_atomic_update_groups("deepseekv4")}
+    @pytest.mark.parametrize(
+        "model_name",
+        [
+            "deepseekv4",
+            "DeepSeek-V4-Flash",
+            "deepseek-ai/DeepSeek-V4-Flash",
+            "DeepSeek_V4_Flash_0731",
+        ],
+    )
+    def test_deepseekv4_registers_the_three_fused_pairs(self, model_name):
+        groups = {g.key: g.suffixes for g in get_hf_atomic_update_groups(model_name)}
         assert groups == {
             "wqkv_a": (".self_attn.wq_a.weight", ".self_attn.wkv.weight"),
             "compressor_wkv_gate": (".self_attn.compressor.wkv.weight", ".self_attn.compressor.wgate.weight"),

--- a/tests/fast/backends/training_utils/weight_update/test_atomic_groups.py
+++ b/tests/fast/backends/training_utils/weight_update/test_atomic_groups.py
@@ -31,6 +31,20 @@ class TestHfAtomicUpdateGroups:
             ),
         }
 
+    def test_deepseekv4_checkpoint_layout_registers_bridge_export_names(self):
+        groups = {
+            group.key: group.suffixes
+            for group in get_hf_atomic_update_groups("deepseekv4", dsv4_checkpoint_layout=True)
+        }
+        assert groups == {
+            "wqkv_a": (".attn.wq_a.weight", ".attn.wkv.weight"),
+            "compressor_wkv_gate": (".attn.compressor.wkv.weight", ".attn.compressor.wgate.weight"),
+            "indexer_compressor_wkv_gate": (
+                ".attn.indexer.compressor.wkv.weight",
+                ".attn.indexer.compressor.wgate.weight",
+            ),
+        }
+
     def test_deepseekv4_suffixes_do_not_shadow_each_other(self):
         """endswith matching must resolve uniquely across the three v4 pairs."""
         suffixes = [s for g in get_hf_atomic_update_groups("deepseekv4") for s in g.suffixes]

--- a/tests/fast/backends/training_utils/weight_update/test_cuda_ipc.py
+++ b/tests/fast/backends/training_utils/weight_update/test_cuda_ipc.py
@@ -143,6 +143,27 @@ class TestConnect:
 
 
 class TestColocatedBaseSend:
+    def test_bucket_storage_is_released_after_all_ipc_consumers_finish(self) -> None:
+        protocol = UpdateWeightFromTensor.__new__(UpdateWeightFromTensor)
+        protocol.use_distribute = False
+        protocol._ipc_engine = MagicMock()
+        protocol._ipc_gather_src = 0
+        protocol._ipc_gather_group = MagicMock(name="ipc_group")
+        protocol._selector = "all"
+        future = MagicMock(name="engine_future")
+
+        with (
+            patch(f"{_TENSOR_MODULE}._send_to_colocated_engine", return_value=([future], object())),
+            patch(f"{_TENSOR_MODULE}.async_utils.wait_futures", return_value=[{"success": True}]) as wait,
+            patch(f"{_TENSOR_MODULE}.check_weight_sync_results") as check,
+            patch(f"{_TENSOR_MODULE}.dist.barrier") as barrier,
+        ):
+            protocol.send_bucket([("weight", torch.zeros(1))])
+
+        wait.assert_called_once_with([future])
+        check.assert_called_once_with([{"success": True}], is_lora=False)
+        barrier.assert_called_once_with(group=protocol._ipc_gather_group)
+
     def test_multiple_colocated_buckets_are_sent_serially_in_source_order(self) -> None:
         """Two dtype buckets reach the engine one at a time and in the order they were built."""
         engine = _SerialProbeEngine()

--- a/tests/fast/launch_scripts/test_run_deepseek_v4.py
+++ b/tests/fast/launch_scripts/test_run_deepseek_v4.py
@@ -90,6 +90,20 @@ def test_direct_hf_full_train_skips_offline_weight_conversion(tmp_path, monkeypa
     train.assert_called_once_with(args)
 
 
+def test_trainer_owned_rollout_uses_dummy_sglang_initialization(tmp_path, monkeypatch):
+    module, args = _direct_hf_args(tmp_path, rollout_mxfp8=False)
+    source = tmp_path / "DeepSeek-V4-Flash"
+    source.mkdir()
+    (source / "config.json").write_text('{"expert_dtype": "fp4"}', encoding="utf-8")
+    execute_train = Mock()
+    monkeypatch.setattr(module.U, "execute_train", execute_train)
+
+    module._train(args)
+
+    extra_env_vars = execute_train.call_args.kwargs["extra_env_vars"]
+    assert extra_env_vars["MILES_SGLANG_DUMMY_LOAD"] == "1"
+
+
 def test_trainer_owned_rollout_paths_select_source_and_p1_schema(tmp_path):
     module, p1 = _direct_hf_args(tmp_path, rollout_mxfp8=True)
     _, p2 = _direct_hf_args(tmp_path, rollout_mxfp8=False)

--- a/tests/fast/launch_scripts/test_run_deepseek_v4.py
+++ b/tests/fast/launch_scripts/test_run_deepseek_v4.py
@@ -1,3 +1,5 @@
+from unittest.mock import Mock
+
 import pytest
 
 from tests.fast.launch_scripts.py_harness import (
@@ -45,3 +47,55 @@ def test_the_rollout_profile_follows_the_hardware(monkeypatch, tmp_path, overrid
     assert f"--rollout-num-gpus-per-engine {expected_size}" in train_command
     assert f"--sglang-tp-size {expected_size}" in train_command
     assert f"--sglang-ep-size {expected_size}" in train_command
+
+
+def _direct_hf_args(tmp_path, *, rollout_mxfp8: bool):
+    module = import_launch_script(REPO_ROOT / "scripts/run_deepseek_v4.py")
+    return module, module.ScriptArgs(
+        model_name="DeepSeek-V4-Flash",
+        init_model_source="hf",
+        rollout_weight_source="trainer",
+        model_dir=str(tmp_path),
+        model_local_dir=str(tmp_path),
+        hardware="B300",
+        train_fp8=False,
+        train_mxfp8=True,
+        rollout_fp8=not rollout_mxfp8,
+        rollout_mxfp8=rollout_mxfp8,
+    )
+
+
+def test_direct_hf_full_train_skips_offline_weight_conversion(tmp_path, monkeypatch):
+    module, args = _direct_hf_args(tmp_path, rollout_mxfp8=True)
+    prepare_download = Mock()
+    prepare_single = Mock()
+    prepare_mxfp8 = Mock()
+    prepare_spmd = Mock()
+    prepare_schema = Mock()
+    train = Mock()
+    monkeypatch.setattr(module, "_prepare_download", prepare_download)
+    monkeypatch.setattr(module, "_prepare_single", prepare_single)
+    monkeypatch.setattr(module, "_prepare_mxfp8", prepare_mxfp8)
+    monkeypatch.setattr(module, "_prepare_spmd", prepare_spmd)
+    monkeypatch.setattr(module, "_prepare_mxfp8_schema", prepare_schema)
+    monkeypatch.setattr(module, "_train", train)
+
+    module._full_train(args)
+
+    prepare_download.assert_called_once_with(args)
+    prepare_single.assert_not_called()
+    prepare_mxfp8.assert_not_called()
+    prepare_spmd.assert_not_called()
+    prepare_schema.assert_called_once_with(args)
+    train.assert_called_once_with(args)
+
+
+def test_trainer_owned_rollout_paths_select_source_and_p1_schema(tmp_path):
+    module, p1 = _direct_hf_args(tmp_path, rollout_mxfp8=True)
+    _, p2 = _direct_hf_args(tmp_path, rollout_mxfp8=False)
+    source = tmp_path / "DeepSeek-V4-Flash"
+
+    assert module._trainer_checkpoint_path(p1) == str(source)
+    assert module._rollout_checkpoint_path(p1) == str(tmp_path / "DeepSeek-V4-Flash-MXFP8-schema")
+    assert module._trainer_checkpoint_path(p2) == str(source)
+    assert module._rollout_checkpoint_path(p2) == str(source)

--- a/tests/fast/launch_scripts/test_run_deepseek_v4.py
+++ b/tests/fast/launch_scripts/test_run_deepseek_v4.py
@@ -1,3 +1,4 @@
+import json
 from unittest.mock import Mock
 
 import pytest
@@ -113,3 +114,25 @@ def test_trainer_owned_rollout_paths_select_source_and_p1_schema(tmp_path):
     assert module._rollout_checkpoint_path(p1) == str(tmp_path / "DeepSeek-V4-Flash-MXFP8-schema")
     assert module._trainer_checkpoint_path(p2) == str(source)
     assert module._rollout_checkpoint_path(p2) == str(source)
+
+
+def test_p3_uses_native_hybrid_trainer_and_packed_mxfp4_rollout(tmp_path, monkeypatch):
+    module, args = _direct_hf_args(tmp_path, rollout_mxfp8=False)
+    args.dsv4_mxfp4_qat = True
+    args.skip_saving = True
+    source = tmp_path / "DeepSeek-V4-Flash"
+    source.mkdir()
+    (source / "config.json").write_text(json.dumps({"expert_dtype": "fp4"}), encoding="utf-8")
+    execute_train = Mock()
+    monkeypatch.setattr(module.U, "execute_train", execute_train)
+
+    module._train(args)
+
+    train_args = execute_train.call_args.kwargs["train_args"]
+    assert "--megatron-to-hf-mode bridge" in train_args
+    assert "--dsv4-impl megatron" in train_args
+    assert "--qkv-format thd" in train_args
+    assert "--dsv4-mxfp4-qat" in train_args
+    assert "--fp8-recipe mxfp8" in train_args
+    assert "--rollout-fp4-experts" in train_args
+    assert execute_train.call_args.kwargs["extra_env_vars"]["SGLANG_DSV4_FP4_EXPERTS"] == "1"

--- a/tests/fast/optimizers/test_nvme_stream.py
+++ b/tests/fast/optimizers/test_nvme_stream.py
@@ -5,11 +5,53 @@ keeps working against pinned host memory while the log still claims otherwise.
 """
 
 import os
+from unittest.mock import Mock
 
 import pytest
 import torch
 
 from miles_plugins.optimizers import nvme_stream
+
+
+def test_fetch_main_never_materializes_adam_moments():
+    bucket = object.__new__(nvme_stream._Bucket)
+    bucket._move = Mock(return_value=128)
+
+    assert bucket.fetch_main() == 128
+    bucket._move.assert_called_once_with(("main",), to_disk=False)
+
+
+def test_model_param_restore_streams_and_releases_each_bucket():
+    calls = []
+
+    class FakeBucket:
+        entries = [object()]
+
+        def __init__(self, index):
+            self.index = index
+
+        def fetch_main(self):
+            calls.append(("fetch", self.index))
+            return 4
+
+        def flush(self, segments):
+            calls.append(("flush", self.index, segments))
+            return 4
+
+    store = object.__new__(nvme_stream.NVMeOptimizerStateStore)
+    store.buckets = [FakeBucket(0), FakeBucket(1)]
+    store._copy_main_to_model_params = lambda entries: calls.append(("copy", entries[0]))
+
+    store.restore_model_params_from_main()
+
+    assert calls == [
+        ("fetch", 0),
+        ("copy", store.buckets[0].entries[0]),
+        ("flush", 0, ("main",)),
+        ("fetch", 1),
+        ("copy", store.buckets[1].entries[0]),
+        ("flush", 1, ("main",)),
+    ]
 
 
 def test_disk_buffer_matches_shape_and_dtype_and_is_not_pinned(tmp_path):

--- a/tests/fast/utils/test_arguments.py
+++ b/tests/fast/utils/test_arguments.py
@@ -459,6 +459,51 @@ def test_stream_optimizer_state_to_disk_rejects_fault_tolerant_training():
         miles_validate_args(args)
 
 
+def _make_cpu_offload_streaming_args(*, rematerialize: bool) -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    get_miles_extra_args_provider()(parser)
+    extra = [
+        "--stream-optimizer-state-to-disk",
+        "--colocate",
+        "--offload-train",
+        "--offload-train-target",
+        "cpu",
+        "--num-rollout",
+        "1",
+    ]
+    if rematerialize:
+        extra.append("--rematerialize-param-from-master-weight")
+    args = parser.parse_args(extra + REQUIRED_ARGS)
+    vars(args).update(
+        optimizer="adam",
+        use_distributed_optimizer=True,
+        optimizer_cpu_offload=False,
+        offload_optimizer_states=False,
+        use_precision_aware_optimizer=False,
+        overlap_param_gather=False,
+        compute_advantages_and_returns=True,
+        num_critic_only_steps=0,
+    )
+    _set_megatron_parallel_sizes(args)
+    return args
+
+
+def test_stream_optimizer_state_to_disk_accepts_cpu_offload_with_rematerialization():
+    args = _make_cpu_offload_streaming_args(rematerialize=True)
+
+    miles_validate_args(args)
+
+    assert args.offload_train_target == "cpu"
+    assert args.rematerialize_param_from_master_weight is True
+
+
+def test_stream_optimizer_state_to_disk_rejects_cpu_offload_without_rematerialization():
+    args = _make_cpu_offload_streaming_args(rematerialize=False)
+
+    with pytest.raises(AssertionError, match="requires --rematerialize-param-from-master-weight"):
+        miles_validate_args(args)
+
+
 class TestCriticSaveDerivation:
     def _validate(self, extra):
         parser = argparse.ArgumentParser()

--- a/tests/fast/utils/test_hf_rollout_schema.py
+++ b/tests/fast/utils/test_hf_rollout_schema.py
@@ -1,0 +1,103 @@
+"""Tests for metadata-only Hugging Face rollout schemas."""
+
+import json
+import struct
+from pathlib import Path
+
+import pytest
+
+from miles.utils.hf_rollout_schema import build_mxfp8_quantization_config, create_mxfp8_rollout_schema
+
+
+def _write_safetensors_header(path: Path, tensors: dict[str, dict]) -> None:
+    header = json.dumps(tensors).encode("utf-8")
+    path.write_bytes(struct.pack("<Q", len(header)) + header)
+
+
+def _write_checkpoint(path: Path) -> None:
+    path.mkdir()
+    tensors = {
+        "model.embed_tokens.weight": {"dtype": "BF16", "shape": [32, 64], "data_offsets": [0, 1]},
+        "model.layers.0.input_layernorm.weight": {
+            "dtype": "BF16",
+            "shape": [64],
+            "data_offsets": [1, 2],
+        },
+        "model.layers.0.self_attn.wq_a.weight": {
+            "dtype": "F8_E4M3",
+            "shape": [64, 64],
+            "data_offsets": [2, 3],
+        },
+        "model.layers.0.self_attn.wo_a.weight": {
+            "dtype": "F8_E4M3",
+            "shape": [64, 64],
+            "data_offsets": [3, 4],
+        },
+        "model.layers.0.mlp.experts.0.gate_proj.weight": {
+            "dtype": "I8",
+            "shape": [64, 32],
+            "data_offsets": [4, 5],
+        },
+        "lm_head.weight": {"dtype": "BF16", "shape": [32, 64], "data_offsets": [5, 6]},
+    }
+    shard_name = "model-00001-of-00001.safetensors"
+    _write_safetensors_header(path / shard_name, tensors)
+    (path / "config.json").write_text(
+        json.dumps(
+            {
+                "architectures": ["TestForCausalLM"],
+                "expert_dtype": "fp4",
+                "quantization_config": {"quant_method": "fp8"},
+            }
+        )
+    )
+    (path / "model.safetensors.index.json").write_text(
+        json.dumps({"weight_map": {name: shard_name for name in tensors}})
+    )
+    (path / "tokenizer.json").write_text("{}")
+
+
+def test_mxfp8_config_uses_headers_without_treating_packed_experts_as_unquantized(tmp_path):
+    source = tmp_path / "source"
+    _write_checkpoint(source)
+
+    quantization_config = build_mxfp8_quantization_config(source)
+
+    assert quantization_config["quant_method"] == "mxfp8"
+    assert quantization_config["weight_block_size"] == [1, 32]
+    ignored = quantization_config["modules_to_not_convert"]
+    assert "model.embed_tokens" in ignored
+    assert "model.layers.0.input_layernorm" in ignored
+    assert "model.layers.0.self_attn.wo_a" in ignored
+    assert "lm_head" in ignored
+    assert "model.layers.0.self_attn.wq_a" not in ignored
+    assert not any("experts.0.gate_proj" in name for name in ignored)
+
+
+def test_schema_contains_model_metadata_but_no_weight_index_or_payload(tmp_path):
+    source = tmp_path / "source"
+    destination = tmp_path / "schema"
+    _write_checkpoint(source)
+
+    created = create_mxfp8_rollout_schema(source, destination)
+
+    assert created == destination.resolve()
+    assert (destination / "tokenizer.json").is_file()
+    assert not (destination / "model.safetensors.index.json").exists()
+    assert not list(destination.glob("*.safetensors"))
+    config = json.loads((destination / "config.json").read_text())
+    assert config["expert_dtype"] == "fp8"
+    assert config["quantization_config"]["quant_method"] == "mxfp8"
+    marker = json.loads((destination / ".miles-rollout-schema.json").read_text())
+    assert marker["weight_payloads"] is False
+
+
+def test_schema_refuses_directory_with_weight_payloads(tmp_path):
+    source = tmp_path / "source"
+    destination = tmp_path / "schema"
+    _write_checkpoint(source)
+    destination.mkdir()
+    (destination / "unexpected.safetensors").write_bytes(b"payload")
+
+    with pytest.raises(ValueError, match="containing weight payloads"):
+        create_mxfp8_rollout_schema(source, destination)

--- a/tests/fast/utils/test_mxfp4.py
+++ b/tests/fast/utils/test_mxfp4.py
@@ -1,0 +1,78 @@
+import torch
+
+from miles.utils.mxfp4 import E2M1_VALUES, MXFP4_GROUP_SIZE, mxfp4_quantize
+
+
+E8M0_BIAS = 127
+
+
+def _dequantize_mxfp4(packed: torch.Tensor, scale: torch.Tensor) -> torch.Tensor:
+    logical_shape = (*packed.shape[:-1], packed.shape[-1] * 2)
+    codes = packed.view(torch.uint8)
+    nibbles = torch.stack((codes & 0x0F, (codes >> 4) & 0x0F), dim=-1).flatten(-2)
+    table = torch.tensor(E2M1_VALUES + tuple(-value for value in E2M1_VALUES), device=packed.device)
+    values = table[nibbles.long()].reshape(-1, MXFP4_GROUP_SIZE)
+    scale_factor = torch.exp2(scale.view(torch.uint8).float() - E8M0_BIAS).reshape(-1, 1)
+    return (values * scale_factor).reshape(logical_shape)
+
+
+def test_quantize_is_exact_on_representable_values():
+    row = torch.tensor(E2M1_VALUES).repeat(MXFP4_GROUP_SIZE // len(E2M1_VALUES))
+    weight = torch.stack([row, -row])
+
+    packed, scale = mxfp4_quantize(weight)
+
+    assert torch.equal(_dequantize_mxfp4(packed, scale), weight)
+
+
+def test_quantize_round_trips_represented_values():
+    torch.manual_seed(0)
+    weight = torch.randn(64, 4 * MXFP4_GROUP_SIZE) * 0.05
+
+    packed, scale = mxfp4_quantize(weight)
+    decoded = _dequantize_mxfp4(packed, scale)
+
+    repacked, rescale = mxfp4_quantize(decoded)
+    assert torch.equal(_dequantize_mxfp4(repacked, rescale), decoded)
+
+
+def test_quantize_keeps_error_within_the_grid_spacing():
+    torch.manual_seed(0)
+    weight = torch.randn(32, 2 * MXFP4_GROUP_SIZE)
+
+    packed, scale = mxfp4_quantize(weight)
+    decoded = _dequantize_mxfp4(packed, scale)
+
+    blocks = weight.reshape(-1, MXFP4_GROUP_SIZE)
+    exponent = scale.view(torch.uint8).float().reshape(-1, 1) - E8M0_BIAS
+    tolerance = torch.exp2(exponent)
+    assert ((decoded.reshape(-1, MXFP4_GROUP_SIZE) - blocks).abs() <= tolerance).all()
+
+
+def test_quantize_emits_the_packed_layout():
+    weight = torch.zeros(1, MXFP4_GROUP_SIZE)
+    weight[0, 0] = 1.0
+    weight[0, 1] = 6.0
+
+    packed, scale = mxfp4_quantize(weight)
+
+    assert packed.shape == (1, MXFP4_GROUP_SIZE // 2)
+    assert scale.shape == (1, 1)
+    assert packed.view(torch.uint8)[0, 0].item() == (7 << 4) | 2
+
+
+def test_quantize_emits_scales_that_carry_their_value():
+    weight = torch.zeros(1, MXFP4_GROUP_SIZE)
+    weight[0, 0] = 48.0
+
+    _, scale = mxfp4_quantize(weight)
+
+    assert scale.dtype == torch.float8_e8m0fnu
+    assert scale.float().item() == 8.0
+    assert scale.view(torch.uint8).item() == 3 + E8M0_BIAS
+
+
+def test_quantize_encodes_zero_blocks_without_nan():
+    packed, scale = mxfp4_quantize(torch.zeros(2, MXFP4_GROUP_SIZE))
+
+    assert torch.equal(_dequantize_mxfp4(packed, scale), torch.zeros(2, MXFP4_GROUP_SIZE))

--- a/tools/convert_hf_to_mxfp8.py
+++ b/tools/convert_hf_to_mxfp8.py
@@ -22,24 +22,12 @@ import torch
 from sglang.srt.layers.quantization.fp8_utils import block_quant_dequant
 from tqdm import tqdm
 
+from miles.utils.hf_rollout_schema import MXFP8_SKIP_WEIGHT_SUBSTRINGS
 from miles.utils.mxfp8 import MXFP8_GROUP_SIZE
 from miles.utils.mxfp8 import mxfp8_quantize as quantize_mxfp8
 
 
-SKIP_WEIGHT_SUBSTRINGS = (
-    "layernorm",
-    "embed",
-    "router",
-    "mlp.gate.",
-    "norm",
-    "lm_head",
-    "eh_proj",
-    "weights_proj",
-    "head.",
-    "wo_a",
-    "ffn.gate.",
-    "compressor.",
-)
+SKIP_WEIGHT_SUBSTRINGS = MXFP8_SKIP_WEIGHT_SUBSTRINGS
 
 SOURCE_FP8_BLOCK_SIZE = [128, 128]
 TARGET_MXFP8_BLOCK_SIZE = [1, MXFP8_GROUP_SIZE]

--- a/tools/param_name_remap.py
+++ b/tools/param_name_remap.py
@@ -1,19 +1,3 @@
-import json
-from collections.abc import Callable
+from miles.utils.hf_parameter_names import get_param_name_remap
 
-
-def _is_deepseek_v4_native(config_path: str, weight_map: dict) -> bool:
-    # Only native-format V4 checkpoints need the HF remap; re-saved HF-format V4
-    # and V3/V3.2 checkpoints are already HF-named (embed.weight is the native marker).
-    with open(config_path) as f:
-        is_v4_arch = "DeepseekV4ForCausalLM" in json.load(f).get("architectures", [])
-    return is_v4_arch and "embed.weight" in weight_map
-
-
-def get_param_name_remap(config_path: str, weight_map: dict) -> Callable[[str], str]:
-    # DeepSeek-V4 native checkpoints remap to HF names; everything else is identity.
-    if _is_deepseek_v4_native(config_path, weight_map):
-        from sglang.srt.models.deepseek_v4 import DeepseekV4ForCausalLM
-
-        return DeepseekV4ForCausalLM.remap_weight_name_to_dpsk_hf_format
-    return lambda name: name
+__all__ = ["get_param_name_remap"]


### PR DESCRIPTION
## Summary

- allow colocated CPU trainer offload to be combined with NVMe-streamed Adam state when parameter rematerialization is enabled
- restore model parameter shards from streamed FP32 main weights one bucket at a time
- release each main-weight bucket immediately, without loading Adam moments during rematerialization

This is stacked on #3135; its diff will reduce to this commit after the parent stack lands.

## Why

DeepSeek V4 training fits during the first backward, but the Adam state created by the first optimizer step remains resident and causes the next backward to OOM. Trainer disk offload avoids host pressure but currently crashes in TorchMemorySaver/CUDACachingAllocator during hot weight update. CPU trainer offload has a stable hot-update lifecycle; streaming optimizer state to NVMe removes the active-training Adam-state peak, but previously could not rematerialize evicted FP32 main weights.

## Tests

- 40 focused CPU tests passed
- 2 focused CUDA tests passed on B300, including clearing a parameter buffer, restoring it bit-exactly from NVMe, and verifying the FP32 main storage returns to zero bytes
- Ruff and `git diff --check` passed
