### PR TITLE
feat(weight-update): broadcast EP-local expert weights

### DIFF
--- a/miles/backends/megatron_utils/update_weight/hf_weight_iterator_direct.py
+++ b/miles/backends/megatron_utils/update_weight/hf_weight_iterator_direct.py
@@ -1,3 +1,5 @@
+import dataclasses
+import re
 from argparse import Namespace
 from collections.abc import Sequence
 
@@ -20,18 +22,22 @@ from ..sglang import monkey_patch_torch_reductions
 
 
 class HfWeightIteratorDirect(MegatronHfWeightIteratorBase):
-    # Lower bound: TP/ETP/EP are always gathered; PP follows the requirement.
-    forced_placement = WeightUpdatePlacement(gather_pp=False)
+    # TP/ETP stay gathered; raw per-expert exports may retain PP and EP shards.
+    forced_placement = WeightUpdatePlacement(gather_pp=False, gather_ep=False)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         non_expert_infos, expert_infos = _get_megatron_local_param_infos(
             self.args, self.model, gather_pp=self.placement.gather_pp
         )
+        if not self.placement.gather_ep and not _can_keep_ep_sharded(
+            self.model_name, self.quantization_config, expert_infos
+        ):
+            self.placement = dataclasses.replace(self.placement, gather_ep=True)
         ep_size = get_parallel_state().ep.size
         self._non_expert_batches = _pack_param_infos_by_size(self.args, non_expert_infos)
-        # An expert batch materializes ep_size x its metadata size after the EP all_gather.
-        self._expert_batches = _pack_param_infos_by_size(self.args, expert_infos, size_multiplier=ep_size)
+        size_multiplier = ep_size if self.placement.gather_ep else 1
+        self._expert_batches = _pack_param_infos_by_size(self.args, expert_infos, size_multiplier=size_multiplier)
 
     def _iter_hf_param_units(self, weights, *, materialize):
         rank = dist.get_rank()
@@ -51,7 +57,11 @@ class HfWeightIteratorDirect(MegatronHfWeightIteratorBase):
             pbar.update(1)
         for param_infos in self._expert_batches:
             named_params = _materialize_expert_batch(
-                self.args, param_infos, weights, gather_pp=self.placement.gather_pp
+                self.args,
+                param_infos,
+                weights,
+                gather_pp=self.placement.gather_pp,
+                gather_ep=self.placement.gather_ep,
             )
             if materialize:
                 yield from self._convert_to_hf_param_units(named_params)
@@ -130,11 +140,12 @@ def _materialize_expert_batch(
     megatron_local_weights,
     *,
     gather_pp: bool,
+    gather_ep: bool,
 ) -> list[tuple[str, torch.Tensor]]:
-    """Load -> PP broadcast (when gather_pp) -> ETP all_gather -> EP all_gather.
+    """Load -> optional PP broadcast -> ETP gather -> optional EP gather.
 
-    Expert metadata is EP-local; the full expert set is materialized by a
-    symmetric EP all_gather with a name exchange.
+    Expert metadata is EP-local. ``gather_ep`` adds the symmetric name and
+    tensor all-gathers that materialize the full expert set on every EP rank.
     """
     monkey_patch_torch_reductions()
     params = _load_or_allocate_params(param_infos, megatron_local_weights)
@@ -144,7 +155,7 @@ def _materialize_expert_batch(
     etp_gathered = all_gather_params_async(args, list(zip(param_infos, params, strict=True)))
 
     ep = get_parallel_state().ep
-    if ep.size == 1:
+    if not gather_ep or ep.size == 1:
         return [(info.name, param) for info, param in zip(param_infos, etp_gathered, strict=True)]
 
     names = [info.name for info in param_infos]
@@ -166,6 +177,36 @@ def _materialize_expert_batch(
         handle.wait()
 
     return [named for per_rank in all_gathered for named in per_rank]
+
+
+_INDIVIDUAL_EXPERT_WEIGHT = re.compile(
+    r"^module\.module\.decoder\.layers\.\d+\.mlp\.experts\.linear_fc[12]\.weight\d+$"
+)
+
+
+def _can_keep_ep_sharded(
+    model_name: str,
+    quantization_config: dict | None,
+    expert_infos: Sequence[ParamInfo],
+) -> bool:
+    """Whether every rank can export its EP-local experts independently.
+
+    The first supported slice is unquantized BF16 Qwen3-MoE with one globally
+    numbered Megatron parameter per expert. Fused all-expert exports retain the
+    existing EP gather.
+    """
+    if "qwen3moe" not in model_name.lower() or quantization_config is not None or get_parallel_state().ep.size <= 1:
+        return False
+
+    local_has_experts = bool(expert_infos)
+    local_supported = all(
+        info.dtype == torch.bfloat16 and _INDIVIDUAL_EXPERT_WEIGHT.search(info.name) is not None
+        for info in expert_infos
+    )
+    group = get_gloo_group()
+    all_capabilities: list = [None] * dist.get_world_size(group=group)
+    dist.all_gather_object(all_capabilities, (local_has_experts, local_supported), group=group)
+    return all(has_experts and supported for has_experts, supported in all_capabilities)
 
 
 def _pack_param_infos_by_size(

--- a/miles/backends/training_utils/weight_update/hf_weight_iterator/__init__.py
+++ b/miles/backends/training_utils/weight_update/hf_weight_iterator/__init__.py
@@ -4,7 +4,7 @@ import dataclasses
 import itertools
 from abc import ABC, abstractmethod
 from argparse import Namespace
-from collections.abc import Iterator, Mapping, Sequence
+from collections.abc import Callable, Iterator, Mapping, Sequence
 from typing import ClassVar
 
 import torch
@@ -26,8 +26,9 @@ class WeightUpdatePlacement:
     """
 
     gather_pp: bool
-    # Always gathered today; explicit so a future protocol can relax them.
+    # TP also governs ETP reconstruction; current iterators always gather it.
     gather_tp: bool = True
+    # Capable iterator/protocol pairs may retain EP-local parameter sets.
     gather_ep: bool = True
 
 
@@ -78,6 +79,7 @@ class HfWeightIteratorBase(ABC):
         include_base: bool = True,
         adapters: Sequence[tuple[str, object]] = (),
         materialize: bool = True,
+        unit_filter: Callable[[list[tuple[str, torch.Tensor]]], bool] | None = None,
     ) -> Iterator[list[tuple[str, torch.Tensor]]]:
         """Model weights as size-bounded buckets of HF-named GPU tensors;
         atomic update groups are never split across buckets.
@@ -86,6 +88,7 @@ class HfWeightIteratorBase(ABC):
         model parameters. ``adapters``: ``(lora_name, adapter_or_None)`` pairs
         whose tensors join the stream under ``{lora_name}:{hf_key}`` names.
         ``materialize=False`` joins every collective but yields nothing.
+        ``unit_filter`` runs after atomic groups are complete and before packing.
         """
         hf_param_units = self._iter_hf_param_units(weights, materialize=materialize) if include_base else iter(())
         for lora_name, adapter in adapters:
@@ -94,6 +97,8 @@ class HfWeightIteratorBase(ABC):
             )
         atomic_update_groups = self._hf_atomic_update_groups() if include_base and materialize else []
         hf_param_units = assemble_atomic_update_groups(hf_param_units, atomic_update_groups)
+        if unit_filter is not None:
+            hf_param_units = (unit for unit in hf_param_units if unit_filter(unit))
         yield from pack_units_by_size(hf_param_units, self.args.update_weight_buffer_size)
 
     @abstractmethod

