### PR TITLE
Native LoRA fixes: grad dtype order, gloo barriers, strict adapter load, trainer-owned adapter

### DIFF
--- a/miles/backends/megatron_utils/lora_utils.py
+++ b/miles/backends/megatron_utils/lora_utils.py
@@ -153,7 +153,8 @@ def reduce_marked_lora_grads(model: Sequence[torch.nn.Module]) -> None:
                 grad = param.grad
             if grad is not None:
                 grads.append(grad)
-        for dt in {g.dtype for g in grads}:
+        # set iteration order follows address-derived hashes and need not agree across ranks
+        for dt in sorted({g.dtype for g in grads}, key=str):
             gs = [g for g in grads if g.dtype == dt]
             if len(gs) == 1:
                 dist.all_reduce(gs[0], op=dist.ReduceOp.SUM, group=group)

--- a/miles/backends/megatron_utils/lora_utils.py
+++ b/miles/backends/megatron_utils/lora_utils.py
@@ -11,6 +11,7 @@ import torch
 import torch.distributed as dist
 
 from miles.backends.training_utils.parallel import get_parallel_state
+from miles.utils.distributed_utils import get_gloo_group
 from miles.utils.lora import is_lora_enabled, lora_rollout_enabled  # noqa: F401  (re-exported)
 
 logger = logging.getLogger(__name__)
