### PR TITLE
Opt into frozen multimodal tower sync with --mm-tower-sync, for any tower name

### DIFF
--- a/miles/backends/megatron_utils/update_weight/hf_weight_iterator.py
+++ b/miles/backends/megatron_utils/update_weight/hf_weight_iterator.py
@@ -127,17 +127,49 @@ def _gather_pp_full_adapter(
 
 
 _MM_TOWER_CACHE: list[tuple[str, "torch.Tensor"]] | None = None
+_INKLING_MM_PROVIDER = "inkling_mm_model_provider"
+_INKLING_MM_TOWERS = ("visual", "audio")
+_warned_implicit_mm_tower_sync = False
+
+
+def mm_tower_names(args) -> tuple[str, ...]:
+    """Module names of the frozen multimodal towers re-sent on every weight
+    update; empty when tower sync is off. `--mm-tower-sync` decides. The
+    Inkling MM provider implies its two towers so launches that predate the
+    flag keep syncing."""
+    global _warned_implicit_mm_tower_sync
+    names = getattr(args, "mm_tower_sync", None)
+    if names is not None:
+        return tuple(names)
+    if _INKLING_MM_PROVIDER in (getattr(args, "custom_model_provider_path", None) or ""):
+        if not _warned_implicit_mm_tower_sync:
+            logger.warning(
+                "mm tower sync: enabled implicitly by the %s provider; pass --mm-tower-sync %s",
+                _INKLING_MM_PROVIDER,
+                " ".join(_INKLING_MM_TOWERS),
+            )
+            _warned_implicit_mm_tower_sync = True
+        return _INKLING_MM_TOWERS
+    return ()
+
+
+def is_mm_tower_key(key: str, tower_names: Sequence[str]) -> bool:
+    """`model.visual.blocks.0.attn.proj.weight` and `visual.merger.ln_q.weight`
+    both belong to the `visual` tower."""
+    dotted = f".{key}"
+    return any(f".{name}." in dotted for name in tower_names)
 
 
 def _iter_mm_tower_units(args, *, materialize):
-    """Transitional: Inkling MM trains only the language model; the frozen
-    vision/audio towers are deliberately unregistered trainer-side (ckpt
-    compat) and exist only on pre_process ranks, so the boot checkpoint is the
-    uniform source every rank can re-send from (loads are idempotent).
-    Goes away when the towers become real megatron params (Kimi-style) or the
-    engine keeps them across offload."""
+    """Frozen multimodal towers (Inkling, Qwen3.5-VL, GLM-5.3-Flash, ...) train only
+    the language model; the towers are not megatron params, so the weight
+    update never carries them and a released engine would come back without
+    them. The boot checkpoint is the uniform source every rank can re-send
+    from (loads are idempotent). Goes away when the towers become real
+    megatron params (Kimi-style) or the engine keeps them across offload."""
     global _MM_TOWER_CACHE
-    if "inkling_mm_model_provider" not in (args.custom_model_provider_path or ""):
+    tower_names = mm_tower_names(args)
+    if not tower_names:
         return
     if not materialize:
         return
@@ -150,11 +182,7 @@ def _iter_mm_tower_units(args, *, materialize):
         ckpt_dir = args.hf_checkpoint
         with open(os.path.join(ckpt_dir, "model.safetensors.index.json"), encoding="utf-8") as f:
             weight_map = json.load(f)["weight_map"]
-        tower_keys = sorted(
-            k
-            for k in weight_map
-            if ".visual." in f".{k}" or ".audio." in f".{k}" or k.startswith(("visual.", "audio."))
-        )
+        tower_keys = sorted(k for k in weight_map if is_mm_tower_key(k, tower_names))
         by_shard: dict[str, list[str]] = {}
         for k in tower_keys:
             by_shard.setdefault(weight_map[k], []).append(k)
@@ -163,7 +191,7 @@ def _iter_mm_tower_units(args, *, materialize):
             with safe_open(os.path.join(ckpt_dir, shard), framework="pt", device="cpu") as f:
                 for k in keys:
                     cache.append((k, f.get_tensor(k)))
-        logger.info("mm tower sync: caching %d tower tensors from %s", len(cache), ckpt_dir)
+        logger.info("mm tower sync: caching %d tensors of towers %s from %s", len(cache), list(tower_names), ckpt_dir)
         _MM_TOWER_CACHE = cache
     for name, tensor in _MM_TOWER_CACHE:
         yield [(name, tensor.to(torch.cuda.current_device()))]

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -448,6 +448,20 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 ),
             )
             parser.add_argument(
+                "--mm-tower-sync",
+                type=str,
+                nargs="*",
+                default=None,
+                metavar="TOWER",
+                help=(
+                    "Re-send the frozen multimodal tower weights from --hf-checkpoint to the "
+                    "engines on every weight update, so the engines can release their weights "
+                    "during training. Each TOWER is a module name matched against checkpoint "
+                    "weight names as '.TOWER.' (e.g. 'visual audio' selects model.visual.* and "
+                    "model.audio.*). Off by default; the Inkling MM provider implies 'visual audio'."
+                ),
+            )
+            parser.add_argument(
                 "--recompute-loss-function",
                 action="store_true",
                 help="Whether to enable recompute loss function to save memory during training.",

--- a/scripts/run_inkling.py
+++ b/scripts/run_inkling.py
@@ -361,7 +361,10 @@ def _train(args: ScriptArgs):
     if args.is_mm:
         # The mm provider wires the frozen HF vision/audio towers; it overrides the
         # text provider from the model sh (MODEL_ARGS precede train_args; last one wins).
-        inkling_args = "--custom-model-provider-path miles_plugins.models.inkling.model.inkling_mm_model_provider "
+        inkling_args = (
+            "--custom-model-provider-path miles_plugins.models.inkling.model.inkling_mm_model_provider "
+            "--mm-tower-sync visual audio "
+        )
 
     misc_args = (
         "--transformer-impl transformer_engine "

--- a/tests/fast/backends/megatron_utils/test_mm_tower_sync.py
+++ b/tests/fast/backends/megatron_utils/test_mm_tower_sync.py
@@ -1,0 +1,128 @@
+"""Frozen multimodal tower re-send is opted into with --mm-tower-sync, for any tower name."""
+
+from tests.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=60, suite="stage-a-cpu", labels=[])
+
+import json
+from argparse import Namespace
+
+import pytest
+import torch
+from safetensors.torch import save_file
+
+from miles.backends.megatron_utils.update_weight import hf_weight_iterator as hwi
+
+_INKLING = "miles_plugins.models.inkling.model.inkling_mm_model_provider"
+
+
+def _args(mm_tower_sync=None, provider=None, hf_checkpoint=None):
+    return Namespace(mm_tower_sync=mm_tower_sync, custom_model_provider_path=provider, hf_checkpoint=hf_checkpoint)
+
+
+@pytest.fixture
+def checkpoint(tmp_path):
+    """A two-shard HF checkpoint: language weights plus a `visual` tower and an `audio` tower."""
+    tensors = {
+        "model.language_model.layers.0.mlp.weight": torch.ones(2, 2),
+        "lm_head.weight": torch.ones(2),
+        "model.visual.blocks.0.attn.proj.weight": torch.full((2,), 3.0),
+        "model.visual.merger.ln_q.weight": torch.full((2,), 4.0),
+        "audio.encoder.weight": torch.full((2,), 5.0),
+    }
+    shards = {
+        "model-00001.safetensors": [
+            "model.language_model.layers.0.mlp.weight",
+            "model.visual.blocks.0.attn.proj.weight",
+        ],
+        "model-00002.safetensors": ["lm_head.weight", "model.visual.merger.ln_q.weight", "audio.encoder.weight"],
+    }
+    weight_map = {}
+    for shard, keys in shards.items():
+        save_file({k: tensors[k] for k in keys}, str(tmp_path / shard))
+        weight_map.update({k: shard for k in keys})
+    (tmp_path / "model.safetensors.index.json").write_text(json.dumps({"weight_map": weight_map}))
+    return tmp_path, tensors
+
+
+@pytest.fixture(autouse=True)
+def _fresh_cache(monkeypatch):
+    monkeypatch.setattr(hwi, "_MM_TOWER_CACHE", None)
+    monkeypatch.setattr(hwi, "_warned_implicit_mm_tower_sync", False)
+    monkeypatch.setattr(torch.cuda, "current_device", lambda: "cpu")
+
+
+class TestTowerNames:
+    def test_off_by_default(self):
+        assert hwi.mm_tower_names(_args()) == ()
+        assert hwi.mm_tower_names(_args(provider="my_pkg.vlm_provider")) == ()
+
+    def test_flag_names_the_towers(self):
+        assert hwi.mm_tower_names(_args(mm_tower_sync=["visual"])) == ("visual",)
+        assert hwi.mm_tower_names(_args(mm_tower_sync=["vision_tower", "audio"])) == ("vision_tower", "audio")
+
+    def test_inkling_provider_implies_its_towers(self, caplog):
+        with caplog.at_level("WARNING"):
+            assert hwi.mm_tower_names(_args(provider=_INKLING)) == ("visual", "audio")
+            hwi.mm_tower_names(_args(provider=_INKLING))
+        assert sum("--mm-tower-sync visual audio" in r.message for r in caplog.records) == 1
+
+    def test_explicit_flag_overrides_the_inkling_default(self):
+        assert hwi.mm_tower_names(_args(mm_tower_sync=["visual"], provider=_INKLING)) == ("visual",)
+        # An empty flag value switches the implicit sync off.
+        assert hwi.mm_tower_names(_args(mm_tower_sync=[], provider=_INKLING)) == ()
+
+
+class TestTowerKeys:
+    @pytest.mark.parametrize(
+        "key",
+        ["model.visual.blocks.0.attn.proj.weight", "visual.merger.ln_q.weight", "language_model.visual.x"],
+    )
+    def test_matches_the_tower_as_a_dotted_module(self, key):
+        assert hwi.is_mm_tower_key(key, ("visual",))
+
+    @pytest.mark.parametrize("key", ["model.visualizer.weight", "model.layers.0.visual_gate", "lm_head.weight"])
+    def test_does_not_match_a_prefix_of_another_name(self, key):
+        assert not hwi.is_mm_tower_key(key, ("visual",))
+
+
+class TestIterUnits:
+    def test_off_yields_nothing_and_reads_no_checkpoint(self, checkpoint):
+        ckpt_dir, _ = checkpoint
+        args = _args(hf_checkpoint=str(ckpt_dir / "does-not-exist"))
+        assert list(hwi._iter_mm_tower_units(args, materialize=True)) == []
+
+    def test_non_materializing_ranks_yield_nothing(self, checkpoint):
+        ckpt_dir, _ = checkpoint
+        args = _args(mm_tower_sync=["visual"], hf_checkpoint=str(ckpt_dir))
+        assert list(hwi._iter_mm_tower_units(args, materialize=False)) == []
+        assert hwi._MM_TOWER_CACHE is None
+
+    def test_yields_exactly_the_named_towers_from_the_checkpoint(self, checkpoint):
+        ckpt_dir, tensors = checkpoint
+        args = _args(mm_tower_sync=["visual"], hf_checkpoint=str(ckpt_dir))
+        units = list(hwi._iter_mm_tower_units(args, materialize=True))
+        names = [name for unit in units for name, _ in unit]
+        assert sorted(names) == ["model.visual.blocks.0.attn.proj.weight", "model.visual.merger.ln_q.weight"]
+        for unit in units:
+            ((name, tensor),) = unit
+            assert torch.equal(tensor, tensors[name])
+
+    def test_two_towers(self, checkpoint):
+        ckpt_dir, _ = checkpoint
+        args = _args(mm_tower_sync=["visual", "audio"], hf_checkpoint=str(ckpt_dir))
+        names = [name for unit in hwi._iter_mm_tower_units(args, materialize=True) for name, _ in unit]
+        # Grouped by shard so each shard is opened once; order within the run is not a contract.
+        assert sorted(names) == [
+            "audio.encoder.weight",
+            "model.visual.blocks.0.attn.proj.weight",
+            "model.visual.merger.ln_q.weight",
+        ]
+
+    def test_checkpoint_is_read_once(self, checkpoint, monkeypatch):
+        ckpt_dir, _ = checkpoint
+        args = _args(mm_tower_sync=["visual"], hf_checkpoint=str(ckpt_dir))
+        first = [name for unit in hwi._iter_mm_tower_units(args, materialize=True) for name, _ in unit]
+        (ckpt_dir / "model.safetensors.index.json").unlink()
+        second = [name for unit in hwi._iter_mm_tower_units(args, materialize=True) for name, _ in unit]
+        assert first == second


### PR DESCRIPTION
## Problem

The weight update can re-send the frozen vision/audio towers from the HF checkpoint, so a colocated engine can release its weights during training and get them all back at the next update. That re-send is gated on the provider path containing `inkling_mm_model_provider` (`_iter_mm_tower_units` in `hf_weight_iterator.py`). Every other VLM that trains only its language model cannot use it, and has to keep the engine weights resident with `--offload-rollout-level kv_cache`.

Measured on B300 (267 GB) nodes with the engine and trainer colocated:

| Model | Engine weights held through log-prob and train | Tower that blocks releasing them |
|---|---|---|
| GLM-5.3-Flash, 6 nodes | 87.35 GB per GPU | 347 tensors, 1.13 GB |
| Qwen3.8-27B, 4 nodes | 73 GB per GPU | 333 tensors, 0.92 GB |

The GLM run OOMs in the log-prob pass with the engine resident. Nothing in the re-send is Inkling-specific except the gate: it already selects any `.visual.` or `.audio.` key from the checkpoint index.

## Change

- `--mm-tower-sync TOWER [TOWER ...]` names the tower modules to re-send. A checkpoint key belongs to a tower when `.TOWER.` appears in `.key`, so `model.visual.blocks.0.attn.proj.weight` and `visual.merger.ln_q.weight` both match `visual`, and `model.visualizer.x` does not.
- `_iter_mm_tower_units` gates on `mm_tower_names(args)` instead of the provider string. The body is unchanged: read the index once, load the tower tensors to CPU, cache, yield after the language weights on every update.
- Inkling: the MM provider still implies `visual audio` when the flag is absent, with a one-time warning asking for the explicit flag. `scripts/run_inkling.py` passes `--mm-tower-sync visual audio`. Passing the flag with no values switches the implicit sync off.

## Compatibility

- Flag absent and provider not Inkling: the function returns at its first line, as before. Text runs are unaffected.
- Inkling launches with only the provider path: same towers as before, plus a warning.
- Engines load the same bytes they loaded at boot, in place. Sending them again is idempotent.

## Test

`tests/fast/backends/megatron_utils/test_mm_tower_sync.py`: default off, flag names the towers, Inkling fallback and its override, key matching, no checkpoint read when off, non-materializing ranks yield nothing, the named towers come back from a two-shard checkpoint, the checkpoint is read once. Ran with the rest of `tests/fast/backends/megatron_utils` and `tests/fast/backends/training_utils/weight_update` inside the miles image: 305 passed.

Downstream use: fleet-ai runs GLM-5.3-Flash and Qwen3.8-27B browser RL with `--mm-tower-sync visual` and the default offload level, replacing `--offload-rollout-level kv_cache` and `--check-weight-update-skip-list visual.`.
