### PR TITLE
Keep empty_cache away from an offloaded trainer after a colocated sync

### DIFF
--- a/miles/backends/training_utils/weight_update/protocols/cuda_ipc.py
+++ b/miles/backends/training_utils/weight_update/protocols/cuda_ipc.py
@@ -189,6 +189,8 @@ class UpdateWeightFromTensor(WeightTransferProtocol):
         del long_lived_tensors
 
     def after_engines_resumed(self) -> None:
+        if self.args.offload_train:
+            return
         torch.cuda.ipc_collect()
         torch.cuda.empty_cache()
 

--- a/tests/fast/backends/training_utils/weight_update/protocols/test_cuda_ipc.py
+++ b/tests/fast/backends/training_utils/weight_update/protocols/test_cuda_ipc.py
@@ -1,0 +1,39 @@
+from argparse import Namespace
+from unittest.mock import Mock
+
+import pytest
+import torch
+
+from miles.backends.training_utils.weight_update.protocols.cuda_ipc import UpdateWeightFromTensor
+
+
+def _protocol(*, offload_train: bool) -> UpdateWeightFromTensor:
+    protocol = object.__new__(UpdateWeightFromTensor)
+    protocol.args = Namespace(offload_train=offload_train)
+    return protocol
+
+
+class TestAfterEnginesResumed:
+    def test_a_resident_trainer_returns_its_ipc_blocks_to_the_pool(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Without offload the cached IPC blocks are safe to release once the engines have consumed them."""
+        ipc_collect = Mock()
+        empty_cache = Mock()
+        monkeypatch.setattr(torch.cuda, "ipc_collect", ipc_collect)
+        monkeypatch.setattr(torch.cuda, "empty_cache", empty_cache)
+
+        _protocol(offload_train=False).after_engines_resumed()
+
+        ipc_collect.assert_called_once_with()
+        empty_cache.assert_called_once_with()
+
+    def test_an_offloaded_trainer_leaves_the_paused_allocations_alone(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """With offload the trainer may hold paused memory-saver blocks, which empty_cache would free twice."""
+        ipc_collect = Mock()
+        empty_cache = Mock()
+        monkeypatch.setattr(torch.cuda, "ipc_collect", ipc_collect)
+        monkeypatch.setattr(torch.cuda, "empty_cache", empty_cache)
+
+        _protocol(offload_train=True).after_engines_resumed()
+
+        ipc_collect.assert_not_called()
+        empty_cache.assert_not_called()


### PR DESCRIPTION
## Symptom

`tests/e2e/megatron/model_scripts/test_deepseek_v4_flash_4layer_ci.py` (colocated, `--offload-train`, 4×H200) dies during its third and last `update_weights`. The dying ranks print

```
[torch_memory_saver.cpp] CUresult error: 1 (invalid argument)  file=csrc/core.cpp func=free line=104
```

and exit without a Python traceback; the driver then sees `WorkerUnreachableError: Worker died or is unreachable when calling 'update_weights': ActorUnavailableError(... Socket closed ...)`.

Reproduced on an unmodified `main` (`2ed189c0db`) on a 4×H200 devbox with `radixark/miles:dev`, and on `main`-based CI: https://github.com/radixark/miles/pull/2542 (`stage-c-4-gpu-h200 (2)`, two consecutive runs). `main` itself never runs this lane: the test is registered with `labels=["megatron", "model-scripts"]`, so it only executes on PRs carrying `run-ci-image`.

## Root cause

- #3147 (`bf482051a8`, "Bound the trainer's GPU memory during the LoRA weight sync") added `protocol.after_engines_resumed()` at the end of `WeightUpdater.update_weights()`. For the colocated protocol (`UpdateWeightFromTensor`) it runs `torch.cuda.ipc_collect()` followed by `torch.cuda.empty_cache()` so the IPC buffers go back to the pool once the engines have consumed them.
- With `--offload-train` the trainer calls `sleep()` right before every in-loop sync, which pauses every `torch_memory_saver` allocation (`pause(tag=None)`). `empty_cache()` then walks the caching allocator's free blocks, some of which are paused memory-saver blocks.
- The `torch_memory_saver` build pinned in `docker/Dockerfile` predates upstream fix `d7a3a51` ("Do not release the VMM handle twice when freeing paused memory"). Freeing a paused block calls `cuMemRelease` on a handle that `pause()` already released, which fails with `CUDA_ERROR_INVALID_VALUE`; `CURESULT_CHECK` prints the line above and calls `exit(1)`.
- The logs pin the crash to that call: the failing sync prints `Timer finalize_and_resume_engines end` but never `Memory-Usage after update_weights`, and `after_engines_resumed()` is the only statement between the two. Whether a paused block ends up in the free pool depends on when the colocated engines drop their IPC references, which is why the third sync fails most often and why the same head occasionally passes.

## Fix

- `UpdateWeightFromTensor.after_engines_resumed` returns early when `args.offload_train` is set: an offloaded trainer may hold paused memory-saver blocks, so releasing the cache is not safe for it. A resident trainer keeps the #3147 behavior.
- Unit tests in `tests/fast/backends/training_utils/weight_update/protocols/test_cuda_ipc.py` cover both branches.
- Verified on the devbox: three consecutive runs of the DSv4 test on this change pass with zero `CUresult error` lines and all three `update_weights` completing; the same test is green on https://github.com/radixark/miles/pull/2542 since the change landed there (`5c6b944110`).

## Not done here

- Bumping the `torch_memory_saver` pin in `docker/Dockerfile` to a build that includes `d7a3a51` would remove the underlying double release, but needs an image rebuild and its own validation.

## Why nobody caught it earlier

- The DSv4 colocated test only runs in the nightly and on PRs labeled `run-ci-image`; regular PR CI skips the `stage-c-*` lanes. #3147 landed on 2026-09-08 and the first nightly after it (2026-09-09) is where the test started failing.
- The crash is probabilistic: it needs a paused memory-saver block to be sitting in the caching allocator's free pool when `empty_cache()` runs, which depends on when the colocated engines release their IPC references. The same head can pass one run and fail the next, so a single green run does not clear it.
- The dying rank prints one C++ line and calls `exit(1)`, so the Ray-side error is a generic `ActorUnavailableError`; the job summary only shows `Job entrypoint command failed`.

## Existing work

- #3192 (`fix(docker): bump torch_memory_saver to pick up the free-while-paused fix`) bumps the CUDA `torch_memory_saver` pin to `b5588e83d`, the merge of upstream torch_memory_saver#95, which fixes the double release itself. That is the proper fix; it needs an image rebuild.
- This PR is the code-side guard that avoids the crash with the current pin. With #3192 merged, the `empty_cache()` call under `--offload-train` becomes safe again and this guard can be dropped or kept as belt and braces; the maintainers' call.
