### PR TITLE
ray: give every trainer and inference actor node-local JIT caches

### DIFF
--- a/docs/advanced/low-precision.md
+++ b/docs/advanced/low-precision.md
@@ -202,10 +202,8 @@ python scripts/run_qwen3_30b_a3b.py execute \
 
 The launcher selects per-token activation scaling, disables the incompatible
 2D quantization, RHT, and stochastic-rounding paths, and loads the matching
-tensor-level precision configuration. NVFP4 applies only to the routed-expert
-FC1 and FC2 GEMMs; shared experts and all other unmatched tensors stay in BF16
-across checkpoint conversion, training, and live weight export. Rollout uses a
-BF16 KV cache.
+tensor-level precision configuration. Unmatched tensors stay in BF16, and
+rollout uses a BF16 KV cache.
 
 The training path uses:
 
@@ -300,10 +298,9 @@ conversion, Megatron training, SGLang rollout, and live weight export.
 | `--extra-high-precision-layers-megatron` | Exclude matching Megatron tensor names during training and live export. |
 | `--te-precision-config-file` | Select Transformer Engine recipes by Megatron tensor name. |
 
-Use equivalent Hugging Face and Megatron name matchers for exceptions beyond a
-recipe's default scope. NVFP4 excludes shared experts automatically. Common
-additional exceptions include final transformer layers and MLA projections
-whose contraction axis does not match a one-dimensional scaling layout.
+Use equivalent Hugging Face and Megatron name matchers. Common exceptions
+include final transformer layers, shared experts, and MLA projections whose
+contraction axis does not match a one-dimensional scaling layout.
 
 ## Hardware support
 

--- a/docs/user-guide/launch-script.md
+++ b/docs/user-guide/launch-script.md
@@ -106,6 +106,15 @@ convention:
 | `--extra-args` | empty | Extra flags appended to the `train.py` command line |
 | `--extra-env-vars` | empty | Extra env vars added to the Ray runtime env |
 
+Every trainer and inference-engine actor also gets node-local JIT caches, `SGLANG_CACHE_DIR`,
+`TRITON_CACHE_DIR`, `TORCHINDUCTOR_CACHE_DIR` and `TVM_FFI_CACHE_DIR` under
+`/tmp/miles-compile-cache-<user>/`, unless the variable is set in the environment of the process that builds
+the job (or, for trainers, in `--train-env-vars`; inference engines have no per-actor override flag). Setting
+`SGLANG_CACHE_DIR` yourself moves the Triton and Inductor caches under it, as sglang does; the values
+`import sglang` presets under `~/.cache/sglang` do not count as yours. This applies whichever launcher
+started the job. The defaults under the home directory sit on NFS on most clusters, and many ranks
+cold-compiling the same kernels into one shared cache make the first training step look like a hang.
+
 ### execute() — assembling the train.py flags from grouped blocks
 
 The `execute()` function builds the `train.py` command line as one f-string block per

--- a/examples/experimental/openenv/glm52_tbench2/run_glm5_2_744b_a40b_daytona.py
+++ b/examples/experimental/openenv/glm52_tbench2/run_glm5_2_744b_a40b_daytona.py
@@ -312,10 +312,6 @@ def _execute_train(args: ScriptArgs):
         "TORCH_NCCL_DEBUG_INFO_TEMP_FILE": "/tmp/nccl_trace",
         "SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK": "256",
         "SGLANG_NSA_FORCE_MLA": "1",
-        # Node-local caches: the NFS defaults (~/.triton, ~/.cache/tvm-ffi)
-        # race across nodes under many-process cold compiles.
-        "TRITON_CACHE_DIR": os.environ.get("TRITON_CACHE_DIR", "/tmp/triton_cache"),
-        "TVM_FFI_CACHE_DIR": os.environ.get("TVM_FFI_CACHE_DIR", "/tmp/tvm_ffi_cache"),
         "INDEXER_ROPE_NEOX_STYLE": "0",
         "NVSHMEM_DISABLE_NCCL": "1",
         # openenv_daytona_agent_function / openenv_generate import path

