### PR TITLE
fix(docker): bump torch_memory_saver to pick up the free-while-paused fix

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -163,7 +163,7 @@ RUN pip install "git+https://github.com/NVIDIA-NeMo/Emerging-Optimizers.git@v0.3
 
 # torch_memory_saver's source build needs TMS_CUDA_MAJOR; take it from torch.
 RUN TMS_CUDA_MAJOR=$(python3 -c "import torch; print(torch.version.cuda.split('.')[0])") \
-    pip install git+https://github.com/fzyzcjy/torch_memory_saver.git@f05a8754daf68238d54e4cf31cb3ba866684bbaf --no-cache-dir --force-reinstall
+    pip install git+https://github.com/fzyzcjy/torch_memory_saver.git@b5588e83de86412a48689a6583a4b567e75f7acc --no-cache-dir --force-reinstall
 RUN pip install "nvidia-modelopt[torch]>=0.37.0" --no-build-isolation
 RUN pip install git+https://github.com/radixark/Megatron-Bridge.git@bridge --no-deps --no-build-isolation
 RUN pip install megatron-energon --no-deps


### PR DESCRIPTION
## Problem

`test_deepseek_v4_flash_4layer_ci.py` has been failing in the [nightly](https://github.com/radixark/miles/actions/runs/34368332492) since 09-09 with:

```text
[torch_memory_saver.cpp] CUresult error: 1 (invalid argument) file=csrc/core.cpp func=free
```

The failure started after weight sync began calling `torch.cuda.empty_cache()` while the trainer is paused by `torch_memory_saver`.

With the current CUDA pin (`f05a8754d`), if `empty_cache()` frees a cached segment inside a paused region, `torch_memory_saver` tries to release the same allocation again and crashes. This is [torch_memory_saver#92](https://github.com/fzyzcjy/torch_memory_saver/issues/92), fixed by [#95](https://github.com/fzyzcjy/torch_memory_saver/pull/95).

The test passed in the 09-08 nightly and in PR CI on 09-09, then started failing after the `empty_cache()` change landed on main.

## Fix

Bump the CUDA `torch_memory_saver` pin to [b5588e83d](https://github.com/fzyzcjy/torch_memory_saver/commit/b5588e83de86412a48689a6583a4b567e75f7acc), the merge commit of [#95](https://github.com/fzyzcjy/torch_memory_saver/pull/95).

This is the smallest bump containing the fix. The package version remains `0.0.9.post1` and no build changes are needed.

ROCm already pins `06caa5348`, which includes the fix, so it is unchanged.