### PR TITLE
perf(loss): reduce sequence statistics across context parallel ranks

### DIFF
--- a/miles/backends/training_utils/loss_hub/losses.py
+++ b/miles/backends/training_utils/loss_hub/losses.py
@@ -4,11 +4,7 @@ from typing import Protocol
 
 import torch
 
-from miles.backends.training_utils.cp_utils import (
-    all_gather_with_cp,
-    get_local_response_loss_masks,
-    get_sum_of_sample_mean,
-)
+from miles.backends.training_utils.cp_utils import get_local_response_loss_masks, get_sum_of_sample_mean
 from miles.backends.training_utils.loss_hub.corrections import vanilla_tis_function
 from miles.backends.training_utils.loss_hub.logit_processors import get_log_probs_and_entropy, get_values
 from miles.backends.training_utils.loss_hub.math_utils import (
@@ -17,6 +13,7 @@ from miles.backends.training_utils.loss_hub.math_utils import (
     compute_gspo_kl,
     compute_opsm_mask,
     compute_policy_loss,
+    compute_sequence_kl,
 )
 from miles.backends.training_utils.parallel import get_parallel_state
 from miles.utils.function_registry import load_function
@@ -68,8 +65,8 @@ def policy_loss_function(
     """Compute policy loss (PPO/GSPO) and metrics.
 
     Computes current log-probabilities and entropy from model logits, then
-    calculates PPO-style clipped policy gradient loss. For GSPO, gathers
-    full sequences via context-parallel all-gather before computing per-sample
+    calculates PPO-style clipped policy gradient loss. For GSPO, reduces
+    masked log-ratio sums across context-parallel ranks to compute per-sample
     KL. Optionally applies TIS (Truncated Importance Sampling) correction and
     adds KL loss term if configured.
 
@@ -137,45 +134,32 @@ def policy_loss_function(
     train_log_probs_list = log_probs
     old_log_probs_list = old_log_probs
 
-    # Pre-gather log probs if needed by OPSM or GSPO to avoid duplicate gathering
-    need_full_log_probs = args.use_opsm or args.advantage_estimator == "gspo"
-
-    full_log_probs = None
-    full_old_log_probs = None
-    if need_full_log_probs:
-        full_log_probs = [
-            all_gather_with_cp(log_prob, total_length, response_length)
-            for log_prob, total_length, response_length in zip(
-                log_probs, total_lengths, response_lengths, strict=False
-            )
-        ]
-        if args.skip_actor_forward_only and not args.use_rollout_logprobs:
-            full_old_log_probs = [full_log_prob.detach() for full_log_prob in full_log_probs]
-        else:
-            full_old_log_probs = [
-                all_gather_with_cp(old_log_prob, total_length, response_length)
-                for old_log_prob, total_length, response_length in zip(
-                    old_log_probs, total_lengths, response_lengths, strict=False
-                )
-            ]
+    local_loss_mask_list = get_local_response_loss_masks(
+        total_lengths,
+        response_lengths,
+        batch["loss_masks"],
+        args.qkv_format,
+        max_seq_lens,
+    )
+    sequence_kl = None
+    if args.use_opsm or args.advantage_estimator == "gspo":
+        with torch.set_grad_enabled(torch.is_grad_enabled() and args.advantage_estimator == "gspo"):
+            sequence_kl = compute_sequence_kl(log_probs, old_log_probs, local_loss_mask_list, batch["loss_masks"])
 
     # Compute OPSM mask if enabled
     if args.use_opsm:
         opsm_mask, opsm_clipfrac = compute_opsm_mask(
             args=args,
-            full_log_probs=full_log_probs,
-            full_old_log_probs=full_old_log_probs,
             advantages=advantages_list,
             loss_masks=batch["loss_masks"],
+            sequence_kl=sequence_kl,
         )
 
     # Compute KL divergence (GSPO uses sequence-level KL, others use per-token KL)
     if args.advantage_estimator == "gspo":
         ppo_kl = compute_gspo_kl(
-            full_log_probs=full_log_probs,
-            full_old_log_probs=full_old_log_probs,
             local_log_probs=log_probs,
-            loss_masks=batch["loss_masks"],
+            sequence_kl=sequence_kl,
         )
         old_log_probs = torch.cat(old_log_probs, dim=0)
         log_probs = torch.cat(log_probs, dim=0)
@@ -184,13 +168,6 @@ def policy_loss_function(
         log_probs = torch.cat(log_probs, dim=0)
         ppo_kl = old_log_probs - log_probs
 
-    local_loss_mask_list = get_local_response_loss_masks(
-        total_lengths,
-        response_lengths,
-        batch["loss_masks"],
-        args.qkv_format,
-        max_seq_lens,
-    )
     local_loss_masks = torch.cat(local_loss_mask_list, dim=0).to(device=ppo_kl.device)
     active_tokens = local_loss_masks.bool()
     ppo_kl = torch.where(

--- a/miles/backends/training_utils/loss_hub/math_utils.py
+++ b/miles/backends/training_utils/loss_hub/math_utils.py
@@ -180,74 +180,56 @@ def compute_approx_kl(
     return kl
 
 
+def compute_sequence_kl(
+    log_probs: list[torch.Tensor],
+    old_log_probs: list[torch.Tensor],
+    local_loss_masks: list[torch.Tensor],
+    loss_masks: list[torch.Tensor],
+) -> torch.Tensor:
+    """Reduce one masked log-ratio sum per sequence across context-parallel ranks."""
+    numerators = torch.stack(
+        [
+            ((old_log_prob - log_prob) * mask).sum()
+            for log_prob, old_log_prob, mask in zip(log_probs, old_log_probs, local_loss_masks, strict=True)
+        ]
+    )
+    cp = get_parallel_state().cp
+    if cp.size > 1:
+        # Empty ranks must still participate in the backward collective.
+        numerators.requires_grad_(torch.is_grad_enabled())
+        numerators = dist.nn.all_reduce(numerators, group=cp.group)
+    # Response masks are replicated across CP ranks; their counts are already global.
+    denominators = torch.stack([mask.sum() for mask in loss_masks]).clamp_min(1)
+    return numerators / denominators
+
+
 def compute_opsm_mask(
     args: Namespace,
-    full_log_probs: list[torch.Tensor],
-    full_old_log_probs: list[torch.Tensor],
+    sequence_kl: torch.Tensor,
     advantages: list[torch.Tensor],
     loss_masks: list[torch.Tensor],
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    """Compute Off-Policy Sequence Masking (OPSM) mask.
-
-    Args:
-        args: Configuration containing `opsm_delta` threshold.
-        full_log_probs: Current policy log-probs per sample.
-        full_old_log_probs: Old policy log-probs per sample.
-        advantages: Advantage values per sample.
-        loss_masks: Loss masks per sample.
-
-    Returns:
-        Tuple of `(opsm_mask, opsm_clipfrac)` where `opsm_mask` is a
-        concatenated tensor of per-token masks and
-        `opsm_clipfrac` is the count of masked sequences.
-    """
+    """Compute the per-token OPSM mask and count of masked sequences."""
     opsm_mask_list = []
-    device = advantages[0].device
-    opsm_clipfrac = torch.tensor(0.0, device=device)
+    opsm_clipfrac = torch.tensor(0.0, device=advantages[0].device)
 
-    for full_log_prob, full_old_log_prob, advantage, loss_mask in zip(
-        full_log_probs, full_old_log_probs, advantages, loss_masks, strict=False
-    ):
-        # Calculate sequence-level KL
-        seq_kl = ((full_old_log_prob - full_log_prob) * loss_mask).sum() / torch.clamp_min(loss_mask.sum(), 1)
-
+    for seq_kl, advantage, loss_mask in zip(sequence_kl, advantages, loss_masks, strict=False):
         # Create mask: 0 if (advantage < 0 and seq_kl > delta), else 1
         mask = ((advantage < 0) & (seq_kl > args.opsm_delta)).float()
         opsm_clipfrac += mask.sum() / torch.clamp_min(loss_mask.sum(), 1)
-
         opsm_mask_list.append(1 - mask)
 
-    opsm_mask = torch.cat(opsm_mask_list, dim=0)
-    return opsm_mask, opsm_clipfrac
+    return torch.cat(opsm_mask_list, dim=0), opsm_clipfrac
 
 
 def compute_gspo_kl(
-    full_log_probs: list[torch.Tensor],
-    full_old_log_probs: list[torch.Tensor],
+    sequence_kl: torch.Tensor,
     local_log_probs: list[torch.Tensor],
-    loss_masks: list[torch.Tensor],
 ) -> torch.Tensor:
-    """Compute GSPO-style per-sequence KL divergence.
-
-    Args:
-        full_log_probs: Current policy log-probs per sample (full or CP-local).
-        full_old_log_probs: Old policy log-probs per sample (full or CP-local).
-        local_log_probs: Local (CP-local) log-probs for expansion shape reference.
-        loss_masks: Loss masks per sample.
-
-    Returns:
-        Concatenated tensor of per-token KL values where each token in a
-        sequence has the same KL value (the sequence-level KL).
-    """
-    # Compute sequence-level KL and expand to per-token
-    ppo_kl = [
-        ((old_logprob - log_prob) * loss_mask).sum() / torch.clamp_min(loss_mask.sum(), 1)
-        for log_prob, old_logprob, loss_mask in zip(full_log_probs, full_old_log_probs, loss_masks, strict=False)
-    ]
-    ppo_kl = [kl.expand_as(log_prob) for kl, log_prob in zip(ppo_kl, local_log_probs, strict=False)]
-    ppo_kl = torch.cat(ppo_kl, dim=0)
-
-    return ppo_kl
+    """Expand each sequence's global masked mean log-ratio to its local tokens."""
+    return torch.cat(
+        [kl.expand_as(log_prob) for kl, log_prob in zip(sequence_kl, local_log_probs, strict=False)], dim=0
+    )
 
 
 @torch.compile(dynamic=True)

--- a/tests/fast/backends/training_utils/loss/test_sequence_kl_cp.py
+++ b/tests/fast/backends/training_utils/loss/test_sequence_kl_cp.py
@@ -1,0 +1,136 @@
+"""Compare sequence-statistic reduction with full-response reconstruction on Gloo."""
+
+from functools import partial
+from unittest.mock import patch
+
+import pytest
+import torch
+import torch.distributed as dist
+from tests.fast.dist_utils import init_gloo, run_multiprocess
+
+from miles.backends.training_utils.cp_utils import (
+    all_gather_with_cp,
+    get_sum_of_sample_mean,
+    slice_log_prob_with_cp,
+    slice_with_cp,
+)
+from miles.backends.training_utils.loss_hub import losses
+from miles.backends.training_utils.parallel import GroupInfo, ParallelState, set_parallel_state
+
+from .loss_test_utils import make_args
+
+
+def _set_state(rank, size, tp_group):
+    trivial = GroupInfo(rank=0, size=1, group=None)
+    cp = GroupInfo(rank=rank, size=size, group=dist.group.WORLD if size > 1 else None)
+    set_parallel_state(
+        ParallelState(
+            intra_dp=trivial,
+            intra_dp_cp=cp,
+            cp=cp,
+            tp=GroupInfo(rank=0, size=1, group=tp_group),
+            pp=trivial,
+            ep=trivial,
+            etp=trivial,
+            indep_dp=trivial,
+        )
+    )
+
+
+def _run_case(rank, world_size, port, *, qkv_format):
+    init_gloo(rank, world_size, port=port)
+    tp_group = [dist.new_group([r]) for r in range(world_size)][rank]
+    _set_state(rank, world_size, tp_group)
+    generator = torch.Generator().manual_seed(12)
+    total_lengths = [33, 25, 33, 25]
+    response_lengths = [16, 16, 16, 16]
+    max_seq_lens = [40] * len(total_lengths) if qkv_format == "bshd" else [None] * len(total_lengths)
+    masks = [torch.ones(n) for n in response_lengths]
+    masks[0][2:7] = 0  # Masked observations inside a response.
+    masks[2].zero_()  # A fully masked sequence has denominator one.
+    full_logits = [torch.randn(n, 16, generator=generator) for n in total_lengths]
+    tokens = [torch.randint(16, (n,), generator=generator) for n in total_lengths]
+    # Keep both sides of the OPSM threshold and PPO clipping bounds represented.
+    old_log_probs = [
+        torch.log_softmax(logits, dim=-1)[n - r - 1 : n - 1].gather(1, tok[n - r :].unsqueeze(1)).squeeze(1) + offset
+        for logits, tok, n, r, offset in zip(
+            full_logits, tokens, total_lengths, response_lengths, [0.05, 0.3, -0.4, -0.1], strict=True
+        )
+    ]
+    advantages = [torch.linspace(-1, 1, n) for n in response_lengths]
+
+    def slice_response(xs):
+        return [
+            slice_log_prob_with_cp(x, n, r, qkv_format, m)
+            for x, n, r, m in zip(xs, total_lengths, response_lengths, max_seq_lens, strict=True)
+        ]
+
+    local_logits = torch.cat(
+        [slice_with_cp(x, 0, qkv_format, m) for x, m in zip(full_logits, max_seq_lens, strict=True)]
+    ).unsqueeze(0)
+    batch = dict(
+        total_lengths=total_lengths,
+        response_lengths=response_lengths,
+        max_seq_lens=max_seq_lens,
+        loss_masks=masks,
+        unconcat_tokens=tokens,
+        log_probs=slice_response(old_log_probs),
+        advantages=slice_response(advantages),
+    )
+    reducer = get_sum_of_sample_mean(
+        total_lengths, response_lengths, masks, qkv_format=qkv_format, max_seq_lens=max_seq_lens
+    )
+
+    def reconstructed_kl(log_probs, old_probs, local_masks, loss_masks):
+        full_current = [
+            all_gather_with_cp(x, n, r, qkv_format, m)
+            for x, n, r, m in zip(log_probs, total_lengths, response_lengths, max_seq_lens, strict=True)
+        ]
+        full_old = [
+            all_gather_with_cp(x, n, r, qkv_format, m)
+            for x, n, r, m in zip(old_probs, total_lengths, response_lengths, max_seq_lens, strict=True)
+        ]
+        return torch.stack(
+            [
+                ((old - new) * mask).sum() / mask.sum().clamp_min(1)
+                for old, new, mask in zip(full_old, full_current, loss_masks, strict=True)
+            ]
+        )
+
+    reduce_kl = losses.compute_sequence_kl
+    for estimator, opsm in [("gspo", False), ("gspo", True), ("grpo", True)]:
+        for reuse in [False, True]:
+            args = make_args(
+                advantage_estimator=estimator,
+                use_opsm=opsm,
+                qkv_format=qkv_format,
+                skip_actor_forward_only=reuse,
+                entropy_coef=0.0,
+                observe_training_entropy=False,
+            )
+            results = []
+            for sequence_kl_fn in [reconstructed_kl, reduce_kl]:
+                logits = local_logits.detach().clone().requires_grad_()
+
+                def checked_kl(*inputs, fn=sequence_kl_fn, requires_grad=estimator == "gspo"):
+                    with patch.object(dist.nn, "all_reduce", wraps=dist.nn.all_reduce) as collective:
+                        value = fn(*inputs)
+                    if fn is reduce_kl:
+                        assert collective.call_count == (1 if world_size > 1 else 0)
+                        if world_size > 1:
+                            assert collective.call_args.args[0].numel() == len(response_lengths)
+                    assert value.requires_grad == requires_grad
+                    return value
+
+                with patch.object(losses, "compute_sequence_kl", checked_kl):
+                    loss, metrics = losses.policy_loss_function(args, batch, logits, reducer)
+                loss.backward()
+                results.append((loss.detach(), metrics, logits.grad))
+            torch.testing.assert_close(results[0], results[1], rtol=2e-5, atol=1e-6)
+    dist.destroy_process_group()
+
+
+@pytest.mark.parametrize("world_size", [1, 2, 4])
+@pytest.mark.parametrize("qkv_format", ["thd", "bshd"])
+def test_sequence_reduction_matches_reconstructed_loss_and_gradients(world_size, qkv_format):
+    run_multiprocess(partial(_run_case, qkv_format=qkv_format), world_size=world_size)

--- a/tests/fast/backends/training_utils/loss/test_training_logprob_reuse.py
+++ b/tests/fast/backends/training_utils/loss/test_training_logprob_reuse.py
@@ -86,9 +86,9 @@ def test_reused_training_log_probs_match_an_explicit_detached_baseline(
         args=args,
     )
 
-    gather_spy = Mock(wraps=losses_module.all_gather_with_cp)
+    sequence_kl_spy = Mock(wraps=losses_module.compute_sequence_kl)
     if advantage_estimator == "gspo":
-        monkeypatch.setattr(losses_module, "all_gather_with_cp", gather_spy)
+        monkeypatch.setattr(losses_module, "compute_sequence_kl", sequence_kl_spy)
 
     reuse_batch = make_batch(inputs, "policy_loss")
     del reuse_batch["log_probs"]
@@ -99,7 +99,7 @@ def test_reused_training_log_probs_match_an_explicit_detached_baseline(
         skip_actor_forward_only=True,
     )
     if advantage_estimator == "gspo":
-        assert gather_spy.call_count == len(inputs["response_lens"])
+        assert sequence_kl_spy.call_count == 1
 
     baseline_batch = make_batch(inputs, "policy_loss")
     baseline_batch["log_probs"] = [


### PR DESCRIPTION
GSPO and OPSM reconstruct complete current and old response log-probabilities across CP ranks, then use only their masked mean difference. Compute the local masked sums first and reduce one scalar per sequence in a single collective. Both consumers reuse the result; global mask counts and loss scaling remain unchanged.

This replaces up to two full-response collectives per sample with one batched collective per microbatch. Local masks follow the existing `thd` and padded `bshd` layouts. Empty ranks participate in GSPO backward, while OPSM-only reduction runs without autograd.