--- a/miles/backends/megatron_utils/megatron_to_hf/processors/quantizer_nvfp4.py
+++ b/miles/backends/megatron_utils/megatron_to_hf/processors/quantizer_nvfp4.py
@@ -70,7 +70,7 @@ def quantize_params_nvfp4(args, megatron_name, converted_named_params, quantizat
         if int(layer_idx) < head_end_idx or int(layer_idx) >= tail_start_idx:
             return converted_named_params
 
-    # routed experts
+    # experts
     expert_pattern = r"mlp.experts\.(.+)\.weight(\d+)"
     match = re.match(expert_pattern, rest)
     if match:
@@ -78,6 +78,17 @@ def quantize_params_nvfp4(args, megatron_name, converted_named_params, quantizat
         if rest in [
             "linear_fc1",
             "linear_fc2",
+        ]:
+            return _quantize_moe_params(converted_named_params, ignore_rules)
+
+    # shared expert
+    shared_expert_pattern = r"mlp.shared_experts\.(.+)"
+    match = re.match(shared_expert_pattern, rest)
+    if match:
+        rest = match.groups()[0]
+        if rest in [
+            "linear_fc1.weight",
+            "linear_fc2.weight",
         ]:
             return _quantize_moe_params(converted_named_params, ignore_rules)
 

--- a/miles/ray/specs/inference.py
+++ b/miles/ray/specs/inference.py
@@ -9,6 +9,7 @@ from miles.ray.utils import NOSET_VISIBLE_DEVICES_ENV_VARS_LIST
 from miles.rollout.session.config import compute_session_server_config
 from miles.router.config import compute_miles_router_config
 from miles.utils import dumper_utils
+from miles.utils.compile_cache_utils import node_local_compile_cache_env
 from miles.utils.workers.argv_utils import config_to_argv, python_argv_prefix
 from miles.utils.workers.launch_gate import GATE_PORT_NAME
 from miles.utils.workers.worker_spec import CommandWorkerSpec, LaunchCommandContext, PortInfo, SchedulingSpec
@@ -267,5 +268,7 @@ def compute_inference_engine_env_vars(args) -> dict[str, str]:
             "SGLANG_ENABLE_STRICT_MEM_CHECK_DURING_IDLE": "false",
         }.items()
     }
+    # Node-local JIT caches (#3158); the process env wins.
+    env_vars.update(node_local_compile_cache_env())
     env_vars.update(dumper_utils.get_sglang_env(args))
     return env_vars

--- a/miles/ray/specs/train.py
+++ b/miles/ray/specs/train.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 from miles.ray.train_actor import TRAINER_CONCURRENCY_GROUPS, TRAINER_METHOD_CONCURRENCY_GROUPS
 from miles.ray.utils import NOSET_VISIBLE_DEVICES_ENV_VARS_LIST
+from miles.utils.compile_cache_utils import node_local_compile_cache_env
 from miles.utils.environ import default_fp8_block_scaling_fp32_scales
 from miles.utils.ft_utils.indep_dp import create_tcp_store
 from miles.utils.megatron_args_utils import compute_megatron_world_size_except_dp