--- a/miles/backends/training_utils/weight_update/protocol.py
+++ b/miles/backends/training_utils/weight_update/protocol.py
@@ -15,10 +15,10 @@ from miles.backends.training_utils.weight_update.hf_weight_iterator import Weigh
 class WeightTransferProtocol(ABC):
     """Moves HF-named weight buckets from training ranks to rollout engines.
 
-    ``connect`` makes every pairing decision once: it sets ``is_sender`` and
-    whatever send channels the protocol needs. The updater then drives
-    ``send_bucket`` on sender ranks only; streamed adapter tensors are ordinary
-    bucket entries (``{lora_name}:{hf_key}`` names).
+    ``configure`` resolves topology-dependent sender state collectively, then
+    ``connect`` creates the channels for the current engine set. The updater
+    drives ``send_bucket`` on sender ranks only; streamed adapter tensors are
+    ordinary bucket entries (``{lora_name}:{hf_key}`` names).
     """
 
     required_placement: ClassVar[WeightUpdatePlacement] = WeightUpdatePlacement(gather_pp=False)
@@ -32,6 +32,9 @@ class WeightTransferProtocol(ABC):
         self.is_sender: bool | None = None
         self.group_name = "miles"
         self.update_weight_metrics: dict[str, float] = {}
+
+    def configure(self, parallel_state: ParallelState, placement: WeightUpdatePlacement) -> None:  # noqa: B027
+        """Collectively configure topology-dependent protocol state."""
 
     @abstractmethod
     def connect(
@@ -51,6 +54,10 @@ class WeightTransferProtocol(ABC):
     ) -> bool:
         """Hook before the session frame; return False to skip this round.
         The return value must be identical on every rank."""
+        return True
+
+    def should_send_weight_unit(self, _unit: list[tuple[str, torch.Tensor]]) -> bool:
+        """Whether this sender owns an assembled HF update unit."""
         return True
 
     @abstractmethod

--- a/miles/backends/training_utils/weight_update/protocols/broadcast.py
+++ b/miles/backends/training_utils/weight_update/protocols/broadcast.py
@@ -1,3 +1,4 @@
+import re
 import socket
 from argparse import Namespace
 from collections.abc import Sequence
@@ -9,35 +10,65 @@ import torch
 import torch.distributed as dist
 
 from miles.backends.sglang_utils.sglang_api_client import SGLangApiClient
-from miles.backends.training_utils.parallel import ParallelState, get_parallel_state
+from miles.backends.training_utils.parallel import ParallelState
 from miles.backends.training_utils.weight_update.hf_weight_iterator import WeightUpdatePlacement
 from miles.backends.training_utils.weight_update.protocol import WeightTransferProtocol
-from miles.backends.training_utils.weight_update.utils import get_data_replica_rank_and_size
 from miles.utils import async_utils
 from miles.utils.distributed_lock import create_world_ticket_lock
-from miles.utils.distributed_utils import init_process_group
+from miles.utils.distributed_utils import get_gloo_group, init_process_group
+
+_GLOBAL_EXPERT_HF_NAME = re.compile(r"(?:^|\.)experts\.\d+\.")
 
 
 class UpdateWeightFromDistributed(WeightTransferProtocol):
     """
-    Update distributed engines via NCCL. Each PP rank: group "miles-pp_{pp_rank}",
-    only DP=TP=0 broadcasts. Non-expert (TP) and expert (EP) params separate.
+    Update distributed engines via NCCL from one sender per retained PP/EP shard.
+    One sender per PP shard also owns its dense, router and shared-expert weights.
     """
 
     supports_lora = True
+    required_placement = WeightUpdatePlacement(gather_pp=False, gather_ep=False)
 
     def __init__(self, args: Namespace) -> None:
         super().__init__(args)
         self._model_update_groups = None
-        parallel_state = get_parallel_state()
-        self._engine_lock: AbstractContextManager = (
-            create_world_ticket_lock(
-                prefix="miles/weight_update",
-                participates=parallel_state.intra_dp_cp.rank == 0 and parallel_state.tp.rank == 0,
-            )
-            if parallel_state.pp.size > 1
-            else nullcontext()
+        self._engine_lock: AbstractContextManager = nullcontext()
+        self._placement: WeightUpdatePlacement | None = None
+        self._sends_dense = False
+
+    def configure(self, parallel_state: ParallelState, placement: WeightUpdatePlacement) -> None:
+        """Select one sender per retained PP/EP shard and build their shared lock."""
+        assert self._placement is None, "broadcast protocol topology is already configured"
+        assert placement.gather_tp, "distributed broadcast requires gathered TP/ETP weights"
+
+        pp_shard = 0 if placement.gather_pp else parallel_state.pp.rank
+        ep_shard = 0 if placement.gather_ep else parallel_state.ep.rank
+        group = get_gloo_group()
+        local_coordinate = (dist.get_rank(), pp_shard, ep_shard)
+        all_coordinates: list = [None] * dist.get_world_size(group=group)
+        dist.all_gather_object(all_coordinates, local_coordinate, group=group)
+
+        sender_by_shard: dict[tuple[int, int], int] = {}
+        for rank, rank_pp_shard, rank_ep_shard in all_coordinates:
+            shard = (rank_pp_shard, rank_ep_shard)
+            sender_by_shard[shard] = min(rank, sender_by_shard.get(shard, rank))
+
+        rank = dist.get_rank()
+        sender_rank = sender_by_shard[(pp_shard, ep_shard)]
+        dense_sender_rank = min(
+            candidate_rank
+            for (candidate_pp_shard, _candidate_ep_shard), candidate_rank in sender_by_shard.items()
+            if candidate_pp_shard == pp_shard
         )
+        self.is_sender = rank == sender_rank
+        self._sends_dense = rank == dense_sender_rank
+        self.group_name = f"miles-pp_{pp_shard}" if placement.gather_ep else f"miles-pp_{pp_shard}-ep_{ep_shard}"
+        if len(sender_by_shard) > 1:
+            self._engine_lock = create_world_ticket_lock(
+                prefix="miles/weight_update",
+                participates=self.is_sender,
+            )
+        self._placement = placement
 
     def connect(
         self,
@@ -48,25 +79,34 @@ class UpdateWeightFromDistributed(WeightTransferProtocol):
         placement: WeightUpdatePlacement,
         selector: str,
     ) -> None:
-        """
-        Create NCCL "miles-pp_{pp_rank}" if PP source (DP=TP=0). Lock prevents concurrent broadcasts.
-        """
+        """Create this sender's NCCL group under the shared engine lock."""
+        assert self._placement == placement, "connect placement differs from configured broadcast topology"
+        assert self.is_sender is not None, "configure() must set is_sender before connect()"
         self.rollout_engines = rollout_engines
         self._selector = selector
         self._engine_gpu_counts = engine_gpu_counts
 
-        # One sender per replica set; one NCCL group (sender + all engines) per shard.
-        replica_rank, _ = get_data_replica_rank_and_size(parallel_state, placement)
-        self.is_sender = replica_rank == 0
-        shard = 0 if placement.gather_pp else parallel_state.pp.rank
         if self.is_sender:
-            self.group_name = f"miles-pp_{shard}"
-            disconnect_rollout_engines_from_distributed(
-                self.args, self.group_name, self._model_update_groups, self.rollout_engines
-            )
-            self._model_update_groups = connect_rollout_engines_from_distributed(
-                self.args, self.group_name, rollout_engines
-            )
+            with self._engine_lock:
+                disconnect_rollout_engines_from_distributed(
+                    self.args, self.group_name, self._model_update_groups, self.rollout_engines
+                )
+                self._model_update_groups = connect_rollout_engines_from_distributed(
+                    self.args,
+                    self.group_name,
+                    rollout_engines,
+                    engine_gpu_counts=engine_gpu_counts,
+                )
+
+    def should_send_weight_unit(self, unit: list[tuple[str, torch.Tensor]]) -> bool:
+        """Dense owner sends its full PP slice; other EP owners send routed experts only."""
+        if self._sends_dense:
+            return True
+        routed = [_GLOBAL_EXPERT_HF_NAME.search(name) is not None for name, _tensor in unit]
+        assert routed and (
+            all(routed) or not any(routed)
+        ), f"Weight update unit mixes routed-expert and dense tensors: {[name for name, _tensor in unit]}"
+        return all(routed)
 
     def send_bucket(self, bucket: list[tuple[str, torch.Tensor]]) -> None:
         """Lock → broadcast → clear → unlock. Lock prevents NCCL deadlock."""

--- a/miles/backends/training_utils/weight_update/updater.py
+++ b/miles/backends/training_utils/weight_update/updater.py
@@ -63,6 +63,12 @@ class WeightUpdater:
             model_name=model_name,
             quantization_config=quantization_config,
         )
