### PR TITLE
[DO NOT MERGE] e2e probe for the suite failure tail

### DIFF
--- a/tests/ci/ci_utils.py
+++ b/tests/ci/ci_utils.py
@@ -6,8 +6,10 @@ import os
 import re
 import signal
 import subprocess
+import sys
 import threading
 import time
+from collections import deque
 from collections.abc import Callable
 from dataclasses import dataclass
 
@@ -150,6 +152,28 @@ def _kill_process_tree(pgid: int):
         pass
     except Exception as e:
         logger.warning(f"Error killing process group {pgid}: {e}")
+
+
+FAILURE_TAIL_BYTES = 8_192
+FAILURE_TAIL_LINES = 60
+
+
+def _drain_child_output(stream, tail: deque) -> None:
+    """Pass a child's output straight through, keeping only its last bytes for the failure summary."""
+    held = 0
+    while chunk := stream.read(65_536):
+        sys.stdout.buffer.write(chunk)
+        sys.stdout.buffer.flush()
+        tail.append(chunk)
+        held += len(chunk)
+        while tail and held - len(tail[0]) >= FAILURE_TAIL_BYTES:
+            held -= len(tail.popleft())
+
+
+def _failure_tail(chunks: deque) -> str:
+    text = b"".join(chunks)[-FAILURE_TAIL_BYTES:].decode("utf-8", errors="replace")
+    lines = [line for line in text.splitlines() if line.strip()]
+    return "\n".join(lines[-FAILURE_TAIL_LINES:])
 
 
 def run_with_timeout(
@@ -437,9 +461,11 @@ def run_unittest_files(
 
         process = None
         output_lines = []
+        output_tail: deque = deque(maxlen=FAILURE_TAIL_LINES * 8)
 
         def run_one_file(filename, capture_output=False, record_dir=None, _i=i, _estimated_time=estimated_time):
-            nonlocal process, output_lines
+            nonlocal process, output_lines, output_tail
+            output_tail = deque(maxlen=FAILURE_TAIL_LINES * 8)
 
             full_path = os.path.join(os.getcwd(), filename)
             logger.info(f".\n.\nBegin ({_i}/{len(files) - 1}):\npython3 {full_path}\n.\n.\n")
@@ -467,15 +493,19 @@ def run_unittest_files(
                 for line in process.stdout:
                     logger.info(line.rstrip())
                     output_lines.append(line)
+                    output_tail.append(line.encode("utf-8", errors="replace"))
                 process.wait()
             else:
+                # Chunked pass-through, not a line loop: a GPU suite writes over a hundred megabytes
+                # here and the runner's own stdout stays the destination.
                 process = subprocess.Popen(
                     ["python3", full_path],
-                    stdout=None,
-                    stderr=None,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.STDOUT,
                     start_new_session=True,
                     env=child_env,
                 )
+                _drain_child_output(process.stdout, output_tail)
                 process.wait()
 
             elapsed = time.perf_counter() - file_tic
@@ -568,7 +598,7 @@ def run_unittest_files(
                         logger.info(f"\nFAILED: {filename} returned exit code {ret_code}\n")
                         if was_retried:
                             retried_tests.append((filename, attempt, "failed"))
-                        failed_tests.append((filename, f"exit code {ret_code}"))
+                        failed_tests.append((filename, f"exit code {ret_code}", _failure_tail(output_tail)))
                         break
 
                 except TimeoutError:
@@ -580,7 +610,7 @@ def run_unittest_files(
                     logger.info(f"\nTIMEOUT: {filename} after {effective_timeout} seconds\n")
                     if was_retried:
                         retried_tests.append((filename, attempt, "timeout"))
-                    failed_tests.append((filename, f"timeout after {effective_timeout}s"))
+                    failed_tests.append((filename, f"timeout after {effective_timeout}s", _failure_tail(output_tail)))
                     break
                 except Exception:
                     attempt_elapsed = time.perf_counter() - attempt_tic
@@ -644,8 +674,13 @@ def run_unittest_files(
             logger.info(f"  {test}")
     if failed_tests:
         logger.info("\nFAILED:")
-        for test, reason in failed_tests:
+        for test, reason, _ in failed_tests:
             logger.info(f"  {test} ({reason})")
+        for test, _, tail in failed_tests:
+            if tail:
+                logger.info(f"\nLast output of {test}:")
+                for line in tail.splitlines():
+                    logger.info(f"  | {line}")
     if retried_tests:
         logger.info("\nRETRIED:")
         for test, attempts, result in retried_tests:

--- a/tests/ci/test/test_failure_tail.py
+++ b/tests/ci/test/test_failure_tail.py
@@ -1,0 +1,83 @@
+"""The end of a job log must explain the failure, whatever the log's size.
+
+A GPU suite writes tens of megabytes after the test that failed, so the
+notifier's tail window never reaches the traceback. The suite runner already
+sees every line, so it keeps the failing test's last output and repeats it in
+the summary it prints last.
+"""
+
+import io
+import logging
+import sys
+from collections import deque
+from pathlib import Path
+
+from tests.ci.ci_register import register_cpu_ci
+from tests.ci.ci_utils import FAILURE_TAIL_BYTES, FAILURE_TAIL_LINES
+from tests.ci.ci_utils import TestFile as CITestFile
+from tests.ci.ci_utils import _drain_child_output, _failure_tail, run_unittest_files
+
+register_cpu_ci(est_time=1, suite="stage-a-cpu", labels=[])
+
+# The window ci_failure_analysis downloads from the end of a job log.
+NOTIFIER_TAIL_BYTES = 33_600
+
+
+class _CapturedStdout:
+    def __init__(self):
+        self.buffer = io.BytesIO()
+
+
+def drain(body: bytes) -> tuple[bytes, deque]:
+    tail: deque = deque(maxlen=FAILURE_TAIL_LINES * 8)
+    captured = _CapturedStdout()
+    real, sys.stdout = sys.stdout, captured
+    try:
+        _drain_child_output(io.BytesIO(body), tail)
+    finally:
+        sys.stdout = real
+    return captured.buffer.getvalue(), tail
+
+
+def test_draining_passes_every_byte_through_untouched():
+    body = b"".join(f"line {index}\n".encode() for index in range(50_000))
+    passed_through, _ = drain(body)
+    assert passed_through == body
+
+
+def test_draining_holds_a_bounded_tail_of_a_large_stream():
+    body = b"x" * 40_000_000
+    _, tail = drain(body)
+    assert sum(len(chunk) for chunk in tail) < 1_000_000
+
+
+def test_the_tail_keeps_the_last_lines_and_drops_blank_ones():
+    tail = deque([b"early\n", b"\n   \n", b"AssertionError: boom\n", b"exit 1\n"])
+    assert _failure_tail(tail).splitlines() == ["early", "AssertionError: boom", "exit 1"]
+    assert len(_failure_tail(deque([b"l\n" * 500])).splitlines()) <= FAILURE_TAIL_LINES
+
+
+def test_a_failing_test_explains_itself_inside_the_notifier_window(tmp_path, monkeypatch, caplog):
+    Path(tmp_path / "test_boom.py").write_text(
+        "for index in range(5000):\n"
+        "    print(f'noise {index}')\n"
+        "raise AssertionError('the reactor exploded at step 42')\n"
+    )
+    monkeypatch.chdir(tmp_path)
+    with caplog.at_level(logging.INFO):
+        run_unittest_files([CITestFile(name="test_boom.py")], timeout_per_file=120, continue_on_error=True)
+    assert "FAILED: test_boom.py returned exit code 1" in caplog.text
+    _, separator, summary = caplog.text.rpartition("\nFAILED:\n")
+    assert separator, "the runner printed no failure summary"
+    assert "the reactor exploded at step 42" in summary
+    assert len(summary) < NOTIFIER_TAIL_BYTES
+
+
+def test_the_summary_survives_a_log_far_larger_than_the_notifier_window():
+    body = b"".join(f"progress step {index}\n".encode() for index in range(400_000))
+    body += b"AssertionError: the reactor exploded\n"
+    _, tail = drain(body)
+    rendered = _failure_tail(tail)
+    assert "AssertionError: the reactor exploded" in rendered
+    assert len(rendered.encode()) <= FAILURE_TAIL_BYTES
+    assert len(body) > 100 * NOTIFIER_TAIL_BYTES

--- a/tests/ci/test/test_zz_failure_tail_probe.py
+++ b/tests/ci/test/test_zz_failure_tail_probe.py
@@ -1,0 +1,15 @@
+"""TEMPORARY: proves the suite summary carries a real failure. Not for merge.
+
+Prints far more than the notifier's tail window, then fails, so a real CI run
+exercises the whole chain: child pipe -> failure tail -> summary -> job log ->
+notifier evidence.
+"""
+
+from tests.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=1, suite="stage-a-cpu", labels=[])
+
+if __name__ == "__main__":
+    for index in range(60_000):
+        print(f"probe filler line {index} " + "x" * 60)
+    raise AssertionError("failure-tail probe: the reactor exploded at step 42")


### PR DESCRIPTION
Throwaway. Carries #3149 plus a CPU test that prints 60k lines and then fails, so one real CI run exercises child pipe -> failure tail -> summary -> job log -> notifier evidence. Will be closed once the run is read.