### PR TITLE
fix(session): say why a session is not found and which server answered

### DIFF
--- a/miles/rollout/session/core.py
+++ b/miles/rollout/session/core.py
@@ -349,7 +349,7 @@ class SessionCore:
     async def delete_session(self, session_id: str) -> Response:
         session = self.registry.get_session(session_id)
         if session.closing:
-            raise SessionNotFoundError(f"session not found: session_id={session_id}")
+            raise SessionNotFoundError(f"session not found (closing): session_id={session_id}")
         session.closing = True
         # Acquire the lock so an in-flight chat finishes before we drop the session.
         await session.lock.acquire()
@@ -372,12 +372,12 @@ class SessionCore:
         request_timestamp = time.time()
         session = self.registry.get_session(session_id)
         if session.closing:
-            raise SessionNotFoundError(f"session not found: session_id={session_id}")
+            raise SessionNotFoundError(f"session not found (closing): session_id={session_id}")
 
         # --- Phase 1: prepare request (lock held briefly) ---
         async with session.lock:
             if session.closing:
-                raise SessionNotFoundError(f"session not found: session_id={session_id}")
+                raise SessionNotFoundError(f"session not found (closing): session_id={session_id}")
 
             request_body, client_stream, tito_tokenizer = prepare_chat_request(
                 body, self.config, self.registry.tito_tokenizer

--- a/miles/rollout/session/linear_trajectory.py
+++ b/miles/rollout/session/linear_trajectory.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 import uuid
+from collections import deque
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -286,6 +287,9 @@ class LinearTrajectory:
         self.num_assistant = len(self.generated_checkpoint_message_ends)
 
 
+_REMOVED_SESSION_IDS_REMEMBERED = 1024
+
+
 class SessionRegistry:
     """Session ID -> trajectory mapping with shared tokenizer resources.
 
@@ -302,6 +306,9 @@ class SessionRegistry:
         message_matcher: SessionMessageMatcher | None = None,
     ):
         self.sessions: dict[str, LinearTrajectory] = {}
+        # Recently removed ids, so a 404 can say "deleted" instead of "unknown" (#956). Bounded: this is a
+        # diagnostic, not a registry; ids older than the window degrade to "unknown".
+        self._removed_session_ids: deque[str] = deque(maxlen=_REMOVED_SESSION_IDS_REMEMBERED)
         self.tokenizer = tokenizer
         self.tito_tokenizer = tito_tokenizer
         self.comparator = tito_tokenizer.create_comparator()
@@ -317,12 +324,18 @@ class SessionRegistry:
     def get_session(self, session_id: str) -> LinearTrajectory:
         session = self.sessions.get(session_id)
         if session is None:
-            raise SessionNotFoundError(f"session not found: session_id={session_id}")
+            raise self._not_found(session_id)
         return session
 
     def remove_session(self, session_id: str) -> None:
         if self.sessions.pop(session_id, None) is None:
-            raise SessionNotFoundError(f"session not found: session_id={session_id}")
+            raise self._not_found(session_id)
+        self._removed_session_ids.append(session_id)
+
+    def _not_found(self, session_id: str) -> SessionNotFoundError:
+        if session_id in self._removed_session_ids:
+            return SessionNotFoundError(f"session not found (deleted): session_id={session_id}")
+        return SessionNotFoundError(f"session not found: session_id={session_id}")
 
     def compute_session_mismatch(self, session: LinearTrajectory) -> list[dict] | None:
         """Compare accumulated token IDs against canonical chat template output.

--- a/miles/rollout/session/sessions.py
+++ b/miles/rollout/session/sessions.py
@@ -6,6 +6,7 @@ Thin layer: converts each HTTP request to primitive inputs, calls
 
 import json
 import logging
+from typing import Any
 
 from fastapi import Request
 from fastapi.responses import JSONResponse
@@ -41,7 +42,7 @@ from miles.rollout.session.anthropic_adapter import (
 from miles.rollout.session.anthropic_adapter import _validate_anthropic_features, anthropic_adapter_available
 from miles.rollout.session.config import SessionServerConfig
 from miles.rollout.session.core import JSON_MEDIA_TYPE, SessionCore, _render_json
-from miles.rollout.session.errors import SessionError
+from miles.rollout.session.errors import SessionError, SessionNotFoundError
 from miles.rollout.session.linear_trajectory import SessionRegistry
 from miles.utils.chat_template_utils import get_tito_tokenizer
 from miles.utils.chat_template_utils.message_matcher_hub import (
@@ -86,7 +87,11 @@ def setup_session_routes(app, backend, config: SessionServerConfig, *, use_addit
 
     @app.exception_handler(SessionError)
     async def session_error_handler(request: Request, exc: SessionError):
-        return JSONResponse(status_code=exc.status_code, content={"error": str(exc)})
+        content: dict[str, Any] = {"error": str(exc)}
+        if isinstance(exc, SessionNotFoundError) and core.instance_id is not None:
+            # Lets a client tell "this server never had it" from "a retry landed on another instance" (#956).
+            content["session_server_instance_id"] = core.instance_id
+        return JSONResponse(status_code=exc.status_code, content=content)
 
     @app.exception_handler(SessionMessageMatcherError)
     async def session_message_matcher_error_handler(request: Request, exc: SessionMessageMatcherError):

--- a/miles/rollout/session/v2/core.py
+++ b/miles/rollout/session/v2/core.py
@@ -139,12 +139,12 @@ class SessionCoreV2(SessionCore):
         request_timestamp = time.time()
         session = self.registry.get_session(session_id)
         if session.closing:
-            raise SessionNotFoundError(f"session not found: session_id={session_id}")
+            raise SessionNotFoundError(f"session not found (closing): session_id={session_id}")
 
         # --- Phase 1: prepare request (lock held briefly) ---
         async with session.lock:
             if session.closing:
-                raise SessionNotFoundError(f"session not found: session_id={session_id}")
+                raise SessionNotFoundError(f"session not found (closing): session_id={session_id}")
 
             request_body, client_stream, tito_tokenizer = prepare_chat_request(
                 body, self.config, self.registry.tito_tokenizer

--- a/tests/fast/router/test_session_not_found_reason.py
+++ b/tests/fast/router/test_session_not_found_reason.py
@@ -1,0 +1,31 @@
+"""A 404 from the session registry says whether the id was deleted or never existed (#956).
+
+Registry-level, so the same assertions run for the v1 and v2 registries without a server.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from miles.rollout.session.errors import SessionNotFoundError
+from miles.rollout.session.linear_trajectory import SessionRegistry
+from miles.rollout.session.v2.session_state import SessionRegistryV2
+
+
+@pytest.fixture(params=[SessionRegistry, SessionRegistryV2], ids=["v1", "v2"])
+def registry(request):
+    return request.param(tokenizer=None, tito_tokenizer=MagicMock())
+
+
+def test_unknown_id_keeps_the_plain_message(registry):
+    with pytest.raises(SessionNotFoundError, match=r"^session not found: session_id=never-existed$"):
+        registry.get_session("never-existed")
+
+
+def test_removed_id_is_reported_as_deleted(registry):
+    session_id = registry.create_session()
+    registry.remove_session(session_id)
+    with pytest.raises(SessionNotFoundError, match=r"^session not found \(deleted\): session_id="):
+        registry.get_session(session_id)
+    with pytest.raises(SessionNotFoundError, match=r"\(deleted\)"):
+        registry.remove_session(session_id)

--- a/tests/fast/router/test_sessions.py
+++ b/tests/fast/router/test_sessions.py
@@ -138,6 +138,19 @@ class TestSessionRoutes:
         assert response.status_code == 404
         assert response.json()["error"] == "session not found: session_id=nonexistent"
 
+    def test_not_found_body_names_the_serving_instance(self, router_env):
+        """A retry that lands on another session server must be tellable from a bad id (#956)."""
+        response = requests.get(f"{router_env.url}/sessions/nonexistent", timeout=5.0)
+        assert response.status_code == 404
+        assert response.json()["session_server_instance_id"] == _INSTANCE_ID
+
+    def test_chat_after_delete_says_deleted(self, router_env):
+        session_id = _create_session(router_env.url)
+        assert requests.delete(f"{router_env.url}/sessions/{session_id}", timeout=5.0).status_code == 204
+        response = _post_chat(router_env.url, session_id, {"messages": [{"role": "user", "content": "hi"}]})
+        assert response.status_code == 404
+        assert response.json()["error"] == f"session not found (deleted): session_id={session_id}"
+
 
 class TestSessionProxy:
     def test_proxy_chat_appends_record(self, router_env):


### PR DESCRIPTION
Refs #956.

### What

`SessionRegistry` remembers the last 1024 removed session ids, so `get_session` and `remove_session` on one of them raise `session not found (deleted): ...` instead of the plain message; `SessionRegistryV2` inherits it. The closing-race raises in `core.py` and `v2/core.py` read `session not found (closing): ...`. The `SessionError` handler in `sessions.py` adds `session_server_instance_id` to every `SessionNotFoundError` body when the server has an instance id. The unknown-id message is unchanged, so no existing client or test assertion moves.

#956 reports 404s during timeout storms and reads them as eviction. The registry has no eviction path (a plain dict, no TTL or cap), so the plausible causes are a client retrying a deleted id or a retry reaching a different session-server instance, and today the body cannot distinguish either from a bad id.

### Test

`tests/fast/router/test_sessions.py`: a 404 body carries the configured instance id; a chat after DELETE says deleted. `tests/fast/router/test_session_not_found_reason.py`, parametrized over v1 and v2: an unknown id keeps the plain text; a removed id reports deleted on get and on a repeat remove.

### Verification

- `tests/fast/router`: 403 passed, 1 skipped on this branch; with the four source files restored from main the two HTTP cases and the two removed-id registry cases fail.
- ruff, black 24.3.0 and isort at the pre-commit pins are clean.

### Scope

- The Messages-API compatibility route (`/v1/messages`) renders `SessionError` through its own envelope and still omits the instance id. Separate change if wanted.

cc @jybsuper @guapisolo
