### PR TITLE
test(ci): run the qwen36 session verifier with ROLLBACK, not APPEND_TOOL

### DIFF
--- a/tests/e2e/sglang/test_session_server_multi_role/test_qwen36.py
+++ b/tests/e2e/sglang/test_session_server_multi_role/test_qwen36.py
@@ -16,7 +16,12 @@ CONFIG = ModelConfig(
     tp_size=2,
     enable_spec=True,
     cycles=2,
-    tool_call_failure_mode="append_tool",
+    # Qwen3.6 loops on the APPEND_TOOL sentinel: told "the previous turn did
+    # not emit a tool_call, retry" after it already called and answered, it
+    # re-derives that contradiction until max_tokens instead of retrying or
+    # answering.  ROLLBACK re-samples the turn instead; a genuine no-tool-call
+    # failure still surfaces after MAX_CONSECUTIVE_TOOL_CALL_FAILURE_ROLLBACKS.
+    tool_call_failure_mode="rollback",
     # Anthropic tool-call conversion changes raw assistant serialization;
     # keep this endpoint-only formatting mismatch soft while hard gates stay at 0.
     anthropic_assistant_text_threshold=1.0,


### PR DESCRIPTION
## Problem

`tests/e2e/sglang/test_session_server_multi_role/test_qwen36.py` fails intermittently on scheduled `main` CI — red on 2026-09-08 ([run 34243026014, job 102121823309](https://github.com/radixark/miles/actions/runs/34243026014/job/102121823309)), green on 09-07 and 09-09 with identical sglang / image / Megatron pins:

```
AssertionError: Step 6 tool_result exhausted 2 retries after finish_reason='length'
```

Under `tool_call_failure_mode="append_tool"`, when a `TOOL_RESULT` step finds no `tool_calls` the driver splices in a `Tool call parsing failed: the previous assistant turn did not emit a parseable tool_call. Please retry ...` sentinel `tool` message. Qwen3.6 neither retries nor answers on that sentinel: it deliberates *"I already called and answered"* against *"retry the call"* until `max_tokens` (8192; captured truncations are verbatim loops of one reasoning sentence repeated 100+ times), on roughly 11-14% of first attempts and ~50% of retries. The run fails whenever one sample loses three in a row, which makes the test a coin flip independent of the sglang revision.

The other `append_tool` families pass the same step; under identical conditions `test_qwen35.py` answers it in ~80 tokens with zero truncations.

## Change

Switch qwen36 to `tool_call_failure_mode="rollback"` (the module default), with a short comment recording why. ROLLBACK re-samples the turn instead of injecting the sentinel, and a genuine no-tool-call failure still surfaces as a bounded assertion after `MAX_CONSECUTIVE_TOOL_CALL_FAILURE_ROLLBACKS = 3` instead of an 8192-token loop. qwen35 keeps `append_tool` and continues to cover the lenient-template sentinel path for the Qwen3.5 family.

One file, one config line plus comment. No driver, schedule or model changes.

## Verification

On an 8×H200 devbox matching the failing job's image / miles / sglang / Megatron pins, with per-turn instrumentation on the OpenAI driver:

| run | config | result | OpenAI turns | `finish_reason='length'` | Step 6 completion tokens (p50 / max) |
|---|---|---|---|---|---|
| baseline ×2 | `append_tool` | 1 fail, 1 pass | 778 / 783 | 9 / 8 | 620-1160 / 5220-6959 |
| this change ×2 | `rollback` | see below | 768 / 768 | **0 / 0** | **50 / 102** |

With `rollback`, Step 6 becomes an ordinary re-sample (`tool_call_failure_rollback` in every sample's driver events, no `tool_call_failure_append_tool`), the loop disappears, and the OpenAI `v1` / `v2` sub-runs pass in both runs. The second run passed end to end (exit 0, all three sub-runs).

The first run's Anthropic sub-run failed once with an unrelated assertion — `Anthropic per-model e2e: expected one linear sample, got 2` on 1 of 37 sessions: the session server attached that session's second `/v1/messages` request as a `<new root>` (matched 0 of its 2 messages against the single existing node), producing two leaves. The Anthropic driver does not read `tool_call_failure_mode` and the branch happened before any tool-result step, so this change cannot reach it; it did not recur in the second run and was not seen in five earlier runs on the same box. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
