### PR TITLE
ci(lark): collapse jobs that failed identically into one card row

### DIFF
--- a/.github/workflows/scripts/lark_notify.py
+++ b/.github/workflows/scripts/lark_notify.py
@@ -352,13 +352,33 @@ def analysis_md(analysis: Any, repo: str) -> list[str]:
     return lines
 
 
+def group_identical_failures(jobs: list, reasons: dict | None) -> list[tuple[tuple, list]]:
+    """One defect can fail every shard the same way, and repeating it per job buries the rest.
+
+    Jobs group only on an identical, non-empty analysis: without one there is nothing to
+    compare, so those rows stay separate as before.
+    """
+    groups: list[tuple[tuple, list]] = []
+    members_by_analyses: dict[tuple, list] = {}
+    for job in jobs:
+        analyses = tuple((reasons or {}).get(job.get("id")) or ())
+        if analyses and analyses in members_by_analyses:
+            members_by_analyses[analyses].append(job)
+            continue
+        members = [job]
+        groups.append((analyses, members))
+        if analyses:
+            members_by_analyses[analyses] = members
+    return groups
+
+
 def list_jobs_md(
     jobs: list, limit: int = MAX_LISTED_JOBS, reasons: dict | None = None, repo: str = DEFAULT_REPO
 ) -> str:
     lines = []
-    for job in jobs[:limit]:
-        lines.append(f"- [{job['name']}]({job['html_url']})")
-        for analysis in (reasons or {}).get(job.get("id")) or ():
+    for analyses, members in group_identical_failures(jobs[:limit], reasons):
+        lines.append("- " + ", ".join(f"[{job['name']}]({job['html_url']})" for job in members))
+        for analysis in analyses:
             lines.extend(analysis_md(analysis, repo))
     if len(jobs) > limit:
         lines.append(f"- ... and {len(jobs) - limit} more")

--- a/tests/ci/test/test_lark_notify.py
+++ b/tests/ci/test/test_lark_notify.py
@@ -89,6 +89,36 @@ def test_validated_reason_is_directly_beneath_its_existing_job_link():
     assert content.count("↳") == 3
 
 
+def shard(index):
+    return {
+        "id": index,
+        "name": f"stage-a-cpu ({index}) / run-cpu",
+        "html_url": f"https://example/jobs/{index}",
+        "conclusion": "failure",
+    }
+
+
+def test_one_defect_across_every_shard_collapses_to_a_single_row():
+    same = ANALYSIS(reason="Collection failed because the hardware list was rejected.", tags=("rollout",))
+    content = HANDLER.list_jobs_md([shard(i) for i in range(5)], reasons={i: [same] for i in range(5)})
+    assert content.count("↳") == 2, content
+    assert content.count("stage-a-cpu") == 5
+    assert content.count("\n- ") == 0
+
+
+def test_a_different_failure_keeps_its_own_row():
+    same = ANALYSIS(reason="Collection failed because the hardware list was rejected.")
+    other = ANALYSIS(reason="The deterministic test exited with code 1.")
+    content = HANDLER.list_jobs_md([shard(0), shard(1), shard(2)], reasons={0: [same], 1: [same], 2: [other]})
+    assert content.count("\n- ") == 1, content
+    assert "The deterministic test exited with code 1." in content
+
+
+def test_rows_stay_separate_when_no_analysis_is_available():
+    content = HANDLER.list_jobs_md([shard(0), shard(1), shard(2)], reasons=None)
+    assert content.count("\n- ") == 2, content
+
+
 def test_rerun_reasons_apply_only_to_current_failures():
     current = [job(20, "still"), job(30, "new")]
     previous = {"fixed": job(10, "fixed"), "still": job(19, "still")}


### PR DESCRIPTION
Tonight's nightly card printed the same failure five times:

```
Failed jobs (5)
- stage-b-cpu / run-cpu
  ↳ [rollout] tests/e2e/agentic/test_harbor_e2b_rollout.py
  ↳ Test collection failed because register_cuda_ci() rejected the file's hardware list.
- stage-a-cpu (0) / run-cpu
  ↳ [rollout] tests/e2e/agentic/test_harbor_e2b_rollout.py
  ↳ Test collection failed because register_cuda_ci() rejected the file's hardware list.
... three more, identical
```

Not five failures — one. `collect_tests(sanity_check=True)` AST-checks every registered file in the repo on each `run_suite.py` start, so one missing `hardware=` argument makes every CPU shard raise at `Resolve suite plan`, before a single test runs. The card is job-granular, so the one defect appeared once per shard.

Worth noting what those five rows cost: they were the whole card. Anything else that broke would have been pushed out of view.

## The change

Rows group on an identical, non-empty analysis, and the shared row lists the jobs:

```
- stage-b-cpu / run-cpu, stage-a-cpu (0) / run-cpu, stage-a-cpu (1) / run-cpu, stage-a-cpu (2) / run-cpu, stage-a-cpu (3) / run-cpu
  ↳ [rollout] `tests/e2e/agentic/test_harbor_e2b_rollout.py`
  ↳ Test collection failed because register_cuda_ci() rejected the file's hardware list.
```

Every job keeps its own link, so the row is still a way into each one.

Grouping requires the analysis to be **non-empty and identical**. Without that condition a card with the analysis switched off — where no job has an analysis and there is nothing to compare — would collapse every failed job into a single row. Jobs whose analysis came back unavailable stay separate for the same reason.

## Verification

Three cases in `test_lark_notify.py`:

| case | expected |
|---|---|
| five shards, one identical analysis | one row, five links, one analysis block |
| two identical plus one different | two rows, the different one intact |
| `reasons=None` (analysis off) | one row per job, unchanged |

`pytest tests/ci/test/`: 907 passed, 1 skipped, 0 failed. `pre-commit run --all-files` clean.

Related: #3196 fixes the other half of tonight's damage — the same CPU failure also skipped all seven GPU stages, despite the nightly policy setting `bypass_fastfail=true`.