### PR TITLE
docs(tito): explain abnormal Qwen3 endoftext output

### DIFF
--- a/miles/utils/chat_template_utils/tito_tokenizer.py
+++ b/miles/utils/chat_template_utils/tito_tokenizer.py
@@ -310,6 +310,9 @@ class Qwen3TITOTokenizer(TITOTokenizer):
     ) -> list[int]:
         incremental = self.tokenize_additional_messages(old_messages, new_messages, tools)
         prefix = list(pretokenized_token_ids)
+        # Weakly post-trained Qwen3 models, notably 0.6B, may emit the pretraining/padding token `<|endoftext|>`.
+        # Seen in TITO's March 2026 bring-up; rare in larger models. See https://github.com/radixark/miles/issues/3113.
+        # This is model degeneration, not a valid `<|im_end|>` alias; keep the strict checker reporting it.
         if prefix and prefix[-1] == self._im_end_id:
             prefix.append(self._newline_id)
         return prefix + incremental


### PR DESCRIPTION
## Summary
Document why abnormal Qwen3 `<|endoftext|>` output must remain visible to the strict checker.

## Motivation
[Issue #3113](https://github.com/radixark/miles/issues/3113) proposed accepting Qwen3-0.6B's output as an EOS alias. Jiajun encountered this during TITO's March 2026 bring-up: weakly post-trained small models can emit the pretraining/padding token, and larger models can still do so rarely. Keep this context beside the boundary handling to explain why the strict check matters.

## Before / After
- **Before / After:** The code explained newline handling only; three comment lines now record the abnormal output, its history, and the reason to retain strict reporting.
- **What moved where:** No code moved; the context sits beside Qwen3's EOS check in `merge_tokens`.

## Behavior Preservation
- Python AST comparison against the parent commit: identical. Token handling and checker behavior are unchanged.

## Verification
- `git diff --check`: passed.
- Python 3.12 AST comparison: passed; exactly three comment lines added. No GPU run for this comment-only change.

## Review Focus
- `Qwen3TITOTokenizer.merge_tokens`: abnormal model output must not be mistaken for a valid `<|im_end|>` alias.
