### PR TITLE
fix(fsdp): use actual rollout engine topology for weight synchronization

### DIFF
--- a/miles/backends/fsdp_utils/update_weight_utils.py
+++ b/miles/backends/fsdp_utils/update_weight_utils.py
@@ -1,16 +1,16 @@
 import abc
 import logging
-import socket
 from argparse import Namespace
 from collections.abc import Sequence
+from itertools import accumulate
 from typing import TYPE_CHECKING
 
-import ray
 import torch
 import torch.distributed as dist
 from torch.distributed.tensor import DTensor
 
 from miles.backends.training_utils.conn_status import ConnStatusManager
+from miles.backends.training_utils.weight_update.protocols.broadcast import connect_rollout_engines_from_distributed
 
 try:
     from sglang.srt.utils.patch_torch import monkey_patch_torch_reductions  # type: ignore[import]
@@ -21,7 +21,7 @@ from sglang.srt.utils import MultiprocessingSerializer
 
 from miles.backends.sglang_utils.sglang_api_client import SGLangApiClient
 from miles.utils import async_utils
-from miles.utils.distributed_utils import get_gloo_group, init_process_group
+from miles.utils.distributed_utils import get_gloo_group
 
 if TYPE_CHECKING:
     pass
@@ -151,10 +151,16 @@ class UpdateWeightFromTensor(UpdateWeight):
         """Attach rollout engines and create per-engine IPC (Gloo) groups (sets gather src rank, engine, tp_rank)."""
         self.rollout_engines = rollout_engines
 
