### PR TITLE
rollout: make sandbox credentials file-only

### DIFF
--- a/examples/experimental/agentenv/README.md
+++ b/examples/experimental/agentenv/README.md
@@ -53,7 +53,6 @@ documented in the [AgentENV docs](https://kvcache-ai.github.io/AgentENV/).
 
 ## 2. Point the E2B SDK at it
 
-<!-- 2026-09-09, tianqi, file-only sandbox credentials (#3111) -->
 ```bash
 pip install -e '<miles>[e2b]'   # e2b>=2.12: older releases send the template name in a field AgentENV does not read
 export E2B_API_URL=http://<server>:8000       # control plane
@@ -64,7 +63,6 @@ export OPENENV_E2B_URL_SCHEME=http
 # recent SDKs do validate the format client-side
 mkdir -p ~/.config/e2b && echo e2b_0000000000000000000000000000000000000000 > ~/.config/e2b/api_key
 ```
-<!-- end -->
 
 ## 3. Train
 

--- a/examples/experimental/agentenv/README.md
+++ b/examples/experimental/agentenv/README.md
@@ -53,6 +53,7 @@ documented in the [AgentENV docs](https://kvcache-ai.github.io/AgentENV/).
 
 ## 2. Point the E2B SDK at it
 
+<!-- 2026-09-09, tianqi, file-only sandbox credentials (#3111) -->
 ```bash
 pip install -e '<miles>[e2b]'   # e2b>=2.12: older releases send the template name in a field AgentENV does not read
 export E2B_API_URL=http://<server>:8000       # control plane
@@ -61,8 +62,9 @@ export E2B_SANDBOX_URL=http://<server>:8000   # data plane (envd proxy)
 export OPENENV_E2B_URL_SCHEME=http
 # required, but any well-formed key passes: AgentENV does not check it, while
 # recent SDKs do validate the format client-side
-export E2B_API_KEY=e2b_0000000000000000000000000000000000000000
+mkdir -p ~/.config/e2b && echo e2b_0000000000000000000000000000000000000000 > ~/.config/e2b/api_key
 ```
+<!-- end -->
 
 ## 3. Train
 

--- a/examples/experimental/openenv/README.md
+++ b/examples/experimental/openenv/README.md
@@ -64,7 +64,6 @@ from, and `OPENENV_SANDBOX_BACKEND`, the provider to build them on. Neither has
 a default — the provider decides whose quota a run spends and which credentials
 have to be present — so setting one without the other fails at launch.
 
-<!-- 2026-09-09, tianqi, file-only sandbox credentials (#3111) -->
 Every provider authenticates the same way: a key *file* whose *path* the
 launcher forwards (`~/.config/daytona/api_key`, `~/.config/e2b/api_key`, or
 Modal's `~/.modal.toml`). It never forwards the value, which ray's
@@ -74,7 +73,6 @@ env supply used to silently mask a missing file resolver. The
 agent-function docstrings cover what that means on a multi-host cluster.
 CI runners whose secrets are env-shaped write the file in a one-line step
 before launching.
-<!-- end -->
 
 ### Daytona
 

--- a/examples/experimental/openenv/README.md
+++ b/examples/experimental/openenv/README.md
@@ -64,13 +64,17 @@ from, and `OPENENV_SANDBOX_BACKEND`, the provider to build them on. Neither has
 a default — the provider decides whose quota a run spends and which credentials
 have to be present — so setting one without the other fails at launch.
 
-Every provider authenticates the same way: the credential in the environment
-(`DAYTONA_API_KEY`, `E2B_API_KEY`, or Modal's `MODAL_TOKEN_ID` +
-`MODAL_TOKEN_SECRET` pair), or else a file whose *path* the launcher forwards.
-It never forwards the value, which ray's `runtime_env` records in plaintext;
-the agent-function docstrings cover what that means on a multi-host cluster.
-A partially-supplied credential (one half of Modal's token pair) is treated as
-missing rather than usable.
+<!-- 2026-09-09, tianqi, file-only sandbox credentials (#3111) -->
+Every provider authenticates the same way: a key *file* whose *path* the
+launcher forwards (`~/.config/daytona/api_key`, `~/.config/e2b/api_key`, or
+Modal's `~/.modal.toml`). It never forwards the value, which ray's
+`runtime_env` records in plaintext; a set key env var (`DAYTONA_API_KEY`,
+`E2B_API_KEY`, `MODAL_TOKEN_ID` / `MODAL_TOKEN_SECRET`) is rejected, because
+env supply used to silently mask a missing file resolver. The
+agent-function docstrings cover what that means on a multi-host cluster.
+CI runners whose secrets are env-shaped write the file in a one-line step
+before launching.
+<!-- end -->
 
 ### Daytona
 
@@ -82,7 +86,7 @@ there is nothing to pre-build ahead of a run.
 
 ```bash
 pip install daytona
-mkdir -p ~/.config/daytona && echo dtn_... > ~/.config/daytona/api_key   # or export DAYTONA_API_KEY
+mkdir -p ~/.config/daytona && echo dtn_... > ~/.config/daytona/api_key
 export OPENENV_TB2_TASKS_DIR=/workspace/terminal-bench-2   # the checkout from step 1
 OPENENV_SANDBOX_BACKEND=daytona python run-openenv-tbench2.py
 ```
@@ -98,7 +102,7 @@ microVM platform whose native API *is* the E2B API — set `E2B_API_URL` and
 
 ```bash
 pip install -e '<miles>[e2b]'   # e2b>=2.12 (see the AgentENV recipe)
-export E2B_API_KEY=e2b_...     # or E2B_API_KEY_FILE (default ~/.config/e2b/api_key)
+mkdir -p ~/.config/e2b && echo e2b_... > ~/.config/e2b/api_key   # or E2B_API_KEY_FILE
 export OPENENV_TB2_TASKS_DIR=/workspace/terminal-bench-2
 OPENENV_SANDBOX_BACKEND=e2b python run-openenv-tbench2.py
 ```
@@ -122,7 +126,7 @@ what later creates hit.
 
 ```bash
 pip install modal
-modal token new    # writes ~/.modal.toml; or export MODAL_TOKEN_ID + MODAL_TOKEN_SECRET
+modal token new    # writes ~/.modal.toml
 export OPENENV_TB2_TASKS_DIR=/workspace/terminal-bench-2
 OPENENV_SANDBOX_BACKEND=modal python run-openenv-tbench2.py
 ```
@@ -215,10 +219,10 @@ provider's credentials, then the knobs — the ones shared by every backend
 | --- | --- | --- |
 | `OPENENV_TB2_TASKS_DIR` | off | Switches on per-episode sandbox mode and overrides `--openenv-env-url`. Point it at the terminal-bench-2 checkout from step 1 |
 | `OPENENV_SANDBOX_BACKEND` | — | Required whenever `OPENENV_TB2_TASKS_DIR` is set: `agentenv` (alias for `e2b`), `daytona`, `e2b`, or `modal`. Only the selected backend's settings below are read — the others are ignored silently |
-| `DAYTONA_API_KEY` / `DAYTONA_API_KEY_FILE` | — / `~/.config/daytona/api_key` | Daytona key supply: the env value wins, otherwise the key file is read |
-| `E2B_API_KEY` / `E2B_API_KEY_FILE` | — / `~/.config/e2b/api_key` | E2B key supply, on the same contract |
+| `DAYTONA_API_KEY_FILE` | `~/.config/daytona/api_key` | Daytona key file. File-only: a set `DAYTONA_API_KEY` is rejected |
+| `E2B_API_KEY_FILE` | `~/.config/e2b/api_key` | E2B key file, on the same contract |
 | `E2B_API_URL`, `E2B_SANDBOX_URL` | E2B Cloud | Endpoint overrides — point both at a self-hosted AgentENV gateway |
-| `MODAL_TOKEN_ID` + `MODAL_TOKEN_SECRET` / `MODAL_CONFIG_PATH` | — / `~/.modal.toml` | Modal credential supply. The token PAIR must be complete; otherwise the config file's *path* is forwarded, like the other providers' key files |
+| `MODAL_CONFIG_PATH` | `~/.modal.toml` | Modal config file. File-only: a set `MODAL_TOKEN_ID` / `MODAL_TOKEN_SECRET` is rejected |
 | `MODAL_PROFILE`, `MODAL_ENVIRONMENT` | profile default | Which Modal profile / workspace environment the sandboxes are created in |
 | `OPENENV_<BACKEND>_CREATE_CONCURRENCY` | `4` | Max in-flight creates. Size it to what the endpoint can host — one self-hosted AgentENV machine took 16; on Modal the ceiling above it is the plan's container concurrency |
 | `OPENENV_<BACKEND>_CREATE_MAX_RETRIES` | `8` | How many throttled creates to retry before giving up (the backoff curve itself is not tunable) |

--- a/examples/experimental/openenv/glm52_tbench2/README.md
+++ b/examples/experimental/openenv/glm52_tbench2/README.md
@@ -68,9 +68,11 @@ official `docker_image`. Point `OPENENV_TB2_TASKS_DIR` at it.
 sandboxes (128 in the reference config; each 2 vCPU / 4 GiB / 10 GiB). Keep
 the credential in a file outside git:
 
+<!-- 2026-09-09, tianqi, file-only sandbox credentials (#3111) -->
 ```bash
-printf 'export DAYTONA_API_KEY=dtn_...\n' > ~/.daytona_env && chmod 600 ~/.daytona_env
+mkdir -p ~/.config/daytona && echo dtn_... > ~/.config/daytona/api_key && chmod 600 ~/.config/daytona/api_key
 ```
+<!-- end -->
 
 Images are built per task and cached by definition hash (first episode of a
 task ~10 min, repeats ~1 min).
@@ -93,7 +95,7 @@ that id selects the per-episode sandbox image.
 
 ```bash
 export MILES_ROOT=...  CONTAINER_IMAGE=...  CONTAINER_MOUNTS=...
-export DAYTONA_ENV_FILE=~/.daytona_env
+export DAYTONA_API_KEY_FILE=~/.config/daytona/api_key
 export OPENENV_TB2_TASKS_DIR=...
 export FABRIC_PREFIX=10.4.          # leading octets of the compute-fabric IP
 export WANDB_API_KEY=...            # optional

--- a/examples/experimental/openenv/glm52_tbench2/README.md
+++ b/examples/experimental/openenv/glm52_tbench2/README.md
@@ -68,11 +68,9 @@ official `docker_image`. Point `OPENENV_TB2_TASKS_DIR` at it.
 sandboxes (128 in the reference config; each 2 vCPU / 4 GiB / 10 GiB). Keep
 the credential in a file outside git:
 
-<!-- 2026-09-09, tianqi, file-only sandbox credentials (#3111) -->
 ```bash
 mkdir -p ~/.config/daytona && echo dtn_... > ~/.config/daytona/api_key && chmod 600 ~/.config/daytona/api_key
 ```
-<!-- end -->
 
 Images are built per task and cached by definition hash (first episode of a
 task ~10 min, repeats ~1 min).

--- a/examples/experimental/openenv/glm52_tbench2/launch_16node_slurm.sh
+++ b/examples/experimental/openenv/glm52_tbench2/launch_16node_slurm.sh
@@ -15,9 +15,7 @@ set -uo pipefail
 : "${MILES_ROOT:?path to this miles checkout}"
 : "${CONTAINER_IMAGE:?squashfs image with the miles runtime}"
 : "${CONTAINER_MOUNTS:?must expose the checkouts, model/data dirs and node-local scratch}"
-# 2026-09-09, tianqi, file-only sandbox credentials (#3111)
 : "${DAYTONA_API_KEY_FILE:?path to the Daytona key file (chmod 600, never in git)}"
-# end
 : "${FABRIC_PREFIX:?leading octets of the compute-fabric IP, e.g. 10.4.}"
 
 RECIPE=$MILES_ROOT/examples/experimental/openenv/glm52_tbench2/run_glm5_2_744b_a40b_daytona.py
@@ -40,9 +38,7 @@ srun --overlap --nodes=1 --ntasks=1 --gpus-per-node=4 -w "${nodes[0]}" $C bash -
     ray status 2>/dev/null | grep -q '/$ngpu_total\.0 GPU' && break
     echo \"waiting for ray nodes... (\$t/90)\"; sleep 10
   done
-  # 2026-09-09, tianqi, file-only sandbox credentials (#3111)
   export DAYTONA_API_KEY_FILE=$DAYTONA_API_KEY_FILE
-  # end
   export MILES_SCRIPT_EXTERNAL_RAY=1 MASTER_ADDR=$head_ip OPENENV_RUN_ID=\${OPENENV_RUN_ID:-$SLURM_JOB_ID}
   cd $MILES_ROOT
   python3 $RECIPE train --num-nodes $SLURM_JOB_NUM_NODES $RECIPE_ARGS

--- a/examples/experimental/openenv/glm52_tbench2/launch_16node_slurm.sh
+++ b/examples/experimental/openenv/glm52_tbench2/launch_16node_slurm.sh
@@ -15,7 +15,9 @@ set -uo pipefail
 : "${MILES_ROOT:?path to this miles checkout}"
 : "${CONTAINER_IMAGE:?squashfs image with the miles runtime}"
 : "${CONTAINER_MOUNTS:?must expose the checkouts, model/data dirs and node-local scratch}"
-: "${DAYTONA_ENV_FILE:?file exporting DAYTONA_API_KEY (chmod 600, never in git)}"
+# 2026-09-09, tianqi, file-only sandbox credentials (#3111)
+: "${DAYTONA_API_KEY_FILE:?path to the Daytona key file (chmod 600, never in git)}"
+# end
 : "${FABRIC_PREFIX:?leading octets of the compute-fabric IP, e.g. 10.4.}"
 
 RECIPE=$MILES_ROOT/examples/experimental/openenv/glm52_tbench2/run_glm5_2_744b_a40b_daytona.py
@@ -38,7 +40,9 @@ srun --overlap --nodes=1 --ntasks=1 --gpus-per-node=4 -w "${nodes[0]}" $C bash -
     ray status 2>/dev/null | grep -q '/$ngpu_total\.0 GPU' && break
     echo \"waiting for ray nodes... (\$t/90)\"; sleep 10
   done
-  source $DAYTONA_ENV_FILE
+  # 2026-09-09, tianqi, file-only sandbox credentials (#3111)
+  export DAYTONA_API_KEY_FILE=$DAYTONA_API_KEY_FILE
+  # end
   export MILES_SCRIPT_EXTERNAL_RAY=1 MASTER_ADDR=$head_ip OPENENV_RUN_ID=\${OPENENV_RUN_ID:-$SLURM_JOB_ID}
   cd $MILES_ROOT
   python3 $RECIPE train --num-nodes $SLURM_JOB_NUM_NODES $RECIPE_ARGS

--- a/examples/experimental/openenv/glm52_tbench2/run_glm5_2_744b_a40b_daytona.py
+++ b/examples/experimental/openenv/glm52_tbench2/run_glm5_2_744b_a40b_daytona.py
@@ -86,9 +86,7 @@ class ScriptArgs(U.ExecuteTrainConfig):
     eval_interval: int = 10
     eval_prompt_data: str = ""  # default: <data_dir>/tbench2_eval.jsonl
     n_samples_per_eval_prompt: int = 2
-    # 2026-09-09, tianqi, file-only sandbox credentials (#3111)
     daytona_api_key_file: str = os.environ.get("DAYTONA_API_KEY_FILE", "")
-    # end
     # Load initial weights from this checkpoint dir instead of this run's own
     # (empty) save path. For evaluating an existing checkpoint: point at the
     # source run's checkpoints/, add --start-rollout-id 0 to --extra-args, and
@@ -332,7 +330,6 @@ def _execute_train(args: ScriptArgs):
         "OPENENV_LAUNCHER": args.openenv_launcher,
         "OPENENV_RUN_ID": args.openenv_run_id,
     }
-    # 2026-09-09, tianqi, file-only sandbox credentials (#3111)
     spec = PROVIDER_CREDENTIALS["daytona"]
     sandbox_key_supply(
         extra_env_vars,
@@ -343,7 +340,6 @@ def _execute_train(args: ScriptArgs):
         default_path=spec["default_path"],
         provision_hint=spec["provision_hint"],
     )
-    # end
 
     U.execute_train(
         train_args=train_args,

--- a/examples/experimental/openenv/glm52_tbench2/run_glm5_2_744b_a40b_daytona.py
+++ b/examples/experimental/openenv/glm52_tbench2/run_glm5_2_744b_a40b_daytona.py
@@ -14,7 +14,7 @@ reproduces it. launch_16node_slurm.sh is only a site adapter (container + Ray
 bring-up); see README.md for the environment contract and preparation steps.
 
 Env consumed here (credentials must NOT live in this file):
-    DAYTONA_API_KEY, OPENENV_TB2_TASKS_DIR, OPENENV_LAUNCHER, OPENENV_RUN_ID
+    DAYTONA_API_KEY_FILE, OPENENV_TB2_TASKS_DIR, OPENENV_LAUNCHER, OPENENV_RUN_ID
 """
 
 import importlib.util
@@ -26,6 +26,7 @@ from typing import Literal
 import typer
 
 import miles.utils.external_utils.command_utils as U
+from miles.rollout.agentic.credentials import PROVIDER_CREDENTIALS, sandbox_key_supply
 
 app = typer.Typer()
 
@@ -85,7 +86,9 @@ class ScriptArgs(U.ExecuteTrainConfig):
     eval_interval: int = 10
     eval_prompt_data: str = ""  # default: <data_dir>/tbench2_eval.jsonl
     n_samples_per_eval_prompt: int = 2
-    daytona_api_key: str = os.environ.get("DAYTONA_API_KEY", "")
+    # 2026-09-09, tianqi, file-only sandbox credentials (#3111)
+    daytona_api_key_file: str = os.environ.get("DAYTONA_API_KEY_FILE", "")
+    # end
     # Load initial weights from this checkpoint dir instead of this run's own
     # (empty) save path. For evaluating an existing checkpoint: point at the
     # source run's checkpoints/, add --start-rollout-id 0 to --extra-args, and
@@ -105,7 +108,6 @@ class ScriptArgs(U.ExecuteTrainConfig):
         assert (
             self.num_nodes >= min_nodes and self.num_gpus_per_node == 4
         ), "GB300 config: 8 train nodes plus inference nodes (4 GPUs each)"
-        assert self.daytona_api_key, "DAYTONA_API_KEY must be set in the environment"
         if not self.prompt_data:
             self.prompt_data = f"{self.data_dir}/tbench2_train69.jsonl"
         if self.eval_interval and not self.eval_prompt_data:
@@ -329,8 +331,19 @@ def _execute_train(args: ScriptArgs):
         "OPENENV_DAYTONA_CREATE_MAX_RETRIES": str(args.openenv_daytona_create_max_retries),
         "OPENENV_LAUNCHER": args.openenv_launcher,
         "OPENENV_RUN_ID": args.openenv_run_id,
-        "DAYTONA_API_KEY": args.daytona_api_key,
     }
+    # 2026-09-09, tianqi, file-only sandbox credentials (#3111)
+    spec = PROVIDER_CREDENTIALS["daytona"]
+    sandbox_key_supply(
+        extra_env_vars,
+        provider=spec["provider"],
+        key_env_vars=spec["key_env_vars"],
+        file_env_var=spec["file_env_var"],
+        arg_path=args.daytona_api_key_file,
+        default_path=spec["default_path"],
+        provision_hint=spec["provision_hint"],
+    )
+    # end
 
     U.execute_train(
         train_args=train_args,

--- a/examples/experimental/openenv/openenv_daytona_agent_function.py
+++ b/examples/experimental/openenv/openenv_daytona_agent_function.py
@@ -24,14 +24,9 @@ Env vars (the agent-loop ones in ``openenv_agent_function`` apply too):
                      layers by definition hash, so only the first episode of a
                      task builds (~10 min); repeats start in ~1 min. No named
                      snapshots, so no org snapshot quota.
-  DAYTONA_API_KEY              the Daytona API key, authenticating every
-                     sandbox create/delete. Read from the worker's own
-                     node-local environment; nothing forwards it. Supply it
-                     via platform-injected pod env, or by exporting it in
-                     the shell that starts ray on a single host.
-  DAYTONA_API_KEY_FILE         fallback when DAYTONA_API_KEY is unset: path
-                     of a file holding the key (default
-                     ~/.config/daytona/api_key). Launchers forward this path
+  DAYTONA_API_KEY_FILE         path of a file holding the Daytona API key
+                     (default ~/.config/daytona/api_key). File-only: a set
+                     DAYTONA_API_KEY is rejected. Launchers forward this path
                      instead of the key itself, because ray runtime_env is
                      logged in plaintext. Point it at a file every node can
                      read: a dotfile, K8s Secret mount, or shared-FS path.

--- a/examples/experimental/openenv/openenv_e2b_agent_function.py
+++ b/examples/experimental/openenv/openenv_e2b_agent_function.py
@@ -21,10 +21,10 @@ Env vars (the agent-loop ones in ``openenv_agent_function`` apply too):
                     are built once per task under a recipe-digest alias
                     (first episode of a task pays the build; repeats
                     warm-start), or pre-baked via the tb2_sandbox_e2b CLI.
-  E2B_API_KEY / E2B_API_KEY_FILE   key supply on the contract every backend
-                    shares (file default ~/.config/e2b/api_key; launchers
-                    forward the PATH, never the value). AgentENV accepts any
-                    non-empty key today.
+  E2B_API_KEY_FILE             key file on the contract every backend shares
+                    (default ~/.config/e2b/api_key; launchers forward the
+                    PATH, never the value). File-only: a set E2B_API_KEY is
+                    rejected. AgentENV accepts any non-empty key today.
   E2B_API_URL / E2B_SANDBOX_URL    endpoint overrides read by the SDK itself;
                     set both to target a self-hosted AgentENV.
   OPENENV_E2B_CREATE_CONCURRENCY   max in-flight sandbox creates (default 4).

--- a/examples/experimental/openenv/openenv_modal_agent_function.py
+++ b/examples/experimental/openenv/openenv_modal_agent_function.py
@@ -17,20 +17,22 @@ backends, this variant needs the pinned tbench2_env install from the README
 server).
 
 Credentials are the one place Modal does not fit the other backends' shape: there
-is no single API key, so nothing here reads or forwards one. The SDK resolves
-MODAL_TOKEN_ID + MODAL_TOKEN_SECRET from the worker's own environment, else the
+is no single API key, so nothing here reads or forwards one. The SDK reads the
 config file at MODAL_CONFIG_PATH (default ``~/.modal.toml``) — and the launcher
-forwards that PATH, never the token, on the same reasoning as the other
-providers' key files (see openenv_launch_common).
+forwards that PATH, never a token, on the same reasoning as the other
+providers' key files (see openenv_launch_common). A set MODAL_TOKEN_ID /
+MODAL_TOKEN_SECRET is rejected so env supply cannot silently mask a missing file.
 
 Env vars (the agent-loop ones in ``openenv_agent_function`` apply too):
   OPENENV_TB2_TASKS_DIR       path to a terminal-bench-2 checkout. The first
                     episode of a task pays its image build; repeats hit
                     Modal's layer cache, and all tasks share every layer but
                     the last (see tb2_sandbox_modal.task_image).
-  MODAL_TOKEN_ID / MODAL_TOKEN_SECRET / MODAL_CONFIG_PATH   credential supply,
-                    read by the SDK itself. MODAL_PROFILE / MODAL_ENVIRONMENT
-                    select a profile / workspace environment when set.
+  MODAL_CONFIG_PATH             credential file the SDK reads (default
+                    ~/.modal.toml). File-only: a set MODAL_TOKEN_ID /
+                    MODAL_TOKEN_SECRET is rejected. MODAL_PROFILE /
+                    MODAL_ENVIRONMENT select a profile / workspace environment
+                    when set.
   OPENENV_MODAL_APP                app the sandboxes are created under
                     (default openenv-tbench2) — what a sweep scopes to.
   OPENENV_MODAL_CREATE_CONCURRENCY max in-flight sandbox creates (default 4).

--- a/examples/experimental/openenv/tb2_sandbox_daytona.py
+++ b/examples/experimental/openenv/tb2_sandbox_daytona.py
@@ -153,11 +153,9 @@ _DEFAULT_API_KEY_FILE = "~/.config/daytona/api_key"
 
 
 def resolve_api_key() -> str:
-    # 2026-09-09, tianqi, file-only sandbox credentials (#3111)
     """The Daytona API key from the key file (see
     credentials.resolve_provider_api_key). A set DAYTONA_API_KEY is rejected."""
     return resolve_provider_api_key("DAYTONA_API_KEY", "DAYTONA_API_KEY_FILE", _DEFAULT_API_KEY_FILE)
-    # end
 
 
 _client_lock = threading.Lock()

--- a/examples/experimental/openenv/tb2_sandbox_daytona.py
+++ b/examples/experimental/openenv/tb2_sandbox_daytona.py
@@ -39,7 +39,6 @@ from tb2_sandbox_recipe import (
 )
 from miles.rollout.agentic.credentials import resolve_provider_api_key
 
-
 # Every knob describing ONE Daytona sandbox lives here, next to the create
 # that uses it; the backend module keeps only the fan-out knobs. Read at import:
 # a rollout worker is a fresh process per run.
@@ -154,9 +153,11 @@ _DEFAULT_API_KEY_FILE = "~/.config/daytona/api_key"
 
 
 def resolve_api_key() -> str:
-    """The Daytona API key: DAYTONA_API_KEY, else the key file (see
-    recipe.resolve_provider_api_key for the file-indirection rationale)."""
+    # 2026-09-09, tianqi, file-only sandbox credentials (#3111)
+    """The Daytona API key from the key file (see
+    credentials.resolve_provider_api_key). A set DAYTONA_API_KEY is rejected."""
     return resolve_provider_api_key("DAYTONA_API_KEY", "DAYTONA_API_KEY_FILE", _DEFAULT_API_KEY_FILE)
+    # end
 
 
 _client_lock = threading.Lock()

--- a/examples/experimental/openenv/tb2_sandbox_e2b.py
+++ b/examples/experimental/openenv/tb2_sandbox_e2b.py
@@ -275,13 +275,11 @@ _DEFAULT_API_KEY_FILE = "~/.config/e2b/api_key"
 
 
 def resolve_api_key() -> str:
-    # 2026-09-09, tianqi, file-only sandbox credentials (#3111)
     """The E2B API key from the key file (see
     credentials.resolve_provider_api_key). A set E2B_API_KEY is rejected.
     AgentENV does not enforce keys today, but recent SDKs validate the format
     client-side — provision a well-formed one (e2b_ + 40 hex chars)."""
     return resolve_provider_api_key("E2B_API_KEY", "E2B_API_KEY_FILE", _DEFAULT_API_KEY_FILE)
-    # end
 
 
 def bake(tasks_dir: Path, task_id: str, force: bool) -> None:

--- a/examples/experimental/openenv/tb2_sandbox_e2b.py
+++ b/examples/experimental/openenv/tb2_sandbox_e2b.py
@@ -55,7 +55,6 @@ from tb2_sandbox_recipe import (
 )
 from miles.rollout.agentic.credentials import resolve_provider_api_key
 
-
 # The user every build command and the env server run as. The TB2 task images
 # are built for a root agent (their solutions and tests apt-install freely), so
 # anything less would change the task environment, not just the build.
@@ -276,11 +275,13 @@ _DEFAULT_API_KEY_FILE = "~/.config/e2b/api_key"
 
 
 def resolve_api_key() -> str:
-    """The E2B API key: E2B_API_KEY, else the key file (see
-    recipe.resolve_provider_api_key for the file-indirection rationale). AgentENV does
-    not enforce keys today, but recent SDKs validate the format client-side —
-    provision a well-formed one (e2b_ + 40 hex chars)."""
+    # 2026-09-09, tianqi, file-only sandbox credentials (#3111)
+    """The E2B API key from the key file (see
+    credentials.resolve_provider_api_key). A set E2B_API_KEY is rejected.
+    AgentENV does not enforce keys today, but recent SDKs validate the format
+    client-side — provision a well-formed one (e2b_ + 40 hex chars)."""
     return resolve_provider_api_key("E2B_API_KEY", "E2B_API_KEY_FILE", _DEFAULT_API_KEY_FILE)
+    # end
 
 
 def bake(tasks_dir: Path, task_id: str, force: bool) -> None:

--- a/miles/rollout/agentic/credentials.py
+++ b/miles/rollout/agentic/credentials.py
@@ -11,11 +11,9 @@ PROVIDER_CREDENTIALS holds one entry per backend in
 openenv_sandbox_common.AGENT_MODULES; a provider is added there, not by
 growing a branch:
 
-  # 2026-09-09, tianqi, file-only sandbox credentials (#3111)
   key_env_vars   vars that must be UNSET; a set value is rejected (env supply
                  used to silently mask a missing file resolver). Modal's
                  pair is both halves
-  # end
   file_env_var   the path-valued var the launcher forwards instead of secrets
   forward        addresses/selectors, safe to forward by value
   target         (var, label, default description) echoed so a launch says
@@ -62,10 +60,8 @@ PROVIDER_CREDENTIALS = {
     },
     "modal": {
         "provider": "Modal",
-        # 2026-09-09, tianqi, file-only sandbox credentials (#3111)
         # Modal has no single API key: the SDK reads the config file whose path
         # MODAL_CONFIG_PATH names. Token env vars are rejected, not used.
-        # end
         "key_env_vars": ("MODAL_TOKEN_ID", "MODAL_TOKEN_SECRET"),
         "file_env_var": "MODAL_CONFIG_PATH",
         "arg_attr": "modal_config_file",
@@ -95,9 +91,7 @@ def forward_address(env: dict[str, str], var: str, value: str) -> None:
         raise ValueError(
             f"{var} looks like it embeds credentials ('@'), and anything forwarded "
             "to rollout workers is logged in plaintext by ray. Put the credential "
-            # 2026-09-09, tianqi, file-only sandbox credentials (#3111)
             "in the provider's key file and leave a bare address here."
-            # end
         )
     env[var] = value
 
@@ -112,7 +106,6 @@ def sandbox_key_supply(
     default_path: str,
     provision_hint: str,
 ) -> None:
-    # 2026-09-09, tianqi, file-only sandbox credentials (#3111)
     """Key-supply contract, shared by the sandbox backends: rollout workers
     read the provider credential from a file they can read (a dotfile, K8s
     Secret mount, or shared-FS path). The launcher forwards only the file PATH,
@@ -146,7 +139,6 @@ def sandbox_key_supply(
             f"({key_file}; {file_env_var} overrides). Provision the file with:\n"
             f"  {provision_hint}"
         )
-    # end
 
 
 def preflight_sdk(module: str, install_hint: str, min_version: str | None = None) -> None:
@@ -197,7 +189,6 @@ def _version_tuple(version: str) -> tuple[int, ...]:
 
 
 def _file_only_env_message(names: str, key_file: Path, file_env_var: str, provision_hint: str | None = None) -> str:
-    # 2026-09-09, tianqi, file-only sandbox credentials (#3111)
     msg = (
         f"{names} is set; sandbox credentials are file-only "
         f"(env supply silently masked a missing file resolver). "
@@ -206,11 +197,9 @@ def _file_only_env_message(names: str, key_file: Path, file_env_var: str, provis
     if provision_hint:
         msg += f". Provision the file with:\n  {provision_hint}"
     return msg
-    # end
 
 
 def resolve_provider_api_key(env_var: str, file_env_var: str, default_path: str) -> str:
-    # 2026-09-09, tianqi, file-only sandbox credentials (#3111)
     """A provider API key from the key file only.
 
     The file indirection (*file_env_var*, default *default_path*) exists so
@@ -230,4 +219,3 @@ def resolve_provider_api_key(env_var: str, file_env_var: str, default_path: str)
     if not key:
         raise RuntimeError(f"no API key: {key_file} is missing or empty ({file_env_var} overrides)")
     return key
-    # end

--- a/miles/rollout/agentic/credentials.py
+++ b/miles/rollout/agentic/credentials.py
@@ -1,16 +1,21 @@
 """Sandbox-provider credentials and endpoints for agent-function launchers.
 
 The contract every sandbox backend shares: rollout workers read a provider
-credential from their own environment or from a key file; the launcher
-forwards only the file PATH (never the value, which would ride ray's
-runtime_env in plaintext) and address-like variables by value.
+credential from a key file; the launcher forwards only the file PATH (never
+the value, which would ride ray's runtime_env in plaintext) and address-like
+variables by value. A set key env var is rejected: env supply used to win
+silently over a missing or unread file, which is how a worker-side resolver
+gap passed every unit test until the first GPU e2e run.
 
 PROVIDER_CREDENTIALS holds one entry per backend in
 openenv_sandbox_common.AGENT_MODULES; a provider is added there, not by
 growing a branch:
 
-  key_env_vars   what a worker must ALL have for the env-supply path to work
-                 (Modal's credential is a token PAIR, not one key)
+  # 2026-09-09, tianqi, file-only sandbox credentials (#3111)
+  key_env_vars   vars that must be UNSET; a set value is rejected (env supply
+                 used to silently mask a missing file resolver). Modal's
+                 pair is both halves
+  # end
   file_env_var   the path-valued var the launcher forwards instead of secrets
   forward        addresses/selectors, safe to forward by value
   target         (var, label, default description) echoed so a launch says
@@ -57,8 +62,10 @@ PROVIDER_CREDENTIALS = {
     },
     "modal": {
         "provider": "Modal",
-        # Modal has no single API key: the SDK wants both token halves, or the
-        # config file whose path MODAL_CONFIG_PATH names.
+        # 2026-09-09, tianqi, file-only sandbox credentials (#3111)
+        # Modal has no single API key: the SDK reads the config file whose path
+        # MODAL_CONFIG_PATH names. Token env vars are rejected, not used.
+        # end
         "key_env_vars": ("MODAL_TOKEN_ID", "MODAL_TOKEN_SECRET"),
         "file_env_var": "MODAL_CONFIG_PATH",
         "arg_attr": "modal_config_file",
@@ -88,8 +95,9 @@ def forward_address(env: dict[str, str], var: str, value: str) -> None:
         raise ValueError(
             f"{var} looks like it embeds credentials ('@'), and anything forwarded "
             "to rollout workers is logged in plaintext by ray. Put the credential "
-            "in the provider's key file (or the worker environment) and leave a "
-            "bare address here."
+            # 2026-09-09, tianqi, file-only sandbox credentials (#3111)
+            "in the provider's key file and leave a bare address here."
+            # end
         )
     env[var] = value
 
@@ -104,24 +112,23 @@ def sandbox_key_supply(
     default_path: str,
     provision_hint: str,
 ) -> None:
+    # 2026-09-09, tianqi, file-only sandbox credentials (#3111)
     """Key-supply contract, shared by the sandbox backends: rollout workers
-    get the provider credential from their OWN environment (e.g.
-    platform-injected) or from a file they can read (a dotfile, K8s Secret
-    mount, or shared-FS path). The launcher forwards only the file PATH, never
-    the value: worker env rides ray's runtime_env, which exec_command_cpu
-    echoes into driver logs and ray persists in job metadata, all in
-    plaintext."""
+    read the provider credential from a file they can read (a dotfile, K8s
+    Secret mount, or shared-FS path). The launcher forwards only the file PATH,
+    never the value: worker env rides ray's runtime_env, which
+    exec_command_cpu echoes into driver logs and ray persists in job metadata,
+    all in plaintext. A set key env var is rejected so it cannot silently
+    satisfy preflight while the file path is missing or unread."""
     key_file = Path(arg_path or default_path).expanduser()
+    set_vars = tuple(var for var in key_env_vars if os.environ.get(var, "").strip())
+    if set_vars:
+        names = " + ".join(set_vars)
+        raise ValueError(_file_only_env_message(names, key_file, file_env_var, provision_hint))
     try:
         key_present = bool(key_file.read_text(encoding="utf-8").strip())
     except OSError:
         key_present = False
-    # Either supply is fine; neither is fully verifiable from here (the
-    # launcher cannot probe worker nodes), so echo which one is in effect.
-    # A provider whose credential is several variables (Modal's token pair) is
-    # only satisfied by having ALL of them; a partial set is a misconfiguration
-    # that would fail every episode.
-    names = " + ".join(key_env_vars)
     if key_present:
         env[file_env_var] = str(key_file)
         print(
@@ -133,20 +140,13 @@ def sandbox_key_supply(
         # An explicitly configured path that doesn't resolve on the launcher
         # is a config error; failing every episode later is far worse.
         raise ValueError(f"{file_env_var}={arg_path} is missing or empty")
-    elif all(os.environ.get(var, "").strip() for var in key_env_vars):
-        print(
-            f"{provider} credential supply: worker environment ({names} "
-            "set here; workers are assumed to have them in their own env — "
-            "single-host inheritance or platform-injected pod env)",
-            flush=True,
-        )
     else:
         raise ValueError(
             f"the {provider} sandbox mode needs credentials: put them in a file "
-            f"({key_file}; {file_env_var} overrides) or in the "
-            f"environment as {names}. Provision the file with:\n"
+            f"({key_file}; {file_env_var} overrides). Provision the file with:\n"
             f"  {provision_hint}"
         )
+    # end
 
 
 def preflight_sdk(module: str, install_hint: str, min_version: str | None = None) -> None:
@@ -196,24 +196,38 @@ def _version_tuple(version: str) -> tuple[int, ...]:
     return tuple(parts)
 
 
+def _file_only_env_message(names: str, key_file: Path, file_env_var: str, provision_hint: str | None = None) -> str:
+    # 2026-09-09, tianqi, file-only sandbox credentials (#3111)
+    msg = (
+        f"{names} is set; sandbox credentials are file-only "
+        f"(env supply silently masked a missing file resolver). "
+        f"Unset {names} and put the key in {key_file} ({file_env_var} overrides)"
+    )
+    if provision_hint:
+        msg += f". Provision the file with:\n  {provision_hint}"
+    return msg
+    # end
+
+
 def resolve_provider_api_key(env_var: str, file_env_var: str, default_path: str) -> str:
-    """A provider API key: *env_var*, else the key file.
+    # 2026-09-09, tianqi, file-only sandbox credentials (#3111)
+    """A provider API key from the key file only.
 
     The file indirection (*file_env_var*, default *default_path*) exists so
     launchers can hand rollout workers a PATH instead of the secret itself:
     anything a launcher forwards rides ray's runtime_env, which is echoed into
-    driver logs and persisted in job metadata in plaintext. Env vars the
-    worker already has (platform-injected, single-host inheritance) never pass
-    through ray, so *env_var* is checked first.
+    driver logs and persisted in job metadata in plaintext. *env_var* is
+    not a supply path: if it is set, this errors and names the file to create,
+    rather than silently winning over a missing or unread file.
     """
-    key = os.environ.get(env_var, "").strip()
-    if key:
-        return key
     key_file = Path(os.environ.get(file_env_var, "").strip() or default_path).expanduser()
+    if os.environ.get(env_var, "").strip():
+        raise RuntimeError(_file_only_env_message(env_var, key_file, file_env_var))
     try:
         key = key_file.read_text(encoding="utf-8").strip()
     except OSError:
         key = ""
     if not key:
-        raise RuntimeError(f"no API key: {env_var} is unset and {key_file} is missing or empty")
+        raise RuntimeError(f"no API key: {key_file} is missing or empty ({file_env_var} overrides)")
     return key
+    # end

--- a/tests/fast/examples/experimental/openenv/test_tb2_sandbox_daytona.py
+++ b/tests/fast/examples/experimental/openenv/test_tb2_sandbox_daytona.py
@@ -34,11 +34,16 @@ def test_sandbox_labels_explicit_launcher_and_run_id(monkeypatch):
     assert labels["openenv-run-id"] == "tb2-grpo-0717"
 
 
-def test_make_daytona_reuses_one_client(monkeypatch):
+def test_make_daytona_reuses_one_client(monkeypatch, tmp_path):
     """One client per call is a socket leak: the SDK owns a connection pool with
     no close(), and this runs once per create attempt, retries included."""
     monkeypatch.setattr(sandbox, "_client", None)
-    monkeypatch.setenv("DAYTONA_API_KEY", "dtn_test")
+    # 2026-09-09, tianqi, file-only sandbox credentials (#3111)
+    key_file = tmp_path / "api_key"
+    key_file.write_text("dtn_test\n")
+    monkeypatch.delenv("DAYTONA_API_KEY", raising=False)
+    monkeypatch.setenv("DAYTONA_API_KEY_FILE", str(key_file))
+    # end
     built = []
 
     class _Daytona:
@@ -55,12 +60,17 @@ def test_make_daytona_reuses_one_client(monkeypatch):
     assert all(c is clients[0] for c in clients)
 
 
-def test_resolve_api_key_env_value_wins(monkeypatch, tmp_path: Path):
+# 2026-09-09, tianqi, invert env-wins tests for file-only supply (#3111)
+def test_resolve_api_key_rejects_a_set_env_var(monkeypatch, tmp_path: Path):
     key_file = tmp_path / "api_key"
     key_file.write_text("dtn_from_file\n")
     monkeypatch.setenv("DAYTONA_API_KEY", "dtn_from_env")
     monkeypatch.setenv("DAYTONA_API_KEY_FILE", str(key_file))
-    assert sandbox.resolve_api_key() == "dtn_from_env"
+    with pytest.raises(RuntimeError, match="DAYTONA_API_KEY is set"):
+        sandbox.resolve_api_key()
+
+
+# end
 
 
 def test_resolve_api_key_falls_back_to_file(monkeypatch, tmp_path: Path):

--- a/tests/fast/examples/experimental/openenv/test_tb2_sandbox_daytona.py
+++ b/tests/fast/examples/experimental/openenv/test_tb2_sandbox_daytona.py
@@ -38,12 +38,10 @@ def test_make_daytona_reuses_one_client(monkeypatch, tmp_path):
     """One client per call is a socket leak: the SDK owns a connection pool with
     no close(), and this runs once per create attempt, retries included."""
     monkeypatch.setattr(sandbox, "_client", None)
-    # 2026-09-09, tianqi, file-only sandbox credentials (#3111)
     key_file = tmp_path / "api_key"
     key_file.write_text("dtn_test\n")
     monkeypatch.delenv("DAYTONA_API_KEY", raising=False)
     monkeypatch.setenv("DAYTONA_API_KEY_FILE", str(key_file))
-    # end
     built = []
 
     class _Daytona:
@@ -60,7 +58,6 @@ def test_make_daytona_reuses_one_client(monkeypatch, tmp_path):
     assert all(c is clients[0] for c in clients)
 
 
-# 2026-09-09, tianqi, invert env-wins tests for file-only supply (#3111)
 def test_resolve_api_key_rejects_a_set_env_var(monkeypatch, tmp_path: Path):
     key_file = tmp_path / "api_key"
     key_file.write_text("dtn_from_file\n")
@@ -68,9 +65,6 @@ def test_resolve_api_key_rejects_a_set_env_var(monkeypatch, tmp_path: Path):
     monkeypatch.setenv("DAYTONA_API_KEY_FILE", str(key_file))
     with pytest.raises(RuntimeError, match="DAYTONA_API_KEY is set"):
         sandbox.resolve_api_key()
-
-
-# end
 
 
 def test_resolve_api_key_falls_back_to_file(monkeypatch, tmp_path: Path):

--- a/tests/fast/examples/experimental/openenv/test_tb2_sandbox_e2b.py
+++ b/tests/fast/examples/experimental/openenv/test_tb2_sandbox_e2b.py
@@ -238,7 +238,6 @@ def test_task_build_resources_floors(tmp_path: Path):
 # --- key supply --------------------------------------------------------------
 
 
-# 2026-09-09, tianqi, invert env-wins tests for file-only supply (#3111)
 def test_resolve_api_key_rejects_a_set_env_var(monkeypatch, tmp_path: Path):
     key_file = tmp_path / "api_key"
     key_file.write_text("e2b_from_file\n")
@@ -246,9 +245,6 @@ def test_resolve_api_key_rejects_a_set_env_var(monkeypatch, tmp_path: Path):
     monkeypatch.setenv("E2B_API_KEY_FILE", str(key_file))
     with pytest.raises(RuntimeError, match="E2B_API_KEY is set"):
         sandbox.resolve_api_key()
-
-
-# end
 
 
 def test_resolve_api_key_falls_back_to_file(monkeypatch, tmp_path: Path):

--- a/tests/fast/examples/experimental/openenv/test_tb2_sandbox_e2b.py
+++ b/tests/fast/examples/experimental/openenv/test_tb2_sandbox_e2b.py
@@ -17,7 +17,6 @@ import pytest
 
 import tb2_sandbox_e2b as sandbox
 
-
 # --- template aliasing -------------------------------------------------------
 
 
@@ -239,12 +238,17 @@ def test_task_build_resources_floors(tmp_path: Path):
 # --- key supply --------------------------------------------------------------
 
 
-def test_resolve_api_key_env_value_wins(monkeypatch, tmp_path: Path):
+# 2026-09-09, tianqi, invert env-wins tests for file-only supply (#3111)
+def test_resolve_api_key_rejects_a_set_env_var(monkeypatch, tmp_path: Path):
     key_file = tmp_path / "api_key"
     key_file.write_text("e2b_from_file\n")
     monkeypatch.setenv("E2B_API_KEY", "e2b_from_env")
     monkeypatch.setenv("E2B_API_KEY_FILE", str(key_file))
-    assert sandbox.resolve_api_key() == "e2b_from_env"
+    with pytest.raises(RuntimeError, match="E2B_API_KEY is set"):
+        sandbox.resolve_api_key()
+
+
+# end
 
 
 def test_resolve_api_key_falls_back_to_file(monkeypatch, tmp_path: Path):

--- a/tests/fast/rollout/agentic/test_credentials.py
+++ b/tests/fast/rollout/agentic/test_credentials.py
@@ -62,6 +62,18 @@ def test_a_forwarded_url_may_not_smuggle_a_credential():
 # --- launcher-side key supply -------------------------------------------------
 
 
+# 2026-09-09, tianqi, file-only sandbox credentials (#3111)
+@pytest.fixture(autouse=True)
+def _clear_provider_key_env(monkeypatch):
+    """Ambient key env vars would fail file-only tests that never set them."""
+    for spec in PROVIDER_CREDENTIALS.values():
+        for var in spec["key_env_vars"]:
+            monkeypatch.delenv(var, raising=False)
+
+
+# end
+
+
 def _supply(env, spec_name, *, arg_path="", **overrides):
     spec = PROVIDER_CREDENTIALS[spec_name]
     kwargs = {
@@ -84,6 +96,18 @@ def test_readable_file_forwards_the_path_never_the_value(tmp_path):
     assert "dtn_secret_value" not in str(env)
 
 
+# 2026-09-09, tianqi, set key env var is rejected even with a readable file (#3111)
+def test_set_key_env_is_rejected_even_when_the_file_is_readable(monkeypatch, tmp_path):
+    key_file = tmp_path / "api_key"
+    key_file.write_text("dtn_from_file\n")
+    monkeypatch.setenv("DAYTONA_API_KEY", "dtn_from_env")
+    with pytest.raises(ValueError, match="DAYTONA_API_KEY is set"):
+        _supply({}, "daytona", arg_path=str(key_file))
+
+
+# end
+
+
 def test_configured_path_that_does_not_resolve_is_an_error(tmp_path):
     with pytest.raises(ValueError, match="is missing or empty"):
         _supply({}, "e2b", arg_path=str(tmp_path / "absent"))
@@ -96,37 +120,35 @@ def test_empty_file_is_not_a_credential(tmp_path):
         _supply({}, "e2b", arg_path=str(key_file))
 
 
-def test_unreadable_path_counts_as_absent(monkeypatch, tmp_path):
-    """A path that raises on read (here: a directory) is 'no file', so the env
-    supply still satisfies — the launcher cannot probe worker nodes anyway."""
+# 2026-09-09, tianqi, invert env-wins tests for file-only supply (#3111)
+def test_unreadable_path_does_not_fall_back_to_env(monkeypatch, tmp_path):
+    """A path that raises on read (here: a directory) is not a credential, and
+    a set key env var must not silently satisfy preflight."""
     monkeypatch.setenv("E2B_API_KEY", "e2b_from_env")
-    env: dict[str, str] = {}
-    _supply(env, "e2b", default_path=str(tmp_path))
-    assert env == {}
+    with pytest.raises(ValueError, match="E2B_API_KEY is set"):
+        _supply({}, "e2b", default_path=str(tmp_path))
 
 
-def test_worker_environment_supply_is_accepted_without_forwarding(monkeypatch, tmp_path):
-    """When the launcher itself has the credential in env, workers are assumed
-    to have it too (platform-injected / single-host inheritance) and nothing is
-    forwarded."""
+def test_worker_environment_supply_is_rejected(monkeypatch, tmp_path):
+    """Env supply used to skip forwarding; it now errors and names the file."""
     monkeypatch.setenv("DAYTONA_API_KEY", "dtn_from_env")
-    env: dict[str, str] = {}
-    _supply(env, "daytona", default_path=str(tmp_path / "absent"))
-    assert env == {}
+    with pytest.raises(ValueError, match="DAYTONA_API_KEY is set"):
+        _supply({}, "daytona", default_path=str(tmp_path / "absent"))
 
 
-def test_modal_token_pair_must_be_complete(monkeypatch, tmp_path):
-    """Half a token pair is a misconfiguration, not a usable credential: it
-    would authenticate nothing and fail every episode."""
+def test_modal_token_env_is_rejected(monkeypatch, tmp_path):
+    """Token env vars are the old supply path: a set value is rejected whether
+    the pair is complete or not, and the error names the config file."""
     monkeypatch.setenv("MODAL_TOKEN_ID", "ak-123")
-    monkeypatch.delenv("MODAL_TOKEN_SECRET", raising=False)
-    with pytest.raises(ValueError, match="MODAL_TOKEN_ID \\+ MODAL_TOKEN_SECRET"):
+    with pytest.raises(ValueError, match="MODAL_TOKEN_ID is set"):
         _supply({}, "modal", default_path=str(tmp_path / "absent"))
 
     monkeypatch.setenv("MODAL_TOKEN_SECRET", "as-456")
-    env: dict[str, str] = {}
-    _supply(env, "modal", default_path=str(tmp_path / "absent"))
-    assert env == {}  # the token halves are never forwarded
+    with pytest.raises(ValueError, match="file-only"):
+        _supply({}, "modal", default_path=str(tmp_path / "absent"))
+
+
+# end
 
 
 def test_modal_config_file_is_forwarded_by_path(tmp_path):
@@ -140,8 +162,7 @@ def test_modal_config_file_is_forwarded_by_path(tmp_path):
     assert "as-456" not in str(env)
 
 
-def test_missing_credential_names_what_to_provision(monkeypatch, tmp_path):
-    monkeypatch.delenv("E2B_API_KEY", raising=False)
+def test_missing_credential_names_what_to_provision(tmp_path):
     with pytest.raises(ValueError, match="mkdir -p ~/.config/e2b"):
         _supply({}, "e2b", default_path=str(tmp_path / "absent"))
 
@@ -192,20 +213,25 @@ def test_version_tuple_reads_leading_numbers():
 # --- worker-side key resolution -------------------------------------------------
 
 
-def test_resolve_env_value_wins_over_the_file(monkeypatch, tmp_path):
+# 2026-09-09, tianqi, invert env-wins tests for file-only supply (#3111)
+def test_resolve_rejects_a_set_key_env_var(monkeypatch, tmp_path):
     key_file = tmp_path / "api_key"
     key_file.write_text("from_file\n")
     monkeypatch.setenv("PROV_API_KEY", "from_env")
     monkeypatch.setenv("PROV_API_KEY_FILE", str(key_file))
-    assert resolve_provider_api_key("PROV_API_KEY", "PROV_API_KEY_FILE", "~/nope") == "from_env"
+    with pytest.raises(RuntimeError, match="PROV_API_KEY is set"):
+        resolve_provider_api_key("PROV_API_KEY", "PROV_API_KEY_FILE", "~/nope")
 
 
-def test_resolve_falls_back_to_the_file_and_strips_whitespace(monkeypatch, tmp_path):
+def test_resolve_reads_the_file_and_strips_whitespace(monkeypatch, tmp_path):
     key_file = tmp_path / "api_key"
     key_file.write_text("  from_file \n")
     monkeypatch.delenv("PROV_API_KEY", raising=False)
     monkeypatch.setenv("PROV_API_KEY_FILE", str(key_file))
     assert resolve_provider_api_key("PROV_API_KEY", "PROV_API_KEY_FILE", "~/nope") == "from_file"
+
+
+# end
 
 
 def test_resolve_default_path_expands_the_home_dir(monkeypatch, tmp_path):
@@ -217,8 +243,12 @@ def test_resolve_default_path_expands_the_home_dir(monkeypatch, tmp_path):
     assert resolve_provider_api_key("PROV_API_KEY", "PROV_API_KEY_FILE", "~/.config/api_key") == "from_default"
 
 
-def test_resolve_missing_key_names_both_supplies(monkeypatch, tmp_path):
+# 2026-09-09, tianqi, file-only error names the key file (#3111)
+def test_resolve_missing_key_names_the_file(monkeypatch, tmp_path):
     monkeypatch.delenv("PROV_API_KEY", raising=False)
     monkeypatch.setenv("PROV_API_KEY_FILE", str(tmp_path / "absent"))
-    with pytest.raises(RuntimeError, match="PROV_API_KEY is unset"):
+    with pytest.raises(RuntimeError, match="missing or empty"):
         resolve_provider_api_key("PROV_API_KEY", "PROV_API_KEY_FILE", "~/nope")
+
+
+# end

--- a/tests/fast/rollout/agentic/test_credentials.py
+++ b/tests/fast/rollout/agentic/test_credentials.py
@@ -62,16 +62,12 @@ def test_a_forwarded_url_may_not_smuggle_a_credential():
 # --- launcher-side key supply -------------------------------------------------
 
 
-# 2026-09-09, tianqi, file-only sandbox credentials (#3111)
 @pytest.fixture(autouse=True)
 def _clear_provider_key_env(monkeypatch):
     """Ambient key env vars would fail file-only tests that never set them."""
     for spec in PROVIDER_CREDENTIALS.values():
         for var in spec["key_env_vars"]:
             monkeypatch.delenv(var, raising=False)
-
-
-# end
 
 
 def _supply(env, spec_name, *, arg_path="", **overrides):
@@ -96,16 +92,12 @@ def test_readable_file_forwards_the_path_never_the_value(tmp_path):
     assert "dtn_secret_value" not in str(env)
 
 
-# 2026-09-09, tianqi, set key env var is rejected even with a readable file (#3111)
 def test_set_key_env_is_rejected_even_when_the_file_is_readable(monkeypatch, tmp_path):
     key_file = tmp_path / "api_key"
     key_file.write_text("dtn_from_file\n")
     monkeypatch.setenv("DAYTONA_API_KEY", "dtn_from_env")
     with pytest.raises(ValueError, match="DAYTONA_API_KEY is set"):
         _supply({}, "daytona", arg_path=str(key_file))
-
-
-# end
 
 
 def test_configured_path_that_does_not_resolve_is_an_error(tmp_path):
@@ -120,7 +112,6 @@ def test_empty_file_is_not_a_credential(tmp_path):
         _supply({}, "e2b", arg_path=str(key_file))
 
 
-# 2026-09-09, tianqi, invert env-wins tests for file-only supply (#3111)
 def test_unreadable_path_does_not_fall_back_to_env(monkeypatch, tmp_path):
     """A path that raises on read (here: a directory) is not a credential, and
     a set key env var must not silently satisfy preflight."""
@@ -146,9 +137,6 @@ def test_modal_token_env_is_rejected(monkeypatch, tmp_path):
     monkeypatch.setenv("MODAL_TOKEN_SECRET", "as-456")
     with pytest.raises(ValueError, match="file-only"):
         _supply({}, "modal", default_path=str(tmp_path / "absent"))
-
-
-# end
 
 
 def test_modal_config_file_is_forwarded_by_path(tmp_path):
@@ -213,7 +201,6 @@ def test_version_tuple_reads_leading_numbers():
 # --- worker-side key resolution -------------------------------------------------
 
 
-# 2026-09-09, tianqi, invert env-wins tests for file-only supply (#3111)
 def test_resolve_rejects_a_set_key_env_var(monkeypatch, tmp_path):
     key_file = tmp_path / "api_key"
     key_file.write_text("from_file\n")
@@ -231,9 +218,6 @@ def test_resolve_reads_the_file_and_strips_whitespace(monkeypatch, tmp_path):
     assert resolve_provider_api_key("PROV_API_KEY", "PROV_API_KEY_FILE", "~/nope") == "from_file"
 
 
-# end
-
-
 def test_resolve_default_path_expands_the_home_dir(monkeypatch, tmp_path):
     (tmp_path / ".config").mkdir()
     (tmp_path / ".config" / "api_key").write_text("from_default\n")
@@ -243,12 +227,8 @@ def test_resolve_default_path_expands_the_home_dir(monkeypatch, tmp_path):
     assert resolve_provider_api_key("PROV_API_KEY", "PROV_API_KEY_FILE", "~/.config/api_key") == "from_default"
 
 
-# 2026-09-09, tianqi, file-only error names the key file (#3111)
 def test_resolve_missing_key_names_the_file(monkeypatch, tmp_path):
     monkeypatch.delenv("PROV_API_KEY", raising=False)
     monkeypatch.setenv("PROV_API_KEY_FILE", str(tmp_path / "absent"))
     with pytest.raises(RuntimeError, match="missing or empty"):
         resolve_provider_api_key("PROV_API_KEY", "PROV_API_KEY_FILE", "~/nope")
-
-
-# end


### PR DESCRIPTION
Fixes #3111.

Sandbox provider keys used to resolve **env-first**. That let `E2B_API_KEY` / `DAYTONA_API_KEY` / Modal token env vars silently satisfy preflight while the key *file* was missing or unread — the Harbor gap that only showed up on GPU e2e. The file is now the only supply path.

- `sandbox_key_supply` forwards the file path (never the secret) and **rejects a set key env var**, naming the file to create.
- `resolve_provider_api_key` reads the file only; a set key env var is a hard error that names the file.
- OpenEnv / AgentENV / glm52 docs and the glm52 Daytona launcher provision by file. Harbor and HUD keep their own copies (Harbor is out of scope on the issue).

## Tests

CPU-only, no GPU, no E2B/Harbor e2e:

```bash
pytest tests/fast/rollout/agentic/test_credentials.py tests/fast/examples/experimental/openenv -q
```

124 passed, 3 skipped.

Inverted the old env-wins tests: file-only succeeds and never puts the secret in the forwarded env; a set key env var fails and names the file path.