### PR TITLE
Rebuild the weight-sync groups outside the paused memory-saver regions

### DIFF
--- a/miles/backends/megatron_utils/actor.py
+++ b/miles/backends/megatron_utils/actor.py
@@ -818,18 +818,20 @@ class MegatronTrainRayActor(TrainRayActor):
         del info
 
         process_groups_are_temporary = self.args.offload_train and self._asleep
-        if process_groups_are_temporary:
-            reload_process_groups()
+        groups_outlive_the_pause = self.args.offload_train and not self.args.colocate
+        with torch_memory_saver.disable() if groups_outlive_the_pause else nullcontext():
+            if process_groups_are_temporary:
+                reload_process_groups()
 
-        needs_reconnect = self.weight_updater.conn_status.needs_reconnect(snapshot_cell_id_to_hashes)
-        if needs_reconnect:
-            self.weight_updater.connect_rollout_engines(
-                rollout_engines,
-                engine_gpu_counts=engine_gpu_counts,
-                engine_gpu_offsets=engine_gpu_offsets,
-            )
-            self.weight_updater.conn_status.mark_reconnected(snapshot_cell_id_to_hashes)
-            dist.barrier(group=get_gloo_group())
+            needs_reconnect = self.weight_updater.conn_status.needs_reconnect(snapshot_cell_id_to_hashes)
+            if needs_reconnect:
+                self.weight_updater.connect_rollout_engines(
+                    rollout_engines,
+                    engine_gpu_counts=engine_gpu_counts,
+                    engine_gpu_offsets=engine_gpu_offsets,
+                )
+                self.weight_updater.conn_status.mark_reconnected(snapshot_cell_id_to_hashes)
+                dist.barrier(group=get_gloo_group())
 
         if self.args.debug_skip_weight_update:
             if dist.get_rank() == 0:

--- a/tests/fast/backends/megatron_utils/test_shared_ppo_lifecycle.py
+++ b/tests/fast/backends/megatron_utils/test_shared_ppo_lifecycle.py
@@ -193,6 +193,7 @@ def test_update_weights_only_uses_temporary_process_groups_when_asleep(actor_mod
         debug_skip_weight_update=True,
         debug_train_only=False,
         offload_train=True,
+        colocate=False,
         rematerialize_param_from_master_weight=False,
     )
     worker._asleep = asleep
@@ -208,8 +209,11 @@ def test_update_weights_only_uses_temporary_process_groups_when_asleep(actor_mod
     )
     reload_groups = Mock()
     destroy_groups = Mock()
+    saver = Mock()
+    saver.disable.return_value = nullcontext()
     monkeypatch.setattr(actor_module, "reload_process_groups", reload_groups)
     monkeypatch.setattr(actor_module, "destroy_process_groups", destroy_groups)
+    monkeypatch.setattr(actor_module, "torch_memory_saver", saver)
     monkeypatch.setattr(actor_module.dist, "get_rank", lambda: 1)
 
     worker.update_weights(info)


### PR DESCRIPTION
Stacked on #3204.

## Symptom