-        # Here we assume the gpu id of rollout engines and train actors are the same.
-        for i, engine in enumerate(self.rollout_engines):
-            start_rank = i * self.args.rollout_num_gpus_per_engine
-            end_rank = (i + 1) * self.args.rollout_num_gpus_per_engine
+        if engine_gpu_counts is None:
+            engine_gpu_counts = [self.args.rollout_num_gpus_per_engine] * len(rollout_engines)
+        if engine_gpu_offsets is None:
+            engine_gpu_offsets = list(accumulate(engine_gpu_counts, initial=0))[:-1]
+
+        self._ipc_engine = None
+        self._ipc_gather_src = None
+        self._ipc_gather_group = None
+        for engine, start_rank, count in zip(rollout_engines, engine_gpu_offsets, engine_gpu_counts, strict=True):
+            end_rank = start_rank + count
             group_ranks = list(range(start_rank, end_rank))
             new_group = dist.new_group(
                 ranks=group_ranks,
@@ -167,6 +173,9 @@ class UpdateWeightFromTensor(UpdateWeight):
                 self.tp_rank = dist.get_rank() - start_rank
 
     def update_bucket_weights(self, named_tensors, weight_version=None) -> None:
+        if self._ipc_engine is None:
+            return
+
         monkey_patch_torch_reductions()
         logger.info("Using flattened tensor bucket")
         named_tensors_by_dtypes = {}
@@ -243,34 +252,9 @@ class UpdateWeightFromDistributed(UpdateWeight):
         self._is_src_rank = dist.get_rank() == 0
         if self._is_src_rank:
             self._group_name = "miles"
-            master_address = ray._private.services.get_node_ip_address()
-            with socket.socket() as sock:
-                sock.bind(("", 0))
-                master_port = sock.getsockname()[1]
-            # +1 for the trainer's source rank (rank 0); rollout engine ranks start at 1
-            world_size = self.args.rollout_num_gpus + 1
-
-            futures = [
-                async_utils.submit(
-                    api_client.init_weights_update_group(
-                        master_address,
-                        master_port,
-                        i * self.args.rollout_num_gpus_per_engine + 1,
-                        world_size,
-                        self._group_name,
-                        backend="nccl",
-                    )
-                )
-                for i, api_client in enumerate(self.rollout_engines)
-            ]
-            self._model_update_groups = init_process_group(
-                backend="nccl",
-                init_method=f"tcp://{master_address}:{master_port}",
-                world_size=world_size,
-                rank=0,
-                group_name=self._group_name,
+            self._model_update_groups = connect_rollout_engines_from_distributed(
+                self.args, self._group_name, rollout_engines, engine_gpu_counts=engine_gpu_counts
             )
-            async_utils.wait_futures(futures)
 
     def update_bucket_weights(self, named_tensors, weight_version=None) -> None:
         """Send names/dtypes/shapes metadata to engines, then broadcast the tensors (contiguous;

--- a/tests/fast/backends/test_fsdp_update_weight.py
+++ b/tests/fast/backends/test_fsdp_update_weight.py
@@ -442,3 +442,84 @@ def test_fsdp_actor_rejects_a_mismatched_engine_weight_version(monkeypatch):
         actor.update_weights(_make_updatable_engines(engines, has_new_engines=True))
 
     assert updater.update_weights_calls == 1
+
+
+@pytest.mark.parametrize(
+    "counts,offsets,expected_groups",
+    [
+        ([1, 2], [1, 3], [[1], [3, 4]]),
+        ([1, 2], None, [[0], [1, 2]]),
+        (None, None, [[0, 1], [2, 3]]),
+    ],
+)
+def test_fsdp_ipc_groups_follow_engine_layout(monkeypatch, counts, offsets, expected_groups):
+    engines = [object(), object()]
+    for rank in range(5):
+        groups = []
+        updater = update_weight_utils.UpdateWeightFromTensor(Namespace(rollout_num_gpus_per_engine=2), None)
+        monkeypatch.setattr(update_weight_utils.dist, "get_rank", lambda rank=rank: rank)
+
+        def new_group(ranks, backend, groups=groups):
+            assert backend == "gloo"
+            groups.append(ranks)
+            return tuple(ranks)
+
+        monkeypatch.setattr(update_weight_utils.dist, "new_group", new_group)
+        updater.connect_rollout_engines(engines, engine_gpu_counts=counts, engine_gpu_offsets=offsets)
+
+        assert groups == expected_groups
+        matching = [i for i, members in enumerate(expected_groups) if rank in members]
+        if matching:
+            index = matching[0]
+            members = expected_groups[index]
+            assert updater._ipc_engine is engines[index]
+            assert updater._ipc_gather_src == members[0]
+            assert updater._ipc_gather_group == tuple(members)
+            assert updater.tp_rank == members.index(rank)
+        else:
+            assert updater._ipc_engine is updater._ipc_gather_src is updater._ipc_gather_group is None
+
+
+def test_fsdp_ipc_reconnect_drops_rank_without_engine(monkeypatch):
+    updater = update_weight_utils.UpdateWeightFromTensor(Namespace(rollout_num_gpus_per_engine=2), None)
+    monkeypatch.setattr(update_weight_utils.dist, "get_rank", lambda: 2)
+    monkeypatch.setattr(update_weight_utils.dist, "new_group", lambda ranks, backend: tuple(ranks))
+    updater.connect_rollout_engines([object()], engine_gpu_counts=[3], engine_gpu_offsets=[0])
+    assert updater._ipc_engine is not None
+    updater.connect_rollout_engines([object()], engine_gpu_counts=[1], engine_gpu_offsets=[4])
+    assert updater._ipc_engine is updater._ipc_gather_src is updater._ipc_gather_group is None
+
+    def unexpected_gather(*args, **kwargs):
+        pytest.fail("A rank without an engine must not enter an IPC gather")
+
+    monkeypatch.setattr(update_weight_utils.dist, "gather_object", unexpected_gather)
+    updater.update_bucket_weights([("weight", torch.ones(2))])
+
+
+def test_fsdp_distributed_group_uses_actual_engine_counts(monkeypatch):
+    from miles.backends.training_utils.weight_update.protocols import broadcast
+
+    class Engine:
+        async def init_weights_update_group(self, address, port, rank_offset, world_size, group_name, backend):
+            self.membership = (rank_offset, world_size, group_name)
+
+    engines = [Engine(), Engine()]
+    group = object()
+    joined = {}
+
+    def join(**kwargs):
+        joined.update(kwargs)
+        return group
+
+    monkeypatch.setattr(update_weight_utils.dist, "get_rank", lambda: 0)
+    monkeypatch.setattr(broadcast.ray._private.services, "get_node_ip_address", lambda: "127.0.0.1")
+    monkeypatch.setattr(broadcast, "init_process_group", join)
+    updater = update_weight_utils.UpdateWeightFromDistributed(
+        Namespace(rollout_num_gpus_per_engine=4, rollout_num_gpus=8), None
+    )
+    updater.connect_rollout_engines(engines, engine_gpu_counts=[1, 2], engine_gpu_offsets=[8, 12])
+
+    assert [engine.membership for engine in engines] == [(1, 4, "miles"), (2, 4, "miles")]
+    assert joined["world_size"] == 4
+    assert joined["rank"] == 0
+    assert updater._model_update_groups is group


### PR DESCRIPTION
## Motivation

The FSDP weight updater receives `engine_gpu_counts` and `engine_gpu_offsets`, but previously constructed transfer groups using the fixed `rollout_num_gpus_per_engine` setting.

This assumes that every rollout engine has the same number of GPUs and that colocated engines occupy consecutive trainer ranks. Heterogeneous engine sizes, nonzero starting offsets, or reserved GPU gaps break that assumption.

For example, with:

```python
engine_gpu_counts = [1, 2]
engine_gpu_offsets = [1, 3]
```

the colocated IPC groups should contain ranks `[1]` and `[3, 4]`. With `rollout_num_gpus_per_engine=2`, the previous code instead created `[0, 1]` and `[2, 3]`, assigning trainer ranks to the wrong engines.

The distributed path had the same fixed-size assumption when assigning NCCL rank offsets. It also derived the group size from `rollout_num_gpus`, which may differ from the GPU count of the engines actually joining the group.

## Changes

### Colocated IPC synchronization

- Build each Gloo gather group from the engine's supplied GPU offset and count.
- Assign the gather source and engine-local `tp_rank` from that group's actual rank range.
- Clear the previous engine, gather source, and gather group when reconnecting, so ranks no longer covered by an engine do not retain a stale assignment.
- Skip IPC bucket sends on ranks without an assigned engine. The existing FSDP parameter-gather path still runs on those ranks.

When counts are omitted, the updater continues to use the configured uniform engine size. When offsets are omitted, it derives consecutive offsets from the engine counts.

### Distributed synchronization

Reuse `connect_rollout_engines_from_distributed`, the existing shared broadcast helper, to construct the NCCL group.

The helper assigns consecutive communication ranks from the actual engine counts and reserves rank 0 for the trainer. For engines with GPU counts `[1, 2]`, their starting ranks are `1` and `2`, and the group size is `4`.

These communication ranks are independent of physical GPU offsets, which remain relevant to colocated IPC placement.

## Validation

Extended `tests/fast/backends/test_fsdp_update_weight.py` with regression coverage for:

- Heterogeneous engine sizes with explicit offsets and gaps.
- Consecutive offsets derived from heterogeneous counts.
- The existing uniform-layout defaults.
- Gather-source, engine assignment, and local TP-rank mapping.
- Reconnection that leaves a previously assigned trainer rank without an engine.
- Distributed group membership derived from actual counts rather than configured fleet totals.
```bash
python -m pytest --noconftest \
  tests/fast/backends/test_fsdp_update_weight.py -q
```
All applicable pre-commit checks and `git diff --check` passed.