### PR TITLE
tracking: add --log-sample-completions

### DIFF
--- a/docs/user-guide/monitoring.md
+++ b/docs/user-guide/monitoring.md
@@ -33,6 +33,10 @@ ray job submit --address=auto -- \
 Available flags: `--use-wandb`, `--wandb-project`, `--wandb-group`. `WANDB_API_KEY`
 should be supplied via Ray's `env_vars` rather than baked into the launch script.
 
+Pass `--log-sample-completions N` to also log the first N prompt/response pairs of every rollout step
+(taken round-robin across prompts) as a `rollout/completions` table, with reward, status and response
+length. Only wandb renders it today; other backends ignore it.
+
 ## What to watch
 
 | Signal | Healthy pattern | Red flag |

--- a/miles/ray/rollout/metrics.py
+++ b/miles/ray/rollout/metrics.py
@@ -90,6 +90,39 @@ def log_rollout_data(rollout_id, args, samples, rollout_extra_metrics, rollout_t
     step = compute_rollout_step(args, rollout_id)
     log_dict["rollout/step"] = step
     tracking.log(args, log_dict, step_key="rollout/step")
+    if args.log_sample_completions > 0:
+        columns, rows = sample_completion_rows(samples, args.log_sample_completions)
+        tracking.log_table("rollout/completions", columns, rows)
+
+
+SAMPLE_COMPLETION_COLUMNS = ["prompt", "response", "reward", "status", "response_length"]
+
+
+def _prompt_text(prompt) -> str:
+    if isinstance(prompt, list):
+        # Chat-format prompt: one "role: content" line per message.
+        return "\n".join(f"{m.get('role', '?')}: {m.get('content', '')}" for m in prompt)
+    return str(prompt)
+
+
+def sample_completion_rows(samples: list[Sample], limit: int) -> tuple[list[str], list[list]]:
+    """Rows for the sampled-completions table: the first ``limit`` samples of the
+    step taken round-robin across prompt groups (``group_index``), so a small
+    table shows different prompts rather than one prompt's n responses. Every
+    cell is a string or an int so the table has no mixed-type column."""
+    groups = list(group_by(samples, key=lambda s: s.group_index).values())
+    ordered = [group[i] for i in range(max((len(g) for g in groups), default=0)) for group in groups if i < len(group)]
+    rows = [
+        [
+            _prompt_text(s.prompt)[:2048],
+            str(s.response)[:4096],
+            str(s.reward)[:256],
+            s.status.name,
+            s.response_length,
+        ]
+        for s in ordered[:limit]
+    ]
+    return SAMPLE_COMPLETION_COLUMNS, rows
 
 
 def _compute_metrics_from_samples(args, samples):

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -1998,6 +1998,15 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 help="Whether to turn on passrate logging, which will log the pass@n of the responses in the rollout.",
             )
             parser.add_argument(
+                "--log-sample-completions",
+                type=int,
+                default=0,
+                help=(
+                    "Log this many sampled prompt/response rows per rollout step as a `rollout/completions` "
+                    "table on backends with a table type (wandb). 0 disables it."
+                ),
+            )
+            parser.add_argument(
                 "--log-reward-category",
                 type=str,
                 default=None,

--- a/miles/utils/tracking_utils/base.py
+++ b/miles/utils/tracking_utils/base.py
@@ -38,6 +38,11 @@ class TrackingBackend(ABC):
         backends that take the step numerically on every log call."""
         return
 
+    def log_table(self, name: str, columns: list[str], rows: list[list[Any]]) -> None:
+        """Log a table of text rows (e.g. sampled completions); no-op for backends
+        without a table type."""
+        return
+
 
 # Thin adapters for backwards compatibility to keep wandb_utils and tensorboard_utils untouched.
 class WandbBackend(TrackingBackend):
@@ -58,6 +63,13 @@ class WandbBackend(TrackingBackend):
         import wandb
 
         wandb.log(metrics)
+
+    def log_table(self, name: str, columns: list[str], rows: list[list[Any]]) -> None:
+        import wandb
+
+        # Like log(): no explicit step, the table rides with the metrics of the
+        # same call site and the dashboard picks the x-axis.
+        wandb.log({name: wandb.Table(columns=columns, data=rows)})
 
     def define_step_key_metric_group(self, prefix: str, step_key: str) -> None:
         # Call from the primary tracking process: definitions from secondary shared-mode writers are lost.
@@ -177,6 +189,10 @@ class TrackingManager:
     def log(self, metrics: dict[str, Any], step: int | None = None, step_key: str | None = None) -> None:
         for backend in self._backends:
             backend.log(metrics, step=step, step_key=step_key)
+
+    def log_table(self, name: str, columns: list[str], rows: list[list[Any]]) -> None:
+        for backend in self._backends:
+            backend.log_table(name, columns, rows)
 
     def define_step_key_metric_group(self, prefix: str, step_key: str) -> None:
         for backend in self._backends:

--- a/miles/utils/tracking_utils/tracking.py
+++ b/miles/utils/tracking_utils/tracking.py
@@ -37,6 +37,11 @@ def init_tracking(args, primary: bool = True, **kwargs):
     _manager.init(args, primary=primary, **kwargs)
 
 
+def log_table(name: str, columns: list[str], rows: list[list]) -> None:
+    """Log a table of text rows to the backends that support tables (wandb)."""
+    _manager.log_table(name, columns, rows)
+
+
 def define_step_key_metric_group(prefix: str, step_key: str) -> None:
     """Declare a metric group plotted against its own step key (e.g. ``{name}/*`` vs ``{name}/step``).
     Only wandb acts on this; must be called from the primary tracking process or definitions may be lost."""

--- a/tests/fast/ray/rollout/conftest.py
+++ b/tests/fast/ray/rollout/conftest.py
@@ -56,6 +56,7 @@ def make_args(**overrides: Any) -> Namespace:
         grpo_std_normalization=False,
         reward_key=None,
         log_reward_category=None,
+        log_sample_completions=0,
         log_passrate=False,
         pin_rollout_manager_to_head=False,
         # placement / colocation

--- a/tests/fast/ray/rollout/test_sample_completion_rows.py
+++ b/tests/fast/ray/rollout/test_sample_completion_rows.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+from tests.fast.ray.rollout.conftest import make_args, make_sample
+
+from miles.ray.rollout import metrics as metrics_module
+from miles.ray.rollout.metrics import SAMPLE_COMPLETION_COLUMNS, log_rollout_data, sample_completion_rows
+from miles.utils.types import Sample
+
+
+def _sample(prompt, response: str, reward=1.0, status=Sample.Status.COMPLETED, group_index=0):
+    s = make_sample(response_length=len(response), status=status)
+    s.prompt = prompt
+    s.response = response
+    s.reward = reward
+    s.group_index = group_index
+    return s
+
+
+def test_rows_take_one_sample_per_prompt_first():
+    # log_rollout_data receives the flat sample list of the step; prompts are
+    # told apart by group_index.
+    samples = [
+        _sample("p0", "a", group_index=0),
+        _sample("p0", "b", group_index=0),
+        _sample("p1", "c", group_index=1),
+        _sample("p1", "d", group_index=1),
+    ]
+
+    columns, rows = sample_completion_rows(samples, limit=3)
+
+    assert columns == SAMPLE_COMPLETION_COLUMNS
+    assert [(row[0], row[1]) for row in rows] == [("p0", "a"), ("p1", "c"), ("p0", "b")]
+
+
+def test_rows_are_strings_and_ints_only():
+    chat = [{"role": "system", "content": "be brief"}, {"role": "user", "content": "hi"}]
+    truncated = _sample(chat, "resp", reward={"score": 0.5}, status=Sample.Status.TRUNCATED)
+    no_reward = _sample("q", "xy", reward=None, group_index=1)
+
+    _, rows = sample_completion_rows([truncated, no_reward], limit=10)
+
+    assert rows[0][0] == "system: be brief\nuser: hi"
+    assert rows[0][2] == str({"score": 0.5})
+    assert rows[0][3] == "TRUNCATED"
+    assert rows[0][4] == 4
+    # None and numbers become strings too, so a wandb.Table column never mixes types.
+    assert rows[1][2] == "None"
+    assert all(isinstance(cell, (str, int)) for row in rows for cell in row)
+
+
+def test_empty_step_gives_no_rows():
+    assert sample_completion_rows([], limit=4) == (SAMPLE_COMPLETION_COLUMNS, [])
+
+
+def test_log_rollout_data_logs_a_table_only_when_enabled(monkeypatch):
+    monkeypatch.setattr(metrics_module.tracking, "log", Mock())
+    log_table = Mock()
+    monkeypatch.setattr(metrics_module.tracking, "log_table", log_table)
+    samples = [_sample("p0", "a"), _sample("p0", "b")]
+
+    log_rollout_data(0, make_args(log_sample_completions=0), samples, {}, rollout_time=1.0)
+    assert log_table.call_count == 0
+
+    log_rollout_data(0, make_args(log_sample_completions=1), samples, {}, rollout_time=1.0)
+    assert log_table.call_count == 1
+    (name, columns, rows), _ = log_table.call_args
+    assert name == "rollout/completions"
+    assert columns == SAMPLE_COMPLETION_COLUMNS
+    assert len(rows) == 1

--- a/tests/fast/utils/tracking_utils/test_log_table.py
+++ b/tests/fast/utils/tracking_utils/test_log_table.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import sys
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+from miles.utils.tracking_utils.base import TensorboardBackend, TrackingManager, WandbBackend
+
+
+class _FakeTable:
+    def __init__(self, columns, data):
+        self.columns = columns
+        self.data = data
+
+
+@pytest.fixture
+def fake_wandb(monkeypatch):
+    fake = ModuleType("wandb")
+    fake.Table = _FakeTable
+    fake.log_calls = []
+    fake.log = lambda payload: fake.log_calls.append(payload)
+    monkeypatch.setitem(sys.modules, "wandb", fake)
+    return fake
+
+
+def test_wandb_backend_logs_a_table(fake_wandb):
+    WandbBackend().log_table("rollout/completions", ["prompt", "response"], [["p", "r"]])
+
+    assert len(fake_wandb.log_calls) == 1
+    table = fake_wandb.log_calls[0]["rollout/completions"]
+    assert isinstance(table, _FakeTable)
+    assert table.columns == ["prompt", "response"]
+    assert table.data == [["p", "r"]]
+
+
+def test_backends_without_tables_ignore_log_table():
+    # The ABC default is a no-op, so a table never reaches a backend that
+    # cannot render one.
+    TensorboardBackend().log_table("rollout/completions", ["prompt"], [["p"]])
+
+
+def test_manager_fans_out_to_enabled_backends(fake_wandb, monkeypatch):
+    manager = TrackingManager({"wandb": (WandbBackend, "use_wandb")})
+    monkeypatch.setattr(WandbBackend, "init", lambda self, args, primary=True, **kwargs: None)
+    manager.init(SimpleNamespace(use_wandb=True), primary=True)
+
+    manager.log_table("rollout/completions", ["prompt"], [["p"]])
+
+    assert len(fake_wandb.log_calls) == 1


### PR DESCRIPTION
### What

Adds `--log-sample-completions N` (default `0`). When set, `log_rollout_data` in `miles/ray/rollout/metrics.py` logs the first N prompt/response pairs of every rollout step as a `rollout/completions` table with reward, status and response length, right after the step's scalar metrics. Rows are taken round-robin across prompt groups (`group_index`), so a small table shows different prompts rather than one prompt's n responses; chat prompts render as `role: content` lines, prompt and response text are capped at 2048 and 4096 characters, and every cell is a string or an int so no table column mixes types (wandb rejects mixed columns by default). Tables travel through a new `log_table` method on `TrackingBackend` in `miles/utils/tracking_utils/base.py`: the base implementation is a no-op, `WandbBackend` logs a `wandb.Table`, and `TrackingManager` plus a `tracking.log_table` facade fan it out. mlflow, tensorboard, prometheus and the dashboard are untouched. The monitoring guide gets a paragraph.

### Test

`tests/fast/utils/tracking_utils/test_log_table.py` injects a fake `wandb` module and checks the table payload (name, columns, rows), that a backend without tables ignores the call, and that the manager fans out only to enabled backends. `tests/fast/ray/rollout/test_sample_completion_rows.py` checks the round-robin order over the flat sample list the executor passes, the limit, the rendering of chat prompts, dict and missing rewards, status and length, the empty step, and that `log_rollout_data` calls `tracking.log_table` once when the flag is on and never when it is 0. The rollout test fixture gains the new field with its default.

### Verification

- The seven new tests pass; `tests/fast/ray/rollout`, `tests/fast/utils/tracking_utils`, `tests/fast/dashboard` and `tests/fast/utils/test_arguments.py`: 966 passed, 4 skipped.
- Disabling the call site in `log_rollout_data` makes the `log_rollout_data` test fail.
- The flag parses through the miles argument provider.
- ruff, black and isort at the pre-commit pins are clean on the changed files.

### Scope

- The rollout executor logs from a secondary shared-mode wandb writer (`x_primary=False`); scalar metrics already travel that way, but this is the first `wandb.Table` in the codebase and I could not confirm on a live wandb project that shared mode uploads the table. Worth one real run before relying on it.
- wandb is the only backend with a table type today. A trackio implementation is a one-method follow-up once #3201 lands (`trackio.Table` has the same columns/data shape).
- Eval rollouts are not covered; `log_eval_rollout_data` can reuse `sample_completion_rows` if wanted.
- No GPU run; the change is confined to CPU-side logging.

cc @fzyzcjy @guapisolo
