### PR TITLE
Fix Nemotron-H forward compatibility when MTP is disabled

### DIFF
--- a/miles_plugins/megatron_bridge/nemotron_h.py
+++ b/miles_plugins/megatron_bridge/nemotron_h.py
@@ -13,9 +13,8 @@ This plugin is a non-invasive drop-in that:
    blow up on the 2-tuple unpack in ``_forward_attention`` / ``_forward_mlp``.
 3. For Nemotron-H models, patches
    :class:`~megatron.core.models.mamba.MambaModel` ``forward`` to
-   transparently swallow the ``loss_mask`` kwarg so miles' generic training
-   loop (which was designed around ``GPTModel``) can keep passing it
-   unconditionally.
+   adapt Miles' ``mtp_kwargs`` to the model's forward arguments while
+   preserving ``loss_mask``.
 
 Importing this module is idempotent — safe to import multiple times.
 """
@@ -182,13 +181,11 @@ def _install_nemotronh_hybrid_layer_shims() -> None:
 
 
 def _install_mamba_model_loss_mask_shim() -> None:
-    """Make ``MambaModel.forward`` silently accept (and drop) ``loss_mask``.
+    """Adapt Miles MTP arguments while preserving the model loss mask.
 
-    Miles' generic training loop was written against ``GPTModel.forward``,
-    which has ``loss_mask: Optional[Tensor] = None`` as a keyword-only arg.
-    ``MambaModel.forward`` does not accept ``loss_mask``, so passing it raises
-    ``TypeError``. The loss itself is still computed downstream from the batch
-    ``loss_masks`` field — it is only the forward call that must drop it.
+    The Megatron HybridModel exposed as MambaModel accepts ``loss_mask`` but
+    not ``mtp_labels``. Omit absent MTP labels so its forward remains usable
+    when MTP is disabled; shift labels for models that support MTP.
     """
     from megatron.core.models.mamba import MambaModel
 
@@ -201,8 +198,9 @@ def _install_mamba_model_loss_mask_shim() -> None:
         # process_mtp_loss expects next-token-shifted labels; miles passes raw tokens.
         mtp_labels = (mtp_kwargs or {}).get("mtp_labels")
         if mtp_labels is not None:
-            mtp_labels = torch.roll(mtp_labels, shifts=-1, dims=-1)
-        return _orig_forward(self, *args, loss_mask=loss_mask, mtp_labels=mtp_labels, **kwargs)
+            # HybridModel.forward does not accept even mtp_labels=None.
+            kwargs["mtp_labels"] = torch.roll(mtp_labels, shifts=-1, dims=-1)
+        return _orig_forward(self, *args, loss_mask=loss_mask, **kwargs)
 
     MambaModel.forward = forward
     MambaModel._miles_loss_mask_shim_installed = True

--- a/tests/fast/backends/megatron_utils/test_nemotron_h_forward.py
+++ b/tests/fast/backends/megatron_utils/test_nemotron_h_forward.py
@@ -1,0 +1,50 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+import torch
+
+
+def install_shim(monkeypatch: pytest.MonkeyPatch, model_class: type) -> None:
+    stub = ModuleType("megatron.core.models.mamba")
+    stub.MambaModel = model_class
+    monkeypatch.setitem(sys.modules, stub.__name__, stub)
+    path = Path(__file__).resolve().parents[4] / "miles_plugins/megatron_bridge/nemotron_h.py"
+    spec = importlib.util.spec_from_file_location("nemotron_h_forward_under_test", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    module._install_mamba_model_loss_mask_shim()
+    module._install_mamba_model_loss_mask_shim()
+
+
+@pytest.mark.parametrize("mtp_kwargs", [None, {}, {"mtp_labels": None}])
+def test_forward_without_mtp_keyword(monkeypatch: pytest.MonkeyPatch, mtp_kwargs: dict[str, None] | None) -> None:
+    class Model:
+        def forward(self, tokens: torch.Tensor, *, loss_mask: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+            return tokens, loss_mask
+
+    install_shim(monkeypatch, Model)
+    tokens = torch.tensor([[1, 2, 3]])
+    mask = torch.tensor([[0, 1, 1]])
+    result = Model().forward(tokens, loss_mask=mask, mtp_kwargs=mtp_kwargs)
+    assert result[0] is tokens
+    assert result[1] is mask
+
+
+def test_forward_shifts_mtp_labels_once_without_mutating_input(monkeypatch: pytest.MonkeyPatch) -> None:
+    class Model:
+        def forward(self, *, loss_mask: torch.Tensor, mtp_labels: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+            return loss_mask, mtp_labels
+
+    install_shim(monkeypatch, Model)
+    labels = torch.tensor([[1, 2, 3], [4, 5, 6]])
+    mask = torch.ones_like(labels)
+    mtp_kwargs = {"mtp_labels": labels}
+    result = Model().forward(loss_mask=mask, mtp_kwargs=mtp_kwargs)
+    assert result[0] is mask
+    torch.testing.assert_close(result[1], torch.tensor([[2, 3, 1], [5, 6, 4]]))
+    torch.testing.assert_close(labels, torch.tensor([[1, 2, 3], [4, 5, 6]]))
+    assert mtp_kwargs["mtp_labels"] is labels


### PR DESCRIPTION
The Nemotron-H forward shim always passes `mtp_labels`, including `None`. Megatron's `HybridModel.forward` does not accept that keyword, so an MTP-disabled run fails on its first training forward.

Only forward MTP labels when they are present. Preserve the existing next-token shift and loss-mask forwarding, and correct the shim's stale docstring.

Validation:
- Four regression cases pass in the full Miles pytest setup; the unpatched base fails the three MTP-disabled cases.
- Tests cover absent/empty/None MTP labels, a strict forward signature, loss-mask propagation, one-time label shifting, input preservation, and idempotent shim installation.
- All applicable pre-commit hooks pass.

The non-None label test uses a forward implementation that accepts MTP labels; it does not claim end-to-end MTP-enabled model support.
