### PR TITLE
fix(megatron): align BSHD routing replay token order

### DIFF
--- a/miles/backends/megatron_utils/actor.py
+++ b/miles/backends/megatron_utils/actor.py
@@ -522,6 +522,7 @@ class MegatronTrainRayActor(TrainRayActor):
                     register_replay_list_func=m.register_replay_list_func,
                     if_sp_region=m.if_sp_region,
                     indices_are_token_positions=m.replay_indices_are_token_positions,
+                    sequence_first=m is routing_replay_manager,
                 )
 
         with inverse_timer("train_wait"), timer("train"):

--- a/miles/backends/training_utils/replay_data.py
+++ b/miles/backends/training_utils/replay_data.py
@@ -39,6 +39,7 @@ def fill_replay_data(
     register_replay_list_func: RegisterReplayListFunc,
     if_sp_region=True,
     indices_are_token_positions=False,
+    sequence_first=False,
 ):
     """Load rollout replay tensors into module replay queues.
 
@@ -48,6 +49,9 @@ def fill_replay_data(
     log-prob and train forwards, pads/slices them to match the local CP/SP
     token layout, and then delegates stream-to-module mapping to
     `register_replay_list_func`.
+
+    For `bshd`, `sequence_first` selects Megatron MoE's `[S, B]` token order;
+    indexer replay consumes the default `[B, S]` order.
     """
     if data_key not in rollout_data:
         raise ValueError(f"{data_key} is required in rollout_data for replay.")
@@ -96,6 +100,8 @@ def fill_replay_data(
                 replay_data = [slice_with_cp(r, pad_func, qkv_format, max_seqlen) for r in replay_data]
             replay_data = torch.stack(replay_data, dim=0)
             batch_size, seqlen, num_layers, topk = replay_data.shape
+            if sequence_first:
+                replay_data = replay_data.transpose(0, 1)
             replay_data = replay_data.reshape(batch_size * seqlen, num_layers, topk)
         else:
             pad_size = parallel_state.tp.size * args.data_pad_size_multiplier

--- a/tests/fast/backends/training_utils/test_replay_data.py
+++ b/tests/fast/backends/training_utils/test_replay_data.py
@@ -2,10 +2,13 @@ from tests.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=60, suite="stage-a-cpu", labels=[])
 
+from types import SimpleNamespace
+
 import pytest
 import torch
 
-from miles.backends.training_utils.replay_data import register_replay_list_sequential
+from miles.backends.training_utils import parallel
+from miles.backends.training_utils.replay_data import fill_replay_data, register_replay_list_sequential
 
 
 class _Replay:
@@ -45,3 +48,111 @@ def test_register_replay_list_sequential_rejects_out_of_range_stream_idx():
 
     with pytest.raises(AssertionError, match="out of range"):
         register_replay_list_sequential(replays, replay_data)
