### PR TITLE
[CI] disable the two FT determinism tests #3148 missed

### DIFF
--- a/tests/e2e/ft/test_trainer_ft_deterministic_dp2_cp2_real_rollout.py
+++ b/tests/e2e/ft/test_trainer_ft_deterministic_dp2_cp2_real_rollout.py
@@ -10,6 +10,7 @@ register_cuda_ci(
     est_time=3200,
     suite="stage-c-8-gpu-h200",
     labels=["ft-short"],
+    disabled="will enable in future FT delivery",
 )
 
 _MODE: str = "dp2_cp2_real_rollout"

--- a/tests/e2e/ft/test_trainer_ft_deterministic_dp4_cp2.py
+++ b/tests/e2e/ft/test_trainer_ft_deterministic_dp4_cp2.py
@@ -10,6 +10,7 @@ register_cuda_ci(
     est_time=2900,
     suite="stage-c-8-gpu-h200",
     labels=["ft-short"],
+    disabled="will enable in future FT delivery",
 )
 
 _MODE: str = "dp4_cp2"


### PR DESCRIPTION
Follow-up to #3148, which disabled the FT variants that were red on the 2026-09-08 nightly. Tonight's nightly (34368332492) failed on two that were not on that list:

- `test_trainer_ft_deterministic_dp2_cp2_real_rollout` — failing since the 09-07 nightly, missed because it happened to be green on 09-08, the night the list was drawn up. Easy to confuse with `with_failure_dp2_cp2_real_rollout_dense`, which #3148 did disable.
- `test_trainer_ft_deterministic_dp4_cp2` — first red on 09-09.

Both fail the same way as the variants already disabled:

```
AssertionError: CellReconfigureEvent sequence mismatch in
  /node_public/dumps/trainer_ft_deterministic_dp4_cp2/target/phase_a/events
```

## What this leaves

All four `deterministic_*` variants are now off, so the event sequence check runs nowhere. Ten of the fourteen `test_trainer_ft_*` tests are disabled; only the four `no_failure_*` still run:

| variant family | state |
|---|---|
| `deterministic_*` (4) | all disabled |
| `with_failure_*` (3) | all disabled |
| `random_*` (2) | all disabled |
| `realistic_gsm8k` | disabled |
| `no_failure_*` (4) | running |

Worth treating `CellReconfigureEvent sequence mismatch` as a real bug rather than continuing to widen the disable list — the check is now unenforced, not merely flaky.