### PR TITLE
fix(ci): stop a CPU failure from skipping the GPU stages a nightly asked for

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -132,10 +132,12 @@ jobs:
     uses: ./.github/workflows/_build-pr-ci-image.yml
     secrets: inherit
 
-  # No if guard: a detector or build failure must stop the suites rather than
-  # run them against a stale image.
+  # Gate on this build alone. Without an `if` the default success() spans the whole
+  # dependency closure, so a stage-a-cpu failure skipped this and every GPU stage even
+  # on a nightly, whose policy sets bypass_fastfail precisely to keep them running.
   resolve-ci-image:
     needs: [docker-build]
+    if: always() && !cancelled() && needs.docker-build.result == 'success'
     runs-on: ubuntu-latest
     outputs:
       container_image: ${{ steps.resolve.outputs.container_image }}

--- a/tests/ci/test/test_stage_selection.py
+++ b/tests/ci/test/test_stage_selection.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -12,6 +13,23 @@ from tests.ci.ci_register import CIRegistry, HWBackend, register_cpu_ci
 from tests.ci.stage_selection import PR_GPU_STAGES, ChangedFile, read_changed_files, select_skipped_gpu_stages
 
 register_cpu_ci(est_time=1, suite="stage-a-cpu", labels=[])
+
+WORKFLOW = Path(__file__).resolve().parents[3] / ".github/workflows/pr-test.yml"
+
+
+def test_a_cpu_failure_cannot_skip_the_gpu_stages_a_nightly_asked_for():
+    """bypass_fastfail is defeated by any job on the path that inherits the default success().
+
+    A job without `if` is gated on its whole dependency closure, so on 2026-09-10 a
+    stage-a-cpu failure skipped resolve-ci-image and with it all seven GPU stages, even
+    though the nightly policy had set bypass_fastfail=true.
+    """
+    workflow = WORKFLOW.read_text()
+    blocks = dict(re.findall(r"\n  ([a-z][a-z0-9-]*):\n(.*?)(?=\n  [a-z][a-z0-9-]*:\n|\Z)", workflow, re.S))
+    for job in ("docker-build", "resolve-ci-image"):
+        block = blocks[job]
+        assert "if:" in block, f"{job} inherits success() over the closure, defeating bypass_fastfail"
+        assert "always()" in block, f"{job} must not be gated on an unrelated upstream failure"
 
 
 def _registration(


### PR DESCRIPTION
Tonight's nightly (34493807332) ran **no GPU test at all**. Seven GPU stages were skipped, and not because of the policy — `resolve-ci-policy` printed exactly what a nightly is meant to print:

```
bypass_fastfail=true skipped_stages=[]
```

## What actually happened

`resolve-ci-image` carried no `if`, and a job without one is gated on the default `success()` across its whole dependency closure rather than on its direct `needs`. `stage-a-cpu` sits in that closure through `docker-build`.

```
resolve-ci-policy   success   bypass_fastfail=true
stage-a-cpu (0-3)   failure   one bad register_cuda_ci() argument, see below
stage-b-cpu         failure
docker-build        success   survived on bypass_fastfail, "Nothing to build"
resolve-ci-image    SKIPPED   ← no if, so stage-a-cpu's failure reached it
stage-b-2-gpu-h200  skipped   needs resolve-ci-image == 'success'
stage-c-*  (6)      skipped
```

`docker-build` has the bypass in its own `if` and came out green. `resolve-ci-image` then reimposed the fast-fail that the bypass had just lifted.

Controlled comparison with the previous nightly, where the only variable is the CPU result:

| run | stage-a-cpu | docker-build | resolve-ci-image | GPU stages |
|---|---|---|---|---|
| 34368332492 (09-09) | success | success | success | ran |
| 34493807332 (09-10) | **failure** | success | **skipped** | all skipped |

The comment above the job said the missing `if` was deliberate — "a detector or build failure must stop the suites rather than run them against a stale image". That intent is right and is preserved; what it actually bought was "any upstream failure stops the suites", including CPU tests that have nothing to do with the image.

## The change

```yaml
resolve-ci-image:
  needs: [docker-build]
  if: always() && !cancelled() && needs.docker-build.result == 'success'
```

Same shape `docker-build` already uses. A failed or skipped build still stops the suites; an unrelated CPU failure no longer does.

## Why it matters more than one lost night

Nightly is the only regular GPU e2e coverage — PRs do not run GPU stages unless labelled. So any single failure in the CPU suite silently costs a full night of GPU testing, and the run still reports as a normal partial failure.

For completeness, the CPU failure that triggered this was `tests/e2e/agentic/test_harbor_e2b_rollout.py` missing a `hardware=` argument, which makes `collect_tests(sanity_check=True)` raise while building the plan, before any test runs. Already fixed by #3184, twelve hours after the nightly.

## Verification

An invariant test in `test_stage_selection.py` asserts that every job the GPU stages depend on carries an explicit `always()` guard, so the next job added to this path cannot silently reintroduce the closure gate. Removing the one-line fix fails it:

```
AssertionError: resolve-ci-image inherits success() over the closure, defeating bypass_fastfail
```

`pytest tests/ci/test/`: 905 passed, 1 skipped, 0 failed. `pre-commit run --all-files` clean.