+
+
+@pytest.mark.parametrize("lengths", [(3, 3), (3, 5), (3,)])
+@pytest.mark.parametrize("sequence_first", [True, False], ids=["moe", "indexer"])
+@pytest.mark.parametrize("cp_size,allgather_cp", [(1, False), (2, False), (2, True)])
+@pytest.mark.parametrize("tp_size,sequence_parallel", [(1, False), (2, False), (2, True)])
+def test_fill_replay_bshd_token_alignment(
+    monkeypatch, lengths, sequence_first, cp_size, allgather_cp, tp_size, sequence_parallel
+):
+    max_seqlen = 8
+    tokens = [torch.arange(1, length + 1) + sample * 100 for sample, length in enumerate(lengths)]
+    # Each token has unique expert IDs in both streams and top-k slots.
+    expert_offsets = torch.arange(4).reshape(2, 2)
+    routes = [token_ids[:-1, None, None] * 10 + expert_offsets for token_ids in tokens]
+    args = SimpleNamespace(qkv_format="bshd", allgather_cp=allgather_cp, sequence_parallel=sequence_parallel)
+
+    for cp_rank in range(cp_size):
+        positions = list(range(max_seqlen))
+        if cp_size > 1:
+            if allgather_cp:
+                width = max_seqlen // cp_size
+                positions = positions[cp_rank * width : (cp_rank + 1) * width]
+            else:
+                width = max_seqlen // (2 * cp_size)
+                back = 2 * cp_size - cp_rank - 1
+                positions = (
+                    positions[cp_rank * width : (cp_rank + 1) * width] + positions[back * width : (back + 1) * width]
+                )
+
+        for tp_rank in range(tp_size):
+            state = SimpleNamespace(
+                cp=SimpleNamespace(size=cp_size, rank=cp_rank), tp=SimpleNamespace(size=tp_size, rank=tp_rank)
+            )
+            monkeypatch.setattr(parallel, "_parallel_state", state)
+            rollout_data = {
+                "routes": routes,
+                "tokens": tokens,
+                "max_seq_lens": [max_seqlen] * len(tokens),
+            }
+            iterator = SimpleNamespace(reset=lambda: None, get_next=lambda keys, batch=rollout_data: batch)
+            replays = [_Replay(), _Replay()]
+            fill_replay_data(
+                args=args,
+                models=None,
+                data_iterator=[iterator],
+                num_microbatches=[1],
+                rollout_data=rollout_data,
+                data_key="routes",
+                replay_list=replays,
+                register_replay_list_func=register_replay_list_sequential,
+                if_sp_region=sequence_first,
+                sequence_first=sequence_first,
+            )
+
+            local_positions = positions
+            if sequence_parallel and sequence_first:
+                width = len(positions) // tp_size
+                local_positions = positions[tp_rank * width : (tp_rank + 1) * width]
+            # Enumerate token identities in the consumer's order, including masked rows.
+            samples = range(len(tokens))
+            token_order = (
+                [(sample, pos) for pos in local_positions for sample in samples]
+                if sequence_first
+                else [(sample, pos) for sample in samples for pos in local_positions]
+            )
+            expected = torch.stack(
+                [
+                    tokens[sample][pos] * 10 + expert_offsets if pos < lengths[sample] - 1 else torch.full((2, 2), -1)
+                    for sample, pos in token_order
+                ]
+            )
+            for stream, replay in enumerate(replays):
+                assert len(replay.recorded) == 1
+                torch.testing.assert_close(replay.recorded[0], expected[:, stream])
+
+
+@pytest.mark.parametrize("sequence_first", [False, True])
+@pytest.mark.parametrize("tp_size,sequence_parallel", [(1, False), (2, True)])
+def test_fill_replay_thd_preserves_packed_order(monkeypatch, sequence_first, tp_size, sequence_parallel):
+    args = SimpleNamespace(
+        qkv_format="thd", allgather_cp=False, sequence_parallel=sequence_parallel, data_pad_size_multiplier=2
+    )
+    expected = torch.tensor([0, 1, -1, 2, 3, -1])
+    if tp_size == 2:
+        expected = torch.cat([expected, torch.tensor([-1, -1])])
+    for tp_rank in range(tp_size):
+        state = SimpleNamespace(cp=SimpleNamespace(size=1, rank=0), tp=SimpleNamespace(size=tp_size, rank=tp_rank))
+        monkeypatch.setattr(parallel, "_parallel_state", state)
+        rollout_data = {
+            "routes": [torch.tensor([0, 1]).reshape(2, 1, 1), torch.tensor([2, 3]).reshape(2, 1, 1)],
+            "tokens": [torch.arange(3), torch.arange(3)],
+            "max_seq_lens": None,
+        }
+        iterator = SimpleNamespace(reset=lambda: None, get_next=lambda keys, batch=rollout_data: batch)
+        replay = _Replay()
+        fill_replay_data(
+            args=args,
+            models=None,
+            data_iterator=[iterator],
+            num_microbatches=[1],
+            rollout_data=rollout_data,
+            data_key="routes",
+            replay_list=[replay],
+            register_replay_list_func=register_replay_list_sequential,
+            sequence_first=sequence_first,
+        )
+        local_expected = expected.chunk(tp_size)[tp_rank] if sequence_parallel else expected
+        torch.testing.assert_close(replay.recorded[0][:, 0], local_expected)


### PR DESCRIPTION
## Summary
Align Megatron BSHD routing replay with the router's sequence-first token order.

## Symptom & Reproduction
- Megatron runs using `--use-rollout-routing-replay --qkv-format bshd --micro-batch-size 2` can replay another token's expert IDs, even with TP=CP=1.
- For two three-token samples, replay rows are `[0,1,-1,2,3,-1]` instead of the required `[0,2,1,3,-1,-1]`: three of four valid tokens are misaligned. Matching tensor shapes do not detect this.
- The new multi-sample regression cases fail before the transpose and pass afterward.

## Root Cause
1. `fill_replay_data` stacks samples as `[B,S,L,K]` and flattens tokens in batch-first order.
2. `LanguageModelEmbedding.forward` converts hidden states to `[S,B,H]`.
3. `TopKRouter.routing` flattens `[S,B,E]`, pairing sequence-first token scores with batch-first replay rows.

The consumer ordering is visible in the pinned [Megatron router](https://github.com/radixark/Megatron-LM/blob/8c1e05747eb612b382df2632783df5c83a853646/megatron/core/transformer/moe/router.py#L816).

## Fix
Let the Megatron actor request sequence-first replay only for its MoE routing manager. Transpose after CP slicing and before flattening/SP slicing. Keep indexer replay batch-first; packed THD and FSDP retain their existing behavior.

## Verification
- `python -B -m pytest tests/fast/backends/training_utils/test_replay_data.py --confcutdir=tests/fast/backends/training_utils -o addopts= -p no:cacheprovider -q --tb=short`: **61 passed**, covering equal/unequal sample lengths, single samples, padding, multiple streams/top-k slots, TP/SP, both CP layouts through CPU rank simulation, batch-first ordering, and THD preservation.
- Black 24.3.0, isort 5.13.2, Ruff 0.14.7, and `git diff --check`: passed.
- Local global pytest fixtures cannot load because the installed SGLang lacks `encoding_dsv4`; the focused command excludes those unrelated rollout fixtures. No loader or CP slicing implementation is mocked.
- GPU distributed training has not been run.

## Review Focus
- `sequence_first`: only the Megatron MoE consumer opts in; the transpose must precede SP slicing.