+        if getattr(args, "ci_require_ep_local_weight_update", False):
+            assert not self._hf_weight_iterator.placement.gather_ep, (
+                "--ci-require-ep-local-weight-update expected the resolved weight iterator "
+                "placement to have gather_ep=False"
+            )
+        self.protocol.configure(self.parallel_state, self._hf_weight_iterator.placement)
         self.weights_getter = weights_getter
         self.weight_version = 0
         self.is_lora = is_lora
@@ -126,6 +132,7 @@ class WeightUpdater:
                 include_base=sync_base,
                 adapters=adapters,
                 materialize=protocol.is_sender,
+                unit_filter=protocol.should_send_weight_unit,
             ):
                 if protocol.is_sender:
                     if driver and checksums is not None:

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -2535,6 +2535,11 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 action="store_true",
             )
             parser.add_argument(
+                "--ci-require-ep-local-weight-update",
+                action="store_true",
+                help="Fail unless the selected weight iterator keeps routed experts EP-local.",
+            )
+            parser.add_argument(
                 "--ci-metric-checker-key",
                 type=str,
                 default=None,
@@ -2925,6 +2930,10 @@ def miles_validate_args(args):
             if hasattr(args, k):
                 logger.info(f"Warning: Argument {k} is already set to {getattr(args, k)}, will override with {v}.")
             setattr(args, k, v)
+
+    assert (
+        not getattr(args, "ci_require_ep_local_weight_update", False) or args.ci_test
+    ), "--ci-require-ep-local-weight-update requires --ci-test"
 
     validate_dashboard_args(args)
 

--- a/tests/e2e/megatron/test_qwen3_30B_A3B/_common.py
+++ b/tests/e2e/megatron/test_qwen3_30B_A3B/_common.py
@@ -17,6 +17,7 @@ class CaseConfig:
     tp_size: int
     ep_size: int
     rollout_num_gpus_per_engine: int
+    etp_size: int = 1
     sglang_ep_size: int = None
     sglang_dp_size: int = None
     sglang_enable_dp_attention: bool = False
@@ -39,10 +40,15 @@ class CaseConfig:
         # Validation only — topology values are passed explicitly, not inferred.
         if self.fully_async and self.colocate:
             raise ValueError("fully_async requires colocate=False: train_async.py rejects colocation")
-        if self.num_gpus_per_node % (self.cp_size * self.pp_size) != 0:
+        if self.num_gpus_per_node % (self.tp_size * self.cp_size * self.pp_size) != 0:
             raise ValueError(
-                "num_gpus_per_node must be divisible by cp_size * pp_size: "
-                f"{self.num_gpus_per_node=} {self.cp_size=} {self.pp_size=}"
+                "num_gpus_per_node must be divisible by tp_size * cp_size * pp_size: "
+                f"{self.num_gpus_per_node=} {self.tp_size=} {self.cp_size=} {self.pp_size=}"
+            )
+        if self.num_gpus_per_node % (self.etp_size * self.ep_size * self.pp_size) != 0:
+            raise ValueError(
+                "num_gpus_per_node must be divisible by etp_size * ep_size * pp_size: "
+                f"{self.num_gpus_per_node=} {self.etp_size=} {self.ep_size=} {self.pp_size=}"
             )
         if not self.colocate and self.rollout_num_gpus is None:
             raise ValueError("rollout_num_gpus must be set when colocate is False")
@@ -134,7 +140,7 @@ def build_train_args(case: CaseConfig, *, wandb_file: str) -> str:
         f"--pipeline-model-parallel-size {case.pp_size} "
         f"--context-parallel-size {case.cp_size} "
         f"--expert-model-parallel-size {case.ep_size} "
-        "--expert-tensor-parallel-size 1 "
+        f"--expert-tensor-parallel-size {case.etp_size} "
         "--recompute-granularity full "
         "--recompute-method uniform "
         "--recompute-num-layers 1 "

--- a/tests/e2e/megatron/test_qwen3_30B_A3B/test_disagg_broadcast_etp.py
+++ b/tests/e2e/megatron/test_qwen3_30B_A3B/test_disagg_broadcast_etp.py
@@ -1,0 +1,42 @@
+import os
+
+from tests.ci.ci_register import register_cuda_ci, register_rocm_ci
+from tests.ci.metric_history import register_ci_gate
+from tests.e2e.megatron.test_qwen3_30B_A3B._common import CaseConfig, execute, prepare
+
+register_cuda_ci(est_time=1300, suite="stage-c-8-gpu-h200", labels=["megatron", "weight-update"])
+register_rocm_ci(est_time=900, suite="nightly-stage-c-8-gpu-mi350", labels=["megatron", "weight-update"])
+
+register_ci_gate(metric_key="train/grad_norm")
+register_ci_gate(metric_key="train/ppo_kl")
+register_ci_gate(metric_key="train/train_rollout_logprob_abs_diff")
+register_ci_gate(metric_key="train/train_rollout_kl")
+register_ci_gate(metric_key="rollout/raw_reward")
+
+# TP4 and ETP2 form different groups, so this case catches expert weights
+# gathered over the regular TP group before the EP-local broadcast.
+CASE = CaseConfig(
+    use_deepep=False,
+    use_fp8_rollout=False,
+    use_int4_rollout=False,
+    use_bridge=False,
+    use_r3=False,
+    num_gpus_per_node=4,
+    cp_size=1,
+    pp_size=1,
+    tp_size=4,
+    ep_size=2,
+    etp_size=2,
+    colocate=False,
+    rollout_num_gpus=2,
+    rollout_num_gpus_per_engine=2,
+    update_weight_transfer_mode="broadcast",
+    extra_args="--ci-require-ep-local-weight-update ",
+)
+
+
+if __name__ == "__main__":
+    for proxy_var in ("http_proxy", "https_proxy", "HTTP_PROXY", "HTTPS_PROXY"):
+        os.environ.pop(proxy_var, None)
+    prepare(CASE, need_fp8=CASE.use_fp8_rollout, need_int4=CASE.use_int4_rollout, all_bridge=CASE.use_bridge)
+    execute(CASE, wandb_file=__file__)

--- a/tests/fast/backends/megatron_utils/test_hf_weight_iterator_direct.py
+++ b/tests/fast/backends/megatron_utils/test_hf_weight_iterator_direct.py
@@ -1,6 +1,7 @@
 import sys
 import types
 from argparse import Namespace
+from types import SimpleNamespace
 
 from tests.ci.ci_register import register_cpu_ci
 
@@ -9,6 +10,7 @@ register_cpu_ci(est_time=60, suite="stage-a-cpu", labels=[])
 import pytest
 import torch
 
+from miles.backends.training_utils.weight_update.hf_weight_iterator import WeightUpdatePlacement
 from miles.utils.types import ParamInfo
 
 
@@ -56,10 +58,12 @@ def _install_import_stubs(monkeypatch):
     for name in [
         "megatron",
         "megatron.core",
+        "megatron.core.utils",
         "megatron.core.transformer",
         "megatron.core.transformer.transformer_layer",
     ]:
         monkeypatch.setitem(sys.modules, name, types.ModuleType(name))
+    sys.modules["megatron.core.utils"].unwrap_model = lambda model: model
     sys.modules["megatron.core.transformer.transformer_layer"].get_transformer_layer_offset = lambda *args: 0
 
 
@@ -91,15 +95,75 @@ def direct_module(monkeypatch):
             sys.modules[name] = module
 
 
-def _param(name: str, size: int) -> ParamInfo:
+def _param(name: str, size: int, *, dtype=torch.float32) -> ParamInfo:
     return ParamInfo(
         name=name,
-        dtype=torch.float32,
+        dtype=dtype,
         shape=torch.Size([size]),
         attrs={},
         size=size,
         src_rank=0,
     )
+
+
+def _make_direct_iterator(
+    direct_module,
+    monkeypatch,
+    *,
+    expert_infos,
+    model_name="qwen3moe",
+    quantization_config=None,
+    placement=None,
+    peer_capabilities=None,
+    ep_size=4,
+):
+    placement = placement or WeightUpdatePlacement(gather_pp=False, gather_ep=False)
+
+    def fake_super_init(self, args, model, *, placement, model_name, quantization_config):
+        self.args = args
+        self.model = model
+        self.placement = placement
+        self.model_name = model_name
+        self.quantization_config = quantization_config
+
+    monkeypatch.setattr(direct_module.MegatronHfWeightIteratorBase, "__init__", fake_super_init)
+    monkeypatch.setattr(
+        direct_module,
+        "_get_megatron_local_param_infos",
+        lambda *args, **kwargs: ([], expert_infos),
+    )
+    monkeypatch.setattr(
+        direct_module,
+        "get_parallel_state",
+        lambda: SimpleNamespace(ep=SimpleNamespace(size=ep_size)),
+    )
+    monkeypatch.setattr(direct_module, "get_gloo_group", lambda: "gloo")
+
+    world_size = len(peer_capabilities) if peer_capabilities is not None else 2
+    monkeypatch.setattr(direct_module.dist, "get_world_size", lambda *args, **kwargs: world_size)
+
+    def fake_all_gather_object(object_list, obj, group=None):
+        assert group == "gloo"
+        object_list[:] = peer_capabilities if peer_capabilities is not None else [obj] * world_size
+
+    monkeypatch.setattr(direct_module.dist, "all_gather_object", fake_all_gather_object)
+
+    expert_batch_multipliers = []
+
+    def fake_pack(_args, infos, *, size_multiplier=1):
+        if infos:
+            expert_batch_multipliers.append(size_multiplier)
+        return [list(infos)] if infos else []
+
+    monkeypatch.setattr(direct_module, "_pack_param_infos_by_size", fake_pack)
+    iterator = direct_module.HfWeightIteratorDirect(
+        Namespace(update_weight_buffer_size=1024),
+        [],
+        placement=placement,
+        model_name=model_name,
+        quantization_config=quantization_config,
+    )
+    return iterator, expert_batch_multipliers
 
 
 def test_gather_batches_pack_by_size_only(direct_module, monkeypatch):
@@ -114,3 +178,153 @@ def test_gather_batches_pack_by_size_only(direct_module, monkeypatch):
         Namespace(update_weight_buffer_size=6), params, size_multiplier=2
     )
     assert [[param.name for param in batch] for batch in batches] == [["layer.a"], ["layer.b"], ["layer.c"]]
