### PR TITLE
tools: let convert_torch_dist_to_hf export a bridge checkpoint

### DIFF
--- a/tests/fast/tools/test_convert_torch_dist_to_hf.py
+++ b/tests/fast/tools/test_convert_torch_dist_to_hf.py
@@ -1,0 +1,95 @@
+"""tools/convert_torch_dist_to_hf.py: bridge mode routes through AutoBridge.export_ckpt (#634)."""
+
+import importlib.util
+import pickle
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+_TOOL = Path(__file__).resolve().parents[3] / "tools" / "convert_torch_dist_to_hf.py"
+
+
+@pytest.fixture
+def tool(monkeypatch):
+    """Import the tool as a module; importing must leave pickle.Unpickler alone."""
+    before = pickle.Unpickler
+    spec = importlib.util.spec_from_file_location("convert_torch_dist_to_hf_under_test", _TOOL)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    assert pickle.Unpickler is before
+    return module
+
+
+@pytest.fixture
+def fake_bridge(monkeypatch):
+    calls: dict[str, object] = {}
+
+    class AutoBridge:
+        @classmethod
+        def from_hf_pretrained(cls, hf_dir, **kwargs):
+            calls["from_hf_pretrained"] = (hf_dir, kwargs)
+            return cls()
+
+        def export_ckpt(self, *, megatron_path, hf_path):
+            calls["export_ckpt"] = (megatron_path, hf_path)
+
+    bridge_pkg = types.ModuleType("megatron.bridge")
+    bridge_pkg.AutoBridge = AutoBridge
+    monkeypatch.setitem(sys.modules, "megatron.bridge", bridge_pkg)
+    return calls
+
+
+def test_bridge_mode_exports_through_autobridge(tool, fake_bridge, monkeypatch, tmp_path):
+    copied = {}
+    monkeypatch.setattr(tool, "copy_assets", lambda src, dst: copied.update(src=src, dst=dst))
+    monkeypatch.setattr(tool, "save_tensors", lambda *a, **k: pytest.fail("raw path must not run in bridge mode"))
+
+    tool.main(
+        [
+            "--input-dir",
+            "ckpt",
+            "--output-dir",
+            str(tmp_path / "out"),
+            "--origin-hf-dir",
+            "hf",
+            "--megatron-to-hf-mode",
+            "bridge",
+        ]
+    )
+
+    assert fake_bridge["from_hf_pretrained"] == ("hf", {"trust_remote_code": True})
+    assert fake_bridge["export_ckpt"] == ("ckpt", str(tmp_path / "out"))
+    assert copied == {"src": "hf", "dst": str(tmp_path / "out")}
+    assert pickle.Unpickler.__name__ != "UnpicklerWrapper"
+
+
+def test_bridge_mode_needs_the_origin_hf_dir(tool, fake_bridge, tmp_path):
+    with pytest.raises(ValueError, match="--origin-hf-dir"):
+        tool.main(["--input-dir", "ckpt", "--output-dir", str(tmp_path / "out"), "--megatron-to-hf-mode", "bridge"])
+    assert "export_ckpt" not in fake_bridge
+
+
+def test_bridge_mode_without_the_package_says_so(tool, monkeypatch, tmp_path):
+    monkeypatch.setitem(sys.modules, "megatron.bridge", None)
+    with pytest.raises(RuntimeError, match="megatron.bridge"):
+        tool.main(
+            [
+                "--input-dir",
+                "ckpt",
+                "--output-dir",
+                str(tmp_path / "out"),
+                "--origin-hf-dir",
+                "hf",
+                "--megatron-to-hf-mode",
+                "bridge",
+            ]
+        )
+
+
+def test_default_mode_is_raw_and_the_flag_is_constrained(tool):
+    parser = tool.build_parser()
+    assert parser.parse_args(["--input-dir", "a", "--output-dir", "b"]).megatron_to_hf_mode == "raw"
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--input-dir", "a", "--output-dir", "b", "--megatron-to-hf-mode", "direct"])

--- a/tools/convert_torch_dist_to_hf.py
+++ b/tools/convert_torch_dist_to_hf.py
@@ -1,4 +1,5 @@
 import argparse
+import contextlib
 import json
 import os
 import pickle
@@ -27,7 +28,19 @@ class UnpicklerWrapper(pickle.Unpickler):
         return super().find_class(mod_name, name)
 
 
-pickle.Unpickler = UnpicklerWrapper
+@contextlib.contextmanager
+def _megatron_classes_as_dummies():
+    """Unpickle the raw torch_dist checkpoint without importing Megatron's argument classes.
+
+    Scoped to the raw path on purpose: the bridge path hands the checkpoint to megatron.bridge, which
+    needs those classes intact.
+    """
+    original = pickle.Unpickler
+    pickle.Unpickler = UnpicklerWrapper
+    try:
+        yield
+    finally:
+        pickle.Unpickler = original
 
 
 class WrappedStorageReader(dist_cp.FileSystemReader):
@@ -157,11 +170,41 @@ def copy_assets(origin_hf_dir, output_dir):
         shutil.copy(src, dst)
 
 
