### PR TITLE
tito: Qwen3's second EOS is a turn end, and an alias for the comparator

### DIFF
--- a/miles/ray/rollout/metrics.py
+++ b/miles/ray/rollout/metrics.py
@@ -119,7 +119,13 @@ def _compute_metrics_from_samples(args, samples):
         assert session_server_version in ("v1", "v2"), "TITO metrics require session server v1 or v2"
         metric_prefix = f"tito_session_mismatch_rate/{session_server_version}"
         log_dict[metric_prefix] = np.mean([len(v) > 0 for v in tito_vals]).item()
-        for mtype in ("special_token_count", "special_token_type", "non_assistant_text", "assistant_text"):
+        for mtype in (
+            "special_token_count",
+            "special_token_type",
+            "non_assistant_text",
+            "assistant_text",
+            "eos_alias",
+        ):
             log_dict[f"{metric_prefix}/{mtype}"] = np.mean(
                 [any(m.get("type") == mtype for m in v) for v in tito_vals]
             ).item()

--- a/miles/utils/chat_template_utils/tito_tokenizer.py
+++ b/miles/utils/chat_template_utils/tito_tokenizer.py
@@ -88,6 +88,10 @@ class TITOTokenizer:
 
     max_trim_tokens: int = 0
     trailing_token_ids: frozenset[int] = frozenset()
+    # Special tokens the model may emit interchangeably at a turn end (Qwen3's
+    # two EOS ids).  The comparator reports a swap inside one group as the
+    # non-severe ``eos_alias`` mismatch instead of ``special_token_type``.
+    eos_alias_groups: tuple[frozenset[int], ...] = ()
     chat_template_kwarg_aliases: frozenset[str] = frozenset()
 
     # The family's fixed renderer contract. DEFAULT uses the model's native
@@ -140,6 +144,7 @@ class TITOTokenizer:
             assistant_start_str=self._assistant_start_str,
             special_token_ids=self.special_token_ids,
             trim_trailing_ids=self.trailing_token_ids or None,