+
+
+def test_direct_iterator_can_keep_pp_and_ep_local(direct_module):
+    assert direct_module.HfWeightIteratorDirect.forced_placement == WeightUpdatePlacement(
+        gather_pp=False,
+        gather_ep=False,
+    )
+
+
+def test_individual_bf16_qwen3moe_experts_keep_ep_local_and_pack_local_size(direct_module, monkeypatch):
+    expert = _param(
+        "module.module.decoder.layers.0.mlp.experts.linear_fc1.weight7",
+        8,
+        dtype=torch.bfloat16,
+    )
+
+    iterator, multipliers = _make_direct_iterator(direct_module, monkeypatch, expert_infos=[expert])
+
+    assert iterator.placement.gather_ep is False
+    assert multipliers == [1]
+
+
+@pytest.mark.parametrize(
+    ("model_name", "quantization_config", "expert_name", "dtype"),
+    [
+        ("deepseekv3", None, "module.module.decoder.layers.0.mlp.experts.linear_fc1.weight7", torch.bfloat16),
+        ("qwen3moe", {}, "module.module.decoder.layers.0.mlp.experts.linear_fc1.weight7", torch.bfloat16),
+        ("qwen3moe", None, "module.module.decoder.layers.0.mlp.experts.linear_fc1.weight", torch.bfloat16),
+        ("qwen3moe", None, "module.module.decoder.layers.0.mlp.experts.other.weight7", torch.bfloat16),
+        ("qwen3moe", None, "module.module.decoder.layers.0.mlp.experts.linear_fc1.weight7", torch.float32),
+    ],
+)
+def test_unsupported_expert_export_falls_back_to_ep_gather(
+    direct_module,
+    monkeypatch,
+    model_name,
+    quantization_config,
+    expert_name,
+    dtype,
+):
+    expert = _param(expert_name, 8, dtype=dtype)
+
+    iterator, multipliers = _make_direct_iterator(
+        direct_module,
+        monkeypatch,
+        expert_infos=[expert],
+        model_name=model_name,
+        quantization_config=quantization_config,
+    )
+
+    assert iterator.placement.gather_ep is True
+    assert multipliers == [4]
+
+
+def test_one_unsupported_rank_makes_every_rank_fall_back_to_ep_gather(direct_module, monkeypatch):
+    expert = _param(
+        "module.module.decoder.layers.0.mlp.experts.linear_fc2.weight3",
+        8,
+        dtype=torch.bfloat16,
+    )
+
+    iterator, multipliers = _make_direct_iterator(
+        direct_module,
+        monkeypatch,
+        expert_infos=[expert],
+        peer_capabilities=[(True, True), (True, False)],
+    )
+
+    assert iterator.placement.gather_ep is True
+    assert multipliers == [4]
+
+
+def test_a_rank_without_expert_metadata_makes_every_rank_fall_back_to_ep_gather(direct_module, monkeypatch):
+    expert = _param(
+        "module.module.decoder.layers.0.mlp.experts.linear_fc2.weight3",
+        8,
+        dtype=torch.bfloat16,
+    )
+
+    iterator, multipliers = _make_direct_iterator(
+        direct_module,
+        monkeypatch,
+        expert_infos=[expert],
+        peer_capabilities=[(True, True), (False, True)],
+    )
+
+    assert iterator.placement.gather_ep is True
+    assert multipliers == [4]
+
+
+def test_single_ep_rank_keeps_the_legacy_gathered_placement(direct_module, monkeypatch):
+    expert = _param(
+        "module.module.decoder.layers.0.mlp.experts.linear_fc2.weight0",
+        8,
+        dtype=torch.bfloat16,
+    )
+
+    iterator, multipliers = _make_direct_iterator(
+        direct_module,
+        monkeypatch,
+        expert_infos=[expert],
+        ep_size=1,
+    )
+
+    assert iterator.placement.gather_ep is True
+    assert multipliers == [1]
+
+
+def test_materialize_expert_batch_without_ep_gather_still_gathers_etp(direct_module, monkeypatch):
+    info = _param(
+        "module.module.decoder.layers.0.mlp.experts.linear_fc2.weight3",
+        2,
+        dtype=torch.bfloat16,
+    )
+    local = torch.tensor([1.0, 2.0], dtype=torch.bfloat16)
+    etp_gathered = torch.tensor([1.0, 2.0, 3.0, 4.0], dtype=torch.bfloat16)
+    etp_calls = []
+
+    monkeypatch.setattr(direct_module, "monkey_patch_torch_reductions", lambda: None)
+    monkeypatch.setattr(direct_module, "_load_or_allocate_params", lambda *args: [local])
+    monkeypatch.setattr(direct_module, "_set_tp_attrs", lambda *args: None)
+
+    def fake_gather_etp(args, infos_and_params):
+        etp_calls.append(infos_and_params)
+        return [etp_gathered]
+
+    monkeypatch.setattr(direct_module, "all_gather_params_async", fake_gather_etp)
+    monkeypatch.setattr(
+        direct_module,
+        "get_parallel_state",
+        lambda: SimpleNamespace(ep=SimpleNamespace(size=4, group="ep")),
+    )
+
+    def unexpected_ep_collective(*args, **kwargs):
+        raise AssertionError("EP collectives must not run for an EP-local expert batch")
+
+    monkeypatch.setattr(direct_module.dist, "all_gather_object", unexpected_ep_collective)
+    monkeypatch.setattr(direct_module.dist, "all_gather", unexpected_ep_collective)
+
+    result = direct_module._materialize_expert_batch(
+        Namespace(),
+        [info],
+        {},
+        gather_pp=False,
+        gather_ep=False,
+    )
+
+    assert len(etp_calls) == 1
+    assert [name for name, _tensor in result] == [info.name]
+    assert result[0][1] is etp_gathered

