### PR TITLE
loss: add --top-entropy-quantile

### DIFF
--- a/docs/user-guide/cli-reference.md
+++ b/docs/user-guide/cli-reference.md
@@ -71,6 +71,7 @@ then push up until you OOM.
 | `--kl-loss-type` | `k1` | `k1`, `k2`, `k3`, `low_var_kl`. |
 | `--entropy-coef` | `0.0` | Entropy bonus weight. |
 | `--observe-training-entropy` | off | Log training entropy even when `--entropy-coef` is `0.0`; detached from backward when the coefficient is zero. |
+| `--top-entropy-quantile` | `1.0` | Keep only this share of response tokens, the highest-entropy ones, in the policy loss ([Beyond the 80/20 Rule](https://arxiv.org/abs/2506.01939)); the paper uses `0.2`. Threshold per micro-batch on each rank. |
 | `--eps-clip` | `0.2` | PPO/GRPO low clip. |
 | `--eps-clip-high` | `–` | Asymmetric high clip (DAPO-style). |
 | `--use-tis` | off | Truncated Importance Sampling for train/inference precision mismatch. |
@@ -240,6 +241,7 @@ Sections mirror the launch-script argument groups.
 | `--kl-loss-coef` | float | `0.0` | KL weight in loss (0 means monitor). |
 | `--kl-loss-type` | enum | `k1` | `k1`, `k2`, `k3`, `low_var_kl`. |
 | `--entropy-coef` | float | `0.0` | Entropy bonus weight. |
+| `--top-entropy-quantile` | float | `1.0` | Share of highest-entropy response tokens kept in the policy loss. |
 | `--observe-training-entropy` | flag | off | Log detached training entropy when entropy bonus weight is zero. |
 | `--eps-clip` | float | `0.2` | PPO/GRPO low clip. |
 | `--eps-clip-high` | float | – | Asymmetric high clip. |

--- a/miles/backends/training_utils/loss_hub/losses.py
+++ b/miles/backends/training_utils/loss_hub/losses.py
@@ -17,6 +17,7 @@ from miles.backends.training_utils.loss_hub.math_utils import (
     compute_gspo_kl,
     compute_opsm_mask,
     compute_policy_loss,
+    compute_top_entropy_mask,
 )
 from miles.backends.training_utils.parallel import get_parallel_state
 from miles.utils.function_registry import load_function
@@ -110,7 +111,8 @@ def policy_loss_function(
     response_lengths = batch["response_lengths"]
     total_lengths = batch["total_lengths"]
     max_seq_lens = batch.get("max_seq_lens", None)
-    calculate_entropy = args.entropy_coef != 0 or args.observe_training_entropy
+    use_top_entropy_mask = args.top_entropy_quantile < 1.0
+    calculate_entropy = args.entropy_coef != 0 or args.observe_training_entropy or use_top_entropy_mask
 
     log_probs_and_entropy = get_log_probs_and_entropy(
         logits,
@@ -226,6 +228,17 @@ def policy_loss_function(
     if args.use_opsm:
         pg_loss = pg_loss * opsm_mask
 
+    if use_top_entropy_mask:
+        # Beyond the 80/20 rule: only the highest-entropy tokens get a policy
+        # gradient. Like the OPSM mask, this scales the loss without changing
+        # the reducer's denominators.
+        top_entropy_mask = compute_top_entropy_mask(
+            torch.cat(log_probs_and_entropy["entropy"], dim=0),
+            local_loss_masks,
+            args.top_entropy_quantile,
+        )
+        pg_loss = pg_loss * top_entropy_mask
+
     # Apply off-policy correction using importance sampling if enabled
     if args.get_mismatch_metrics or args.use_tis:
         # NOTE:
@@ -305,6 +318,9 @@ def policy_loss_function(
     if calculate_entropy:
         entropy = log_probs_and_entropy["entropy"]
         entropy = torch.cat(entropy, dim=0)
+        if use_top_entropy_mask:
+            # Keep the entropy bonus on the same tokens as the policy gradient.
+            entropy = entropy * top_entropy_mask
         entropy_loss = sum_of_sample_mean(entropy)
         if args.entropy_coef != 0:
             loss = pg_loss - args.entropy_coef * entropy_loss

--- a/miles/backends/training_utils/loss_hub/math_utils.py
+++ b/miles/backends/training_utils/loss_hub/math_utils.py
@@ -221,6 +221,26 @@ def compute_opsm_mask(
     return opsm_mask, opsm_clipfrac
 
 
+def compute_top_entropy_mask(entropy: torch.Tensor, loss_mask: torch.Tensor, quantile: float) -> torch.Tensor:
+    """Keep only the top-``quantile`` share of active tokens by entropy.
+
+    From "Beyond the 80/20 Rule" (https://arxiv.org/abs/2506.01939): the policy
+    gradient is applied to the high-entropy "forking" tokens only. ``quantile``
+    is the share of active tokens to keep (1.0 keeps every token, 0.2 keeps the
+    fifth with the highest entropy). The threshold is the ``1 - quantile``
+    quantile of the entropies of the tokens this rank computes the loss for in
+    the current micro-batch. Tokens outside ``loss_mask`` are always dropped.
+
+    Returns a float mask with the shape of ``entropy``; it never carries a gradient.
+    """
+    active = loss_mask.bool()
+    if quantile >= 1.0 or not active.any():
+        return active.to(entropy.dtype)
+    threshold = torch.quantile(entropy[active].detach().float(), 1.0 - quantile)
+    keep = active & (entropy.detach().float() >= threshold)
+    return keep.to(entropy.dtype)
+
+
 def compute_gspo_kl(
     full_log_probs: list[torch.Tensor],
     full_old_log_probs: list[torch.Tensor],

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -1512,6 +1512,16 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 help="Interval (in rollout steps) to update ref model from actor. If None, ref model is not updated.",
             )
             parser.add_argument("--entropy-coef", type=float, default=0.0, help="Entropy loss coef")
+            parser.add_argument(
+                "--top-entropy-quantile",
+                type=float,
+                default=1.0,
+                help=(
+                    "Keep only this share of response tokens, the ones with the highest entropy, in the policy "
+                    "loss (Beyond the 80/20 Rule, https://arxiv.org/abs/2506.01939). 1.0 keeps every token; the "
+                    "paper uses 0.2. The threshold is taken over the tokens of each micro-batch on each rank."
+                ),
+            )
             parser.add_argument("--gamma", type=float, default=1.0, help="PPO GAE gamma")
             parser.add_argument("--lambd", type=float, default=1.0, help="PPO GAE lambd")
             parser.add_argument("--normalize-advantages", action="store_true", default=False)
@@ -2929,6 +2939,8 @@ def miles_validate_args(args):
     validate_dashboard_args(args)
 
     args.ft_components = _resolve_ft_components(args)
+    assert 0.0 < args.top_entropy_quantile <= 1.0, "--top-entropy-quantile must be in (0, 1]"
+
     assert not ("rollout" in args.ft_components and args.eval_num_gpus > 0), (
         "rollout fault tolerance does not support a dedicated eval fleet (--eval-num-gpus > 0): "
         "the eval fleet pins engine addresses once at startup, so a healed eval cell would make "

--- a/tests/fast/backends/training_utils/loss/loss_test_utils.py
+++ b/tests/fast/backends/training_utils/loss/loss_test_utils.py
@@ -91,6 +91,7 @@ _ARGS_DEFAULTS = dict(
     eps_clip=0.2,
     eps_clip_high=0.2,
     entropy_coef=0.01,
+    top_entropy_quantile=1.0,
     use_kl_loss=False,
     kl_loss_coef=0.0,
     use_unbiased_kl=False,

--- a/tests/fast/backends/training_utils/loss/test_top_entropy_quantile.py
+++ b/tests/fast/backends/training_utils/loss/test_top_entropy_quantile.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+import pytest
+import torch
+import torch.distributed as dist
+
+from miles.backends.training_utils.cp_utils import get_sum_of_sample_mean
+from miles.backends.training_utils.loss_hub import losses as losses_module
+from miles.backends.training_utils.loss_hub.losses import policy_loss_function
+from miles.backends.training_utils.loss_hub.math_utils import compute_top_entropy_mask
+
+from .loss_test_utils import deep_clone, make_args, make_batch, make_inputs, make_parallel_state
+
+
+@pytest.fixture(scope="module")
+def process_group(tmp_path_factory):
+    if dist.is_initialized():
+        yield
+        return
+    rendezvous = tmp_path_factory.mktemp("top-entropy-quantile") / "process-group"
+    dist.init_process_group("gloo", init_method=f"file://{rendezvous}", rank=0, world_size=1)
+    try:
+        yield
+    finally:
+        dist.destroy_process_group()
+
+
+def _run_policy_loss(args, inputs):
+    batch = make_batch(inputs, "policy_loss")
+    logits = deep_clone(inputs["policy_logits"])
+    logits.requires_grad_(True)
+    reducer = get_sum_of_sample_mean(
+        batch["total_lengths"],
+        batch["response_lengths"],
+        batch["loss_masks"],
+        args.calculate_per_token_loss,
+        args.qkv_format,
+        batch.get("max_seq_lens"),
+    )
+    loss, metrics = policy_loss_function(args, batch, logits, reducer)
+    loss.backward()
+    return loss.detach(), metrics, logits.grad.clone()
+
+
+def _make(quantile: float):
+    make_parallel_state()
+    args = make_args(
+        advantage_estimator="grpo",
+        entropy_coef=0.0,
+        observe_training_entropy=False,
+        top_entropy_quantile=quantile,
+    )
+    inputs = make_inputs(
+        seed=7,
+        batch_size=2,
+        prompt_lens=[16, 24],
+        response_lens=[12, 20],
+        vocab_size=64,
+        args=args,
+    )
+    return args, inputs
+
+
+def test_quantile_one_leaves_the_policy_loss_untouched(process_group, monkeypatch):
+    spy = Mock(wraps=losses_module.compute_top_entropy_mask)
+    monkeypatch.setattr(losses_module, "compute_top_entropy_mask", spy)
+
+    args, inputs = _make(quantile=1.0)
+    loss, metrics, grad = _run_policy_loss(args, inputs)
+
+    baseline_args = make_args(advantage_estimator="grpo", entropy_coef=0.0, observe_training_entropy=False)
+    baseline_loss, baseline_metrics, baseline_grad = _run_policy_loss(baseline_args, inputs)
+
+    assert spy.call_count == 0
+    assert torch.equal(loss, baseline_loss)
+    assert torch.equal(grad, baseline_grad)
+    assert torch.equal(metrics["pg_loss"], baseline_metrics["pg_loss"])
+
+
+def test_quantile_below_one_masks_low_entropy_tokens(process_group, monkeypatch):
+    returned = []
+
+    def recording_mask(*call_args):
+        mask = compute_top_entropy_mask(*call_args)
+        returned.append(mask)
+        return mask
+
+    spy = Mock(side_effect=recording_mask)
+    monkeypatch.setattr(losses_module, "compute_top_entropy_mask", spy)
+
+    args, inputs = _make(quantile=0.25)
+    loss, metrics, grad = _run_policy_loss(args, inputs)
+    full_args, full_inputs = _make(quantile=1.0)
+    full_loss, _, full_grad = _run_policy_loss(full_args, full_inputs)
+
+    assert spy.call_count == 1
+    (entropy, loss_mask, quantile), _ = spy.call_args
+    assert quantile == 0.25
+    assert entropy.shape == loss_mask.shape == (sum(inputs["response_lens"]),)
+    kept = returned[0]
+    # A quarter of 32 response tokens survive the threshold.
+    assert kept.sum().item() == 8
+    # Entropy is computed for the mask even though no entropy bonus or metric asked for it.
+    assert metrics["entropy_loss"].item() > 0
+    assert not torch.equal(loss, full_loss)
+    assert not torch.equal(grad, full_grad)

--- a/tests/fast/backends/training_utils/loss_hub/test_top_entropy_mask.py
+++ b/tests/fast/backends/training_utils/loss_hub/test_top_entropy_mask.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import torch
+
+from miles.backends.training_utils.loss_hub.math_utils import compute_top_entropy_mask
+
+
+def test_keeps_the_top_share_of_active_tokens_by_entropy():
+    entropy = torch.tensor([0.1, 0.9, 0.5, 0.7, 0.3, 0.8])
+    loss_mask = torch.tensor([1.0, 1.0, 1.0, 1.0, 1.0, 0.0])
+
+    mask = compute_top_entropy_mask(entropy, loss_mask, quantile=0.4)
+
+    # Five active tokens; the 0.6 quantile of {0.1, 0.9, 0.5, 0.7, 0.3} is 0.58, so
+    # 0.9 and 0.7 survive. The masked-out 0.8 never counts, however high it is.
+    assert mask.tolist() == [0.0, 1.0, 0.0, 1.0, 0.0, 0.0]
+    assert mask.dtype == entropy.dtype
+
+
+def test_quantile_one_returns_the_loss_mask():
+    entropy = torch.tensor([0.1, 0.9, 0.5])
+    loss_mask = torch.tensor([1.0, 0.0, 1.0])
+
+    assert compute_top_entropy_mask(entropy, loss_mask, quantile=1.0).tolist() == [1.0, 0.0, 1.0]
+
+
+def test_all_inactive_tokens_stay_masked_without_quantile_error():
+    entropy = torch.tensor([0.1, 0.9])
+    loss_mask = torch.zeros(2)
+
+    assert compute_top_entropy_mask(entropy, loss_mask, quantile=0.2).tolist() == [0.0, 0.0]
+
+
+def test_mask_does_not_carry_gradient():
+    entropy = torch.tensor([0.1, 0.9, 0.5], requires_grad=True)
+    loss_mask = torch.ones(3)
+
+    mask = compute_top_entropy_mask(entropy, loss_mask, quantile=0.5)
+
+    assert not mask.requires_grad

--- a/tests/fast/backends/training_utils/test_true_on_policy_loss_metrics.py
+++ b/tests/fast/backends/training_utils/test_true_on_policy_loss_metrics.py
@@ -22,6 +22,7 @@ def _make_args(*, use_rollout_logprobs: bool) -> Namespace:
         calculate_per_token_loss=False,
         qkv_format="thd",
         entropy_coef=0.0,
+        top_entropy_quantile=1.0,
         use_kl_loss=False,
         use_unbiased_kl=False,
         kl_loss_type="k1",


### PR DESCRIPTION
### What

Adds `--top-entropy-quantile` (default `1.0`), the token filter from [Beyond the 80/20 Rule](https://arxiv.org/abs/2506.01939): only the highest-entropy share of response tokens receives a policy gradient. `compute_top_entropy_mask` in `miles/backends/training_utils/loss_hub/math_utils.py` takes the `1 - quantile` threshold over the active tokens this rank scores in the micro-batch and returns a float mask; `policy_loss_function` multiplies `pg_loss` by it right after the OPSM mask, so the reducer's denominators are unchanged, the same way OPSM works today. Entropy is now computed whenever the mask is on, detached unless `--entropy-coef` already asks for a gradient, and it still feeds the `entropy_loss` metric. When the mask is on, the entropy bonus of `--entropy-coef` is taken over the same kept tokens, as in TRL. The flag sits next to `--entropy-coef` in `miles/utils/arguments.py` with a `(0, 1]` range check in `miles_validate_args` that runs after the custom-config override, and the CLI reference lists it. With the default nothing changes.

### Test

`tests/fast/backends/training_utils/loss_hub/test_top_entropy_mask.py` covers the helper on fixed tensors: the top share survives and masked-out tokens never count, `1.0` returns the loss mask, an all-masked input does not reach `torch.quantile`, and the mask carries no gradient. `tests/fast/backends/training_utils/loss/test_top_entropy_quantile.py` runs `policy_loss_function` through the existing loss test helpers: with `1.0` the loss, gradient and `pg_loss` are bitwise equal to a run without the flag and the helper is never called; with `0.25` the helper sees one entropy value per response token, keeps a quarter of them, entropy is computed although no bonus or metric asked for it, and loss and gradient change.

### Verification

- The six new tests pass; `tests/fast/backends/training_utils` plus `tests/fast/utils/test_arguments.py`: 455 passed, plus the 12 loss snapshot compares against the miles-artifacts snapshots, which pass unchanged (the flag is off by default).
- Replacing the threshold with "keep every active token" makes the helper and loss tests fail.
- The flag parses through the miles argument provider.
- ruff, black and isort at the pre-commit pins are clean on the changed files.

### Scope

- The quantile is taken per micro-batch on each rank (and per context-parallel shard). TRL gathers entropies across processes before taking the quantile; that needs a process-group all-gather in the loss path and is left for a follow-up if wanted.
- No snapshot config is added: loss snapshots live in the external miles-artifacts repo, so a new config would fail compare mode until a snapshot is pushed there.
- No GPU run; the loss path is exercised on CPU through the fast loss tests only.

cc @guapisolo @yueming-yuan
