### PR TITLE
glm53-flash: honour --offload-rollout-level and add --mm-tower-sync for frozen vision towers

### DIFF
--- a/miles/backends/megatron_utils/update_weight/update_weight_from_tensor.py
+++ b/miles/backends/megatron_utils/update_weight/update_weight_from_tensor.py
@@ -74,6 +74,39 @@ def _pp_assemble_full_adapter(
     return sorted(merged.items())
 
 
+_INKLING_MM_PROVIDER = "inkling_mm_model_provider"
+_INKLING_MM_TOWERS = ("visual", "audio")
+_warned_implicit_mm_tower_sync = False
+
+
+def mm_tower_names(args) -> tuple[str, ...]:
+    """Module names of the frozen multimodal towers re-sent on every weight
+    update; empty when tower sync is off. `--mm-tower-sync` decides. The
+    Inkling MM provider implies its two towers so launches that predate the
+    flag keep syncing. Backport of radixark/miles#3159."""
+    global _warned_implicit_mm_tower_sync
+    names = getattr(args, "mm_tower_sync", None)
+    if names is not None:
+        return tuple(names)
+    if _INKLING_MM_PROVIDER in (getattr(args, "custom_model_provider_path", None) or ""):
+        if not _warned_implicit_mm_tower_sync:
+            logger.warning(
+                "mm tower sync: enabled implicitly by the %s provider; pass --mm-tower-sync %s",
+                _INKLING_MM_PROVIDER,
+                " ".join(_INKLING_MM_TOWERS),
+            )
+            _warned_implicit_mm_tower_sync = True
+        return _INKLING_MM_TOWERS
+    return ()
+
+
+def is_mm_tower_key(key: str, tower_names: Sequence[str]) -> bool:
+    """`model.visual.blocks.0.attn.proj.weight` and `visual.merger.ln_q.weight`
+    both belong to the `visual` tower."""
+    dotted = f".{key}"
+    return any(f".{name}." in dotted for name in tower_names)
+
+
 class UpdateWeightFromTensor:
     """
     Update rollout engines from tensor dict:
@@ -328,8 +361,8 @@ class UpdateWeightFromTensor:
         send requires homogeneous per-rank bucket counts (num_dtypes is taken from
         rank 0 and indexed into every rank's list), so a src-only contribution
         breaks assembly. The duplicates are ~15MB/rank and load idempotently."""
-        provider = getattr(self.args, "custom_model_provider_path", None) or ""
-        if "inkling_mm_model_provider" not in provider:
+        tower_names = mm_tower_names(self.args)
+        if not tower_names:
             return None
         if self._mm_tower_cache is None:
             if self._ipc_gather_group is not None:
@@ -340,11 +373,7 @@ class UpdateWeightFromTensor:
                 ckpt_dir = self.args.hf_checkpoint
                 with open(os.path.join(ckpt_dir, "model.safetensors.index.json"), encoding="utf-8") as f:
                     weight_map = json.load(f)["weight_map"]
-                tower_keys = sorted(
-                    k
-                    for k in weight_map
-                    if ".visual." in f".{k}" or ".audio." in f".{k}" or k.startswith(("visual.", "audio."))
-                )
+                tower_keys = sorted(k for k in weight_map if is_mm_tower_key(k, tower_names))
                 by_shard: dict[str, list[str]] = {}
                 for k in tower_keys:
                     by_shard.setdefault(weight_map[k], []).append(k)

--- a/miles/ray/rollout/rollout_manager.py
+++ b/miles/ray/rollout/rollout_manager.py
@@ -50,6 +50,15 @@ logging.getLogger("httpcore").setLevel(logging.WARNING)
 logger = logging.getLogger(__name__)
 
 
+def _get_rollout_offload_tags(levels: list[str]) -> tuple[str, ...]:
+    tags = [GPU_MEMORY_TYPE_CUDA_GRAPH]
+    if "kv_cache" in levels:
+        tags.append(GPU_MEMORY_TYPE_KV_CACHE)
+    if "weight" in levels:
+        tags.append(GPU_MEMORY_TYPE_WEIGHTS)
+    return tuple(tags)
+
+
 @ray.remote
 class RolloutManager:
     """The class to run rollout and convert rollout data to training data."""
@@ -60,6 +69,7 @@ class RolloutManager:
 
         self.pg = pg
         self.args = args
+        self._offload_tags = _get_rollout_offload_tags(args.offload_rollout_level)
         # set by the training actor after each weight update
         self.weight_version: int | None = None
         # TODO make args immutable
@@ -285,6 +295,7 @@ class RolloutManager:
     # TODO may parallelly execute offload/onload across services
     async def offload(self, tags: list[str] | None = None):
         self.health_monitoring_pause()
+        tags = list(self._offload_tags) if tags is None else tags
         for srv in self.servers.values():
             await srv.offload(tags=tags)
 
@@ -293,10 +304,14 @@ class RolloutManager:
             await srv.onload(tags)
 
     async def onload_weights(self):
-        await self.onload(tags=[GPU_MEMORY_TYPE_WEIGHTS])
+        if GPU_MEMORY_TYPE_WEIGHTS in self._offload_tags:
+            await self.onload(tags=[GPU_MEMORY_TYPE_WEIGHTS])
 
     async def onload_kv(self):
-        await self.onload(tags=[GPU_MEMORY_TYPE_KV_CACHE, GPU_MEMORY_TYPE_CUDA_GRAPH])
+        tags = [GPU_MEMORY_TYPE_CUDA_GRAPH]
+        if GPU_MEMORY_TYPE_KV_CACHE in self._offload_tags:
+            tags.insert(0, GPU_MEMORY_TYPE_KV_CACHE)
+        await self.onload(tags=tags)
 
     # -------------------------- engine management -----------------------------
 

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -403,6 +403,20 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 ),
             )
             parser.add_argument(
+                "--mm-tower-sync",
+                type=str,
+                nargs="*",
+                default=None,
+                metavar="TOWER",
+                help=(
+                    "Re-send the frozen multimodal tower weights from --hf-checkpoint to the "
+                    "engines on every weight update, so the engines can release their weights "
+                    "during training. Each TOWER is a module name matched against checkpoint "
+                    "weight names as '.TOWER.' (e.g. 'visual audio' selects model.visual.* and "
+                    "model.audio.*). Off by default; the Inkling MM provider implies 'visual audio'."
+                ),
+            )
+            parser.add_argument(
                 "--recompute-loss-function",
                 action="store_true",
                 help="Whether to enable recompute loss function to save memory during training.",

--- a/tests/fast/backends/megatron_utils/test_mm_tower_sync.py
+++ b/tests/fast/backends/megatron_utils/test_mm_tower_sync.py
@@ -1,0 +1,119 @@
+"""Frozen multimodal tower re-send is opted into with --mm-tower-sync, for any tower name (radixark/miles#3159)."""
+
+from tests.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=60, suite="stage-a-cpu", labels=[])
+
+import json
+from argparse import Namespace
+
+import pytest
+import torch
+from safetensors.torch import save_file
+
+from miles.backends.megatron_utils.update_weight import update_weight_from_tensor as uwt
+
+_INKLING = "miles_plugins.models.inkling.model.inkling_mm_model_provider"
+
+
+def _args(mm_tower_sync=None, provider=None, hf_checkpoint=None):
+    return Namespace(mm_tower_sync=mm_tower_sync, custom_model_provider_path=provider, hf_checkpoint=hf_checkpoint)
+
+
+_IN_GATHER_GROUP = object()
+
+
+def _updater(args, gather_group=_IN_GATHER_GROUP):
+    """The method under test touches only these three attributes."""
+    updater = object.__new__(uwt.UpdateWeightFromTensor)
+    updater.args = args
+    updater._mm_tower_cache = None
+    updater._ipc_gather_group = gather_group
+    return updater
+
+
+@pytest.fixture
+def checkpoint(tmp_path):
+    tensors = {
+        "model.language_model.layers.0.mlp.weight": torch.ones(2, 2),
+        "model.visual.blocks.0.attn.proj.weight": torch.full((2,), 3.0),
+        "model.visual.merger.ln_q.weight": torch.full((2,), 4.0),
+        "audio.encoder.weight": torch.full((2,), 5.0),
+    }
+    shards = {
+        "model-00001.safetensors": [
+            "model.language_model.layers.0.mlp.weight",
+            "model.visual.blocks.0.attn.proj.weight",
+        ],
+        "model-00002.safetensors": ["model.visual.merger.ln_q.weight", "audio.encoder.weight"],
+    }
+    weight_map = {}
+    for shard, keys in shards.items():
+        save_file({k: tensors[k] for k in keys}, str(tmp_path / shard))
+        weight_map.update({k: shard for k in keys})
+    (tmp_path / "model.safetensors.index.json").write_text(json.dumps({"weight_map": weight_map}))
+    return tmp_path, tensors
+
+
+@pytest.fixture(autouse=True)
+def _fresh(monkeypatch):
+    monkeypatch.setattr(uwt, "_warned_implicit_mm_tower_sync", False)
+
+
+def test_off_by_default():
+    assert uwt.mm_tower_names(_args()) == ()
+    assert uwt.mm_tower_names(_args(provider="fti.trainers.miles.vision.qwen3_5.model_provider")) == ()
+    assert _updater(_args(hf_checkpoint="/nonexistent"))._mm_tower_named_tensors() is None
+
+
+def test_inkling_provider_implies_its_towers_and_the_flag_overrides():
+    assert uwt.mm_tower_names(_args(provider=_INKLING)) == ("visual", "audio")
+    assert uwt.mm_tower_names(_args(mm_tower_sync=["visual"], provider=_INKLING)) == ("visual",)
+    assert uwt.mm_tower_names(_args(mm_tower_sync=[], provider=_INKLING)) == ()
+
+
+@pytest.mark.parametrize(
+    "key,expected",
+    [
+        ("model.visual.blocks.0.attn.proj.weight", True),
+        ("visual.merger.ln_q.weight", True),
+        ("model.visualizer.weight", False),
+        ("lm_head.weight", False),
+    ],
+)
+def test_tower_key_match(key, expected):
+    assert uwt.is_mm_tower_key(key, ("visual",)) is expected
+
+
+def test_named_towers_come_from_the_checkpoint_and_are_read_once(checkpoint):
+    ckpt_dir, tensors = checkpoint
+    updater = _updater(_args(mm_tower_sync=["visual"], hf_checkpoint=str(ckpt_dir)))
+    got = updater._mm_tower_named_tensors()
+    assert sorted(name for name, _ in got) == [
+        "model.visual.blocks.0.attn.proj.weight",
+        "model.visual.merger.ln_q.weight",
+    ]
+    for name, tensor in got:
+        assert torch.equal(tensor, tensors[name])
+    (ckpt_dir / "model.safetensors.index.json").unlink()
+    assert updater._mm_tower_named_tensors() is got
+
+
+def test_two_towers(checkpoint):
+    ckpt_dir, _ = checkpoint
+    got = _updater(_args(mm_tower_sync=["visual", "audio"], hf_checkpoint=str(ckpt_dir)))._mm_tower_named_tensors()
+    assert sorted(name for name, _ in got) == [
+        "audio.encoder.weight",
+        "model.visual.blocks.0.attn.proj.weight",
+        "model.visual.merger.ln_q.weight",
+    ]
+
+
+def test_ranks_outside_the_ipc_gather_group_contribute_nothing(checkpoint):
+    ckpt_dir, _ = checkpoint
+    assert (
+        _updater(
+            _args(mm_tower_sync=["visual"], hf_checkpoint=str(ckpt_dir)), gather_group=None
+        )._mm_tower_named_tensors()
+        == []
+    )

