### PR TITLE
ci: declare hardware on the two CUDA tests that landed after #2701

### DIFF
--- a/tests/e2e/agentic/test_harbor_e2b_rollout.py
+++ b/tests/e2e/agentic/test_harbor_e2b_rollout.py
@@ -41,6 +41,7 @@ import miles.utils.external_utils.command_utils as U
 register_cuda_ci(
     est_time=1200,
     suite="stage-c-2-gpu-h200",
+    hardware=["hopper"],
     labels=["agentic"],
     disabled="needs a network route to the sandbox service and its key on the runner; run manually on a GPU devbox that has both",
 )

--- a/tests/fast-gpu/test_true_on_policy_logprob_chunking.py
+++ b/tests/fast-gpu/test_true_on_policy_logprob_chunking.py
@@ -1,6 +1,6 @@
 from tests.ci.ci_register import register_cuda_ci
 
-register_cuda_ci(est_time=180, suite="stage-b-2-gpu-h200", labels=["megatron"])
+register_cuda_ci(est_time=180, suite="stage-b-2-gpu-h200", labels=["megatron"], hardware=["hopper"])
 
 import gc
 import os


### PR DESCRIPTION
### What

Adds `hardware=["hopper"]` to the two `register_cuda_ci` calls that have none: `tests/e2e/agentic/test_harbor_e2b_rollout.py` (from #2876) and `tests/fast-gpu/test_true_on_policy_logprob_chunking.py` (from #2825).

#2701 made `hardware=` mandatory and swept the files on main at the time; these two merged the same day without it. On main at f211937b5 the registration parser raises before listing anything:

```
python tests/ci/run_suite.py --hw cpu --suite stage-a-cpu --match-all-labels --list-only
ValueError: tests/e2e/agentic/test_harbor_e2b_rollout.py: hardware in register_cuda_ci() must list at least one arch from ['hopper', 'blackwell']
```

and, once that file is fixed, the same error for the chunking test. The Resolve suite plan step runs this command, so every PR's stage-a-cpu job stops there. No PR Test run had executed against main since f211937b5, which is why it had not shown up red.

### Test

No new test; the registration parser is the check.

### Verification

- With this change `--list-only` resolves for stage-a-cpu (436 tests), stage-b-2-gpu-h200 (5 tests, the chunking test listed) and stage-c-2-gpu-h200 (15 tests, the harbor test listed as disabled).

### Scope

- Both tests sit in H200 suites, so they declare hopper only; widen to blackwell once someone has run them there.
- ROCm registrations do not take `hardware`, so the mi350 files are unaffected.

cc @fzyzcjy @yushengsu-thu
