### PR TITLE
fix(megatron): restore the memory saver's region flag after deep_ep init

### DIFF
--- a/miles/backends/megatron_utils/__init__.py
+++ b/miles/backends/megatron_utils/__init__.py
@@ -9,12 +9,19 @@ try:
     old_init = deep_ep.Buffer.__init__
 
     def new_init(self, *args, **kwargs):
-        if torch_memory_saver._impl is not None:
-            torch_memory_saver._impl._binary_wrapper.cdll.tms_set_interesting_region(False)
-        old_init(self, *args, **kwargs)
-        torch.cuda.synchronize()
-        if torch_memory_saver._impl is not None:
-            torch_memory_saver._impl._binary_wrapper.cdll.tms_set_interesting_region(True)
+        # Keep DeepEP's buffers out of the memory saver's region for the duration of __init__, then put the flag
+        # back to whatever it was. Restoring True unconditionally clobbered a caller that had the region off (#807).
+        # torch_memory_saver.disable() is not usable here: it asserts the region is on when entered.
+        cdll = torch_memory_saver._impl._binary_wrapper.cdll if torch_memory_saver._impl is not None else None
+        was_interesting = cdll.tms_get_interesting_region() if cdll is not None else None
+        if cdll is not None:
+            cdll.tms_set_interesting_region(False)
+        try:
+            old_init(self, *args, **kwargs)
+            torch.cuda.synchronize()
+        finally:
+            if cdll is not None:
+                cdll.tms_set_interesting_region(was_interesting)
 
     deep_ep.Buffer.__init__ = new_init
 except ImportError:

--- a/tests/fast/backends/megatron_utils/test_deep_ep_interesting_region.py
+++ b/tests/fast/backends/megatron_utils/test_deep_ep_interesting_region.py
@@ -1,0 +1,97 @@
+"""The deep_ep.Buffer.__init__ wrapper restores the memory saver's region flag instead of forcing it on (#807)."""
+
+import importlib
+import sys
+import types
+
+import pytest
+
+_PACKAGE = "miles.backends.megatron_utils"
+
+
+def _reimport_against(monkeypatch, deep_ep, tms):
+    """Import the package once more with fake deep_ep / torch_memory_saver in place, so its import-time wrapper
+    binds to the fakes. The caller's fixture puts the real module back afterwards."""
+    monkeypatch.setitem(sys.modules, "deep_ep", deep_ep)
+    monkeypatch.setitem(sys.modules, "torch_memory_saver", types.SimpleNamespace(torch_memory_saver=tms))
+    monkeypatch.setattr("torch.cuda.synchronize", lambda: None)
+    sys.modules.pop(_PACKAGE, None)
+    return importlib.import_module(_PACKAGE)
+
+
+@pytest.fixture
+def wrapped_buffer():
+    """A fake deep_ep.Buffer wrapped by the package's import-time hook, plus the recorded region-flag writes.
+    Restores the real package module and its parent attribute on teardown so later tests see the real one."""
+    parent = importlib.import_module("miles.backends")
+    original_module = sys.modules.get(_PACKAGE)
+    original_attr = getattr(parent, "megatron_utils", None)
+    calls: list[bool] = []
+    state = {"interesting": True}
+
+    def set_region(value):
+        state["interesting"] = bool(value)
+        calls.append(bool(value))
+
+    cdll = types.SimpleNamespace(
+        tms_get_interesting_region=lambda: state["interesting"], tms_set_interesting_region=set_region
+    )
+    tms = types.SimpleNamespace(_impl=types.SimpleNamespace(_binary_wrapper=types.SimpleNamespace(cdll=cdll)))
+
+    class Buffer:
+        def __init__(self, *args, **kwargs):
+            self.args = args
+
+    deep_ep = types.ModuleType("deep_ep")
+    deep_ep.Buffer = Buffer
+    try:
+        yield Buffer, calls, state, tms, deep_ep
+    finally:
+        if original_module is not None:
+            sys.modules[_PACKAGE] = original_module
+        else:
+            sys.modules.pop(_PACKAGE, None)
+        if original_attr is not None:
+            parent.megatron_utils = original_attr
+
+
+@pytest.mark.parametrize("initial", [True, False])
+def test_init_restores_the_region_flag_it_found(wrapped_buffer, monkeypatch, initial):
+    Buffer, calls, state, tms, deep_ep = wrapped_buffer
+    _reimport_against(monkeypatch, deep_ep, tms)
+    state["interesting"] = initial
+    calls.clear()
+
+    Buffer(1, 2)
+
+    assert calls == [False, initial]
+    assert state["interesting"] is initial
+
+
+@pytest.mark.parametrize("initial", [True, False])
+def test_init_restores_the_flag_when_the_wrapped_init_raises(wrapped_buffer, monkeypatch, initial):
+    Buffer, calls, state, tms, deep_ep = wrapped_buffer
+
+    def boom(self, *args, **kwargs):
+        raise RuntimeError("init failed")
+
+    Buffer.__init__ = boom
+    _reimport_against(monkeypatch, deep_ep, tms)
+    state["interesting"] = initial
+    calls.clear()
+
+    with pytest.raises(RuntimeError, match="init failed"):
+        Buffer()
+
+    assert calls == [False, initial]
+    assert state["interesting"] is initial
+
+
+def test_init_is_a_plain_passthrough_when_the_saver_is_not_initialized(wrapped_buffer, monkeypatch):
+    Buffer, calls, state, tms, deep_ep = wrapped_buffer
+    tms._impl = None
+    _reimport_against(monkeypatch, deep_ep, tms)
+
+    Buffer(3)
+
+    assert calls == []


### PR DESCRIPTION
Fixes #807 (the remaining item; the numpy assertion and the dist_init_addr assignment were fixed in 00a698ea7 and a8ee4a59a).

### What

The `deep_ep.Buffer.__init__` wrapper in `miles/backends/megatron_utils/__init__.py` cleared `tms_set_interesting_region` before the wrapped init and set it back to True unconditionally afterwards, so a caller that had the region off got it switched on. The wrapper now reads `tms_get_interesting_region()` first, clears it, and restores the value it read in a `finally`, so an exception inside the wrapped init also leaves the flag as it found it. `torch_memory_saver.disable()` is not usable here: at the pinned commit (f05a8754) its implementation asserts the region is on when entered, which is exactly the case this fix is for.

### Test

`tests/fast/backends/megatron_utils/test_deep_ep_interesting_region.py` imports the module against a fake `deep_ep` and a fake `torch_memory_saver` whose cdll records `tms_set_interesting_region` calls. Parametrized over an initial flag of True and False, it asserts the call sequence is `[False, initial]` and the final flag equals the initial one; a third case makes the wrapped init raise and asserts the flag is still restored.

### Verification

- The five cases pass; with `__init__.py` restored from main the initial-False case and both raising cases fail.
- `tests/fast/backends/megatron_utils`: 289 passed, 11 skipped, run with and without the new file (284 passed without) to confirm the fixture leaves the real module in place for later tests.
- ruff, black 24.3.0 and isort at the pre-commit pins are clean. `run_suite --list-only` cannot list anything on current main until #3184 lands; the file sits under tests/fast, which is auto-registered.

### Scope

- This is the only call site of `tms_set_interesting_region` in miles/; every other torch_memory_saver use goes through `pause`, `resume`, `disable` and `get_cpu_backup`.

cc @fzyzcjy @yueming-yuan