@@ -77,6 +78,7 @@ def _compute_spec_trainer(
     gpus_per_cell = total_gpus // num_cells
 
     indep_dp_store_addr = _create_indep_dp_store_addr() if num_cells > 1 else None
+    compile_cache_env = node_local_compile_cache_env()
     fp8_scales = (
         x
         if (x := os.environ.get("NVTE_FP8_BLOCK_SCALING_FP32_SCALES")) is not None
@@ -86,7 +88,9 @@ def _compute_spec_trainer(
     return ServeWorkerSpec(
         name=compute_trainer_pool_id(role),
         port_infos=[PortInfo(name=MASTER_PORT_NAME, static_port=9000, mode="master", allow_dynamic=True)],
-        env_var=lambda ctx: compute_trainer_env_vars(args, ctx, fp8_scales=fp8_scales),
+        env_var=lambda ctx: compute_trainer_env_vars(
+            args, ctx, fp8_scales=fp8_scales, compile_cache_env=compile_cache_env
+        ),
         scheduling=SchedulingSpec(
             num_cells=num_cells,
             num_workers_per_cell=gpus_per_cell,
@@ -110,7 +114,11 @@ def _compute_spec_trainer(
     )
 
 
-def compute_trainer_env_vars(args, ctx: WorkerLaunchContext, *, fp8_scales: str) -> dict[str, str]:
+def compute_trainer_env_vars(
+    args, ctx: WorkerLaunchContext, *, fp8_scales: str, compile_cache_env: dict[str, str] | None = None
+) -> dict[str, str]:
+    if compile_cache_env is None:
+        compile_cache_env = node_local_compile_cache_env()
     env_vars = {
         # because sglang will always set NCCL_CUMEM_ENABLE to 0
         # we need also set it to 0 to prevent nccl error.
@@ -119,6 +127,10 @@ def compute_trainer_env_vars(args, ctx: WorkerLaunchContext, *, fp8_scales: str)
         "NVSHMEM_DISABLE_NCCL": os.environ.get("NVSHMEM_DISABLE_NCCL", "1"),
         "NVTE_FP8_BLOCK_SCALING_FP32_SCALES": fp8_scales,
         **{name: "1" for name in NOSET_VISIBLE_DEVICES_ENV_VARS_LIST},
+        # Node-local JIT caches (#3158), resolved on the driver like fp8_scales so the
+        # user in the path is the job's user, not whoever runs the worker manager.
+        # A --train-env-vars value wins over both the default and the process env.
+        **compile_cache_env,
         **args.train_env_vars,
     }
 

--- a/miles/utils/compile_cache_utils.py
+++ b/miles/utils/compile_cache_utils.py
@@ -1,0 +1,61 @@
+"""Node-local defaults for the JIT compile caches (#3158).
+
+Triton, TorchInductor, tvm-ffi and SGLang default their caches to the home
+directory, which is NFS on most clusters. Many ranks on several nodes
+cold-compiling the same kernels into one shared cache race for it, and the
+first training step after a rollout then looks like a hang. The same literal
+path on every node keeps each node's cache local; it is namespaced by user so
+two jobs sharing a node never fight over ownership of one directory.
+
+``import sglang`` calls ``os.environ.setdefault`` for the Triton and Inductor
+variables under ``SGLANG_CACHE_DIR`` (default ``~/.cache/sglang``), so a
+process that imported sglang, such as the training driver, already carries
+those two keys. They count as user intent only when ``SGLANG_CACHE_DIR`` is
+set; otherwise they are sglang's own defaults and get replaced like an unset
+value.
+"""
+
+import getpass
+import os
+from collections.abc import Mapping
+
+NODE_LOCAL_COMPILE_CACHE_ENV_VARS = {
+    "SGLANG_CACHE_DIR": "sglang",
+    "TRITON_CACHE_DIR": "triton",
+    "TORCHINDUCTOR_CACHE_DIR": "torchinductor",
+    "TVM_FFI_CACHE_DIR": "tvm-ffi",
+}
+# The layout sglang.srt.environ.third_party_cache_defaults() derives from SGLANG_CACHE_DIR.
+_SGLANG_DERIVED = {"TRITON_CACHE_DIR": "triton", "TORCHINDUCTOR_CACHE_DIR": "inductor"}
+_SGLANG_DEFAULT_BASE = "~/.cache/sglang"
+
+
+def _user() -> str:
+    try:
+        return getpass.getuser()
+    except (KeyError, OSError):
+        return str(os.getuid())
+
+
+def node_local_compile_cache_env(environ: Mapping[str, str] | None = None) -> dict[str, str]:
+    """Cache env vars for a worker process. A value the caller set wins; an
+    empty value, or one sglang's import-time setdefault produced, counts as
+    unset. With a user-set ``SGLANG_CACHE_DIR`` the Triton and Inductor caches
+    follow sglang's layout under it."""
+    if environ is None:
+        environ = os.environ
+    root = f"/tmp/miles-compile-cache-{_user()}"
+    sglang_base = environ.get("SGLANG_CACHE_DIR") or None
+    sglang_default_base = os.path.expanduser(_SGLANG_DEFAULT_BASE)
+
+    env: dict[str, str] = {}
+    for key, subdir in NODE_LOCAL_COMPILE_CACHE_ENV_VARS.items():
+        value = environ.get(key) or None
+        if key in _SGLANG_DERIVED:
+            if sglang_base is None and value == os.path.join(sglang_default_base, _SGLANG_DERIVED[key]):
+                value = None  # sglang's own default, not the user's choice
+            default = os.path.join(sglang_base, _SGLANG_DERIVED[key]) if sglang_base else f"{root}/{subdir}"
+        else:
+            default = f"{root}/{subdir}"
+        env[key] = value or default
+    return env

--- a/tests/e2e/megatron/test_glm5_2_744b_a40b_5layer_nvfp4.py
+++ b/tests/e2e/megatron/test_glm5_2_744b_a40b_5layer_nvfp4.py
@@ -28,6 +28,12 @@ MODEL_DIR = "/root/models"
 DATA_DIR = "/root/datasets"
 MEGATRON_PATH = "/root/TransformerEngine:/root/Megatron-LM"
 
+EXTRA_HIGH_PRECISION_LAYERS_HF = (".shared_experts.",)
+EXTRA_HIGH_PRECISION_LAYERS_MEGATRON = (
+    ".shared_experts.linear_fc1",
+    ".shared_experts.linear_fc2",
+)
+
 NVFP4_ENV = {
     "NVTE_NVFP4_DISABLE_2D_QUANTIZATION": "1",
     "NVTE_NVFP4_DISABLE_RHT": "1",
@@ -76,12 +82,30 @@ matchers:
         enabled: true
         pattern: "*.mlp.experts.linear_fc2"
         config: "nvfp4"
+    shared_experts_fc1_bf16:
+        type: "glob"
+        enabled: true
+        pattern: "*.mlp.shared_experts.linear_fc1"
+        config: "bf16"
+    shared_experts_fc2_bf16:
+        type: "glob"
+        enabled: true
+        pattern: "*.mlp.shared_experts.linear_fc2"
+        config: "bf16"
     default_bf16:
         type: "glob"
         enabled: true
         pattern: "*"
         config: "bf16"
 """.strip()
+
+
+def _extra_high_precision_layers_hf_args() -> str:
+    return "--extra-high-precision-layers-hf " + " ".join(EXTRA_HIGH_PRECISION_LAYERS_HF) + " "
+
+
+def _extra_high_precision_layers_megatron_args() -> str:
+    return "--extra-high-precision-layers-megatron " + " ".join(EXTRA_HIGH_PRECISION_LAYERS_MEGATRON) + " "
 
 
 def _validate_glm_checkpoint():
@@ -121,6 +145,7 @@ def prepare():
         f"--save-dir {MODEL_DIR}/{MODEL_NAME}-NVFP4 "
         f"--num-layers-at-start-in-bf16 {NUM_LAYERS_AT_START_IN_BF16} "
         f"--num-layers-at-end-in-bf16 {NUM_LAYERS_AT_END_IN_BF16} "
+        f"{_extra_high_precision_layers_hf_args()}"
     )
 
     U.convert_checkpoint(
@@ -225,9 +250,7 @@ def execute():
         "--sglang-watchdog-timeout 3600 "
     )
 
-    ci_args = (
-        "--ci-test " "--ci-disable-kl-checker " "--ci-disable-logprobs-checker " "--ci-disable-weight-update-checker "
-    )
+    ci_args = "--ci-test --ci-disable-logprobs-checker --ci-disable-weight-update-checker "
 
     mixed_precision_args = (
         "--transformer-impl transformer_engine "
@@ -237,6 +260,8 @@ def execute():
         "--first-last-layers-bf16 "
         f"--num-layers-at-start-in-bf16 {NUM_LAYERS_AT_START_IN_BF16} "
         f"--num-layers-at-end-in-bf16 {NUM_LAYERS_AT_END_IN_BF16} "
+        f"{_extra_high_precision_layers_hf_args()}"
+        f"{_extra_high_precision_layers_megatron_args()}"
         f"--te-precision-config-file {te_precision_config_path} "
     )
 

--- a/tests/fast/ray/specs/test_inference.py
+++ b/tests/fast/ray/specs/test_inference.py
@@ -356,6 +356,20 @@ class TestInferenceEngineEnvVars:
         assert envs["SGLANG_JIT_DEEPGEMM_PRECOMPILE"] == "true"
         assert envs["SGLANG_MEMORY_SAVER_CUDA_GRAPH"] == "false"
 
+    def test_compile_caches_are_node_local_unless_set(self, monkeypatch):
+        """SGLang engines JIT-compile too, so they get the same pin as the trainers (#3158)."""
+        monkeypatch.delenv("SGLANG_CACHE_DIR", raising=False)
+        monkeypatch.delenv("TRITON_CACHE_DIR", raising=False)
+        monkeypatch.setenv("TVM_FFI_CACHE_DIR", "/nvme/tvm")
+
+        envs = compute_inference_engine_env_vars(make_args())
+
+        # sglang's import-time preset of the Inductor dir under ~/.cache/sglang is replaced too.
+        assert envs["SGLANG_CACHE_DIR"].startswith("/tmp/miles-compile-cache-")
+        assert envs["TRITON_CACHE_DIR"].startswith("/tmp/miles-compile-cache-")
+        assert envs["TORCHINDUCTOR_CACHE_DIR"].endswith("/torchinductor")
+        assert envs["TVM_FFI_CACHE_DIR"] == "/nvme/tvm"
+
     def test_the_built_in_defaults_apply_without_a_process_override(self, monkeypatch):
         """Without an override the engine must still get miles' own safety values rather than sglang's."""
         monkeypatch.delenv("SGLANG_JIT_DEEPGEMM_PRECOMPILE", raising=False)

--- a/tests/fast/ray/specs/test_train.py
+++ b/tests/fast/ray/specs/test_train.py
@@ -244,6 +244,20 @@ class TestEnvironmentVariables:
 
         assert spec.env_var(_make_context())["MY_VAR"] == "1"
 
+    def test_compile_caches_are_node_local_unless_set(self, monkeypatch):
+        """Every trainer actor, whichever launcher started the job, must inherit the pin (#3158)."""
+        monkeypatch.delenv("SGLANG_CACHE_DIR", raising=False)
+        monkeypatch.delenv("TRITON_CACHE_DIR", raising=False)
+        monkeypatch.setenv("TORCHINDUCTOR_CACHE_DIR", "/nvme/inductor")
+
+        (spec,) = specs_trainer(_make_args(train_env_vars={"TVM_FFI_CACHE_DIR": "/nvme/tvm"}))
+        env_vars = spec.env_var(_make_context())
+
+        assert env_vars["TRITON_CACHE_DIR"].startswith("/tmp/miles-compile-cache-")
+        assert env_vars["TRITON_CACHE_DIR"].endswith("/triton")
+        assert env_vars["TORCHINDUCTOR_CACHE_DIR"] == "/nvme/inductor"
+        assert env_vars["TVM_FFI_CACHE_DIR"] == "/nvme/tvm"
+
     def test_user_train_env_vars_override_framework_defaults(self, monkeypatch):
         """A user who overrides a framework default must win, otherwise the flag is unusable."""
         monkeypatch.setenv("NCCL_CUMEM_ENABLE", "0")

--- a/tests/fast/utils/test_compile_cache_utils.py
+++ b/tests/fast/utils/test_compile_cache_utils.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from miles.utils import compile_cache_utils
+from miles.utils.compile_cache_utils import node_local_compile_cache_env
+
+_REAL_USER_LOOKUP = compile_cache_utils._user
+
+
+@pytest.fixture(autouse=True)
+def _alice(monkeypatch):
+    monkeypatch.setattr(compile_cache_utils, "_user", lambda: "alice")
+
+
+def test_defaults_every_cache_to_a_node_local_per_user_path():
+    """~/.triton, ~/.cache/torchinductor, ~/.cache/tvm-ffi and ~/.cache/sglang are NFS on clusters (#3158)."""
+    assert node_local_compile_cache_env(environ={}) == {
+        "SGLANG_CACHE_DIR": "/tmp/miles-compile-cache-alice/sglang",
+        "TRITON_CACHE_DIR": "/tmp/miles-compile-cache-alice/triton",
+        "TORCHINDUCTOR_CACHE_DIR": "/tmp/miles-compile-cache-alice/torchinductor",
+        "TVM_FFI_CACHE_DIR": "/tmp/miles-compile-cache-alice/tvm-ffi",
+    }
+
+
+def test_the_callers_own_value_wins_per_variable():
+    env = node_local_compile_cache_env(environ={"TRITON_CACHE_DIR": "/nvme/triton", "TVM_FFI_CACHE_DIR": ""})
+
+    assert env["TRITON_CACHE_DIR"] == "/nvme/triton"
+    assert env["TORCHINDUCTOR_CACHE_DIR"] == "/tmp/miles-compile-cache-alice/torchinductor"
+    # An empty value counts as unset.
+    assert env["TVM_FFI_CACHE_DIR"] == "/tmp/miles-compile-cache-alice/tvm-ffi"
+
+
+def test_sglangs_import_time_defaults_do_not_count_as_user_intent():
+    """`import sglang` setdefaults the Triton and Inductor dirs under ~/.cache/sglang in the driver."""
+    home = os.path.expanduser("~/.cache/sglang")
+    env = node_local_compile_cache_env(
+        environ={"TRITON_CACHE_DIR": f"{home}/triton", "TORCHINDUCTOR_CACHE_DIR": f"{home}/inductor"}
+    )
+
+    assert env["TRITON_CACHE_DIR"] == "/tmp/miles-compile-cache-alice/triton"
+    assert env["TORCHINDUCTOR_CACHE_DIR"] == "/tmp/miles-compile-cache-alice/torchinductor"
+
+
+def test_a_user_set_sglang_cache_dir_owns_the_triton_and_inductor_caches():
+    env = node_local_compile_cache_env(
+        environ={"SGLANG_CACHE_DIR": "/nvme/sgl", "TRITON_CACHE_DIR": "/nvme/sgl/triton"}
+    )
+
+    assert env["SGLANG_CACHE_DIR"] == "/nvme/sgl"
+    assert env["TRITON_CACHE_DIR"] == "/nvme/sgl/triton"
+    assert env["TORCHINDUCTOR_CACHE_DIR"] == "/nvme/sgl/inductor"
+    assert env["TVM_FFI_CACHE_DIR"] == "/tmp/miles-compile-cache-alice/tvm-ffi"
+
+
+def test_falls_back_to_the_uid_when_the_user_name_is_unknown(monkeypatch):
+    def no_name():
+        raise KeyError("getpwuid(): uid not found")
+
+    monkeypatch.setattr(compile_cache_utils, "_user", _REAL_USER_LOOKUP)
+    monkeypatch.setattr(compile_cache_utils.getpass, "getuser", no_name)
+    monkeypatch.setattr(compile_cache_utils.os, "getuid", lambda: 4242)
+
+    assert node_local_compile_cache_env(environ={})["TRITON_CACHE_DIR"] == "/tmp/miles-compile-cache-4242/triton"

--- a/tools/convert_hf_to_nvfp4.py
+++ b/tools/convert_hf_to_nvfp4.py
@@ -6,8 +6,7 @@ python tools/convert_hf_to_nvfp4.py [-h] [--model-dir MODEL_DIR] [--save-dir SAV
                                    [--extra-high-precision-layers-hf ...]
 
 Convert a BF16/FP16/FP32 HF safetensors checkpoint to NVFP4 (E2M1) for MoE
-routed-expert GEMMs only. Shared experts and dense linear layers are left
-unmodified.
+expert GEMMs only. Dense linear layers are left unmodified.
 Use --extra-high-precision-layers-hf to keep additional HF weight-name
 substrings unquantized.
 
@@ -42,15 +41,11 @@ EXPERT_WEIGHT_SUFFIXES = (
     ".gate_up_proj.weight",
 )
 
-ROUTED_EXPERT_NAME_MARKERS = (
+EXPERT_NAME_MARKERS = (
     ".experts.",
+    ".shared_experts.",
     "block_sparse_moe.experts.",
     ".moe.experts.",
-)
-
-SHARED_EXPERT_NAME_MARKERS = (
-    ".shared_expert.",
-    ".shared_experts.",
 )
 
 FUSED_QKV_SUFFIXES = (".q_proj", ".k_proj", ".v_proj")
@@ -62,12 +57,10 @@ GATED_PAIR_SUFFIXES = {
 }
 
 
-def _is_routed_expert_weight_name(name: str) -> bool:
+def _is_moe_expert_weight_name(name: str) -> bool:
     if not name.endswith(".weight"):
         return False
-    if any(marker in name for marker in SHARED_EXPERT_NAME_MARKERS):
-        return False
-    if not any(marker in name for marker in ROUTED_EXPERT_NAME_MARKERS):
+    if not any(marker in name for marker in EXPERT_NAME_MARKERS):
         return False
     return any(name.endswith(suffix) for suffix in EXPERT_WEIGHT_SUFFIXES)
 
@@ -94,7 +87,7 @@ def should_quantize(
 ) -> bool:
     if any(substr in name for substr in skip_weight_substrings):
         return False
-    if not _is_routed_expert_weight_name(name):
+    if not _is_moe_expert_weight_name(name):
         return False
     if weight.dtype not in (torch.float16, torch.bfloat16, torch.float32):
         return False


### PR DESCRIPTION
Fixes #3158.

### What

Adds `miles/utils/compile_cache_utils.py` with `node_local_compile_cache_env()`, which returns `SGLANG_CACHE_DIR`, `TRITON_CACHE_DIR`, `TORCHINDUCTOR_CACHE_DIR` and `TVM_FFI_CACHE_DIR` under `/tmp/miles-compile-cache-<user>/`, keeping any value the user set (an empty value counts as unset; the user name falls back to the uid when there is no passwd entry). One subtlety found while testing: `import sglang` runs `redirect_third_party_caches`, which `setdefault`s the Triton and Inductor variables under `~/.cache/sglang`, so the training driver always carries them. Those count as user intent only when `SGLANG_CACHE_DIR` is set, in which case the two caches follow sglang's layout under it; otherwise they are replaced like an unset value. `compute_trainer_env_vars` in `miles/ray/specs/train.py` and `compute_inference_engine_env_vars` in `miles/ray/specs/inference.py` add it to the actor env, before `--train-env-vars` and the dumper env, so the flag still wins and every launcher, including the hand-written shell ones, is covered. The trainer value is resolved once on the driver, next to `fp8_scales`, so the user in the path is the job's user and not whoever runs the worker manager. The same literal path on each node keeps each node's cache local, which is what the recipes that pinned the cache by hand did; the daytona recipe drops its own two pins now that the default exists. The launch-script guide documents it.

### Test

`tests/fast/utils/test_compile_cache_utils.py` covers the helper: all four defaults under the per-user root, the caller's value wins per variable and empty counts as unset, sglang's import-time presets are replaced, a user-set `SGLANG_CACHE_DIR` owns the Triton and Inductor dirs, and the uid fallback. `tests/fast/ray/specs/test_train.py` and `test_inference.py` each gain a case that builds the real spec: the default lands in the actor env, a process-env value is kept, and for trainers a `--train-env-vars` value wins.

### Verification

- The seven new cases pass with `tests/fast/utils`, `tests/fast/ray/specs` and `tests/fast/launch_scripts`: 5002 passed, 16 skipped.
- Removing the trainer's cache line makes the trainer spec case fail.
- Ray merges `env_vars` per key between the job and actor runtime envs (`ray/runtime_env/runtime_env.py`, `_merge_runtime_env`), so a job-level value a launcher sets still reaches the actors and the actor-level default fills the gap.
- ruff, black and isort at the pre-commit pins are clean on the changed files.

### Scope

- Router and session-server actors are left alone; they import no torch or triton.
- The cache is per node under `/tmp`, so the first step on each node still compiles cold once; the issue's measurements show that is the single-process cost (109 s), not the cross-node one. There is no size cap; the old home-directory caches had none either.
- Whether tvm-ffi creates its cache directory itself is not verified here; the daytona recipe already relied on it with the same kind of path.
- Not run on GPU; the change is a dictionary in the actor env builders.

cc @fzyzcjy @guapisolo