+            eos_alias_groups=self.eos_alias_groups or None,
         )
 
     def apply_chat_template(
@@ -266,12 +271,17 @@ class TITOTokenizer:
 
 
 class Qwen3TITOTokenizer(TITOTokenizer):
-    """Qwen3 variant: handles missing newline at the boundary.
+    """Qwen3 variant: handles the missing newline at the turn boundary.
 
     The Qwen3 chat template emits ``<|im_end|>\\n`` after every message, but
-    the model stops at ``<|im_end|>`` without generating the trailing ``\\n``.
-    ``merge_tokens`` inserts the missing newline so that the pretokenized
-    prefix matches the canonical template output.
+    the model stops at an EOS token without generating the trailing ``\\n``.
+    Qwen3's generation config lists two EOS ids, ``<|im_end|>`` and
+    ``<|endoftext|>``, and small models do end some turns with the latter;
+    ``merge_tokens`` inserts the missing newline after either, so the
+    pretokenized prefix keeps the template's structure.  The two ids form an
+    EOS alias group for the comparator: the template can only render
+    ``<|im_end|>``, so a turn the model ended with ``<|endoftext|>`` is a
+    non-severe ``eos_alias`` mismatch, not a structural one.
     """
 
     reasoning_parser = "qwen3"
@@ -299,6 +309,12 @@ class Qwen3TITOTokenizer(TITOTokenizer):
         assert len(nl_ids) == 1, f"Expected single newline token, got {nl_ids}"
         self._newline_id: int = nl_ids[0]
         self._im_end_id: int = tokenizer.convert_tokens_to_ids("<|im_end|>")
+        eos_ids = {self._im_end_id}
+        endoftext_id = tokenizer.convert_tokens_to_ids("<|endoftext|>")
+        if endoftext_id is not None and endoftext_id != tokenizer.unk_token_id:
+            eos_ids.add(endoftext_id)
+        self._eos_ids: frozenset[int] = frozenset(eos_ids)
+        self.eos_alias_groups = (self._eos_ids,)
         self.trailing_token_ids = frozenset({self._newline_id})
 
     def merge_tokens(
@@ -310,7 +326,7 @@ class Qwen3TITOTokenizer(TITOTokenizer):
     ) -> list[int]:
         incremental = self.tokenize_additional_messages(old_messages, new_messages, tools)
         prefix = list(pretokenized_token_ids)
-        if prefix and prefix[-1] == self._im_end_id:
+        if prefix and prefix[-1] in self._eos_ids:
             prefix.append(self._newline_id)
         return prefix + incremental
 

--- a/miles/utils/chat_template_utils/token_seq_comparator.py
+++ b/miles/utils/chat_template_utils/token_seq_comparator.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from dataclasses import dataclass, field
 from enum import Enum
 
@@ -32,6 +33,13 @@ class MismatchType(Enum):
     # are inherited directly from the pretokenized prefix across turns,
     # so they may not match the chat template's canonical tokenization.
     ASSISTANT_TEXT = "assistant_text"
+
+    # A special-token segment where both sides hold an end-of-turn token from
+    # the same family-declared alias group: the model stopped with one EOS
+    # (Qwen3's ``<|endoftext|>``) where the template can only render another
+    # (``<|im_end|>``).  A model choice, not a template or algorithm bug, so
+    # it is non-severe.
+    EOS_ALIAS = "eos_alias"
 
 
 @dataclass
@@ -76,6 +84,11 @@ class TokenSeqComparator:
         (see :func:`_trim_trailing`).  Stored as a default; callers of
         :meth:`compare_sequences` may supply additional IDs that are
         **unioned** with this set.
+    eos_alias_groups : Iterable[Iterable[int]] | None
+        Groups of special-token IDs the model may emit interchangeably at a
+        turn end (Qwen3's ``<|im_end|>`` / ``<|endoftext|>``).  Two aligned
+        special segments that differ but fall inside one group are reported as
+        :attr:`MismatchType.EOS_ALIAS` instead of ``SPECIAL_TOKEN_TYPE``.
     """
 
     def __init__(
@@ -84,6 +97,7 @@ class TokenSeqComparator:
         assistant_start_str: str,
         special_token_ids: set[int] | None = None,
         trim_trailing_ids: set[int] | None = None,
+        eos_alias_groups: Iterable[Iterable[int]] | None = None,
     ):
         self.tokenizer = tokenizer
         if special_token_ids is not None:
@@ -92,6 +106,7 @@ class TokenSeqComparator:
             self._special_ids = self.collect_special_ids(tokenizer)
         self._assistant_start_str = assistant_start_str
         self._trim_trailing_ids: set[int] | None = set(trim_trailing_ids) if trim_trailing_ids else None
+        self._eos_alias_groups: list[frozenset[int]] = [frozenset(g) for g in (eos_alias_groups or [])]
 
     @staticmethod
     def collect_special_ids(tokenizer) -> set[int]:
@@ -219,8 +234,9 @@ class TokenSeqComparator:
         """
         if exp.is_special:
             if exp.token_ids != act.token_ids:
+                aliased = self._same_eos_alias_group(exp.token_ids, act.token_ids)
                 return Mismatch(
-                    type=MismatchType.SPECIAL_TOKEN_TYPE,
+                    type=MismatchType.EOS_ALIAS if aliased else MismatchType.SPECIAL_TOKEN_TYPE,
                     segment_index=idx,
                     expected_text=self._decode(exp.token_ids),
                     actual_text=self._decode(act.token_ids),
@@ -240,6 +256,12 @@ class TokenSeqComparator:
             expected_text=exp_text,
             actual_text=act_text,
         )
+
+    def _same_eos_alias_group(self, exp_ids: list[int], act_ids: list[int]) -> bool:
+        """True when both single special tokens sit in one declared EOS alias group."""
+        if len(exp_ids) != 1 or len(act_ids) != 1:
+            return False
+        return any(exp_ids[0] in group and act_ids[0] in group for group in self._eos_alias_groups)
 
     def _is_assistant_content(self, segments: list[Segment], idx: int) -> bool:
         """Check if the content segment at *idx* belongs to an assistant message.

--- a/tests/fast/ray/rollout/test_metrics.py
+++ b/tests/fast/ray/rollout/test_metrics.py
@@ -233,6 +233,7 @@ class TestTitoMismatchMetrics:
             f"{metric_prefix}/special_token_type",
             f"{metric_prefix}/non_assistant_text",
             f"{metric_prefix}/assistant_text",
+            f"{metric_prefix}/eos_alias",
         }
         assert {key for key in out if key.startswith("tito_session_mismatch_rate")} == tito_keys
         assert all(out[key] == 0.0 for key in tito_keys)
@@ -256,6 +257,23 @@ class TestTitoMismatchMetrics:
             match=r"tito_session_mismatch_rate/v1/special_token_count=0\.2500",
         ):
             _compute_metrics_from_samples(args, samples)
