### PR TITLE
docs: whether an e2b key is checked is the endpoint's business

### DIFF
--- a/examples/experimental/openenv/openenv_e2b_agent_function.py
+++ b/examples/experimental/openenv/openenv_e2b_agent_function.py
@@ -23,8 +23,9 @@ Env vars (the agent-loop ones in ``openenv_agent_function`` apply too):
                     warm-start), or pre-baked via the tb2_sandbox_e2b CLI.
   E2B_API_KEY / E2B_API_KEY_FILE   key supply on the contract every backend
                     shares (file default ~/.config/e2b/api_key; launchers
-                    forward the PATH, never the value). AgentENV accepts any
-                    non-empty key today.
+                    forward the PATH, never the value). Whether the key is
+                    checked is up to the endpoint: E2B Cloud rejects a wrong
+                    one, a self-hosted server may accept anything.
   E2B_API_URL / E2B_SANDBOX_URL    endpoint overrides read by the SDK itself;
                     set both to target a self-hosted AgentENV.
   OPENENV_E2B_CREATE_CONCURRENCY   max in-flight sandbox creates (default 4).

--- a/miles/rollout/agentic/credentials.py
+++ b/miles/rollout/agentic/credentials.py
@@ -43,8 +43,7 @@ PROVIDER_CREDENTIALS = {
         "file_env_var": "E2B_API_KEY_FILE",
         "arg_attr": "e2b_api_key_file",
         "default_path": "~/.config/e2b/api_key",
-        "provision_hint": "mkdir -p ~/.config/e2b && echo <key> > ~/.config/e2b/api_key"
-        "  # AgentENV accepts any non-empty key today",
+        "provision_hint": "mkdir -p ~/.config/e2b && echo <key> > ~/.config/e2b/api_key",
         "sdk": "e2b",
         "sdk_hint": "pip install -e '<miles>[e2b]'",
         # Older releases send the template name as `alias`, which self-hosted


### PR DESCRIPTION
## What

The e2b entry's missing-credential hint carried an aside — "AgentENV accepts any non-empty key today" — and the openenv backend's env-var doc said the same. Both are dropped or restated as the rule: the key is required either way, and whether it is checked depends on the endpoint.

## Why

`credentials.py` prints that hint for every `HARBOR_ENV_TYPE=e2b` / openenv-e2b run, including against E2B Cloud, where a wrong key is rejected. And it only held while a self-hosted server had no auth: a deployment that puts an auth layer in front makes it wrong without anyone touching this file.

## Not changed

`examples/experimental/agentenv/README.md` keeps its statement, because that page deploys a specific upstream server image and describes that image's behaviour.