--- a/tests/fast/ray/rollout/conftest.py
+++ b/tests/fast/ray/rollout/conftest.py
@@ -92,6 +92,7 @@ def make_args(**overrides: Any) -> Namespace:
         rollout_external_engine_addrs=None,
         # offload / fault tolerance
         offload_rollout=False,
+        offload_rollout_level=["kv_cache", "weight"],
         use_fault_tolerance=False,
         rollout_health_check_interval=10.0,
         rollout_health_check_timeout=30.0,

--- a/tests/fast/ray/rollout/test_rollout_manager_offload.py
+++ b/tests/fast/ray/rollout/test_rollout_manager_offload.py
@@ -1,0 +1,57 @@
+from unittest.mock import AsyncMock
+
+import pytest
+from sglang.srt.constants import GPU_MEMORY_TYPE_CUDA_GRAPH, GPU_MEMORY_TYPE_KV_CACHE, GPU_MEMORY_TYPE_WEIGHTS
+
+from miles.ray.rollout.rollout_manager import RolloutManager, _get_rollout_offload_tags
+
+
+@pytest.mark.parametrize(
+    ("levels", "expected"),
+    [
+        (["kv_cache"], (GPU_MEMORY_TYPE_CUDA_GRAPH, GPU_MEMORY_TYPE_KV_CACHE)),
+        (["weight"], (GPU_MEMORY_TYPE_CUDA_GRAPH, GPU_MEMORY_TYPE_WEIGHTS)),
+        (
+            ["kv_cache", "weight"],
+            (
+                GPU_MEMORY_TYPE_CUDA_GRAPH,
+                GPU_MEMORY_TYPE_KV_CACHE,
+                GPU_MEMORY_TYPE_WEIGHTS,
+            ),
+        ),
+    ],
+)
+def test_get_rollout_offload_tags(levels, expected):
+    assert _get_rollout_offload_tags(levels) == expected
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("levels", "weight_tags", "inference_tags"),
+    [
+        (
+            ["kv_cache"],
+            None,
+            [GPU_MEMORY_TYPE_KV_CACHE, GPU_MEMORY_TYPE_CUDA_GRAPH],
+        ),
+        (
+            ["weight"],
+            [GPU_MEMORY_TYPE_WEIGHTS],
+            [GPU_MEMORY_TYPE_CUDA_GRAPH],
+        ),
+    ],
+)
+async def test_onload_only_restores_configured_allocations(levels, weight_tags, inference_tags):
+    manager = object.__new__(RolloutManager.__ray_actor_class__)
+    manager._offload_tags = _get_rollout_offload_tags(levels)
+    manager.onload = AsyncMock()
+
+    await manager.onload_weights()
+    if weight_tags is None:
+        manager.onload.assert_not_awaited()
+    else:
+        manager.onload.assert_awaited_once_with(tags=weight_tags)
+
+    manager.onload.reset_mock()
+    await manager.onload_kv()
+    manager.onload.assert_awaited_once_with(tags=inference_tags)