@@ -437,7 +438,7 @@ def save_lora_checkpoint(
 
     save_path.mkdir(parents=True, exist_ok=True)
     if dist.is_initialized():
-        dist.barrier()
+        dist.barrier(group=get_gloo_group())
 
     adapter_state: dict[str, torch.Tensor] = {}
     for model_chunk in model:
@@ -507,7 +508,7 @@ def save_lora_checkpoint(
         logger.info(f"Saved optimizer/scheduler state to {save_path}")
 
     if dist.is_initialized():
-        dist.barrier()
+        dist.barrier(group=get_gloo_group())
 
     return str(save_path)
 

--- a/miles/backends/megatron_utils/lora_utils.py
+++ b/miles/backends/megatron_utils/lora_utils.py
@@ -553,19 +553,33 @@ def load_lora_adapter(
     global_rank = dist.get_rank() if dist.is_initialized() else 0
     native_path = adapter_dir / f"adapter_megatron_rank{global_rank}.pt"
     if not native_path.exists():
+        if any(adapter_dir.glob("adapter_megatron_rank*.pt")):
+            raise FileNotFoundError(
+                f"{adapter_dir} holds per-rank adapter shards but none for global rank {global_rank}; "
+                "it was saved under a different parallel layout."
+            )
         legacy = adapter_dir / f"adapter_megatron_tp{tp_rank}_pp{pp_rank}.pt"
         if legacy.exists():
             logger.warning(f"Using legacy tp/pp-named adapter shard {legacy}; only valid when EP<=TP")
             native_path = legacy
     if native_path.exists():
         state_dict = torch.load(native_path, map_location="cpu", weights_only=True)
-        loaded = 0
-        for model_chunk in model:
-            for name, param in model_chunk.named_parameters():
-                if name in state_dict:
-                    param.data.copy_(state_dict[name].to(device=param.device))
-                    loaded += 1
-        logger.info(f"Loaded {loaded} adapter tensors from Megatron-native checkpoint: {native_path}")
+        adapter_params = {
+            name: param
+            for model_chunk in model
+            for name, param in model_chunk.named_parameters()
+            if _is_adapter_param_name(name)
+        }
+        missing = adapter_params.keys() - state_dict.keys()
+        unexpected = state_dict.keys() - adapter_params.keys()
+        if missing or unexpected:
+            raise RuntimeError(
+                f"Adapter checkpoint {native_path} does not match the model's adapter parameters: "
+                f"missing={sorted(missing)}, unexpected={sorted(unexpected)}"
+            )
+        for name, param in adapter_params.items():
+            param.data.copy_(state_dict[name].to(device=param.device))
+        logger.info(f"Loaded {len(adapter_params)} adapter tensors from Megatron-native checkpoint: {native_path}")
 
         iteration = _load_training_state(adapter_dir, optimizer, opt_param_scheduler)
         return True, iteration

--- a/miles/backends/sglang_utils/sglang_engine.py
+++ b/miles/backends/sglang_utils/sglang_engine.py
@@ -9,7 +9,12 @@ from sglang.srt.server_args import ServerArgs
 
 from miles.backends.megatron_utils.lora_utils import convert_target_modules_to_hf, sglang_lora_target_all_sentinel
 from miles.backends.sglang_utils.server_args_utils import server_args_to_argv
-from miles.utils.lora import LORA_ADAPTER_NAME, lora_base_cpu_backup_enabled, lora_rollout_enabled
+from miles.utils.lora import (
+    LORA_ADAPTER_NAME,
+    engine_loads_adapter_from_disk,
+    lora_base_cpu_backup_enabled,
+    lora_rollout_enabled,
+)
 from miles.utils.multi_lora import is_multi_lora_enabled
 
 logger = logging.getLogger(__name__)
@@ -153,10 +158,10 @@ def _compute_server_args(
         else:
             kwargs["lora_target_modules"] = convert_target_modules_to_hf(args.target_modules)
 
-        if args.lora_adapter_path is not None and kwargs.get("load_format") != "dummy":
+        if engine_loads_adapter_from_disk(args):
             kwargs["lora_paths"] = [f"{LORA_ADAPTER_NAME}={args.lora_adapter_path}"]
         elif args.lora_adapter_path is not None:
-            logger.info("dummy base load: skipping startup lora_paths; adapter comes via weight-sync")
+            logger.info("Skipping startup lora_paths: the trainer pushes the adapter in the first weight sync")
         else:
             logger.info("No pre-trained LoRA adapter_path provided, will use random initial weights")
 

--- a/miles/utils/lora.py
+++ b/miles/utils/lora.py
@@ -22,6 +22,11 @@ def lora_rollout_enabled(args: Namespace) -> bool:
     return is_lora_enabled(args) and not getattr(args, "lora_train_only", False)
 
 
+def engine_loads_adapter_from_disk(args: Namespace) -> bool:
+    """Only when no trainer will push the adapter; otherwise the first weight sync carries it."""
+    return args.lora_adapter_path is not None and (args.debug_rollout_only or args.debug_skip_weight_update)
+
+
 def lora_base_cpu_backup_enabled(args: Namespace) -> bool:
     """LoRA + --colocate + --lora-base-cpu-backup all set."""
     return is_lora_enabled(args) and getattr(args, "colocate", False) and getattr(args, "lora_base_cpu_backup", False)

--- a/tests/fast/backends/megatron_utils/test_lora_utils.py
+++ b/tests/fast/backends/megatron_utils/test_lora_utils.py
@@ -5,10 +5,13 @@ exclude-module parsing, and LoRA sync config building — all without GPU.
 """
 
 from argparse import Namespace
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
+import torch
 
+from miles.backends.megatron_utils import lora_utils
 from miles.backends.megatron_utils.lora_utils import (
     _get_lora_class_name,
     _is_adapter_param_name,
@@ -377,3 +380,37 @@ class TestBuildLoraSyncConfigUnderMultiLora:
         )
 
         assert build_lora_sync_config(self._args())["target_modules"] == "all-linear"
+
+
+class _AdapterModel(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.base = torch.nn.Linear(2, 2)
+        self.lora_A = torch.nn.Parameter(torch.zeros(1, 2))
+        self.lora_B = torch.nn.Parameter(torch.zeros(2, 1))
+
+
+def _single_rank(monkeypatch):
+    monkeypatch.setattr(
+        lora_utils,
+        "get_parallel_state",
+        lambda: SimpleNamespace(tp=SimpleNamespace(rank=0), pp=SimpleNamespace(rank=0)),
+    )
+
+
+def test_load_lora_adapter_rejects_a_shard_that_does_not_match_the_adapter(tmp_path, monkeypatch):
+    """A silently partial load resumes training on a half-initialized adapter."""
+    _single_rank(monkeypatch)
+    torch.save({"lora_A": torch.ones(1, 2), "stale_lora_C": torch.ones(1)}, tmp_path / "adapter_megatron_rank0.pt")
+
+    with pytest.raises(RuntimeError, match=r"missing=\['lora_B'\], unexpected=\['stale_lora_C'\]"):
+        lora_utils.load_lora_adapter([_AdapterModel()], str(tmp_path))
+
+
+def test_load_lora_adapter_rejects_shards_saved_under_another_layout(tmp_path, monkeypatch):
+    """Falling through to fresh adapter weights would hide a resharding mistake."""
+    _single_rank(monkeypatch)
+    torch.save({"lora_A": torch.ones(1, 2)}, tmp_path / "adapter_megatron_rank1.pt")
+
+    with pytest.raises(FileNotFoundError, match="none for global rank 0"):
+        lora_utils.load_lora_adapter([_AdapterModel()], str(tmp_path))

--- a/tests/fast/backends/sglang_utils/conftest.py
+++ b/tests/fast/backends/sglang_utils/conftest.py
@@ -51,6 +51,8 @@ def make_engine_args(**overrides: Any) -> Namespace:
         lora_rank=0,
         sglang_api_key=None,
         lora_adapter_path=None,
+        debug_rollout_only=False,
+        debug_skip_weight_update=False,
         multi_lora=False,
         colocate=False,
     )

--- a/tests/fast/backends/sglang_utils/test_compute_server_args.py
+++ b/tests/fast/backends/sglang_utils/test_compute_server_args.py
@@ -22,6 +22,8 @@ def make_args(**overrides: object) -> SimpleNamespace:
         use_rollout_indexer_replay=False,
         fp16=False,
         lora_adapter_path=None,
+        debug_rollout_only=False,
+        debug_skip_weight_update=False,
         multi_lora_n_adapters=1,
         target_modules=["linear_qkv"],
     )
@@ -114,3 +116,20 @@ class TestSglangOverridePrecedence:
         assert server_args["dtype"] == "float16"
         assert server_args["enable_lora"] is True
         assert server_args["mem_fraction_static"] == 0.7
+
+
+class TestAdapterOwnership:
+    def test_a_trainer_run_leaves_the_adapter_to_the_first_weight_sync(self):
+        """An engine that also loaded the adapter from disk would serve stale weights if the sync were skipped."""
+        server_args = compute(make_args(lora_rank=8, lora_adapter_path="/fake/adapter"))
+
+        assert server_args["enable_lora"] is True
+        assert not server_args.get("lora_paths")
+
+    @pytest.mark.parametrize(
+        "flag", ["debug_rollout_only", "debug_skip_weight_update"], ids=["rollout-only", "skip-sync"]
+    )
+    def test_without_a_trainer_push_the_engine_loads_the_adapter_itself(self, flag):
+        server_args = compute(make_args(lora_rank=8, lora_adapter_path="/fake/adapter", **{flag: True}))
+
+        assert server_args["lora_paths"] == ["miles_lora=/fake/adapter"]

--- a/tests/fast/backends/sglang_utils/test_server_args_utils.py
+++ b/tests/fast/backends/sglang_utils/test_server_args_utils.py
@@ -188,7 +188,9 @@ class TestServerArgsToArgv:
     def test_lora_adapter_paths_roundtrip(self):
         """The name=path lora mapping survives the argv boundary."""
         server_args = _server_args(
-            args=_args(lora_rank=8, target_modules=["linear_qkv"], lora_adapter_path="/fake/adapter")
+            args=_args(
+                lora_rank=8, target_modules=["linear_qkv"], lora_adapter_path="/fake/adapter", debug_rollout_only=True
+            )
         )
         _assert_roundtrips(server_args)
 


### PR DESCRIPTION
Four independent fixes to the native (raw-mode) LoRA path, split out of the Kimi K3 PR (#1825) because none of them is K3-specific.

- **Sort LoRA grad dtypes before the EP all-reduce.** `reduce_marked_lora_grads` iterated a `set` of `torch.dtype`, whose order follows address-derived hashes and need not agree across ranks; with mixed fp32 `main_grad` / bf16 `grad` the ranks issue the collectives in different orders.
- **Gloo group for the LoRA checkpoint barriers.** Control-plane barriers go through gloo everywhere else; the default NCCL barrier needs a live communicator and a CUDA allocation around the colocated trainer's sleep/wake boundary.
- **Refuse a LoRA adapter checkpoint that does not match the model.** `load_lora_adapter` copied whatever names matched and logged a count, so a renamed parameter, a changed target set, or shards from another parallel layout resumed on a half-initialized adapter. It now raises on missing/unexpected tensors and on a directory holding per-rank shards but none for this rank. Tests: `test_load_lora_adapter_rejects_*`.
- **The trainer owns the adapter.** `--lora-adapter-path` was consumed by both sides: the trainer loaded it into the model and the engine loaded it again at startup via `lora_paths`, which also pinned the on-disk format to HF PEFT. In every run with a trainer the first weight sync overwrites the engine's adapter before rollout 0, so the startup load was redundant. Engines now load from disk only when no trainer will push (`--debug-rollout-only`, `--debug-skip-weight-update`); the `load_format=dummy` special case collapses into the same rule. Tests: `TestAdapterOwnership`.

Behavior change for HF-adapter runs with a trainer: the engine no longer loads the adapter at startup and waits for the first sync; rollout 0 sees the same weights. Multi-LoRA is untouched.

Exercised on GB300 with the Kimi K3 4-layer recipe (per-rank adapter shards, colocated, `--check-lora-weight-equal` passing); the dtype-order and gloo fixes are validated by reading, not by a reproduced failure.