### PR TITLE
docs: document the custom_rm contract

### DIFF
--- a/docs/user-guide/customization.md
+++ b/docs/user-guide/customization.md
@@ -148,6 +148,45 @@ async def batched_custom_rm(args, samples: list[Sample]) -> list[float]:
 Prefixing any of them with `boxed_` (for example `boxed_math`) extracts `\boxed{}`
 from the response before grading.
 
+**What the function reads.** The whole `Sample` is passed; the fields a reward is
+expected to use are:
+
+| field | type | holds |
+| --- | --- | --- |
+| `response` | `str` | the generated text |
+| `label` | `str`, optional | ground truth, carried through from the prompt data |
+| `prompt` | `str` or chat turns | the prompt as given to the model |
+| `metadata` | `dict` | whatever the data source attached to the row |
+| `index`, `group_index` | `int`, optional | position in the rollout and in its group |
+
+The return value is assigned to `sample.reward`.
+
+**Scoring is skipped when `sample.reward` is already set.** Both the single and
+batched paths in `miles/rollout/sglang_rollout.py` only score samples whose reward
+is still `None`, so an environment that grades itself — a multi-turn agent, or a
+suite like Harbor that returns its own score — can assign `sample.reward` during
+generation and no reward function runs for that sample. If a `--custom-rm-path`
+never appears to fire, check whether something upstream already set the reward.
+
+**Per-sample overrides.** `sample.reward_spec` redirects scoring for one sample,
+which is how a mixed suite grades different rows differently:
+
+```python
+from miles.utils.types import RewardSpec
+
+sample.reward_spec = RewardSpec(custom_rm_path="my_pkg.rewards.strict_match")
+```
+
+The two fields do not resolve the same way:
+
+| setting | resolution order |
+| --- | --- |
+| `custom_rm_path` | `reward_spec.custom_rm_path` → `--custom-rm-path` |
+| `rm_type` | `reward_spec.rm_type` → `metadata["rm_type"]` → `--rm-type` |
+
+`rm_type` falls back to `metadata`; `custom_rm_path` does not. A `custom_rm_path`
+resolved from either source short-circuits `rm_type` entirely.
+
 ### `--custom-reward-post-process-path`
 
 Hook to normalize rewards differently from the default GRPO normalization.


### PR DESCRIPTION
## What

The `--custom-rm-path` section documents the signature but not what the function is allowed to read, so writing a custom reward means reading `miles/utils/types.py` and `miles/rollout/rm_hub/__init__.py` to work it out. This adds what I found doing that.

Docs only, no code change.

## Three additions

**The `Sample` fields a reward is expected to use**, and that the return value is assigned to `sample.reward`.

**That scoring is skipped when `sample.reward` is already set.** Both the single and batched paths in `sglang_rollout.py` only score samples whose reward is still `None`:

```python
if sample.reward is None:
    sample.reward = await async_rm(args, sample)
```

So a self-grading environment silently bypasses `--custom-rm-path`. The environments page mentions that Harbor and τ-bench grade themselves and the score still arrives via `Sample.reward`, but the customization page — where someone writing a `custom_rm` would look — doesn't connect the two. The failure mode is quiet: the flag is set, the function never runs, and nothing explains why.

**That `reward_spec` overrides per sample, and its two fields resolve differently.** From `_resolve_reward_config`:

| setting | resolution order |
| --- | --- |
| `custom_rm_path` | `reward_spec.custom_rm_path` → `--custom-rm-path` |
| `rm_type` | `reward_spec.rm_type` → `metadata["rm_type"]` → `--rm-type` |

`rm_type` falls back to `metadata`; `custom_rm_path` does not. That asymmetry is easy to trip over if you assume both work the same way.

## How I hit this

I was writing a `custom_rm` for a geometry-verification environment and needed to know whether the reward could rely on `label` for ground truth and where to record per-sample diagnostics. Both answers were in the source rather than the docs.

## Notes

- Avoided escaped pipes in the new tables — there are none elsewhere in `docs/`, so union types are written as `str`, optional rather than betting on the renderer.
- Happy to trim if any of this is deliberately left undocumented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)