### PR DESCRIPTION
## Purpose

Let a vision-language model on the GLM-5.3 branch release its engine weights during training. Two commits, both already open against `main` or this branch in other PRs; this PR puts them together on `zhichen/glm53-flash` because that branch is the only one with the GLM-5.3 architecture, and downstream images are built from it.

## Commits

1. **Honour `--offload-rollout-level` in RolloutManager.** Taken unchanged from #2792 (commit 6c0d6d272, files `rollout_manager.py`, its test, `tests/fast/ray/rollout/conftest.py`). Without it `offload(tags=None)` at startup releases the weights regardless of the flag, and `onload_weights` resumes memory that was never paused. Drop this commit if #2792 merges first.
2. **`--mm-tower-sync TOWER...`.** Backport of #3159 to this branch, where the tower re-send lives in `update_weight_from_tensor.py` (main moved it to `hf_weight_iterator.py` in #2754). The re-send of frozen vision/audio towers from the HF checkpoint was gated on the provider path containing `inkling_mm_model_provider`; the flag names the towers instead. Off by default; the Inkling MM provider still implies `visual audio`, with a one-time warning.

## Why

With the gate, a GLM-5.3-Flash or Qwen3.5-VL run that trains only its language model cannot release engine weights: a released engine comes back with the tower unrestored. The workaround, `--offload-rollout-level kv_cache`, keeps 87 GB per GPU of engine weights resident on GLM-5.3-Flash (6 nodes, 267 GB B300s) through the log-prob and train passes, and the log-prob pass OOMs. With `--mm-tower-sync visual` the trainer re-sends the 347 tower tensors (1.13 GB) after the language weights on every update and the engines use the default offload level.

## Tests

`tests/fast/backends/megatron_utils/test_mm_tower_sync.py` (new) and `tests/fast/ray/rollout/test_rollout_manager_offload.py` (from #2792). Run inside the `glm53next` image together with the update-weight and argument suites: 186 passed.
