### PR TITLE
fix(ci): keep the Nemotron-H plugin importable without megatron.bridge

### DIFF
--- a/miles_plugins/megatron_bridge/nemotron_h.py
+++ b/miles_plugins/megatron_bridge/nemotron_h.py
@@ -24,7 +24,6 @@ from __future__ import annotations
 import logging
 
 import torch
-from megatron.bridge.models.conversion.param_mapping import MambaConv1dMapping
 
 logger = logging.getLogger(__name__)
 
@@ -63,7 +62,7 @@ def _build_bridge_subclass():
     """
     from megatron.bridge.models.conversion.mapping_registry import MegatronMappingRegistry
     from megatron.bridge.models.conversion.model_bridge import MegatronModelBridge
-    from megatron.bridge.models.conversion.param_mapping import AutoMapping
+    from megatron.bridge.models.conversion.param_mapping import AutoMapping, MambaConv1dMapping
     from megatron.bridge.models.nemotronh.nemotron_h_bridge import NemotronHBridge
     from megatron.core.models.mamba import MambaModel
 


### PR DESCRIPTION
CPU CI is red on main. `stage-a-cpu` fails with:

```
FAILED tests/fast/backends/megatron_utils/test_nemotron_h_forward.py::test_forward_without_mtp_keyword[None]
  ModuleNotFoundError: No module named 'megatron.bridge'
miles_plugins/megatron_bridge/nemotron_h.py:27: ModuleNotFoundError
```

## How it got there

Two PRs merged fifteen seconds apart, each green on its own:

- **#3164** (21:42:53) added `test_nemotron_h_forward.py`, which loads `miles_plugins/megatron_bridge/nemotron_h.py` directly with `spec.loader.exec_module`.
- **#3163** (21:43:08) added `from megatron.bridge.models.conversion.param_mapping import MambaConv1dMapping` at module scope of that same file.

Neither CI run could see the other's half. `megatron.bridge` is not in the CPU image, so together they break the import.

The file already documents the invariant that was broken, in `_build_bridge_subclass`:

> Build the `MilesNemotronHBridge` class lazily so importing this module does not force `megatron.bridge.models.nemotronh` to load until first use.

Every other `megatron.bridge` import in the file sits inside that function for exactly this reason.

## Blast radius

The CPU suite runs `pytest ... -v -x`, so this is not one red test — the shard aborts at the first failure and everything ordered after it never runs. The run that surfaced this reported `1 failed, 1014 passed` and stopped there. Any PR whose shard contains this test is red, and the tests behind it are silently unrun.

## The change

One line. `MambaConv1dMapping` moves next to `AutoMapping`, which comes from the same module and is used in the same method, so it is a closure variable by the time `mapping_registry()` runs.

## Verification

Both Nemotron-H test files, on a CPU box without `megatron.bridge`:

| | result |
|---|---|
| before | 4 failed, 6 passed |
| after | 10 passed |

`test_nemotron_h_conv_mapping.py` — the test #3163 added for the mapping this import provides — passes either way, so the fix does not undo what that PR set out to do.