--- a/tests/fast/backends/megatron_utils/test_lora_hf_weight_iterator.py
+++ b/tests/fast/backends/megatron_utils/test_lora_hf_weight_iterator.py
@@ -61,8 +61,9 @@ class TestHfWeightIteratorFactory:
 
         full = WeightUpdatePlacement(gather_pp=True)
         keep_pp = WeightUpdatePlacement(gather_pp=False)
+        keep_pp_ep = WeightUpdatePlacement(gather_pp=False, gather_ep=False)
         assert HfWeightIteratorBridge.forced_placement == full
-        assert HfWeightIteratorDirect.forced_placement == keep_pp
+        assert HfWeightIteratorDirect.forced_placement == keep_pp_ep
 
         captured = {}
 
@@ -74,5 +75,5 @@ class TestHfWeightIteratorFactory:
         assert captured["placement"] == full
 
         with patch.object(HfWeightIteratorDirect, "__init__", _capture_init):
-            self._create("raw", required_placement=keep_pp)
-        assert captured["placement"] == keep_pp
+            self._create("raw", required_placement=keep_pp_ep)
+        assert captured["placement"] == keep_pp_ep

--- a/tests/fast/backends/training_utils/weight_update/test_broadcast_engine_lock.py
+++ b/tests/fast/backends/training_utils/weight_update/test_broadcast_engine_lock.py
@@ -7,6 +7,7 @@ import pytest
 import torch
 from torch.distributed import HashStore
 
+from miles.backends.training_utils.weight_update.hf_weight_iterator import WeightUpdatePlacement
 from miles.backends.training_utils.weight_update.protocols.broadcast import UpdateWeightFromDistributed
 from miles.utils.distributed_lock import StoreTicketLock
 
@@ -16,69 +17,314 @@ _NEXT_KEY = f"{_PREFIX}/next"
 _SERVING_KEY = f"{_PREFIX}/serving"
 
 