`tests/e2e/megatron/test_qwen3_4B_offload_disaggregated.py` (added in #3128; 4 training GPUs + 4 rollout GPUs, no `--colocate`, `--offload-train`) dies in its very first `update_weights`:

```
MegatronTrainRayActor.update_weights
  -> WeightUpdater.connect_rollout_engines
  -> protocols/broadcast.py: UpdateWeightFromDistributed.connect
  -> weight_update/utils.py: get_data_replica_rank_and_size
  -> dist.all_gather_object -> torch.ByteTensor(...).to(device)
torch.AcceleratorError: CUDA error: invalid argument
```

Reproduced on an unmodified `main` (`2ed189c0db`) on a 4×H200 devbox (2 training + 2 rollout GPUs), and on `main`-based CI: https://github.com/radixark/miles/pull/2542 (`stage-c-8-gpu-h200 (0)`) as well as #3203 and #3204. The test has never passed in CI: on #3128's own run every `stage-c-*` job was skipped, and `main` does not run the lane without `run-ci-image`.

## Root cause

- With `--offload-train` and no `--colocate` the trainer is asleep at the end of init (`sleep()` destroyed the process groups and paused every `torch_memory_saver` region), so the first sync starts against an offloaded trainer. This is exactly the situation #3128 set out to cover ("the connection setup must not allocate through paused memory-saver blocks").
- `MegatronTrainRayActor.update_weights()` handled the weight transfer inside a `torch_memory_saver.disable()` window, but ran `reload_process_groups()` and `connect_rollout_engines()` before opening it. The broadcast protocol's connect does an object all-gather on the default group, which allocates a small CUDA tensor through the paused allocator and fails with `cudaErrorInvalidValue`.
- #3128 (`f01f9a3166`) fixed the weight source for an offloaded actor (host backup instead of unmapped buffers) but left the connection setup outside the window, and the e2e it added did not run anywhere until now.

## Fix

- Open the `torch_memory_saver.disable()` window before `reload_process_groups()` and the connect, the way the transfer itself already runs, but only when `offload_train and not colocate`.
- Colocated runs keep the old order on purpose: there the engines share the GPUs, and group buffers that outlive the pause eat into the memory the trainer needs while the engines are offloaded. A first version of this change that also covered colocated runs pushed `test_deepseek_v4_flash_4layer_ci.py` into `torch.OutOfMemoryError` during training (https://github.com/radixark/miles/actions/runs/34474196736/job/102865461002).
- `tests/fast/backends/megatron_utils/test_shared_ppo_lifecycle.py::test_update_weights_only_uses_temporary_process_groups_when_asleep` gets a `torch_memory_saver` double whose `disable()` is a context manager, and `colocate=False` in its args, because the window now opens before the `--debug-skip-weight-update` early return.
- Verified on the devbox: the test completes on this change (`Job succeeded`, `--check-weight-update-equal` included) where `main` fails as above; on https://github.com/radixark/miles/pull/2542 `stage-c-8-gpu-h200 (0)` has been green on three consecutive heads since the change landed there (`2163a818e1`).

## Secondary observation, not changed here

- When the trainer dies mid-sync the run on `main` exits; on the refactor branch it used to hang until the suite timeout because the driver held the `InferenceController` lock window across the trainer RPC. That is fixed on the refactor branch only (`63265c87f3`, `9d44ea5544`); `main` does not have that lock window.

## Why nobody caught it earlier

- The disaggregated offload path (`--offload-train` without `--colocate`) had no e2e until #3128 added one, and that e2e only runs in the nightly or on PRs labeled `run-ci-image`; on #3128's own CI every `stage-c-*` job was skipped.
- #3129 (see below) states "Merge order: this PR first, then #3128", but #3128 merged first while #3129 is still open, so `main` carries the test without the guard it depends on.
- The failure is deterministic once the first sync happens against a sleeping actor, but the driver-side log only shows `ActorDiedError`; the `CUDA error: invalid argument` traceback is in the dead worker's stderr.

## Existing work

- #3129 (`fix: guard connection allocations during offloaded weight sync`, @Shi-Dong, open since 2026-09-06) fixes the same crash: it wraps `connect_rollout_engines`, the connection bookkeeping and the barrier in `torch_memory_saver.disable()` whenever `--offload-train` is set, with unit coverage for the connect-fails path. It was validated on the same 4+4 H200 configuration.
- Differences in this PR: it also puts `reload_process_groups()` inside the window, and it leaves colocated runs untouched. The second point comes from an observation on the refactor branch: an earlier version of this change that also covered colocated runs pushed the DSv4 colocated test into a training-time OOM ([job](https://github.com/radixark/miles/actions/runs/34474196736/job/102865461002)); #3129's narrower window (connect only, no `reload_process_groups()`) may not have that effect, but that was not measured.
- #3129 is the author's fix and should take precedence; this PR can be closed once it lands, or reduced to the `reload_process_groups()` part if that is still wanted.
