### PR TITLE
feat(dsv4): run the sparse-MLA and indexer kernels on a 64 KiB shared-memory GPU

### DIFF
--- a/miles_plugins/models/deepseek_v4/ops/kernel/tilelang_indexer_fwd.py
+++ b/miles_plugins/models/deepseek_v4/ops/kernel/tilelang_indexer_fwd.py
@@ -8,6 +8,14 @@ import tilelang
 import torch
 from tilelang import language as T
 
+from miles_plugins.models.deepseek_v4.ops.kernel.tiling import (
+    DeviceLimits,
+    build_with_largest_fitting_tiling,
+    current_target,
+    indexer_forward_block_ns,
+    shared_memory_required,
+)
+
 
 @tilelang.jit(
     pass_configs={
@@ -133,6 +141,40 @@ def _make_causal_cu_seqlens(seq_len_q, seq_len_kv, compress_ratio, device):
     return cu_seqlen_ks, cu_seqlen_ke
 
 
+_fitted_block_N: dict[tuple, int] = {}
+
+
+def _indexer_fwd_within_shared_mem(heads, index_dim, block_N=256):
+    """Build tl_indexer_fwd_impl with the largest block_N this target can host.
+
+    block_N only sets how much of the KV axis one workgroup sweeps per iteration, so shrinking it
+    costs performance and nothing else. Memoized per shape.
+    """
+
+    def build(n):
+        return tl_indexer_fwd_impl(heads=heads, index_dim=index_dim, block_N=n)
+
+    key = (heads, index_dim, block_N)
+    if key in _fitted_block_N:
+        return build(_fitted_block_N[key])
+
+    target = current_target()
+    limits = DeviceLimits.from_target(target)
+    kernel, fitted = build_with_largest_fitting_tiling(
+        requested=block_N,
+        derived=indexer_forward_block_ns(block_N=block_N, limits=limits),
+        compile_tiling=build,
+        required_bytes=lambda n: shared_memory_required(
+            tl_indexer_fwd_impl.get_tir(heads=heads, index_dim=index_dim, block_N=n), target
+        ),
+        budget=limits.shared_memory_per_block,
+        describe=lambda n: f"block_N={n} (requested {block_N})",
+        what="tl_indexer_fwd",
+    )
+    _fitted_block_N[key] = fitted
+    return kernel
+
+
 def indexer_fwd_interface(q, kv, weights, cu_seqlen_ks, cu_seqlen_ke, clean_logits=True):
     """Forward interface matching GLM-5's API but for a single batch element.
 
@@ -150,7 +192,7 @@ def indexer_fwd_interface(q, kv, weights, cu_seqlen_ks, cu_seqlen_ke, clean_logi
     seq_len_kv = kv.shape[0]
 
     clean_logits_kernel = clean_logits_()
-    tl_indexer_fwd_kernel = tl_indexer_fwd_impl(heads=heads, index_dim=index_dim)
+    tl_indexer_fwd_kernel = _indexer_fwd_within_shared_mem(heads=heads, index_dim=index_dim)
 
     logits = torch.empty([seq_len, seq_len_kv], device=q.device, dtype=torch.float32)
     tl_indexer_fwd_kernel(

--- a/miles_plugins/models/deepseek_v4/ops/kernel/tilelang_sparse_mla_bwd.py
+++ b/miles_plugins/models/deepseek_v4/ops/kernel/tilelang_sparse_mla_bwd.py
@@ -9,6 +9,15 @@ import tilelang
 import torch
 from tilelang import language as T
 
+from miles_plugins.models.deepseek_v4.ops.kernel.tiling import (
+    BackwardTiling,
+    DeviceLimits,
+    build_with_largest_fitting_tiling,
+    current_target,
+    shared_memory_required,
+    sparse_mla_backward_tilings,
+)
+
 
 @tilelang.jit(out_idx=[-1])
 def preprocess(
@@ -95,11 +104,15 @@ def bwd(
     block_size=32,
     num_stages=0,
     threads=128,
+    split_store=2,
+    stage_dq_through_shared=True,
+    max_block_H=None,
     indices_dtype=T.int32,
     dtype=T.bfloat16,
     accum_dtype=T.float32,
 ):
     assert topk % block_size == 0, f"topk ({topk}) must be divisible by block_size ({block_size})"
+    assert block_size % split_store == 0, f"block_size ({block_size}) must be divisible by split_store ({split_store})"
     assert dtype == T.bfloat16
     assert accum_dtype == T.float32
 
@@ -116,19 +129,18 @@ def bwd(
     attn_sink_shape = [H]
 
     padded_H = max(tilelang.math.next_power_of_2(H), 16)
-    is_hip = getattr(torch.version, "hip", None)
-    if is_hip:
-        # Split large HIP head tiles to reduce LDS use.
-        max_block_H = 32 if padded_H >= 64 else 64
-    else:
-        max_block_H = 64
+    if max_block_H is None:
+        is_hip = getattr(torch.version, "hip", None)
+        if is_hip:
+            # Split large HIP head tiles to reduce LDS use.
+            max_block_H = 32 if padded_H >= 64 else 64
+        else:
+            max_block_H = 64
     block_H = min(max_block_H, padded_H)
     assert padded_H % block_H == 0
     NH = padded_H // block_H
     BS = block_size
     NS = tilelang.cdiv(topk, block_size)
-
-    split_store = 2
 
     @T.prim_func
     def sparse_mqa_bwd_kernel(
@@ -151,7 +163,8 @@ def bwd(
 
             P_shared_cast = T.alloc_shared([block_H, BS], dtype)
             dP_shared_cast = T.alloc_shared([block_H, BS], dtype)
-            dQ_shared = T.alloc_shared([block_H, D], dtype)
+            if stage_dq_through_shared:
+                dQ_shared = T.alloc_shared([block_H, D], dtype)
 
             acc_p = T.alloc_fragment([block_H, BS], accum_dtype)
             acc_dp = T.alloc_fragment([block_H, BS], accum_dtype)
@@ -227,8 +240,11 @@ def bwd(
                         )
 
             # Store dQ
-            T.copy(acc_dq, dQ_shared)
-            T.copy(dQ_shared, dQ[by, s_i, bz * block_H : (bz + 1) * block_H, :D])
+            if stage_dq_through_shared:
+                T.copy(acc_dq, dQ_shared)
+                T.copy(dQ_shared, dQ[by, s_i, bz * block_H : (bz + 1) * block_H, :D])
+            else:
+                T.copy(acc_dq, dQ[by, s_i, bz * block_H : (bz + 1) * block_H, :D])
 
             # dAttnSink[h] = -sum_{b,s}( Delta[b,s,h] * p_sink[b,s,h] )
             # where p_sink = exp(attn_sink[h]) / Z = exp2(attn_sink[h]*log2e - LSE)
@@ -241,6 +257,81 @@ def bwd(
                 )
 
     return sparse_mqa_bwd_kernel
+
+
+_fitted_tiling: dict[tuple, BackwardTiling] = {}
+
+
+def bwd_within_shared_mem(B, S, S_kv, H, D, topk, sm_scale=None, block_size=32, threads=128):
+    """Build the backward kernel with the largest tiling this target can host.
+
+    Memoized on what the answer depends on, which is not the tensor shape: every shared buffer is
+    sized from block_H, block_size and D, so B/S/S_kv cannot move the requirement. Keying on them
+    would re-run the search for every new sequence length, which THD training produces per
+    microbatch.
+    """
+
+    def build(tiling):
+        return bwd(
+            B,
+            S,
+            S_kv,
+            H,
+            D,
+            topk,
+            sm_scale,
+            block_size=tiling.block_size,
+            threads=tiling.threads,
+            split_store=tiling.split_store,
+            stage_dq_through_shared=tiling.stage_dq_through_shared,
+            max_block_H=tiling.max_block_H,
+        )
+
+    key = (H, D, topk, block_size, threads)
+    if key in _fitted_tiling:
+        return build(_fitted_tiling[key])
+
+    requested = BackwardTiling(block_size, threads, split_store=2, stage_dq_through_shared=True, max_block_H=None)
+    target = current_target()
+    limits = DeviceLimits.from_target(target)
+
+    def required_bytes(tiling):
+        prim_func = bwd.get_tir(
+            B,
+            S,
+            S_kv,
+            H,
+            D,
+            topk,
+            sm_scale,
+            block_size=tiling.block_size,
+            threads=tiling.threads,
+            split_store=tiling.split_store,
+            stage_dq_through_shared=tiling.stage_dq_through_shared,
+            max_block_H=tiling.max_block_H,
+        )
+        return shared_memory_required(prim_func, target)
+
+    kernel, tiling = build_with_largest_fitting_tiling(
+        requested=requested,
+        derived=(
+            candidate
+            for candidate in sparse_mla_backward_tilings(
+                padded_heads=max(tilelang.math.next_power_of_2(H), 16),
+                topk=topk,
+                block_size=block_size,
+                limits=limits,
+            )
+            if candidate != requested
+        ),
+        compile_tiling=build,
+        required_bytes=required_bytes,
+        budget=limits.shared_memory_per_block,
+        describe=lambda t: t.describe(),
+        what="sparse_mqa_bwd",
+    )
+    _fitted_tiling[key] = tiling
+    return kernel
 
 
 def sparse_mqa_bwd_interface(q, kv, attn_sink, o, do, topk_idxs, lse, sm_scale=None):
@@ -263,6 +354,12 @@ def sparse_mqa_bwd_interface(q, kv, attn_sink, o, do, topk_idxs, lse, sm_scale=N
     """
     assert q.is_contiguous() and kv.is_contiguous()
     assert topk_idxs.is_contiguous() and lse.is_contiguous()
+    # Normalised rather than asserted: autograd may legitimately hand back a broadcast view of do
+    # (out.sum().backward() gives a stride-0 tensor). tilelang's stride check runs inside an
+    # "Exception ignored in" context, so a mismatch only prints, and the kernel then reads the
+    # stride-0 pointer as dense -- killing the process on a GPU memory access fault.
+    o = o.contiguous()
+    do = do.contiguous()
     B, S, H, D = q.shape
     _, S_kv, _ = kv.shape
     topk = topk_idxs.shape[-1]
@@ -276,7 +373,7 @@ def sparse_mqa_bwd_interface(q, kv, attn_sink, o, do, topk_idxs, lse, sm_scale=N
         topk = padded_topk
 
     preprocess_kernel = preprocess(B, S, H, D)
-    bwd_kernel = bwd(B, S, S_kv, H, D, topk, sm_scale)
+    bwd_kernel = bwd_within_shared_mem(B, S, S_kv, H, D, topk, sm_scale)
     postprocess_kernel = postprocess(B, S_kv, D)
 
     delta = preprocess_kernel(o, do)

--- a/miles_plugins/models/deepseek_v4/ops/kernel/tilelang_sparse_mla_fwd.py
+++ b/miles_plugins/models/deepseek_v4/ops/kernel/tilelang_sparse_mla_fwd.py
@@ -9,6 +9,15 @@ import tilelang
 import torch
 from tilelang import language as T
 
+from miles_plugins.models.deepseek_v4.ops.kernel.tiling import (
+    DeviceLimits,
+    ForwardTiling,
+    build_with_largest_fitting_tiling,
+    current_target,
+    shared_memory_required,
+    sparse_mla_forward_tilings,
+)
+
 
 @tilelang.jit(
     out_idx=[-2, -1],
@@ -25,6 +34,7 @@ def sparse_mqa_fwd(
     block_I=64,
     num_stages=2,
     threads=256,
+    block_H=None,
 ):
     assert dim == tilelang.math.next_power_of_2(dim), f"dim must be power of 2, got {dim}"
     assert topk % block_I == 0, f"topk ({topk}) must be divisible by block_I ({block_I})"
@@ -53,13 +63,19 @@ def sparse_mqa_fwd(
     NI = tilelang.cdiv(topk, block_I)
     D = dim
 
-    if heads > 64:
-        assert heads % 64 == 0, "heads should be a multiple of 64"
-        REPLICATE_H = heads // 64
+    # block_H caps how many heads one workgroup stages in LDS. Q_shared/O_shared are
+    # [H_per_block, D], so at D=512 bf16 a 64-head block is 65536 B for Q_shared alone, leaving
+    # nothing for KV_shared/S_shared/Lse_shared on a 64 KiB budget. None keeps the original
+    # behaviour: blocks of 64, and only when heads > 64.
+    if block_H is None:
+        block_H = 64
+    if heads > block_H:
+        assert heads % block_H == 0, f"heads ({heads}) should be a multiple of block_H ({block_H})"
+        REPLICATE_H = heads // block_H
+        H_per_block = block_H
     else:
         REPLICATE_H = 1
-
-    H_per_block = padded_H if REPLICATE_H == 1 else 64
+        H_per_block = padded_H
 
     is_hip = getattr(torch.version, "hip", None)
     if is_hip:
@@ -100,7 +116,7 @@ def sparse_mqa_fwd(
             b_i = by
             s_i = bx if REPLICATE_H == 1 else (bx // REPLICATE_H)
 
-            H0 = 0 if REPLICATE_H == 1 else (bx % REPLICATE_H) * 64
+            H0 = 0 if REPLICATE_H == 1 else (bx % REPLICATE_H) * H_per_block
             H1 = H0 + H_per_block
 
             T.copy(Q[b_i, s_i, H0:H1, :D], Q_shared)
@@ -156,6 +172,67 @@ def sparse_mqa_fwd(
     return main
 
 
+_fitted_tiling: dict[tuple, ForwardTiling] = {}
+
+
+def _compile_within_shared_mem(heads, dim, topk, sm_scale, block_I, num_stages, threads):
+    """Compile sparse_mqa_fwd with the largest tiling this target can host. Memoized per shape."""
+
+    def build(tiling):
+        return sparse_mqa_fwd(
+            heads,
+            dim,
+            topk,
+            sm_scale,
+            block_I=tiling.block_I,
+            num_stages=tiling.num_stages,
+            threads=tiling.threads,
+            block_H=tiling.block_H,
+        )
+
+    key = (heads, dim, topk, sm_scale, block_I, num_stages, threads)
+    if key in _fitted_tiling:
+        return build(_fitted_tiling[key])
+
+    requested = ForwardTiling(num_stages, block_I, threads, None)
+    target = current_target()
+    limits = DeviceLimits.from_target(target)
+
+    def required_bytes(tiling):
+        prim_func = sparse_mqa_fwd.get_tir(
+            heads,
+            dim,
+            topk,
+            sm_scale,
+            block_I=tiling.block_I,
+            num_stages=tiling.num_stages,
+            threads=tiling.threads,
+            block_H=tiling.block_H,
+        )
+        return shared_memory_required(prim_func, target)
+
+    kernel, tiling = build_with_largest_fitting_tiling(
+        requested=requested,
+        derived=(
+            candidate
+            for candidate in sparse_mla_forward_tilings(
+                padded_heads=max(tilelang.math.next_power_of_2(heads), 16),
+                topk=topk,
+                block_I=block_I,
+                limits=limits,
+            )
+            if candidate != requested
+        ),
+        compile_tiling=build,
+        required_bytes=required_bytes,
+        budget=limits.shared_memory_per_block,
+        describe=lambda t: t.describe(),
+        what="sparse_mqa_fwd",
+    )
+    _fitted_tiling[key] = tiling
+    return kernel
+
+
 def sparse_mqa_fwd_interface(q, kv, attn_sink, topk_idxs, sm_scale=None, block_I=64, num_stages=2, threads=256):
     """Forward interface for V4 sparse MQA attention.
 
@@ -183,14 +260,6 @@ def sparse_mqa_fwd_interface(q, kv, attn_sink, topk_idxs, sm_scale=None, block_I
         topk_idxs = torch.cat([topk_idxs, pad], dim=-1).contiguous()
         topk = padded_topk
 
-    kernel = sparse_mqa_fwd(
-        heads,
-        dim,
-        topk,
-        sm_scale,
-        block_I=block_I,
-        num_stages=num_stages,
-        threads=threads,
-    )
+    kernel = _compile_within_shared_mem(heads, dim, topk, sm_scale, block_I, num_stages, threads)
     out, lse = kernel(q, kv, attn_sink, topk_idxs)
     return out, lse

--- a/miles_plugins/models/deepseek_v4/ops/kernel/tiling.py
+++ b/miles_plugins/models/deepseek_v4/ops/kernel/tiling.py
@@ -1,0 +1,308 @@
+"""Choose a kernel tiling the compiler's target can actually host.
+
+The DeepSeek-V4 tilelang kernels ship with tilings tuned for one GPU; on a smaller shared-memory
+budget they do not compile at all. Rather than tabulate replacements per architecture, this derives
+candidates from the target's own limits and asks tilelang how much shared memory each one needs.
+
+Both numbers come from tilelang. The budget is in the target description it builds for every
+compilation; the requirement is the ``dyn_shared_memory_buf`` attribute on the lowered device
+function, the same figure it formats into "Requested dynamic shared memory N exceeds device limit
+M". Reading it needs lowering but not code generation, roughly 4x cheaper than a build.
+
+This depends on three tilelang internals -- ``JITImpl.get_tir``, ``engine.lower`` with device
+compilation disabled, and the attribute name -- all pinned by tests. It is a deliberate trade
+against matching error strings, which would fail silently rather than loudly.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable, Iterable, Iterator
+from dataclasses import dataclass
+from typing import Any, TypeVar
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+# Entry points that have already warned about an unreadable requirement, so each says it once.
+_warned_unreadable: set[str] = set()
+
+# tilelang sets this only on functions that use dynamic shared memory, so "absent" is ambiguous
+# between "needs none" and "renamed". Named here so a rename fails in one place.
+SHARED_MEMORY_ATTR = "dyn_shared_memory_buf"
+
+# Diagnostic only: nothing branches on these. A rejection starts the search whether or not it is
+# recognised, so a tilelang reword costs one unhelpful log line rather than the mechanism.
+SHARED_MEMORY_EXCEEDED = "exceeds device limit"  # the shared-memory check at codegen
+WARP_PARTITION_DEGENERATE = "Divide by zero"  # warp partitioning inside T.gemm
+VECTORIZE_FAILED = "is_scalar"  # the vectorizer on the atomic store loop
+
+RETRYABLE_BUILD_ERRORS = (SHARED_MEMORY_EXCEEDED, WARP_PARTITION_DEGENERATE, VECTORIZE_FAILED)
+
+# A block_H that does not divide the head count makes a candidate inapplicable. Its sibling asserts
+# -- a dim that is not a power of two, a topk that does not divide block_I -- are caller errors.
+RETRYABLE_ASSERTIONS = ("block_H",)
+
+
+def is_retryable_build_error(exc: BaseException) -> bool:
+    """Is this a rejection this module already understands? Diagnostic only."""
+    message = str(exc)
+    if isinstance(exc, AssertionError):
+        return any(marker in message for marker in RETRYABLE_ASSERTIONS)
+    return any(marker in message for marker in RETRYABLE_BUILD_ERRORS)
+
+
+# The smallest N one matrix-core instruction covers, which bounds how many warps a gemm's output
+# can split across; below it tilelang's warp partitioning divides by zero. The one limit the target
+# does not carry. MFMA is 16x16x16, Tensor Core MMA is m16n8k16. An unlisted target gets the
+# smaller value, which only offers candidates that then fail to lower.
+_MIN_GEMM_N_PER_WARP = {"hip": 16, "cuda": 8}
+_MIN_GEMM_N_PER_WARP_DEFAULT = 8
+
+# The kernels' own floor, from `padded_H = max(next_power_of_2(H), 16)`. Not derivable from
+# min_gemm_n_per_warp: the head block is the QK^T gemm's M, that limit constrains its N.
+MIN_HEAD_BLOCK = 16
+
+
+@dataclass(frozen=True)
+class DeviceLimits:
+    """The subset of a tilelang target that constrains a tiling."""
+
+    shared_memory_per_block: int
+    warp_size: int
+    max_threads_per_block: int
+    min_gemm_n_per_warp: int
+
+    @classmethod
+    def from_target(cls, target: Any) -> DeviceLimits:
+        attrs = target.attrs
+        return cls(
+            shared_memory_per_block=int(attrs["max_shared_memory_per_block"]),
+            warp_size=int(attrs["thread_warp_size"]),
+            max_threads_per_block=int(attrs.get("max_num_threads", attrs["max_threads_per_block"])),
+            min_gemm_n_per_warp=_MIN_GEMM_N_PER_WARP.get(target.kind.name, _MIN_GEMM_N_PER_WARP_DEFAULT),
+        )
+
+    def threads_for(self, gemm_n: int) -> int:
+        """The widest thread block whose warps each still get a full matrix-core tile.
+
+        The shipped tilings used exactly this expression -- block_I 64, 32, 16 give 256, 128, 64 --
+        so those thread counts were never free parameters.
+        """
+        warps = max(1, gemm_n // self.min_gemm_n_per_warp)
+        return min(warps * self.warp_size, self.max_threads_per_block)
+
+
+def current_target() -> Any:
+    from tilelang.utils.target import determine_target
+
+    return determine_target("auto", return_object=True)
+
+
+def shared_memory_required(prim_func: Any, target: Any) -> int | None:
+    """How much dynamic shared memory tilelang's lowered kernel asks for, in bytes.
+
+    Lowers without generating device code, so it is much cheaper than a build while giving the
+    exact figure the build would have checked. None when it cannot be read -- see
+    SHARED_MEMORY_ATTR.
+    """
+    from tilelang import engine
+
+    with target:
+        lowered = engine.lower(prim_func, target=target, enable_host_codegen=False, enable_device_compile=False)
+    return largest_declared_shared_memory(lowered)
+
+
+def largest_declared_shared_memory(lowered: Any) -> int | None:
+    """Read the requirement off a lowered module. Separate so it is testable without a GPU.
+
+    None when no function declares the attribute. Returning 0 would make every candidate look like
+    it fits, so the search would take the largest and fail with the error it exists to route around.
+    """
+    device_mod = getattr(lowered, "device_mod", lowered)
+    declared = [
+        int(func.attrs[SHARED_MEMORY_ATTR])
+        for _, func in device_mod.functions.items()
+        if func.attrs is not None and SHARED_MEMORY_ATTR in func.attrs
+    ]
+    return max(declared) if declared else None
+
+
+def halvings(start: int, floor: int) -> Iterator[int]:
+    """``start``, then repeated halvings, down to and including ``floor``."""
+    value = start
+    while value >= floor:
+        yield value
+        value //= 2
+
+
+# ---------------------------------------------------------------------------------------------
+# The search
+# ---------------------------------------------------------------------------------------------
+
+
+def build_with_largest_fitting_tiling(
+    *,
+    requested: T,
+    derived: Iterable[T],
+    compile_tiling: Callable[[T], Any],
+    required_bytes: Callable[[T], int | None],
+    budget: int,
+    describe: Callable[[T], str],
+    what: str,
+) -> tuple[Any, T]:
+    """Compile the requested tiling; if it will not build, compile the largest one that fits.
+
+    The requested tiling is attempted optimistically, so a device that fits it pays nothing here --
+    not a wasted compilation and not even a lowering. Only a rejection starts the search, and the
+    search compiles exactly one candidate.
+
+    Any rejection starts it, whether or not this module recognises the message: gating on the text
+    would let a tilelang reword disable the fallback silently. Starting unconditionally cannot give
+    a wrong answer, because a caller error fails every candidate alike and ends at the ``raise``
+    below with the caller's own message -- which names the requested shape and is the useful one.
+    """
+    try:
+        return compile_tiling(requested), requested
+    except Exception as exc:
+        # Carrying the exception out of its `except` block would keep __traceback__, and with it
+        # every caller's locals -- during a forward, its activation tensors, freeable only by the
+        # cyclic collector. The message is all the re-raise needs.
+        requested_error = exc.with_traceback(None)
+        if not is_retryable_build_error(exc):
+            logger.debug(
+                "[%s] the requested tiling was refused for an unrecognised reason (%s: %s); "
+                "searching for a smaller one anyway",
+                what,
+                type(exc).__name__,
+                str(exc).strip().splitlines()[0] if str(exc).strip() else "",
+            )
+
+    for candidate in derived:
+        try:
+            required = required_bytes(candidate)
+        except Exception:
+            continue  # cannot be lowered at all; the requested tiling's error is the one to report
+        if required is None:
+            # Unplannable, so fall back to compiling it and letting that be the answer: a build per
+            # candidate instead of a lowering, which is the price of not knowing.
+            if what not in _warned_unreadable:
+                logger.warning(
+                    "[%s] tilelang did not report %s on the lowered kernel, so tilings are being "
+                    "compiled to find out whether they fit. Check whether tilelang renamed it.",
+                    what,
+                    SHARED_MEMORY_ATTR,
+                )
+                _warned_unreadable.add(what)
+            try:
+                kernel = compile_tiling(candidate)
+            except Exception:
+                continue
+            # Not the message below: with no requirement to attribute the rejection to, all this
+            # says is that the candidate is the first that built.
+            logger.warning(
+                "[%s] the requested tiling did not build; compiled the largest candidate that did: %s",
+                what,
+                describe(candidate),
+            )
+            return kernel, candidate
+        if required > budget:
+            continue
+        logger.warning(
+            "[%s] shared memory forced a smaller tiling on this GPU: %s (needs %d B of %d)",
+            what,
+            describe(candidate),
+            required,
+            budget,
+        )
+        return compile_tiling(candidate), candidate
+
+    raise requested_error
+
+
+# Candidate orders. The shrink order is a statement about cost, not about any one GPU: give up
+# pipeline depth first (latency hiding only), then the KV/index block (more inner iterations), and
+# only then the head block (more grid blocks, and less output one workgroup can accumulate).
+
+
+@dataclass(frozen=True)
+class ForwardTiling:
+    num_stages: int
+    block_I: int
+    threads: int
+    block_H: int | None  # None keeps the kernel's own "one block of padded_H"
+
+    def describe(self) -> str:
+        return f"num_stages={self.num_stages} block_I={self.block_I} threads={self.threads} block_H={self.block_H}"
+
+
+def sparse_mla_forward_tilings(
+    *, padded_heads: int, topk: int, block_I: int, limits: DeviceLimits
+) -> Iterator[ForwardTiling]:
+    """Progressively smaller forward tilings, largest first. Excludes the requested one."""
+    for head_block in halvings(padded_heads, MIN_HEAD_BLOCK):
+        for index_block in halvings(block_I, limits.min_gemm_n_per_warp):
+            if topk % index_block:
+                continue  # would trip sparse_mqa_fwd's own divisibility assert
+            yield ForwardTiling(
+                num_stages=1,
+                block_I=index_block,
+                threads=limits.threads_for(index_block),
+                # None is the kernel's own "one block of padded_H", so a device that needs no
+                # shrinking stays on the exact code path it had before this module existed.
+                block_H=None if head_block == padded_heads else head_block,
+            )
+
+
+@dataclass(frozen=True)
+class BackwardTiling:
+    block_size: int
+    threads: int
+    split_store: int
+    stage_dq_through_shared: bool
+    max_block_H: int | None  # None keeps the kernel's own choice
+
+    def describe(self) -> str:
+        return (
+            f"block_size={self.block_size} threads={self.threads} split_store={self.split_store} "
+            f"stage_dq_through_shared={self.stage_dq_through_shared} max_block_H={self.max_block_H}"
+        )
+
+
+def sparse_mla_backward_tilings(
+    *, padded_heads: int, topk: int, block_size: int, limits: DeviceLimits
+) -> Iterator[BackwardTiling]:
+    """Progressively smaller backward tilings, largest first. Excludes the requested one.
+
+    Two levers here are not tile sizes. ``split_store`` sets the height of ``acc_dkv_shared``, an
+    fp32 buffer, so raising it to ``block_size`` cuts that buffer to one row at the cost of an
+    atomic store pass per row. ``stage_dq_through_shared`` drops a whole ``[block_H, D]`` buffer by
+    writing dQ straight to global memory. Both come last, because both cost bandwidth rather than
+    parallelism, and staging dQ is kept for as long as possible: tilelang reuses dQ_shared, so it
+    costs 480 B rather than the 16 KiB the buffer suggests.
+    """
+    for head_block in halvings(padded_heads, MIN_HEAD_BLOCK):
+        for kv_block in halvings(block_size, limits.min_gemm_n_per_warp):
+            if topk % kv_block:
+                continue
+            for stage_dq in (True, False):
+                for split_store in dict.fromkeys((2, kv_block)):  # deduped, order preserved
+                    if kv_block % split_store:
+                        continue
+                    yield BackwardTiling(
+                        block_size=kv_block,
+                        threads=limits.threads_for(kv_block),
+                        split_store=split_store,
+                        stage_dq_through_shared=stage_dq,
+                        max_block_H=head_block,
+                    )
+
+
+def indexer_forward_block_ns(*, block_N: int, limits: DeviceLimits) -> Iterator[int]:
+    """Halvings of the requested block_N. Excludes the requested one.
+
+    block_N only sets how much of the KV axis one workgroup sweeps per iteration, so shrinking it
+    costs performance and nothing else.
+    """
+    yield from halvings(block_N // 2, limits.min_gemm_n_per_warp)

--- a/tests/fast/test_dsv4_tiling_fallback.py
+++ b/tests/fast/test_dsv4_tiling_fallback.py
@@ -1,0 +1,407 @@
+"""The shared-memory tiling search: what it asks tilelang, what it retries, and what it caches.
+
+The shared-memory query is stubbed out, so no GPU and no compilation are involved; the stubs stand
+in for a lowering of the candidate kernel, which is where the real implementation gets its numbers.
+"""
+
+import inspect
+
+import pytest
+
+tilelang = pytest.importorskip("tilelang", reason="the DeepSeek-V4 kernels are tilelang modules")
+
+from miles_plugins.models.deepseek_v4.ops.kernel import tilelang_indexer_fwd as indexer_fwd  # noqa: E402
+from miles_plugins.models.deepseek_v4.ops.kernel import tilelang_sparse_mla_bwd as sparse_mla_bwd  # noqa: E402
+from miles_plugins.models.deepseek_v4.ops.kernel import tilelang_sparse_mla_fwd as sparse_mla_fwd  # noqa: E402
+from miles_plugins.models.deepseek_v4.ops.kernel import tiling  # noqa: E402
+
+# gfx942 / MI300X-MI308X, as tilelang describes it. Every measured number in this file is from it.
+GFX942 = tiling.DeviceLimits(
+    shared_memory_per_block=65536, warp_size=64, max_threads_per_block=256, min_gemm_n_per_warp=16
+)
+# An Ampere-class CUDA target, for contrast: more shared memory, half the warp, and a Tensor Core
+# minimum of 8 instead of MFMA's 16.
+SM80 = tiling.DeviceLimits(
+    shared_memory_per_block=166912, warp_size=32, max_threads_per_block=1024, min_gemm_n_per_warp=8
+)
+
+SHARED_MEM_ERROR = RuntimeError("Requested dynamic shared memory 85488 exceeds device limit 65536")
+
+
+# ---------------------------------------------------------------------------------------------
+# Device limits come from the compiler's target, not from the framework
+# ---------------------------------------------------------------------------------------------
+
+
+def test_limits_are_read_from_the_tilelang_target():
+    """No torch device API and no architecture string: the target carries all four numbers."""
+    from tvm.target import Target
+
+    target = Target(
+        "hip -keys=hip,gpu -max_num_threads=256 -max_shared_memory_per_block=65536"
+        " -max_threads_per_block=256 -mcpu=gfx942 -thread_warp_size=64"
+    )
+    assert tiling.DeviceLimits.from_target(target) == GFX942
+
+
+def test_an_unknown_target_kind_gets_the_permissive_gemm_minimum():
+    """A target nobody has characterised must not be refused, only planned for conservatively."""
+    from tvm.target import Target
+
+    target = Target("cuda -max_shared_memory_per_block=49152 -max_threads_per_block=1024 -thread_warp_size=32")
+    assert tiling.DeviceLimits.from_target(target).min_gemm_n_per_warp == 8
+
+
+@pytest.mark.parametrize(
+    ("gemm_n", "expected"),
+    [(64, 256), (32, 128), (16, 64), (8, 64)],  # 8 clamps to one warp: there is no half-warp
+)
+def test_thread_width_is_derived_from_the_warp_and_the_matrix_core(gemm_n, expected):
+    """The shipped tilings used exactly these thread counts, so they were never free parameters."""
+    assert GFX942.threads_for(gemm_n) == expected
+
+
+def test_a_narrower_matrix_core_allows_more_warps():
+    """Tensor Core's minimum N is 8, so the same gemm width supports twice as many warps."""
+    assert SM80.threads_for(64) == 8 * 32
+
+
+def test_the_head_block_floor_is_not_the_gemm_width_floor():
+    """Different axes: the head block is the gemm's M, min_gemm_n_per_warp is its N.
+
+    Both are 16 on gfx942, which is a coincidence; deriving one from the other would make the head
+    block floor move with the matrix-core shape.
+    """
+    assert tiling.MIN_HEAD_BLOCK == 16
+    assert list(tiling.halvings(64, tiling.MIN_HEAD_BLOCK)) == [64, 32, 16]
+    assert tiling.MIN_HEAD_BLOCK != SM80.min_gemm_n_per_warp
+
+
+# ---------------------------------------------------------------------------------------------
+# The shared-memory requirement comes from tilelang, exactly
+# ---------------------------------------------------------------------------------------------
+
+
+def test_the_attribute_the_requirement_is_read_from_is_the_one_tilelang_sets():
+    """A canary: tilelang's wrapper reads the same attribute to build its error message."""
+    from tilelang.jit.adapter import wrapper
+
+    assert tiling.SHARED_MEMORY_ATTR in inspect.getsource(wrapper)
+
+
+def test_lowering_without_device_compilation_is_a_supported_call():
+    """The other internal coupling: engine.lower must still accept being told not to compile."""
+    from tilelang import engine
+
+    parameters = inspect.signature(engine.lower).parameters
+    assert "enable_device_compile" in parameters
+    assert "enable_host_codegen" in parameters
+
+
+def test_the_kernel_builders_still_expose_their_tir():
+    """get_tir is what lets a candidate be measured without being built."""
+    for builder in (sparse_mla_fwd.sparse_mqa_fwd, sparse_mla_bwd.bwd, indexer_fwd.tl_indexer_fwd_impl):
+        assert hasattr(builder, "get_tir"), builder
+
+
+def test_the_requirement_is_the_largest_any_device_function_declares():
+    """A lowered module can hold several functions; the block budget has to cover the biggest."""
+
+    class _Func:
+        def __init__(self, attrs):
+            self.attrs = attrs
+
+    class _Mod:
+        functions = {
+            "a": _Func({tiling.SHARED_MEMORY_ATTR: 51184}),
+            "b": _Func({tiling.SHARED_MEMORY_ATTR: 68608}),
+            "c": _Func(None),
+            "d": _Func({"unrelated": 1}),
+        }
+
+    assert tiling.largest_declared_shared_memory(_Mod()) == 68608
+
+
+def test_an_unreadable_requirement_is_none_not_zero():
+    """Zero would be the worst possible answer: every candidate would look like it fits."""
+
+    class _Empty:
+        functions = {}
+
+    class _Renamed:
+        functions = {"main": type("F", (), {"attrs": {"dyn_shared_memory_buffer": 141312}})()}
+
+    assert tiling.largest_declared_shared_memory(_Empty()) is None
+    assert tiling.largest_declared_shared_memory(_Renamed()) is None
+
+
+def test_an_unreadable_requirement_falls_back_to_compiling_rather_than_assuming_it_fits():
+    """A tilelang rename must degrade to try-and-retry, not silently undo the whole fallback."""
+    too_big = RuntimeError("Requested dynamic shared memory 141312 exceeds device limit 65536")
+    compiled = []
+
+    def compile_tiling(candidate):
+        compiled.append(candidate)
+        if candidate in ("requested", "biggest"):
+            raise too_big
+        return f"kernel({candidate})"
+
+    kernel, chosen = tiling.build_with_largest_fitting_tiling(
+        requested="requested",
+        derived=["biggest", "fits"],
+        compile_tiling=compile_tiling,
+        required_bytes=lambda _: None,
+        budget=65536,
+        describe=str,
+        what="probe",
+    )
+
+    assert chosen == "fits", "the search must keep going instead of taking the first candidate"
+    assert compiled == ["requested", "biggest", "fits"]
+    assert kernel == "kernel(fits)"
+
+
+def test_the_requirement_is_read_through_device_mod_when_there_is_one():
+    class _Inner:
+        functions = {"k": type("F", (), {"attrs": {tiling.SHARED_MEMORY_ATTR: 34032}})()}
+
+    class _Outer:
+        device_mod = _Inner()
+        functions = {"host": type("F", (), {"attrs": {tiling.SHARED_MEMORY_ATTR: 999999}})()}
+
+    assert tiling.largest_declared_shared_memory(_Outer()) == 34032
+
+
+# ---------------------------------------------------------------------------------------------
+# The requested tiling is compiled first, and nothing else is even measured
+# ---------------------------------------------------------------------------------------------
+
+
+def _driver(compiled, requirements, derived, *, budget=65536):
+    """Run the driver with scripted outcomes; returns (result, compiled_order, measured_order)."""
+    compiled_order, measured_order = [], []
+
+    def compile_tiling(t):
+        compiled_order.append(t)
+        outcome = compiled.get(t, f"kernel({t})")
+        if isinstance(outcome, BaseException):
+            raise outcome
+        return outcome
+
+    def required_bytes(t):
+        measured_order.append(t)
+        outcome = requirements[t]
+        if isinstance(outcome, BaseException):
+            raise outcome
+        return outcome
+
+    result = tiling.build_with_largest_fitting_tiling(
+        requested="requested",
+        derived=derived,
+        compile_tiling=compile_tiling,
+        required_bytes=required_bytes,
+        budget=budget,
+        describe=str,
+        what="probe",
+    )
+    return result, compiled_order, measured_order
+
+
+def test_a_fitting_request_is_compiled_once_and_nothing_is_measured():
+    """The whole point: on a device that fits the shipped tiling this costs nothing."""
+    (kernel, chosen), compiled, measured = _driver({}, {}, ["never-reached"])
+
+    assert kernel == "kernel(requested)"
+    assert chosen == "requested"
+    assert compiled == ["requested"]
+    assert measured == [], "a fitting request must not trigger a single lowering"
+
+
+def test_a_refused_request_falls_through_to_the_first_candidate_that_fits():
+    (kernel, chosen), compiled, measured = _driver(
+        {"requested": SHARED_MEM_ERROR},
+        {"too-big": 70000, "fits": 51184, "smaller": 33000},
+        ["too-big", "fits", "smaller"],
+    )
+
+    assert chosen == "fits"
+    assert compiled == ["requested", "fits"], "exactly one candidate is compiled"
+    assert measured == ["too-big", "fits"], "measuring stops at the first that fits"
+
+
+def test_a_candidate_that_cannot_be_lowered_is_skipped():
+    """The two non-size rejections surface while lowering, so they are caught there."""
+    (_, chosen), _, measured = _driver(
+        {"requested": SHARED_MEM_ERROR},
+        {"degenerate": RuntimeError("... Divide by zero ..."), "fits": 51184},
+        ["degenerate", "fits"],
+    )
+
+    assert chosen == "fits"
+    assert measured == ["degenerate", "fits"]
+
+
+def test_the_request_s_own_rejection_is_raised_when_nothing_fits():
+    """It names the shape the caller asked for, which the last candidate's error does not."""
+    with pytest.raises(RuntimeError, match="85488"):
+        _driver(
+            {"requested": SHARED_MEM_ERROR},
+            {"a": 90000, "b": 80000},
+            ["a", "b"],
+        )
+
+
+def test_an_empty_candidate_set_raises_the_request_s_rejection_not_none():
+    """There is no "last error" to be None here: the request has always been tried first."""
+    with pytest.raises(RuntimeError, match="85488"):
+        _driver({"requested": SHARED_MEM_ERROR}, {}, [])
+
+
+def test_a_genuine_bug_from_the_request_still_surfaces():
+    """Searching anyway must not swallow it: no candidate fits, so it is what gets raised."""
+    with pytest.raises(RuntimeError, match="illegal memory access"):
+        _driver({"requested": RuntimeError("illegal memory access")}, {"a": 90000}, ["a"])
+
+
+def test_a_caller_error_from_the_request_still_surfaces():
+    """A topk or dim the kernel rejects fails every candidate alike and ends here."""
+    with pytest.raises(AssertionError, match="power of 2"):
+        _driver(
+            {"requested": AssertionError("dim must be power of 2, got 500")},
+            {"a": AssertionError("dim must be power of 2, got 500")},
+            ["a"],
+        )
+
+
+def test_an_unrecognised_rejection_still_finds_a_fitting_tiling():
+    """A tilelang release that rewords "exceeds device limit" must not disable the search."""
+    (_, chosen), compiled, _ = _driver(
+        {"requested": RuntimeError("shared memory request of 85488 over the 65536 B cap")},
+        {"fits": 51184},
+        ["fits"],
+    )
+
+    assert chosen == "fits"
+    assert compiled == ["requested", "fits"]
+
+
+def test_an_inapplicable_block_h_is_retried():
+    """`heads % block_H != 0` means the candidate does not apply, so the next one gets a turn."""
+    (_, chosen), _, _ = _driver(
+        {"requested": AssertionError("heads (48) should be a multiple of block_H (32)")},
+        {"fits": 51184},
+        ["fits"],
+    )
+    assert chosen == "fits"
+
+
+@pytest.mark.parametrize("marker", tiling.RETRYABLE_BUILD_ERRORS)
+def test_every_declared_marker_is_recognised(marker):
+    """Recognition only labels a log line; the search runs either way."""
+    assert tiling.is_retryable_build_error(RuntimeError(f"... {marker} ..."))
+
+
+def test_the_two_markers_without_python_source_are_still_declared():
+    """ "Divide by zero" and "is_scalar" come from tilelang's C++ passes, so no canary is possible."""
+    assert set(tiling.RETRYABLE_BUILD_ERRORS) - {tiling.SHARED_MEMORY_EXCEEDED} == {
+        tiling.WARP_PARTITION_DEGENERATE,
+        tiling.VECTORIZE_FAILED,
+    }
+
+
+# ---------------------------------------------------------------------------------------------
+# What the derivation offers, pinned against what gfx942 was validated on
+# ---------------------------------------------------------------------------------------------
+
+
+def test_the_forward_derivation_offers_the_validated_tiling_at_64_heads():
+    """CP=8 on one node forces TP=1, so every rank holds all 64 heads.
+
+    tilelang reports 51184 B for this tiling, the first offered candidate that fits 64 KiB.
+    """
+    offered = list(tiling.sparse_mla_forward_tilings(padded_heads=64, topk=512, block_I=64, limits=GFX942))
+    assert tiling.ForwardTiling(num_stages=1, block_I=16, threads=64, block_H=32) in offered
+
+
+def test_the_forward_derivation_offers_the_validated_tiling_at_32_heads():
+    """CP=4 / TP=2. block_H stays None because the kernel's own default already blocks at 32."""
+    offered = list(tiling.sparse_mla_forward_tilings(padded_heads=32, topk=512, block_I=64, limits=GFX942))
+    assert tiling.ForwardTiling(num_stages=1, block_I=16, threads=64, block_H=None) in offered
+
+
+def test_the_forward_derivation_shrinks_the_kv_block_before_the_head_block():
+    """Head blocks cost grid blocks; KV blocks cost inner iterations. Order encodes that."""
+    offered = list(tiling.sparse_mla_forward_tilings(padded_heads=64, topk=512, block_I=64, limits=GFX942))
+    head_blocks = [c.block_H for c in offered]
+    assert head_blocks == sorted(head_blocks, key=lambda b: -(b or 64)), head_blocks
+
+
+def test_the_backward_derivation_prefers_keeping_dq_staged():
+    """tilelang reuses dQ_shared, so staging dQ costs 480 B, not the 16 KiB the buffer suggests.
+
+    Keeping it saves a pass of uncoalesced global writes, so it is offered first (52704 B of 65536).
+    """
+    offered = list(tiling.sparse_mla_backward_tilings(padded_heads=64, topk=512, block_size=32, limits=GFX942))
+    staged = tiling.BackwardTiling(
+        block_size=16, threads=64, split_store=16, stage_dq_through_shared=True, max_block_H=16
+    )
+    unstaged = tiling.BackwardTiling(
+        block_size=16, threads=64, split_store=16, stage_dq_through_shared=False, max_block_H=16
+    )
+    assert offered.index(staged) < offered.index(unstaged)
+
+
+def test_the_indexer_derivation_halves_from_the_request():
+    assert list(tiling.indexer_forward_block_ns(block_N=256, limits=GFX942)) == [128, 64, 32, 16]
+
+
+def test_candidates_that_do_not_divide_topk_are_never_offered():
+    """topk % block_I != 0 would trip sparse_mqa_fwd's own assert, so those never get measured."""
+    offered = list(tiling.sparse_mla_forward_tilings(padded_heads=64, topk=48, block_I=64, limits=GFX942))
+    assert offered, "the generator must still offer something for an odd topk"
+    assert all(48 % c.block_I == 0 for c in offered)
+
+
+# ---------------------------------------------------------------------------------------------
+# Memoization
+# ---------------------------------------------------------------------------------------------
+
+
+def test_the_fitted_tiling_is_reused_without_searching_again(monkeypatch):
+    """The search runs at most once per shape.
+
+    Counting builds cannot show this: a request that compiles takes one build either way. What the
+    memo removes is the approach to the search, so the target lookup that begins it is counted.
+    """
+    built, targets = [], []
+    monkeypatch.setattr(sparse_mla_fwd, "_fitted_tiling", {})
+    monkeypatch.setattr(sparse_mla_fwd, "sparse_mqa_fwd", lambda *a, **k: built.append(k) or "kernel")
+    monkeypatch.setattr(sparse_mla_fwd, "current_target", lambda: targets.append(1) or "target")
+    monkeypatch.setattr(sparse_mla_fwd.DeviceLimits, "from_target", staticmethod(lambda _: GFX942))
+
+    request = dict(heads=64, dim=512, topk=512, sm_scale=0.044, block_I=64, num_stages=2, threads=256)
+    sparse_mla_fwd._compile_within_shared_mem(**request)
+    sparse_mla_fwd._compile_within_shared_mem(**request)
+
+    assert len(built) == 2, "one build per call"
+    assert built[0] == built[1]
+    assert len(targets) == 1, "the second call must not reach the search at all"
+
+
+def test_the_backward_search_is_not_repeated_for_every_sequence_length(monkeypatch):
+    """Every shared buffer is sized from block_H, block_size and D, so B/S/S_kv cannot move it.
+
+    Keying the memo on the shape re-runs the search for every new sequence length, and THD training
+    produces a new one per microbatch.
+    """
+    built, targets = [], []
+    monkeypatch.setattr(sparse_mla_bwd, "_fitted_tiling", {})
+    monkeypatch.setattr(sparse_mla_bwd, "bwd", lambda *a, **k: built.append(k) or "kernel")
+    monkeypatch.setattr(sparse_mla_bwd, "current_target", lambda: targets.append(1) or "target")
+    monkeypatch.setattr(sparse_mla_bwd.DeviceLimits, "from_target", staticmethod(lambda _: GFX942))
+
+    for seq_len in (2048, 4096, 8192):
+        sparse_mla_bwd.bwd_within_shared_mem(1, seq_len, seq_len, 64, 512, 512, 0.044)
+
+    assert len(built) == 3, "one build per call"
+    assert len(targets) == 1, "the shape changed, the tiling question did not"


### PR DESCRIPTION
## Problem

The DeepSeek-V4 tilelang kernels ship with tilings tuned for a 160 KiB shared-memory budget. On
gfx942 (MI300X / MI308X / MI325X, 64 KiB per workgroup) they do not compile, and the failure is a
hard error on the first forward pass:

```
RuntimeError: Initialization failed: Requested dynamic shared memory 141312 exceeds device limit 65536
```

Lowering each entry point at the shapes a real DeepSeek-V4-Flash checkpoint uses (`heads=64`,
`kv_lora_rank=512`, `index_topk=512`, indexer `heads=64 dim=128`) on an MI308X:

| kernel | layout | asks for | budget | over by |
|---|---|---:|---:|---:|
| `sparse_mqa_fwd` | CP=4 / TP=2, 32 local heads | 172032 B | 65536 B | 2.6x |
| `sparse_mqa_fwd` | CP=8 / TP=1, 64 local heads | 141312 B | 65536 B | 2.2x |
| `tl_indexer_fwd` | 64 heads, dim 128, `block_N=256` | 100352 B | 65536 B | 1.5x |

CP=4 overshoots by *more* than CP=8: `sparse_mqa_fwd` clamps `num_stages` to 1 only when
`H_per_block == 64`, so at 32 heads the KV pipeline still stages twice. `bwd` caps `max_block_H` at
32, which is not enough on its own; the indexer has no HIP branch at all. DeepSeek-V4 therefore
trains on gfx942 at no parallel layout, and the smaller one fails hardest.

## What this does

### 1. Pick a tiling the target can host

Two numbers tilelang already has, neither advertised as API. The **budget** is in the target
description it builds for every compilation. The **requirement** is the `dyn_shared_memory_buf`
attribute on the lowered device function — the same figure it formats into the error above. Reading
it needs lowering but not code generation, about 4x cheaper than a build (2.0 s against 8.2 s on
gfx942), and it is exact: the three numbers above are read from the attribute and match the error
text byte for byte.

The requested tiling is compiled optimistically, so a device that fits it pays nothing — not a
wasted compilation, not even a lowering. Only a rejection starts the search, which then compiles
exactly one candidate: the largest that fits.

Three things it deliberately avoids:

- **No model of tilelang's allocator.** An earlier revision had one and got it wrong: `Q_shared` and
  `O_shared` share storage, so counting both over-estimated by 27% at `block_H=32` and rejected a
  tiling that builds.
- **No per-architecture tables.** Candidates are derived from the target's limits, so there is no
  `torch.version.hip`, no `get_device_properties` and no architecture-string parsing.
- **No branching on error text.** Gating the search on a recognised message would let a tilelang
  reword disable it *silently*. Any rejection starts the search; a caller error fails every
  candidate alike and ends at the same re-raise of the request's own exception.

### 2. Normalise `o` and `do` in the backward

`sparse_mqa_bwd_interface` asserts contiguity on four of its six tensors, but not on `do` — the one
tensor autograd may legitimately hand back non-contiguous, since `out.sum().backward()` produces a
stride-0 broadcast gradient.

The consequence is not a clean error. tilelang's stride check runs inside an `Exception ignored in:`
context, so it prints and returns; the kernel then walks the stride-0 pointer as though it were
dense and the process is killed by the GPU:

```
ValueError: Static stride mismatch for parameter dO: expected 16384 at index 1, got 0
Exception ignored in: 'tilelang_cython_wrapper.CythonKernelWrapper._check_static_strides'
...
Memory access fault by GPU node-2 (Agent handle: 0x...) on address 0x... Reason: Unknown.
```

Nothing in that output names the tensor that was wrong. A fifth assertion would look consistent but
be wrong: autograd is *allowed* to pass a non-contiguous gradient, so asserting only moves the crash
to a different line. `.contiguous()` is a no-op on an already-contiguous tensor.

## Numerics

Unchanged. Shrinking `block_N` only changes how much of the KV axis one workgroup sweeps per
iteration. `block_H` is plumbing rather than new math — the forward already blocked over heads
through `REPLICATE_H` and the `H0` offset, only the block size was hardwired to 64 — and shrinking
it is safe because V4 attention is MQA (`KV_shared` has no head axis) and the online-softmax state
is already per-head. On a target that fits the shipped tiling, the compiled kernel is the one
compiled before, because the request is always tried first.

## Verification

`tests/fast/test_dsv4_tiling_fallback.py`, 36 tests, no GPU required. They cover the search (a
fitting request costs one compilation and zero lowerings; a refused one measures until the first
candidate that fits and compiles only that; nothing fitting raises the *request's* rejection) and
pin the three tilelang couplings: `get_tir` on the kernel builders, `engine.lower` accepting the
no-device-compilation call, and the `dyn_shared_memory_buf` attribute name. An unreadable
requirement degrades to compiling candidates rather than concluding everything fits.

### On hardware

8x MI308X (gfx942, 65536 B per workgroup). The search resolves to:

```
[sparse_mqa_fwd]  num_stages=1 block_I=16 threads=64 block_H=None                       51184 B / 65536   (32 local heads)
[sparse_mqa_fwd]  num_stages=1 block_I=16 threads=64 block_H=32                         51184 B / 65536   (64 local heads)
[tl_indexer_fwd]  block_N=64 (requested 256)                                            51200 B / 65536
[sparse_mqa_bwd]  block_size=16 threads=64 split_store=16 stage_dq_through_shared=True
                  max_block_H=16                                                        52704 B / 65536
```

The real autograd entry point, `sparse_attn_tilelang` forward then `out.sum().backward()` — exactly
the stride-0 broadcast case — passes at `S=4096 H=32 topk=128` and `S=2048 H=64 topk=128`, output
shapes correct and `q`/`kv` gradients finite. Without the `do` normalisation the same call takes the
process down with the fault above.

A 4-layer DeepSeek-V4-Flash then trains end to end at 131072 tokens, both single-node layouts:

| | CP=4 / TP=2 | CP=8 / TP=1 |
|---|---|---|
| iterations | 3 / 3 | 3 / 3 |
| `context_parallel_size` / `allgather_cp` | 4 / True | 8 / True |
| Megatron→SGLang weight syncs | 32 | 32 |
| step time | 127.2 / 126.7 s | 120.4 / 120.2 s |
| OOM / NaN / shared-memory overflow | 0 / 0 / 0 | 0 / 0 / 0 |

Both runs are from one container whose Miles is this branch on top of `8d9826ea` with nothing else
applied, built from a Dockerfile based on an official `rocm/sgl-dev` image with no post-build
patching — so the tiling search is the only thing between the published kernels and a training run
on this hardware.

## Note for reviewers

The candidates *between* the shipped tiling and the one gfx942 settles on are only reachable on a
budget strictly between 65536 B and 160 KiB, which no device in reach has, so that part of the
order is reasoned rather than measured.

The right long-term home for the measurement is tilelang itself, which computes the number and then
throws it away into a formatted string. Until it exposes it, this reads the attribute.

Supersedes #2857, which solved the same problem with a hand-written per-architecture candidate list
and a pure-torch reference backward. Both are gone here: candidates are derived from the target, and
once the search makes the kernel always buildable there is nothing for a reference path to do.
