### PR TITLE
Bound the trainer's GPU memory during the LoRA weight sync

### DIFF
--- a/miles/backends/megatron_utils/update_weight/hf_weight_iterator.py
+++ b/miles/backends/megatron_utils/update_weight/hf_weight_iterator.py
@@ -53,7 +53,8 @@ class MegatronHfWeightIteratorBase(HfWeightIteratorBase):
             )
         if not any(is_lora_weight_name(name) for name, _tensor in named_tensors):
             raise RuntimeError("LoRA weight sync failed: the adapter export contains no lora_A/lora_B names.")
-        for hf_name, tensor in named_tensors:
+        while named_tensors:
+            hf_name, tensor = named_tensors.pop(0)
             yield [(f"{lora_name}:{hf_name}", tensor)]
 
     @abstractmethod

--- a/miles/backends/training_utils/weight_update/protocol.py
+++ b/miles/backends/training_utils/weight_update/protocol.py
@@ -62,6 +62,9 @@ class WeightTransferProtocol(ABC):
     def finalize(self, weight_version: int) -> None:  # noqa: B027 — optional hook
         """Hook after all sends (e.g. publish + engine reload)."""
 
+    def after_engines_resumed(self) -> None:  # noqa: B027 — optional hook
+        """Hook once the engines have applied every bucket and resumed generation."""
+
     def pop_metrics(self) -> dict[str, float]:
         metrics, self.update_weight_metrics = self.update_weight_metrics, {}
         return metrics

--- a/miles/backends/training_utils/weight_update/protocols/cuda_ipc.py
+++ b/miles/backends/training_utils/weight_update/protocols/cuda_ipc.py
@@ -188,6 +188,10 @@ class UpdateWeightFromTensor(WeightTransferProtocol):
         check_weight_sync_results(async_utils.wait_futures(futures or []), is_lora=False)
         del long_lived_tensors
 
+    def after_engines_resumed(self) -> None:
+        torch.cuda.ipc_collect()
+        torch.cuda.empty_cache()
+
 
 def _send_to_colocated_engine(
     hf_named_tensors: list[tuple[str, torch.Tensor]],

--- a/miles/backends/training_utils/weight_update/updater.py
+++ b/miles/backends/training_utils/weight_update/updater.py
@@ -142,6 +142,7 @@ class WeightUpdater:
                 set_weight_version(protocol.rollout_engines, self.weight_version)
                 resume_engines(protocol.rollout_engines)
             dist.barrier(group=get_gloo_group())
+        protocol.after_engines_resumed()
 
     def _iter_base_buckets(self, *, materialize: bool):
         return self._hf_weight_iterator.iter_hf_weights(self.weights_getter(), materialize=materialize)

--- a/tests/fast/backends/training_utils/weight_update/test_dist_weight_update_lifecycle.py
+++ b/tests/fast/backends/training_utils/weight_update/test_dist_weight_update_lifecycle.py
@@ -84,6 +84,7 @@ def _make_updater(engines: list[_RecordingApiClient], *, pause_generation_mode: 
         send_bucket=MagicMock(),
         after_base_weights=MagicMock(),
         finalize=MagicMock(),
+        after_engines_resumed=MagicMock(),
     )
     iterator = MagicMock()
     iterator.iter_hf_weights.return_value = iter([])


### PR DESCRIPTION
Two GPU-memory leaks in the LoRA weight sync on the unified weight-update stack, found by the 16-node Kimi K3 colocated run (TP4/CP2/PP8/EP8 trainer, 4x TP16 engines, `--colocate-memory-peak-device gpu`). Both scale with the adapter size; K3's 896-expert adapter is ~46 GB per rank, so they surfaced there first.

- **Reclaim CUDA IPC storage after the weight sync.** The producer side of torch CUDA IPC keeps every sent bucket alive until `torch.cuda.ipc_collect()`, and torch only collects implicitly under its own allocator pressure — a torch_memory_saver `resume()` never triggers that. The engines hold the streamed LoRA tensors until `end_weight_update`, so the collect runs from a `CudaIpcProtocol.after_engines_resumed` hook once the session is closed and the engines resumed; collecting after the send loop reclaims nothing. Under the gpu peak device the trainer wakes while the engines still hold their weights (148 GB), and the retained buckets pushed the resume past the GPU: `after update_weights` alloc 136.65 GB against a 90.94 GB baseline, TMS `cudaError 2` on wake_up across 55 ranks.
- **Release gathered LoRA tensors as their buckets are sent.** The PP-gathered adapter stayed alive as one list for the whole sync while each bucket also lived on as its IPC copy, so the trainer's transient was twice the adapter (reserved 182.63 GB = 91 + 91), leaving the engine 275 MB to install the adapter into.

Measured on the same run after the two commits: `after update_weights` alloc back to 90.94 GB, trainer process residency 55 GB -> 3 GB after the sync, wake_up passes with 33 GB free, and a 236-step run completed on the fixed stack.