+
+    def test_eos_alias_mismatch_is_logged_but_not_strict(self):
+        """eos_alias (the model ended a turn with an alias EOS) is a model choice,
+        not a TITO bug: logged per type, never part of the ci_test assertion."""
+        args = make_args(
+            advantage_estimator="ppo",
+            ci_test=True,
+            log_passrate=False,
+            use_session_server="v1",
+        )
+        samples = make_samples_grouped(1, 4)
+        samples[0].metadata = {"tito_session_mismatch": [{"type": "eos_alias"}]}
+        for s in samples[1:]:
+            s.metadata = {"tito_session_mismatch": []}
+        out = _compute_metrics_from_samples(args, samples)
+        assert out["tito_session_mismatch_rate/v1/eos_alias"] == 0.25
+        assert out["tito_session_mismatch_rate/v1/special_token_type"] == 0.0
 
     def test_assistant_text_mismatch_does_not_raise_under_ci_test(self):
         """assistant_text mismatch is non-critical (tokens inherited from the

--- a/tests/fast/utils/chat_template_utils/test_tito_tokenizer.py
+++ b/tests/fast/utils/chat_template_utils/test_tito_tokenizer.py
@@ -227,6 +227,10 @@ class TestConfig:
     def test_qwen3(self, qwen3_tito: Qwen3TITOTokenizer):
         assert qwen3_tito._assistant_start_str == "<|im_start|>assistant"
         assert qwen3_tito._newline_id in qwen3_tito.trailing_token_ids
+        # both EOS ids form the alias group the comparator softens
+        endoftext = qwen3_tito.tokenizer.convert_tokens_to_ids("<|endoftext|>")
+        assert qwen3_tito.eos_alias_groups == (frozenset({qwen3_tito._im_end_id, endoftext}),)
+        assert qwen3_tito.create_comparator()._eos_alias_groups == [frozenset({qwen3_tito._im_end_id, endoftext})]
 
     def test_glm47(self, glm47_tito: GLM47TITOTokenizer):
         assert glm47_tito._assistant_start_str == "<|assistant|>"
@@ -560,6 +564,37 @@ class TestMergeTokensBoundary:
         incremental = qwen3_tito.tokenize_additional_messages(_BND_OLD, _BND_NEW, _BND_TOOLS)
         result = qwen3_tito.merge_tokens(_BND_OLD, _BND_NEW, [100, 200, 300], _BND_TOOLS)
         assert result == [100, 200, 300] + incremental
+
+    def test_qwen3_inserts_newline_after_endoftext(self, qwen3_tito: Qwen3TITOTokenizer):
+        """Qwen3's second EOS: a turn the model ended with <|endoftext|> gets the same
+        missing newline, so the next turn's <|im_start|> keeps the template's structure."""
+        incremental = qwen3_tito.tokenize_additional_messages(_BND_OLD, _BND_NEW, _BND_TOOLS)
+        endoftext = qwen3_tito.tokenizer.convert_tokens_to_ids("<|endoftext|>")
+        nl = qwen3_tito._newline_id
+
+        result = qwen3_tito.merge_tokens(_BND_OLD, _BND_NEW, [100, 200, endoftext], _BND_TOOLS)
+        assert result == [100, 200, endoftext, nl] + incremental
+
+    def test_qwen3_endoftext_turn_is_only_an_eos_alias_mismatch(self, qwen3_tito: Qwen3TITOTokenizer):
+        """End to end through the family's comparator: an accumulated stream whose
+        assistant turn ended with <|endoftext|> differs from the canonical render
+        by exactly that token, classified eos_alias, once merged with the next turn."""
+        old = [
+            {"role": "system", "content": "Be brief."},
+            {"role": "user", "content": "Say hi."},
+            {"role": "assistant", "content": "Hi."},
+        ]
+        new = old + [{"role": "user", "content": "Again."}]
+        canonical_old = qwen3_tito.apply_chat_template(old, add_generation_prompt=False)
+        assert canonical_old.endswith("<|im_end|>\n")
+        # what the engine recorded: the model stopped with <|endoftext|>, no trailing newline
+        endoftext = qwen3_tito.tokenizer.convert_tokens_to_ids("<|endoftext|>")
+        recorded = qwen3_tito._encode_text(canonical_old[: -len("<|im_end|>\n")]) + [endoftext]
+
+        merged = qwen3_tito.merge_tokens(old, new, recorded)
+        expected = qwen3_tito.apply_chat_template(new, add_generation_prompt=True, tokenize=True)
+        mismatches = qwen3_tito.create_comparator().compare_sequences(expected, merged)
+        assert [m.type.value for m in mismatches] == ["eos_alias"]
 
     # -- GLM47: strip ambiguous boundary tokens --
 

--- a/tests/fast/utils/chat_template_utils/test_token_seq_comparator.py
+++ b/tests/fast/utils/chat_template_utils/test_token_seq_comparator.py
@@ -425,3 +425,49 @@ class TestGlm47BoundaryTokens:
         assert len(result) == 1
         assert result[0].type == MismatchType.SPECIAL_TOKEN_TYPE
         assert result[0].segment_index == 2
+
+
+# ---------------------------------------------------------------------------
+# EOS alias groups
+#
+# Qwen3 lists two EOS ids in its generation config; a model may end a turn
+# with <|endoftext|> where the template can only render <|im_end|>.  A family
+# declares such ids as one alias group, and a swap inside the group is the
+# non-severe EOS_ALIAS mismatch instead of SPECIAL_TOKEN_TYPE.
+# ---------------------------------------------------------------------------
+
+
+class TestEosAlias:
+    def _make(self, env: TokenizerEnv, groups) -> TokenSeqComparator:
+        return TokenSeqComparator(
+            env.tokenizer, assistant_start_str=env.config.assistant_start_str, eos_alias_groups=groups
+        )
+
+    def test_swap_inside_group_is_eos_alias(self, qwen3_env: TokenizerEnv):
+        im_start = qwen3_env.token_id("<|im_start|>")
+        im_end = qwen3_env.token_id("<|im_end|>")
+        endoftext = qwen3_env.token_id("<|endoftext|>")
+        text = qwen3_env.encode("assistant\nHi")
+        expected = [im_start] + text + [im_end]
+        actual = [im_start] + text + [endoftext]
+
+        comp = self._make(qwen3_env, [frozenset({im_end, endoftext})])
+        mismatches = comp.compare_sequences(expected, actual)
+        assert [m.type for m in mismatches] == [MismatchType.EOS_ALIAS]
+        assert mismatches[0].expected_text == "<|im_end|>" and mismatches[0].actual_text == "<|endoftext|>"
+
+    def test_swap_outside_group_stays_structural(self, qwen3_env: TokenizerEnv):
+        im_start = qwen3_env.token_id("<|im_start|>")
+        im_end = qwen3_env.token_id("<|im_end|>")
+        endoftext = qwen3_env.token_id("<|endoftext|>")
+        text = qwen3_env.encode("assistant\nHi")
+        expected = [im_start] + text + [im_end]
+        actual = [im_start] + text + [endoftext]
+
+        # no groups declared: the swap is a structural mismatch
+        assert [m.type for m in qwen3_env.comparator.compare_sequences(expected, actual)] == [
+            MismatchType.SPECIAL_TOKEN_TYPE
+        ]
+        # a group that does not contain both ids does not soften it either
+        comp = self._make(qwen3_env, [frozenset({im_end, im_start})])
+        assert [m.type for m in comp.compare_sequences(expected, actual)] == [MismatchType.SPECIAL_TOKEN_TYPE]


### PR DESCRIPTION
## Purpose

Stop the TITO strict gate from filing a model choice as a TITO bug: Qwen3 models may end a turn with their second EOS, `<|endoftext|>`, which the chat template can never render (it always emits `<|im_end|>\n`). Mechanism 2 of #3113, with the dumped evidence there.

## What

- `Qwen3TITOTokenizer`: both EOS ids are turn ends for the `\n` boundary in `merge_tokens` (previously only `<|im_end|>`), and the pair is declared as an EOS alias group. The Qwen3.5 / 3.6 / 3.8 / Next subclasses inherit.
- `TokenSeqComparator`: new `eos_alias_groups` parameter; an aligned special segment whose two ids fall in one group is reported as the new non-severe type `eos_alias` instead of `special_token_type`.
- `metrics.py`: logs `eos_alias` per type. The strict tuple (`special_token_count` / `special_token_type` / `non_assistant_text`) is unchanged.
- Tests: comparator alias classification; Qwen3 `merge_tokens` after `<|endoftext|>`; an end-to-end case through the family's comparator where an `<|endoftext|>`-ended turn yields exactly one `eos_alias`; metrics logging/non-strictness.

## Behaviour change

Sessions where the model ended a turn with `<|endoftext|>` no longer fail the ci_test strict gate; they show up as `tito_session_mismatch_rate/<v>/eos_alias`. Training tokens are untouched.

## Verification

Stage 2: `verify_chat_template.py --model Qwen/Qwen3-0.6B --tito-model qwen3 --thinking both` 74/74 PASS. Stage 3 (2026-09-09, 2×H200): the Harbor e2e of #2876 with the strict gate armed passes on a healthy terminus-2 × Qwen3-0.6B session (`assistant_text` ×2, `eos_alias` ×1). A degenerate session still trips `non_assistant_text` for an unrelated reason — the model emitting `<|im_start|>` mid-turn — tracked as mechanism 3 in #3113, deliberately not in this PR.

## Follow-up

#2876 keeps `--ci-disable-tito-strict-checker` until mechanism 3 of #3113 is also resolved; then it drops the flag and its plumbing and reruns the e2e with the gate armed.