-def _build_protocol(
-    *, pp_size: int, pp_rank: int = 0, tp_rank: int = 0, intra_dp_cp_rank: int = 0
-) -> tuple[UpdateWeightFromDistributed, MagicMock]:
-    parallel_state = SimpleNamespace(
-        pp=SimpleNamespace(size=pp_size, rank=pp_rank),
+def _parallel_state(*, pp_rank: int, ep_rank: int, tp_rank: int = 0, etp_rank: int = 0) -> SimpleNamespace:
+    return SimpleNamespace(
+        pp=SimpleNamespace(rank=pp_rank),
+        ep=SimpleNamespace(rank=ep_rank),
         tp=SimpleNamespace(rank=tp_rank),
-        intra_dp_cp=SimpleNamespace(rank=intra_dp_cp_rank),
+        etp=SimpleNamespace(rank=etp_rank),
     )
+
+
+def _configure_protocol(
+    *,
+    global_rank: int,
+    coordinates: list[tuple[int, int]],
+    pp_rank: int,
+    ep_rank: int,
+    placement: WeightUpdatePlacement | None = None,
+    tp_rank: int = 0,
+    etp_rank: int = 0,
+) -> tuple[UpdateWeightFromDistributed, MagicMock]:
+    protocol = UpdateWeightFromDistributed(Namespace())
+    parallel_state = _parallel_state(pp_rank=pp_rank, ep_rank=ep_rank, tp_rank=tp_rank, etp_rank=etp_rank)
+    placement = placement or WeightUpdatePlacement(gather_pp=False, gather_ep=False)
+
+    def all_gather_coordinates(output, value, *, group) -> None:
+        assert value[-2:] == (
+            0 if placement.gather_pp else pp_rank,
+            0 if placement.gather_ep else ep_rank,
+        )
+        output[:] = (
+            [(rank, *coordinate) for rank, coordinate in enumerate(coordinates)] if len(value) == 3 else coordinates
+        )
+
     with (
-        patch(f"{_BROADCAST_MODULE}.get_parallel_state", return_value=parallel_state),
+        patch(f"{_BROADCAST_MODULE}.get_gloo_group", return_value=MagicMock(name="gloo_group")),
+        patch(f"{_BROADCAST_MODULE}.dist.get_rank", return_value=global_rank),
+        patch(f"{_BROADCAST_MODULE}.dist.get_world_size", return_value=len(coordinates)),
+        patch(f"{_BROADCAST_MODULE}.dist.all_gather_object", side_effect=all_gather_coordinates),
         patch(f"{_BROADCAST_MODULE}.create_world_ticket_lock") as create_lock,
     ):
-        protocol = UpdateWeightFromDistributed(Namespace())
+        protocol.configure(parallel_state, placement)
     return protocol, create_lock
 
 
-class TestEngineLockConstruction:
-    def test_a_single_stage_world_builds_no_lock_at_all(self) -> None:
-        """One PP stage means one source, so there is nothing to exclude and no store to host."""
-        protocol, create_lock = _build_protocol(pp_size=1)
+class TestBroadcastTopology:
+    def test_required_placement_retains_pp_and_ep_shards(self) -> None:
+        assert UpdateWeightFromDistributed.required_placement == WeightUpdatePlacement(
+            gather_pp=False, gather_ep=False
+        )
+
+    def test_a_single_sender_builds_no_lock(self) -> None:
+        protocol, create_lock = _configure_protocol(
+            global_rank=0,
+            coordinates=[(0, 0), (0, 0)],
+            pp_rank=0,
+            ep_rank=0,
+        )
 
         create_lock.assert_not_called()
         assert isinstance(protocol._engine_lock, nullcontext)
+        assert protocol.is_sender
+        assert protocol._sends_dense
+        assert protocol.group_name == "miles-pp_0-ep_0"
 
-    @pytest.mark.parametrize(("pp_size", "pp_rank"), [(2, 0), (2, 1), (3, 0), (3, 1), (3, 2)])
-    def test_every_pipelined_source_contends_on_the_shared_lock(self, pp_size: int, pp_rank: int) -> None:
-        """Every PP stage broadcasts its own slice, so every stage must queue, not just the first."""
-        protocol, create_lock = _build_protocol(pp_size=pp_size, pp_rank=pp_rank)
-
-        create_lock.assert_called_once_with(prefix=_PREFIX, participates=True)
-        assert protocol._engine_lock is create_lock.return_value
-
-    @pytest.mark.parametrize(("tp_rank", "intra_dp_cp_rank"), [(1, 0), (0, 1)])
-    def test_a_rank_that_never_broadcasts_joins_the_collective_without_contending(
-        self, tp_rank: int, intra_dp_cp_rank: int
+    @pytest.mark.parametrize(
+        ("global_rank", "pp_rank", "ep_rank", "is_sender", "sends_dense"),
+        [
+            (0, 0, 0, True, True),
+            (1, 0, 0, False, False),
+            (2, 0, 1, True, False),
+            (3, 0, 1, False, False),
+        ],
+    )
+    def test_ep_senders_share_one_world_lock(
+        self,
+        global_rank: int,
+        pp_rank: int,
+        ep_rank: int,
+        is_sender: bool,
+        sends_dense: bool,
     ) -> None:
-        """Non-source ranks must still call in, since building the lock is collective."""
-        _, create_lock = _build_protocol(pp_size=3, tp_rank=tp_rank, intra_dp_cp_rank=intra_dp_cp_rank)
+        protocol, create_lock = _configure_protocol(
+            global_rank=global_rank,
+            coordinates=[(0, 0), (0, 0), (0, 1), (0, 1)],
+            pp_rank=pp_rank,
+            ep_rank=ep_rank,
+        )
 
-        create_lock.assert_called_once_with(prefix=_PREFIX, participates=False)
+        create_lock.assert_called_once_with(prefix=_PREFIX, participates=is_sender)
+        assert protocol._engine_lock is create_lock.return_value
+        assert protocol.is_sender is is_sender
+        assert protocol._sends_dense is sends_dense
+
+    def test_sender_selection_does_not_assume_regular_tp_matches_expert_tp(self) -> None:
+        protocol, create_lock = _configure_protocol(
+            global_rank=2,
+            coordinates=[(0, 0), (0, 0), (0, 1), (0, 1)],
+            pp_rank=0,
+            ep_rank=1,
+            tp_rank=1,
+            etp_rank=0,
+        )
+
+        assert protocol.is_sender
+        assert not protocol._sends_dense
+        assert protocol.group_name == "miles-pp_0-ep_1"
+        create_lock.assert_called_once_with(prefix=_PREFIX, participates=True)
+
+    @pytest.mark.parametrize(
+        ("global_rank", "pp_rank", "ep_rank", "expected_group"),
+        [
+            (0, 0, 0, "miles-pp_0-ep_0"),
+            (1, 0, 1, "miles-pp_0-ep_1"),
+            (2, 1, 0, "miles-pp_1-ep_0"),
+            (3, 1, 1, "miles-pp_1-ep_1"),
+        ],
+    )
+    def test_each_retained_pp_ep_shard_gets_a_unique_group(
+        self, global_rank: int, pp_rank: int, ep_rank: int, expected_group: str
+    ) -> None:
+        protocol, _ = _configure_protocol(
+            global_rank=global_rank,
+            coordinates=[(0, 0), (0, 1), (1, 0), (1, 1)],
+            pp_rank=pp_rank,
+            ep_rank=ep_rank,
+        )
+
+        assert protocol.is_sender
+        assert protocol.group_name == expected_group
+
+    def test_gathered_ep_keeps_the_existing_pp_group_name(self) -> None:
+        protocol, _ = _configure_protocol(
+            global_rank=1,
+            coordinates=[(0, 0), (1, 0)],
+            pp_rank=1,
+            ep_rank=3,
+            placement=WeightUpdatePlacement(gather_pp=False, gather_ep=True),
+        )
+
+        assert protocol.group_name == "miles-pp_1"
+
+
+class TestWeightUnitOwnership:
+    @staticmethod
+    def _unit(*names: str) -> list[tuple[str, torch.Tensor]]:
+        return [(name, torch.empty(1)) for name in names]
+
+    def test_dense_sender_accepts_every_unit(self) -> None:
+        protocol, _ = _configure_protocol(
+            global_rank=0,
+            coordinates=[(0, 0), (0, 1)],
+            pp_rank=0,
+            ep_rank=0,
+        )
+
+        assert protocol.should_send_weight_unit(self._unit("model.embed_tokens.weight"))
+        assert protocol.should_send_weight_unit(self._unit("model.layers.0.mlp.experts.0.gate_proj.weight"))
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "model.embed_tokens.weight",
+            "model.layers.0.mlp.shared_expert.gate_proj.weight",
+            "model.layers.0.mlp.shared_experts.gate_proj.weight",
+            "model.layers.0.mlp.experts.gate_up_proj",
+        ],
+    )
+    def test_expert_only_sender_rejects_units_without_a_numeric_expert_id(self, name: str) -> None:
+        protocol, _ = _configure_protocol(
+            global_rank=1,
+            coordinates=[(0, 0), (0, 1)],
+            pp_rank=0,
+            ep_rank=1,
+        )
+
+        assert not protocol.should_send_weight_unit(self._unit(name))
+
+    def test_expert_only_sender_accepts_an_atomic_unit_of_routed_expert_weights(self) -> None:
+        protocol, _ = _configure_protocol(
+            global_rank=1,
+            coordinates=[(0, 0), (0, 1)],
+            pp_rank=0,
+            ep_rank=1,
+        )
+
+        assert protocol.should_send_weight_unit(
+            self._unit(
+                "model.layers.0.mlp.experts.37.gate_proj.weight",
+                "model.layers.0.mlp.experts.37.up_proj.weight",
+            )
+        )
+
+    def test_mixed_dense_and_expert_atomic_unit_is_rejected(self) -> None:
+        protocol, _ = _configure_protocol(
+            global_rank=1,
+            coordinates=[(0, 0), (0, 1)],
+            pp_rank=0,
+            ep_rank=1,
+        )
+
+        with pytest.raises(AssertionError, match="mix"):
+            protocol.should_send_weight_unit(
+                self._unit(
+                    "model.layers.0.mlp.experts.37.gate_proj.weight",
+                    "model.layers.0.input_layernorm.weight",
+                )
+            )
+
+
+class TestEngineReconnect:
+    class _RecordingLock:
+        def __init__(self, events: list[str]) -> None:
+            self.events = events
+
+        def __enter__(self):
+            self.events.append("enter")
+
+        def __exit__(self, *exc_info):
+            self.events.append("exit")
 
     def test_reconnecting_to_the_engines_does_not_rebuild_the_lock(self) -> None:
-        """Reconnects are not collective, so entering one there would hang the ranks that skip it."""
-        protocol, create_lock = _build_protocol(pp_size=3)
+        protocol, create_lock = _configure_protocol(
+            global_rank=0,
+            coordinates=[(0, 0), (0, 1)],
+            pp_rank=0,
+            ep_rank=0,
+        )
         lock_after_init = protocol._engine_lock
+        engines = [MagicMock()]
+        parallel_state = _parallel_state(pp_rank=0, ep_rank=0)
 
-        parallel_state = SimpleNamespace(pp=SimpleNamespace(rank=0, size=3), tp=SimpleNamespace(rank=0))
         with (
-            patch(f"{_BROADCAST_MODULE}.get_data_replica_rank_and_size", return_value=(0, 1)),
             patch(f"{_BROADCAST_MODULE}.disconnect_rollout_engines_from_distributed"),
             patch(f"{_BROADCAST_MODULE}.connect_rollout_engines_from_distributed"),
         ):
-            protocol.connect(
-                [MagicMock()],
-                engine_gpu_counts=None,
-                engine_gpu_offsets=None,
-                parallel_state=parallel_state,
-                placement=SimpleNamespace(gather_pp=False),
-                selector="all",
-            )
+            for _ in range(2):
+                protocol.connect(
+                    engines,
+                    engine_gpu_counts=[2],
+                    engine_gpu_offsets=None,
+                    parallel_state=parallel_state,
+                    placement=WeightUpdatePlacement(gather_pp=False, gather_ep=False),
+                    selector="all",
+                )
 
         create_lock.assert_called_once()
         assert protocol._engine_lock is lock_after_init
+
+    def test_disconnect_and_reconnect_are_serialized_and_forward_engine_sizes(self) -> None:
+        events: list[str] = []
+        protocol, _ = _configure_protocol(
+            global_rank=0,
+            coordinates=[(0, 0), (0, 1)],
+            pp_rank=0,
+            ep_rank=0,
+        )
+        protocol._engine_lock = self._RecordingLock(events)
+        engines = [MagicMock(name="engine")]
+        old_group = MagicMock(name="old_group")
+        new_group = MagicMock(name="new_group")
+        protocol._model_update_groups = old_group
+
+        with (
+            patch(
+                f"{_BROADCAST_MODULE}.disconnect_rollout_engines_from_distributed",
+                side_effect=lambda *args: events.append("disconnect"),
+            ) as disconnect,
+            patch(
+                f"{_BROADCAST_MODULE}.connect_rollout_engines_from_distributed",
+                side_effect=lambda *args, **kwargs: (events.append("connect"), new_group)[1],
+            ) as connect,
+        ):
+            protocol.connect(
+                engines,
+                engine_gpu_counts=[2],
+                engine_gpu_offsets=None,
+                parallel_state=_parallel_state(pp_rank=0, ep_rank=0),
+                placement=WeightUpdatePlacement(gather_pp=False, gather_ep=False),
+                selector="all",
+            )
+
+        assert events == ["enter", "disconnect", "connect", "exit"]
+        disconnect.assert_called_once_with(protocol.args, "miles-pp_0-ep_0", old_group, engines)
+        connect.assert_called_once_with(protocol.args, "miles-pp_0-ep_0", engines, engine_gpu_counts=[2])
+        assert protocol._model_update_groups is new_group
+
+    def test_non_sender_does_not_connect_to_the_engines(self) -> None:
+        protocol, _ = _configure_protocol(
+            global_rank=1,
+            coordinates=[(0, 0), (0, 0), (0, 1)],
+            pp_rank=0,
+            ep_rank=0,
+        )
+
+        with (
+            patch(f"{_BROADCAST_MODULE}.disconnect_rollout_engines_from_distributed") as disconnect,
+            patch(f"{_BROADCAST_MODULE}.connect_rollout_engines_from_distributed") as connect,
+        ):
+            protocol.connect(
+                [MagicMock()],
+                engine_gpu_counts=[1],
+                engine_gpu_offsets=None,
+                parallel_state=_parallel_state(pp_rank=0, ep_rank=0),
+                placement=WeightUpdatePlacement(gather_pp=False, gather_ep=False),
+                selector="all",
+            )
+
+        disconnect.assert_not_called()
+        connect.assert_not_called()
 
 
 class TestSendBucketUnderTheEngineLock:

--- a/tests/fast/backends/training_utils/weight_update/test_dist_weight_update_lifecycle.py
+++ b/tests/fast/backends/training_utils/weight_update/test_dist_weight_update_lifecycle.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from miles.backends.training_utils.weight_update.hf_weight_iterator import WeightUpdatePlacement
 from miles.backends.training_utils.weight_update.updater import WeightUpdater
 from miles.utils import async_utils
 
@@ -71,7 +72,13 @@ def _make_engines(
     ]
 
 