-if __name__ == "__main__":
+MEGATRON_TO_HF_MODES = ("raw", "bridge")
+
+
+def convert_with_bridge(input_dir: str, output_dir: str, origin_hf_dir: str) -> None:
+    """Export a megatron.bridge-built checkpoint (Qwen3-VL and friends) through the bridge itself.
+
+    The raw converters in miles.backends.megatron_utils.megatron_to_hf only know the plain decoder
+    layout, so a bridge checkpoint dies there with "Unknown parameter name" (#634). AutoBridge.export_ckpt
+    loads the torch_dist checkpoint under a temporary gloo group and writes safetensors on CPU, so no
+    GPU is needed here either.
+    """
+    try:
+        from megatron.bridge import AutoBridge
+    except ImportError as exc:
+        raise RuntimeError(
+            "--megatron-to-hf-mode bridge needs megatron.bridge, which this environment does not provide; "
+            "run the conversion inside the miles image or install Megatron-Bridge"
+        ) from exc
+    bridge = AutoBridge.from_hf_pretrained(origin_hf_dir, trust_remote_code=True)
+    bridge.export_ckpt(megatron_path=input_dir, hf_path=output_dir)
+
+
+def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser()
     parser.add_argument("--model-name", type=str, default=None)
     parser.add_argument("--input-dir", type=str, required=True)
     parser.add_argument("--output-dir", type=str, required=True)
+    parser.add_argument(
+        "--megatron-to-hf-mode",
+        choices=MEGATRON_TO_HF_MODES,
+        default="raw",
+        help="raw: the per-model converters under miles.backends.megatron_utils.megatron_to_hf; "
+        "bridge: AutoBridge.export_ckpt, required for checkpoints trained with --megatron-to-hf-mode bridge "
+        "(needs --origin-hf-dir).",
+    )
     parser.add_argument(
         "--origin-hf-dir",
         type=str,
@@ -183,10 +226,21 @@ if __name__ == "__main__":
         default=None,
         help="Vocab size for removing padding, if applicable. If not provided, no padding will be removed.",
     )
-    args = parser.parse_args()
+    return parser
+
+
+def main(argv: list[str] | None = None) -> None:
+    args = build_parser().parse_args(argv)
 
     if os.path.exists(args.output_dir) and not args.force:
         raise ValueError(f"Output directory {args.output_dir} already exists. Use --force to overwrite it.")
+
+    if args.megatron_to_hf_mode == "bridge":
+        if args.origin_hf_dir is None:
+            raise ValueError("--megatron-to-hf-mode bridge needs --origin-hf-dir to build the bridge from")
+        convert_with_bridge(args.input_dir, args.output_dir, args.origin_hf_dir)
+        copy_assets(args.origin_hf_dir, args.output_dir)
+        return
 
     if args.model_name is None and args.origin_hf_dir is None:
         raise ValueError(
@@ -200,16 +254,21 @@ if __name__ == "__main__":
     state_dict = {}
     print(f"loading model from {args.input_dir}")
     t = time.time()
-    megatron_args = torch.load(os.path.join(args.input_dir, "common.pt"), weights_only=False)["args"]
-    dist_cp.state_dict_loader._load_state_dict(
-        state_dict,
-        storage_reader=WrappedStorageReader(args.input_dir),
-        planner=EmptyStateDictLoadPlanner(),
-        no_dist=True,
-    )
+    with _megatron_classes_as_dummies():
+        megatron_args = torch.load(os.path.join(args.input_dir, "common.pt"), weights_only=False)["args"]
+        dist_cp.state_dict_loader._load_state_dict(
+            state_dict,
+            storage_reader=WrappedStorageReader(args.input_dir),
+            planner=EmptyStateDictLoadPlanner(),
+            no_dist=True,
+        )
     print(f"model loaded in {time.time()-t:.2f} sec.")
 
     save_tensors(megatron_args, args.model_name, state_dict, args.output_dir, args.chunk_size, args.vocab_size)
 
     if args.origin_hf_dir:
         copy_assets(args.origin_hf_dir, args.output_dir)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Refs #634 (second report, the offline converter); pairs with #3177, which covers the training-time converter.

### What

`tools/convert_torch_dist_to_hf.py` gains `--megatron-to-hf-mode {raw,bridge}` (default `raw`, unchanged behavior). `bridge` needs `--origin-hf-dir`, builds `AutoBridge.from_hf_pretrained(origin_hf_dir, trust_remote_code=True)` and calls `export_ckpt(input_dir, output_dir)`, then copies the tokenizer and config assets as the raw path does. When `megatron.bridge` is not importable the tool says so and names the fix instead of falling back to raw. The module-level script body moves into `build_parser()` and `main(argv)` so the tool can be imported by a test, and the `pickle.Unpickler` swap that lets the raw path unpickle without Megatron's argument classes is now a context manager around the raw load only, since the bridge needs those classes intact. `python tools/convert_torch_dist_to_hf.py ...` behaves as before.

A checkpoint trained with `--megatron-to-hf-mode bridge` (Qwen3-VL and the other megatron.bridge-built models) carries names the raw per-model converters do not know, so the offline tool died with "Unknown parameter name" and had no flag to choose the bridge. `export_ckpt` in the pinned Megatron-Bridge fork loads the torch_dist checkpoint under a temporary gloo group and exports on CPU, so no GPU is needed for the offline path.

### Test

`tests/fast/tools/test_convert_torch_dist_to_hf.py` imports the tool against a fake `megatron.bridge`: bridge mode calls `from_hf_pretrained` and `export_ckpt` with the given paths, never touches the raw path, and leaves `pickle.Unpickler` alone; bridge mode without `--origin-hf-dir` is rejected; a missing package raises with the package name; the flag defaults to raw and rejects other values.

### Verification

- The four cases pass; with the tool restored from main all four error at import (the old script has no `build_parser`, and importing it patches `pickle.Unpickler`).
- `--help` lists the new flag; the raw path's arguments, defaults and messages are unchanged.
- ruff, black 24.3.0 and isort at the pre-commit pins are clean.

### Scope

- Not run here against a real bridge checkpoint: producing one needs a GPU training run, which I will do in the coming days on an H100 and report on this PR. The wiring is exercised only through the fake bridge until then.
- `tools/convert_torch_dist_to_hf_ray.py` keeps calling the raw converters; the same flag could be added there in a follow-up.

cc @yueming-yuan @Zhichenzzz
