### PR TITLE
ci: Skip the actor forward-only pass in the Megatron FSDP-align test

### DIFF
--- a/tests/e2e/fsdp/test_qwen3_0.6B_megatron_fsdp_align.py
+++ b/tests/e2e/fsdp/test_qwen3_0.6B_megatron_fsdp_align.py
@@ -141,6 +141,7 @@ def execute():
                 "--train-memory-margin-bytes 3221225472 "
                 f"--load-debug-rollout-data {debug_data_path} "
                 f"--ci-load-grad-norm {grad_norm_path} "
+                "--skip-actor-forward-only "
                 "--attention-dropout 0.0 "
                 "--hidden-dropout 0.0 "
                 "--accumulate-allreduce-grads-in-fp32 "


### PR DESCRIPTION
Co-authored with: @XinyuJiangCMU

## What

Add `--skip-actor-forward-only` to the Megatron run in `tests/e2e/fsdp/test_qwen3_0.6B_megatron_fsdp_align.py`.

## Why

This test uses one optimizer step per rollout, so the standalone forward-only pass computes the same log-probs again with the same weights before the training forward.

On MI355X, the two passes can produce small numerical differences because Megatron's fused cross entropy is compiled separately for no-grad and training, with `TORCHINDUCTOR_MAX_AUTOTUNE=1`. This causes step-0 `train/ppo_kl` noise around `1e-9` to `2e-8`, which can fail the `1e-9` CI threshold.

With `--skip-actor-forward-only`, the old-policy log-probs are taken directly from the training forward, so `train/ppo_kl = 0` by construction.

The FSDP runs are unchanged, and the FSDP-vs-Megatron grad-norm comparison still runs as before.

## Verification

MI355X, `rocm/sgl-dev:miles-rocm720-mi35x-20260829`:
- Full test with the flag: all 3 jobs passed; `train/ppo_kl = 0.0`, `train/pg_clipfrac = 0.0`, grad-norm check passed.
- Replayed the same Megatron rollout 3 times with a cold Inductor cache:
    - without the flag: 3/3 failed the KL check (`1.3e-9, -1.8e-9, -2.3e-9`)
    - with the flag: 3/3 passed with `train/ppo_kl = 0.0`

## Notes
Replaces #3081, which disabled Inductor max-autotune for ROCm training actors.