### PR TITLE
fix(megatron_to_hf): name bridge mode when a raw convert hits VL wrapper params

### DIFF
--- a/miles/backends/megatron_utils/megatron_to_hf/__init__.py
+++ b/miles/backends/megatron_utils/megatron_to_hf/__init__.py
@@ -29,8 +29,30 @@ def convert_to_hf(args, model_name, name, param, quantization_config=None):
     return quantize_params(args, name, converted_named_tensors, quantization_config)
 
 
-# TODO optimize code details
+# Wrapper prefixes that megatron.bridge-built VL models produce. A converter that knows them (kimi_vl) maps
+# them; for every other model the raw converter raises a bare "Unknown parameter name" that hides the real
+# cause, so _convert_to_hf_core adds the fix to that error instead of guessing up front.
+_BRIDGE_ONLY_PREFIXES = ("vision_model.", "vision_projector.", "language_model.")
+
+
+def _bridge_mode_hint(error: ValueError) -> ValueError:
+    return ValueError(
+        f"{error}. Raw-mode conversion does not support the vision_model / vision_projector / language_model "
+        "wrappers that megatron.bridge VL models use; pass --megatron-to-hf-mode bridge (see examples/geo3k_vlm)."
+    )
+
+
 def _convert_to_hf_core(args, model_name, name, param):
+    try:
+        return _dispatch_to_model_converter(args, model_name, name, param)
+    except ValueError as error:
+        if any(prefix in name for prefix in _BRIDGE_ONLY_PREFIXES):
+            raise _bridge_mode_hint(error) from error
+        raise
+
+
+# TODO optimize code details
+def _dispatch_to_model_converter(args, model_name, name, param):
     model_name = model_name.lower()
     if (
         "glm4moelite" in model_name

--- a/tests/fast/backends/megatron_utils/test_megatron_to_hf_bridge_only_hint.py
+++ b/tests/fast/backends/megatron_utils/test_megatron_to_hf_bridge_only_hint.py
@@ -1,0 +1,38 @@
+"""Raw-mode conversion of a megatron.bridge VL checkpoint must say how to fix it (#634)."""
+
+from argparse import Namespace
+
+import pytest
+import torch
+
+from miles.backends.megatron_utils.megatron_to_hf import _convert_to_hf_core
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "module.module.vision_model.patch_embed.proj.weight",
+        "module.module.vision_projector.encoder.linear_fc1.weight",
+        "module.module.language_model.embedding.word_embeddings.weight",
+    ],
+)
+def test_bridge_only_param_names_point_at_bridge_mode(name):
+    args = Namespace(hidden_size=4, kv_channels=2, num_attention_heads=2, num_query_groups=1)
+    with pytest.raises(ValueError, match=r"--megatron-to-hf-mode bridge") as excinfo:
+        _convert_to_hf_core(args, "qwen3", name, torch.zeros(1))
+    assert f"Unknown parameter name: {name}" in str(excinfo.value)
+
+
+def test_converter_that_knows_the_wrapper_is_left_alone():
+    param = torch.zeros(1)
+    assert _convert_to_hf_core(Namespace(), "kimivl", "module.module.vision_model.encoder.layers.0.w", param) == [
+        ("vision_tower.encoder.layers.0.w", param)
+    ]
+
+
+def test_plain_decoder_param_still_reaches_the_model_converter():
+    args = Namespace(hidden_size=4, kv_channels=2, num_attention_heads=2, num_query_groups=1)
+    param = torch.ones(4)
+    assert _convert_to_hf_core(args, "qwen3", "module.module.decoder.layers.0.input_layernorm.weight", param) == [
+        ("model.layers.0.input_layernorm.weight", param)
+    ]


### PR DESCRIPTION
Fixes #634.

### What

`_convert_to_hf_core` wraps the per-model dispatch. When a converter raises `ValueError` for a parameter whose name carries one of the megatron.bridge VL wrappers (`vision_model.`, `vision_projector.`, `language_model.`), the error keeps the converter's "Unknown parameter name" text and adds the flag to pass, `--megatron-to-hf-mode bridge`, as the geo3k_vlm launchers do. Converters that already map those wrappers (kimi_vl) are untouched, and decoder names still reach their converters unchanged.

An SFT run on Qwen3-VL-8B left on the default raw mode died in the converter with no pointer to the supported path. Qwen3-VL is bridge-only (miles_plugins/models/qwen3_vl.py), and the only place that said so was one flag inside the geo3k_vlm launchers.

### Test

`tests/fast/backends/megatron_utils/test_megatron_to_hf_bridge_only_hint.py`: three wrapper names raise with the flag in the message and the original text preserved; a Kimi-VL `vision_model` name still converts through its own converter; a plain decoder name still converts.

### Verification

- The six cases pass; with `megatron_to_hf/__init__.py` restored from main the three hint cases fail.
- `tests/fast/backends/megatron_utils`: 289 passed, 11 skipped.
- ruff, black 24.3.0 and isort at the pre-commit pins are clean on both files.

### Scope

- `tools/convert_torch_dist_to_hf.py` has no `--megatron-to-hf-mode` flag, so the checkpoint-conversion path in the second report on #634 still cannot pick bridge mode. Separate change.

cc @yueming-yuan @Zhichenzzz
