### PR TITLE
fix(metrics): count rollouts, not rows, when checking pass@k group completeness

### DIFF
--- a/miles/ray/rollout/metrics.py
+++ b/miles/ray/rollout/metrics.py
@@ -298,10 +298,21 @@ def _compute_passrate_from_samples(args, all_samples: list[Sample]) -> dict[str,
 
     Unlike the trainer-side log_passrate (which assumed a flat reward array with
     contiguous groups of n_samples_per_prompt), this groups samples by their
-    group_index field and computes pass@k over complete groups only. This is
-    robust to filtering that may remove individual samples from a group —
-    incomplete groups are excluded from the estimate rather than skewing it
-    or crashing the reshape.
+    group_index field and computes pass@k over complete groups only.
+
+    Each group is collapsed to one row per logical rollout before the
+    completeness check. Session compaction and sub-agents split one rollout into
+    several sibling Samples sharing a rollout ID, so a group can hold more rows
+    than n_samples_per_prompt; counting rows would make every such group look
+    incomplete and drop the metric entirely. Siblings are required to carry the
+    same reward, so keeping any one of them represents the rollout. This is the
+    same logical-rollout unit `_compute_episode_response_length_metrics` and the
+    GRPO reward normalization already use.
+
+    Groups that are still short after collapsing — filtering removed whole
+    rollouts — are excluded rather than skewing the estimate or crashing the
+    reshape in `compute_pass_rate`, which requires exactly group_size rewards
+    per group.
 
     Called on the rollout side (before convert_samples_to_train_data), so
     normally all samples are present and every group is complete.
@@ -310,16 +321,22 @@ def _compute_passrate_from_samples(args, all_samples: list[Sample]) -> dict[str,
     if group_size <= 1:
         return {}
 
-    groups = group_by(all_samples, lambda s: s.group_index)
-    completed_groups = [g for g in groups.values() if len(g) == group_size]
-    if len(completed_groups) < len(groups):
+    rollouts_by_group: dict[int | None, dict[tuple, Sample]] = {}
+    for position, sample in enumerate(all_samples):
+        rollouts_by_group.setdefault(sample.group_index, {}).setdefault(
+            _get_rollout_key(sample, position), sample
+        )
+
+    completed_groups = [g for g in rollouts_by_group.values() if len(g) == group_size]
+    if len(completed_groups) < len(rollouts_by_group):
         logger.warning(
-            f"pass@k: excluding {len(groups) - len(completed_groups)}/{len(groups)} incomplete groups (fewer than n_samples_per_prompt={group_size} samples)."
+            f"pass@k: excluding {len(rollouts_by_group) - len(completed_groups)}/{len(rollouts_by_group)} "
+            f"groups that do not hold exactly n_samples_per_prompt={group_size} rollouts."
         )
     if not completed_groups:
         return {}
 
-    flat_rewards = [sample.get_reward_value(args) for group in completed_groups for sample in group]
+    flat_rewards = [sample.get_reward_value(args) for group in completed_groups for sample in group.values()]
 
     return compute_pass_rate(
         flat_rewards=flat_rewards,

--- a/tests/fast/ray/rollout/test_metrics.py
+++ b/tests/fast/ray/rollout/test_metrics.py
@@ -311,6 +311,68 @@ class TestTitoMismatchMetrics:
 
 
 class TestComputePassrateFromSamples:
+    def test_fanned_out_rollouts_still_report(self):
+        """Regression for #2579.
+
+        Compaction splits one logical rollout across sibling Samples that share a
+        rollout_id, so a group holds more rows than n_samples_per_prompt. Counting
+        rows made every such group look incomplete and pass@k reported nothing.
+        """
+        args = make_args(n_samples_per_prompt=2, log_passrate=True, reward_key=None)
+        samples = []
+        for g in range(2):
+            # rollout 0 of each group fans out into two siblings sharing a reward
+            samples.append(make_sample(group_index=g, index=0, rollout_id=10 * g + 0, reward=0.0))
+            samples.append(make_sample(group_index=g, index=0, rollout_id=10 * g + 0, reward=0.0))
+            samples.append(make_sample(group_index=g, index=1, rollout_id=10 * g + 1, reward=1.0))
+
+        assert _compute_passrate_from_samples(args, samples) == {
+            "pass@1": pytest.approx(0.5),
+            "pass@2": pytest.approx(1.0),
+        }
+
+    def test_fanned_out_matches_unfanned_equivalent(self):
+        """Fanning a rollout out must not change the metric it contributes to."""
+        args = make_args(n_samples_per_prompt=2, log_passrate=True, reward_key=None)
+        flat = [
+            make_sample(group_index=g, index=i, rollout_id=10 * g + i, reward=float(i))
+            for g in range(2)
+            for i in range(2)
+        ]
+        fanned = [
+            make_sample(group_index=g, index=i, rollout_id=10 * g + i, reward=float(i))
+            for g in range(2)
+            for i in range(2)
+            for _ in range(3 if i == 0 else 1)
+        ]
+
+        assert _compute_passrate_from_samples(args, fanned) == _compute_passrate_from_samples(args, flat)
+
+    def test_group_short_of_rollouts_is_still_excluded(self):
+        """Collapsing siblings must not mask a group that genuinely lost a rollout."""
+        args = make_args(n_samples_per_prompt=3, log_passrate=True, reward_key=None)
+        samples = [
+            make_sample(group_index=0, index=0, rollout_id=1, reward=1.0),
+            make_sample(group_index=0, index=0, rollout_id=1, reward=1.0),
+            make_sample(group_index=0, index=1, rollout_id=2, reward=0.0),
+        ]
+
+        assert _compute_passrate_from_samples(args, samples) == {}
+
+    def test_samples_without_rollout_id_fall_back_to_index(self):
+        """rollout_id is optional; index is the documented fallback."""
+        args = make_args(n_samples_per_prompt=2, log_passrate=True, reward_key=None)
+        samples = [
+            make_sample(group_index=g, index=i, rollout_id=None, reward=float(i))
+            for g in range(2)
+            for i in range(2)
+        ]
+
+        assert _compute_passrate_from_samples(args, samples) == {
+            "pass@1": pytest.approx(0.5),
+            "pass@2": pytest.approx(1.0),
+        }
+
     def test_returns_empty_when_group_size_is_one(self):
         args = make_args(n_samples_per_prompt=1)
         samples = make_samples_grouped(4, 1, rewards=[1.0, 0.0, 1.0, 0.0])


### PR DESCRIPTION
Fixes #2579.

## The fix

`_compute_passrate_from_samples` kept only groups whose row count equals `n_samples_per_prompt`. `len(g)` counts flattened trajectory rows; `n_samples_per_prompt` counts logical rollouts. Each group is now collapsed to one row per rollout before the completeness check, reusing the `_get_rollout_key` helper already in this file — the same logical-rollout unit `_compute_episode_response_length_metrics` and the GRPO reward normalization use.

Kept the `==` as the issue asks: `compute_pass_rate` asserts `len(flat_rewards) == num_groups * group_size`, so `>=` would trip the assert or reshape siblings into meaningless positions.

## A second direction the issue does not mention

The issue describes the false negative — with fan-out every bucket exceeds `group_size`, nothing qualifies, pass@k reports nothing. There is also a false positive.

A group holding **2 rollouts as 3 rows** passes an `== 3` check. pass@k is then computed over a reward array where one rollout appears twice:

```
n_samples_per_prompt = 3
group 0: rollout 1 → 2 sibling rows, reward 1.0
         rollout 2 → 1 row,          reward 0.0

before:  {'pass@1': 0.667, 'pass@2': 1.0}     ← 2 rollouts scored as 3
after:   {}                                    ← excluded, as intended
```

Silently wrong is worse than silently absent. The same change fixes both.

## Also corrected

The warning claimed excluded groups had "fewer than" `n_samples_per_prompt` samples, when fan-out means they had more. It now states the condition without asserting a direction. The docstring carried the same inversion and explained the filter only as protection against groups that *lost* samples.

## Tests

Four cases in `TestPassrate`: fan-out reports correctly, a fanned-out layout matches its unfanned equivalent, a group genuinely short a rollout is still excluded, and `rollout_id=None` falls back to `index`.

## What I ran, and what I could not

Verified the four new cases and the four existing passrate cases directly against the patched function, and confirmed the first three fail on unpatched `main`:

```
                                    before          after
fan-out (3 rows, 2 rollouts)        {}              {'pass@1': 0.5, 'pass@2': 1.0}
unfanned equivalent                 0.5 / 1.0       0.5 / 1.0
group missing a rollout             0.667 / 1.0     {}
rollout_id=None → index             0.5 / 1.0       0.5 / 1.0
```

**I could not run the pytest suite locally.** `tests/conftest.py` imports `sglang`, whose `flashinfer_python` build dependency is CUDA-only and does not build on macOS arm64. The verification above imports the real `metrics.py` with only the sglang entrypoint module stubbed, so the function under test is the shipped one — but it is not a substitute for CI, and the new tests have not been executed by pytest. Please run the CPU suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)