-def _make_updater(engines: list[_RecordingApiClient], *, pause_generation_mode: str = "retract") -> WeightUpdater:
+def _make_updater(
+    engines: list[_RecordingApiClient],
+    *,
+    pause_generation_mode: str = "retract",
+    placement: WeightUpdatePlacement | None = None,
+    require_ep_local: bool = False,
+) -> WeightUpdater:
     protocol = SimpleNamespace(
         use_weight_update_session=True,
         needs_base_resync_for_lora=False,
@@ -80,6 +87,8 @@ def _make_updater(engines: list[_RecordingApiClient], *, pause_generation_mode: 
         rollout_engines=engines,
         required_placement=MagicMock(),
         supports_lora=False,
+        configure=MagicMock(),
+        should_send_weight_unit=lambda unit: True,
         begin_sync=lambda weight_version, iter_buckets: True,
         send_bucket=MagicMock(),
         after_base_weights=MagicMock(),
@@ -87,9 +96,14 @@ def _make_updater(engines: list[_RecordingApiClient], *, pause_generation_mode: 
         after_engines_resumed=MagicMock(),
     )
     iterator = MagicMock()
+    iterator.placement = placement or WeightUpdatePlacement(gather_pp=False)
     iterator.iter_hf_weights.return_value = iter([])
     iterator.weight_update_selector = "all"
-    args = Namespace(pause_generation_mode=pause_generation_mode, check_lora_weight_equal=False)
+    args = Namespace(
+        pause_generation_mode=pause_generation_mode,
+        check_lora_weight_equal=False,
+        ci_require_ep_local_weight_update=require_ep_local,
+    )
     with patch(f"{_UPDATER_MODULE}.get_weight_transfer_protocol", return_value=protocol):
         return WeightUpdater(
             args,
@@ -166,6 +180,38 @@ def _run_with_gated_later_engine(
 
 class TestWeightUpdateSessionFrame:
     """The session frame must pause, flush, open, close, publish the version and only then resume, on every engine."""
+
+    def test_protocol_uses_the_resolved_placement_and_filters_complete_units(self):
+        updater = _make_updater(_make_engines([]))
+
+        updater.protocol.configure.assert_called_once_with(
+            updater.parallel_state,
+            updater._hf_weight_iterator.placement,
+        )
+
+        _run(updater)
+
+        assert (
+            updater._hf_weight_iterator.iter_hf_weights.call_args.kwargs["unit_filter"]
+            is updater.protocol.should_send_weight_unit
+        )
+
+    def test_ci_ep_local_requirement_accepts_resolved_local_placement(self):
+        updater = _make_updater(
+            _make_engines([]),
+            placement=WeightUpdatePlacement(gather_pp=False, gather_ep=False),
+            require_ep_local=True,
+        )
+
+        updater.protocol.configure.assert_called_once()
+
+    def test_ci_ep_local_requirement_rejects_resolved_gathered_placement(self):
+        with pytest.raises(AssertionError, match="expected.*gather_ep=False"):
+            _make_updater(
+                _make_engines([]),
+                placement=WeightUpdatePlacement(gather_pp=False, gather_ep=True),
+                require_ep_local=True,
+            )
 
     @pytest.mark.parametrize("pause_generation_mode", ["retract", "abort"])
     def test_every_engine_walks_the_frame_in_order(self, pause_generation_mode):

--- a/tests/fast/backends/training_utils/weight_update/test_hf_weight_iterator.py
+++ b/tests/fast/backends/training_utils/weight_update/test_hf_weight_iterator.py
@@ -20,6 +20,7 @@ from miles.backends.training_utils.weight_update.hf_weight_iterator import (
     WeightUpdatePlacement,
     resolve_placement,
 )
+from miles.backends.training_utils.weight_update.hf_weight_iterator.bucketing import AtomicUpdateGroup
 
 SAMPLE_LORA_WEIGHTS = [
     ("model.layers.0.self_attn.q_proj.lora_A.weight", torch.randn(4, 2)),
@@ -46,7 +47,7 @@ class TestWeightUpdatePlacement:
 class _StubIterator(HfWeightIteratorBase):
     """Concrete subclass with canned base and adapter unit streams."""
 
-    def __init__(self, exported, base=()):
+    def __init__(self, exported, base=(), atomic_groups=()):
         super().__init__(
             Namespace(update_weight_buffer_size=1 << 30),
             [],
@@ -56,6 +57,7 @@ class _StubIterator(HfWeightIteratorBase):
         )
         self._exported = exported
         self._base = base
+        self._atomic_groups = list(atomic_groups)
         self.export_calls = []
 
     def _iter_hf_param_units(self, weights, *, materialize):
@@ -66,6 +68,9 @@ class _StubIterator(HfWeightIteratorBase):
         self.export_calls.append(adapter)
         for name, tensor in self._exported:
             yield [(f"{lora_name}:{name}", tensor)]
+
+    def _hf_atomic_update_groups(self):
+        return self._atomic_groups
 
 
 class TestIterHfWeightsTemplate:
@@ -94,3 +99,26 @@ class TestIterHfWeightsTemplate:
         names = self._names(iterator.iter_hf_weights(None))
         assert names == [SAMPLE_BASE_ONLY_WEIGHTS[0][0]]
         assert iterator.export_calls == []
+
+    def test_unit_filter_runs_after_atomic_assembly_and_before_packing(self):
+        base = [
+            ("layers.0.dense.weight", torch.zeros(1)),
+            ("layers.0.experts.0.gate_proj.weight", torch.zeros(1)),
+            ("layers.0.experts.0.up_proj.weight", torch.zeros(1)),
+        ]
+        atomic_group = AtomicUpdateGroup("expert_gate_up", (".gate_proj.weight", ".up_proj.weight"))
+        iterator = _StubIterator([], base=base, atomic_groups=[atomic_group])
+        filtered_units = []
+
+        def keep_dense(unit):
+            names = [name for name, _tensor in unit]
+            filtered_units.append(names)
+            return ".experts." not in names[0]
+
+        names = self._names(iterator.iter_hf_weights(None, unit_filter=keep_dense))
+
+        assert filtered_units == [
+            ["layers.0.dense.weight"],
+            ["layers.0.experts.0.gate_proj.weight", "layers.0.experts.0.up_proj.weight"],
+        ]
+        assert names == ["layers.0.dense.weight"]

--- a/tests/fast/utils/test_arguments.py
+++ b/tests/fast/utils/test_arguments.py
@@ -416,6 +416,12 @@ class TestCustomConfigAppliedBeforeDerivedArgs:
         with pytest.raises(AssertionError, match="--dump-details is required"):
             miles_validate_args(args)
 
+    def test_ci_ep_local_requirement_from_config_still_requires_ci_test(self, tmp_path):
+        args = self._parse(tmp_path, [], "ci_require_ep_local_weight_update: true\n")
+
+        with pytest.raises(AssertionError, match="requires --ci-test"):
+            miles_validate_args(args)
+
     def test_a_dashboard_switched_off_by_the_config_file_drops_its_requirement(self, tmp_path):
         """A run whose file turns the dashboard off must not be rejected for telemetry it will never write."""
         args = self._parse(tmp_path, ["--use-miles-dashboard"], "use_miles_dashboard: false\n")


### PR DESCRIPTION
## Summary

Send supported raw Qwen3-MoE routed experts directly from their owning EP shards.

ETP reconstruction remains intact. Unsupported model, dtype, quantization, and export layouts collectively fall back to the existing gathered path.

## Motivation

Distributed broadcast previously EP-all-gathered every routed expert onto every training rank before sending. This duplicated expert materialization and cross-EP traffic even though each expert has a global HF name and SGLang accepts partial named weight batches.

## Usage

Existing unquantized BF16 Qwen3-MoE jobs select the EP-local path automatically when they use:

```bash
--update-weight-transfer-mode broadcast \
--megatron-to-hf-mode raw \
--expert-model-parallel-size 2 \
--expert-tensor-parallel-size 2
```

## Design Notes

- **Mental model:** The raw iterator reconstructs each local expert across ETP, then a collective capability gate decides whether expert sets can remain EP-local. The broadcast protocol chooses one sender per retained PP/EP shard and serializes sender groups while rollout ranks load each partial named batch.
- One EP owner per PP shard sends dense and shared weights. Filtering occurs after atomic groups are assembled.
- Bridge, LoRA, quantized, P2P, CUDA IPC, disk, and HF export paths retain their gathered placement.
- The receiver contract follows [SGLang's partial named-batch loader](https://github.com/sgl-project/sglang/blob/cb05a44f35a7c9e27e46d74112cc841ca674ef43/python/sglang/srt/managers/scheduler_components/weight_updater.py#L214-L243).

## Verification

- 130 weight-update and iterator tests passed.
- 184 argument tests passed, including CLI/YAML gating for the E2E-only placement requirement.
- A 4-H200 NCCL materialization smoke observed one ETP gather and zero EP gathers in EP-local mode.
- Its broadcast phase serialized two sender groups.
- Production SGLang receivers loaded exact dense and expert values.
- Black, Ruff, and compileall passed on all changed Python files.
- Diff, topology/config, and CI registration checks passed.
- Added a TP4/ETP2/EP2 disaggregated Qwen3-MoE E2E that fails fast unless the resolved iterator placement is EP-local; its full-model GPU run is delegated to CI.

## Review Focus

- Capability fallback remains collective and conservative.
- Sender ownership covers each routed expert once and dense/shared weights once per PP shard.
- The world ticket lock prevents concurrent sender groups from driving the same rollout ranks.
