### PR TITLE
test(agentic): run the sandbox tests on any provider, not just e2b

### DIFF
--- a/miles/rollout/agentic/credentials.py
+++ b/miles/rollout/agentic/credentials.py
@@ -94,6 +94,24 @@ def forward_address(env: dict[str, str], var: str, value: str) -> None:
     env[var] = value
 
 
+def _key_file_has_value(path: Path) -> bool:
+    try:
+        return bool(path.read_text(encoding="utf-8").strip())
+    except OSError:
+        return False
+
+
+def credential_available(spec: dict, *, arg_path: str = "") -> bool:
+    """Whether either supply this provider accepts is in place on this machine.
+
+    ``sandbox_key_supply`` raises on the same condition; a caller that needs to
+    decide rather than fail asks this.
+    """
+    if _key_file_has_value(Path(arg_path or spec["default_path"]).expanduser()):
+        return True
+    return all(os.environ.get(var, "").strip() for var in spec["key_env_vars"])
+
+
 def sandbox_key_supply(
     env: dict[str, str],
     *,
@@ -112,10 +130,7 @@ def sandbox_key_supply(
     echoes into driver logs and ray persists in job metadata, all in
     plaintext."""
     key_file = Path(arg_path or default_path).expanduser()
-    try:
-        key_present = bool(key_file.read_text(encoding="utf-8").strip())
-    except OSError:
-        key_present = False
+    key_present = _key_file_has_value(key_file)
     # Either supply is fine; neither is fully verifiable from here (the
     # launcher cannot probe worker nodes), so echo which one is in effect.
     # A provider whose credential is several variables (Modal's token pair) is

--- a/scripts/sandbox_smoke/run.py
+++ b/scripts/sandbox_smoke/run.py
@@ -103,7 +103,7 @@ CONNECTORS: dict[str, Callable[..., Any]] = {
 }
 
 
-def main() -> int:
+def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument("--connector", required=True, choices=sorted(CONNECTORS))
     parser.add_argument(
@@ -120,7 +120,7 @@ def main() -> int:
     )
     parser.add_argument("--task", default="", help="override the benchmark's preset smoke instance")
     parser.add_argument("--tasks-dir", type=Path, default=None, help="override the benchmark's task directory")
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     if args.agent != GOLDEN and not args.base_url:
         parser.error(

--- a/tests/e2e/agentic/test_harbor_rollout.py
+++ b/tests/e2e/agentic/test_harbor_rollout.py
@@ -1,29 +1,43 @@
-"""Harbor trials on real e2b sandboxes, through the full rollout path.
+"""Harbor trials on real cloud sandboxes, through the full rollout path.
 
-What the sandbox smoke (scripts/sandbox_smoke) cannot see, this covers: the
-launcher wiring delivering the Harbor environment to rollout workers, the
-session server + TITO recording a real model's turns under the strict gate,
-terminus-2 driving the sandbox from the trainer host, and the reward flowing
-back through generate.reward_func. Rollout only (``--debug-rollout-only``):
-everything Harbor-specific runs before the optimizer step, and skipping that
-step lets the recipe's own model, GLM-4.7-Flash, fit on 2 GPUs. Deliberately
-fixed to harbor x e2b x terminus-2 x TB2 fix-git -- one combination, the one
-we run.
+What the sandbox smoke (``test_sandbox_golden.py``, next to this file) cannot
+see, this covers: the launcher wiring delivering the Harbor environment to
+rollout workers, the session server + TITO recording a real model's turns
+under the strict gate, terminus-2 driving the sandbox from the trainer host,
+and the reward flowing back through generate.reward_func. Rollout only
+(``--debug-rollout-only``): everything Harbor-specific runs before the
+optimizer step, and skipping that step lets the recipe's own model,
+GLM-4.7-Flash, fit on 2 GPUs.
 
-Registered ``disabled`` because it needs what CI runners do not have yet: a
-network route to an E2B-compatible sandbox service and the platform key on
-the machine. Until then, run it manually on a GPU devbox that has both:
+``HARBOR_ENV_TYPE`` picks the sandbox backend, exactly as the recipe does.
+Nothing else here is backend-specific: the credential and SDK preflight is
+the launcher's own ``harbor_env_vars``, so adding a backend to
+``PROVIDER_CREDENTIALS`` is all it takes to run this against it. Which
+combinations have actually been run is recorded in
+``scripts/sandbox_smoke/README.md``.
+
+Registered ``disabled`` because CI runners carry no sandbox credential. Run
+it manually on a GPU devbox that has one:
 
     # on the devbox, from the repo root (2 GPUs)
     # uv, not pip: the branch carries a uv-workspace dependency pip cannot resolve
     uv pip install "harbor[e2b] @ git+https://github.com/harbor-framework/harbor@harbor-miles-v0.20.0"
-    export E2B_API_URL=http://<your-e2b-service>
-    export E2B_SANDBOX_URL=$E2B_API_URL
+    export HARBOR_ENV_TYPE=e2b
+    export E2B_API_URL=http://<your-e2b-service> E2B_SANDBOX_URL=$E2B_API_URL
     # key at ~/.config/e2b/api_key
-    PYTHONPATH=. python tests/e2e/agentic/test_harbor_e2b_rollout.py
+    # what an interactive devbox shell sets and a plain ssh session does not:
+    # the Ray head's address (the launcher falls back to 127.0.0.1) and a file
+    # descriptor limit Ray's worker sockets fit in (1024 kills the raylet)
+    export MASTER_ADDR=$(hostname -i | awk '{print $1}')
+    ulimit -n $(ulimit -Hn)
+    PYTHONPATH=. python tests/e2e/agentic/test_harbor_rollout.py
+
+Swap the extra and the backend name for another provider (``harbor[modal]``
+with ``HARBOR_ENV_TYPE=modal``, ...); each provider's own credential and
+endpoint variables are documented in ``miles/rollout/agentic/credentials.py``.
 
 terminus-2 is a host-process agent: the sandboxes never call back into the
-trainer, so the only network requirement is this machine -> control plane.
+trainer, so the only network requirement is this machine -> the provider.
 """
 
 import json
@@ -37,13 +51,14 @@ from types import SimpleNamespace
 from tests.ci.ci_register import register_cuda_ci
 
 import miles.utils.external_utils.command_utils as U
+from miles.rollout.agentic.credentials import PROVIDER_CREDENTIALS
 
 register_cuda_ci(
     est_time=1200,
     suite="stage-c-2-gpu-h200",
     hardware=["hopper"],
     labels=["agentic"],
-    disabled="needs a network route to the sandbox service and its key on the runner; run manually on a GPU devbox that has both",
+    disabled="CI runners hold no sandbox credential; run it manually on a GPU devbox that has one",
 )
 
 REPO = Path(__file__).resolve().parents[3]
@@ -62,28 +77,48 @@ PROMPT_DATA = "/root/datasets/harbor_tb2_smoke.jsonl"
 TRIALS_DIR = "/tmp/harbor_trials_e2e"
 
 
-def preflight():
-    """Fail fast with instructions instead of failing every trial later."""
+def harbor_worker_env() -> dict[str, str]:
+    """The rollout workers' Harbor environment, assembled by the launcher's own code.
+
+    Building it is also the credential and SDK preflight: the launcher raises
+    with the provider's provision hint when either is missing.
+    """
+    # bound each trial so the smoke stays a smoke: a looping agent would
+    # otherwise run to the engine's context limit. fix-git takes terminus
+    # well over 12 of its one-command turns, so the cap leaves room to solve.
+    os.environ.setdefault("AGENT_TRIAL_TIMEOUT", "1200")
+    os.environ.setdefault("HARBOR_AGENT_MAX_ITERATIONS", "30")
+    args = SimpleNamespace(
+        harbor_env_type=os.environ.get("HARBOR_ENV_TYPE", ""),
+        harbor_env_kwargs=os.environ.get("HARBOR_ENV_KWARGS", ""),
+        harbor_tasks_dir=TASKS_DIR,
+        harbor_trials_dir=TRIALS_DIR,
+        agent_model_name="model",
+        agent_timeout=600,
+        router_external_host="",  # terminus-2 runs on this host; no sandbox callback
+        # every registered provider's key-file argument, so a new backend needs no change here
+        **{spec["arg_attr"]: os.environ.get(spec["file_env_var"], "") for spec in PROVIDER_CREDENTIALS.values()},
+    )
+    return harbor_env_vars(args)
+
+
+def probe_e2b_endpoint() -> None:
+    """Fail before the model download when a configured endpoint is unreachable.
+
+    Only a self-hosted E2B endpoint gets one: its address comes from
+    configuration, so it can be wrong, and an unauthenticated request is
+    enough to prove it answers.
+    """
     api_url = os.environ.get("E2B_API_URL", "").strip()
-    if not api_url:
-        sys.exit("set E2B_API_URL (and E2B_SANDBOX_URL) to your E2B-compatible service; see the module docstring")
-    key_file = Path(os.environ.get("E2B_API_KEY_FILE", "~/.config/e2b/api_key")).expanduser()
-    # non-empty, mirroring the real check (credentials.sandbox_key_supply): an
-    # empty placeholder file must fail here, not deep inside training
-    file_has_key = key_file.is_file() and bool(key_file.read_text().strip())
-    if not os.environ.get("E2B_API_KEY", "").strip() and not file_has_key:
-        sys.exit(f"no e2b credential: set E2B_API_KEY or put a non-empty key at {key_file}")
+    if os.environ.get("HARBOR_ENV_TYPE", "").strip().lower() != "e2b" or not api_url:
+        return
     try:
-        request = urllib.request.Request(f"{api_url}/nodes", headers={"X-API-Key": "preflight"})
+        request = urllib.request.Request(f"{api_url}/nodes", headers={"X-API-Key": "probe"})
         urllib.request.urlopen(request, timeout=10).read()
     except urllib.error.HTTPError:
         pass  # a 401 still proves the control plane answers
     except OSError as e:
-        sys.exit(f"sandbox service unreachable at {api_url} ({e}); does this machine have a route to it?")
-    try:
-        import harbor  # noqa: F401
-    except ImportError:
-        sys.exit("harbor is not importable; see the module docstring for the install line")
+        sys.exit(f"E2B endpoint unreachable at {api_url} ({e}); does this machine have a route to it?")
 
 
 def prepare():
@@ -106,29 +141,7 @@ def prepare():
     Path(PROMPT_DATA).write_text(json.dumps(row) + "\n")
 
 
-def harbor_worker_env() -> dict[str, str]:
-    """The rollout workers' Harbor environment, assembled by the launcher's own code."""
-    # bound each trial so the smoke stays a smoke: a looping agent would
-    # otherwise run to the engine's context limit. fix-git takes terminus
-    # well over 12 of its one-command turns, so the cap leaves room to solve.
-    os.environ.setdefault("AGENT_TRIAL_TIMEOUT", "1200")
-    os.environ.setdefault("HARBOR_AGENT_MAX_ITERATIONS", "30")
-    args = SimpleNamespace(
-        harbor_env_type="e2b",
-        harbor_env_kwargs="",
-        harbor_tasks_dir=TASKS_DIR,
-        harbor_trials_dir=TRIALS_DIR,
-        agent_model_name="model",
-        agent_timeout=600,
-        router_external_host="",  # terminus-2 runs on this host; no sandbox callback
-        daytona_api_key_file="",
-        e2b_api_key_file=os.environ.get("E2B_API_KEY_FILE", ""),
-        modal_config_file="",
-    )
-    return harbor_env_vars(args)
-
-
-def execute():
+def execute(worker_env: dict[str, str]):
     ckpt_args = f"--hf-checkpoint {MODEL_DIR} "
     rollout_args = (
         f"--prompt-data {PROMPT_DATA} "
@@ -162,7 +175,7 @@ def execute():
 
     extra_env_vars = {
         "PYTHONPATH": ":".join([*agentic_pythonpath_dirs(), str(REPO)]),
-        **harbor_worker_env(),
+        **worker_env,
     }
     U.execute_train(
         train_args=train_args,
@@ -183,9 +196,10 @@ def check_trials():
 
 
 if __name__ == "__main__":
-    preflight()
+    worker_env = harbor_worker_env()
+    probe_e2b_endpoint()
     prepare()
     for proxy_var in ("http_proxy", "https_proxy", "HTTP_PROXY", "HTTPS_PROXY"):
         os.environ.pop(proxy_var, None)
-    execute()
+    execute(worker_env)
     check_trials()

--- a/tests/e2e/agentic/test_sandbox_golden.py
+++ b/tests/e2e/agentic/test_sandbox_golden.py
@@ -52,7 +52,9 @@ def smoke() -> ModuleType:
 @pytest.mark.parametrize("backend", sorted(PROVIDER_CREDENTIALS))
 def test_golden_episode(smoke: ModuleType, backend: str):
     spec = PROVIDER_CREDENTIALS[backend]
-    if not credential_available(spec):
+    # the override too, not just the default path: a machine that keeps its key
+    # elsewhere runs rollouts fine and must not report as having no credential
+    if not credential_available(spec, arg_path=os.environ.get(spec["file_env_var"], "")):
         pytest.skip(f"no {spec['provider']} credential here; provision it with: {spec['provision_hint']}")
     # lacking the SDK or harbor means this case cannot run, not that it failed
     pytest.importorskip(spec["sdk"], reason=f"{spec['provider']} SDK missing: {spec['sdk_hint']}")

--- a/tests/e2e/agentic/test_sandbox_golden.py
+++ b/tests/e2e/agentic/test_sandbox_golden.py
@@ -1,0 +1,66 @@
+"""A golden episode on each sandbox provider whose credential is present here.
+
+The golden agent is the task's own reference solution, executed by the
+connector, so no GPU, no model and no session server take part: what a pass
+proves is exactly the platform round trip -- template/image resolution,
+sandbox create, exec, verifier, teardown. Offline tests cannot see that layer,
+and ``test_harbor_rollout.py`` covers the layers above it.
+
+This drives ``scripts/sandbox_smoke/run.py`` and adds the CI half: one case per
+provider in ``PROVIDER_CREDENTIALS``, each skipped unless this machine has that
+provider's credential and SDK. So a provider whose
+credential CI does not hold reports as a skip, and starts running the day it
+does, with no test change. A case that does run creates a real sandbox and
+spends real quota, so pick with ``-k`` when you hold several credentials:
+
+    PYTHONPATH=. python -m pytest tests/e2e/agentic/test_sandbox_golden.py -v
+    PYTHONPATH=. python -m pytest tests/e2e/agentic/test_sandbox_golden.py -k modal
+
+Each provider's credential and endpoint variables are documented on
+``PROVIDER_CREDENTIALS``; which combinations have been run is recorded in
+``scripts/sandbox_smoke/README.md``.
+"""
+
+import importlib.util
+import os
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+from tests.ci.ci_register import register_cpu_ci
+
+from miles.rollout.agentic.credentials import PROVIDER_CREDENTIALS, credential_available
+
+# stage-b-cpu, not stage-a: the GPU stages gate on stage-a, so a network-bound
+# case does not belong there. est_time is what a cold provider costs when the
+# case does run; a skip is immediate.
+register_cpu_ci(est_time=600, suite="stage-b-cpu", labels=["agentic"])
+
+RUN_PY = Path(__file__).resolve().parents[3] / "scripts" / "sandbox_smoke" / "run.py"
+
+
+@pytest.fixture(scope="module")
+def smoke() -> ModuleType:
+    """The golden-smoke script, loaded by path because it is named run.py."""
+    spec = importlib.util.spec_from_file_location("sandbox_smoke_run", RUN_PY)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.mark.parametrize("backend", sorted(PROVIDER_CREDENTIALS))
+def test_golden_episode(smoke: ModuleType, backend: str):
+    spec = PROVIDER_CREDENTIALS[backend]
+    if not credential_available(spec):
+        pytest.skip(f"no {spec['provider']} credential here; provision it with: {spec['provision_hint']}")
+    # lacking the SDK or harbor means this case cannot run, not that it failed
+    pytest.importorskip(spec["sdk"], reason=f"{spec['provider']} SDK missing: {spec['sdk_hint']}")
+    pytest.importorskip("harbor", reason="harbor missing; install line in scripts/sandbox_smoke/README.md")
+    # a wrong endpoint fails as an unexplained AgentError, so name the one in effect
+    if spec["target"]:
+        var, label, default_desc = spec["target"]
+        print(f"{spec['provider']} {label}: {os.environ.get(var) or default_desc}", flush=True)
+
+    # the script prints the reward and exit status it judged, which is the failure detail
+    assert smoke.main(["--connector", "harbor", "--backend", backend]) == 0

--- a/tests/fast/rollout/agentic/test_credentials.py
+++ b/tests/fast/rollout/agentic/test_credentials.py
@@ -6,6 +6,7 @@ import pytest
 import miles.rollout.agentic.credentials as credentials
 from miles.rollout.agentic.credentials import (
     PROVIDER_CREDENTIALS,
+    credential_available,
     forward_address,
     preflight_sdk,
     provision_provider,
@@ -244,3 +245,32 @@ def test_provision_provider_wires_key_path_addresses_and_preflight(monkeypatch, 
     assert env["E2B_API_URL"] == "http://agentenv.internal:8000"
     assert "E2B_SANDBOX_URL" not in env  # unset vars are not forwarded
     assert "e2b_secret" not in str(env)
+
+
+def test_credential_available_accepts_either_supply(monkeypatch, tmp_path):
+    """The predicate a caller uses to decide rather than fail: a non-empty key
+    file, or every one of the provider's credential variables."""
+    key_file = tmp_path / "api_key"
+    monkeypatch.delenv("E2B_API_KEY", raising=False)
+    assert not credential_available(PROVIDER_CREDENTIALS["e2b"], arg_path=str(key_file))
+
+    key_file.write_text("  \n")  # a blank placeholder is not a credential
+    assert not credential_available(PROVIDER_CREDENTIALS["e2b"], arg_path=str(key_file))
+
+    key_file.write_text("e2b_secret\n")
+    assert credential_available(PROVIDER_CREDENTIALS["e2b"], arg_path=str(key_file))
+
+    monkeypatch.setenv("E2B_API_KEY", "e2b_secret")
+    assert credential_available(PROVIDER_CREDENTIALS["e2b"], arg_path=str(tmp_path / "absent"))
+
+
+def test_credential_available_needs_every_var_of_a_multi_var_provider(monkeypatch, tmp_path):
+    """Modal's credential is a token pair: half of it is a misconfiguration,
+    not a usable supply."""
+    absent = str(tmp_path / "absent.toml")
+    monkeypatch.setenv("MODAL_TOKEN_ID", "id")
+    monkeypatch.delenv("MODAL_TOKEN_SECRET", raising=False)
+    assert not credential_available(PROVIDER_CREDENTIALS["modal"], arg_path=absent)
+
+    monkeypatch.setenv("MODAL_TOKEN_SECRET", "secret")
+    assert credential_available(PROVIDER_CREDENTIALS["modal"], arg_path=absent)


### PR DESCRIPTION
The two tests that talk to real sandbox platforms were written around e2b, so
supporting another provider meant writing test code. Both now take the provider
from `PROVIDER_CREDENTIALS`:

- **`tests/e2e/agentic/test_sandbox_golden.py`** (new): the golden episode as a
  registered CPU test, one case per provider, skipped unless this machine holds
  that provider's credential and SDK. It drives `scripts/sandbox_smoke/run.py`
  rather than reimplementing it. Registered on `stage-b-cpu`, since the GPU
  stages gate on `stage-a`.
- **`test_harbor_e2b_rollout.py` → `test_harbor_rollout.py`**: the provider comes
  from `HARBOR_ENV_TYPE`, as in the recipe, and the credential/SDK preflight is
  the launcher's own `harbor_env_vars`. Still `disabled`: CI runners hold no
  sandbox credential.
- `credential_available` gives the registry a presence predicate beside the
  `sandbox_key_supply` that raises on the same condition.

## Tests

- Rollout e2e as shipped on 2×H200, e2b: 2 trials, both submitted, reward 1.0
  and 1.0, TITO strict gate clean (2026-09-11). Golden episode on the same
  endpoint: reward 1.0, 22 s.
- `tests/fast/rollout/agentic`, `tests/fast/scripts`, `tests/ci/test`: all pass;
  the golden test skips with an actionable reason on a machine without
  credentials.

Stacked below: the docs re-cut, and the Modal and Daytona cells.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
