### PR TITLE
docs(AMD): Add an AMD ROCm page and fix the AMD image and hardware notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,9 +81,10 @@ the largest models all live on Megatron-LM. See
   release day. Beyond day 0, nearly every frontier model runs on Miles, including Kimi-K2.6
   and Qwen3.5. See [Models](https://miles.radixark.com/docs/models).
 - **Extensive hardware support.** NVIDIA GB300, GB200, B300, B200, H200, H100, and A100, and
-  AMD MI300X, MI325, MI350, and MI355X via ROCm. See
+  AMD MI355X, MI350X, MI325X, and MI300X. See
   [Installation](https://miles.radixark.com/docs/getting-started/installation#hardware-requirements)
-  for per-GPU status and the container image for each.
+  for per-GPU status and [AMD ROCm](https://miles.radixark.com/docs/getting-started/amd) for
+  the ROCm images.
 - **Wide recipe support.** GRPO, GSPO, PPO, and REINFORCE++ for RL, plus SFT and
   [on-policy distillation](https://miles.radixark.com/docs/advanced/on-policy-distillation).
 - **Agentic environments.** Train coding and computer-use agents through connectors for

--- a/docs/advanced/low-precision.md
+++ b/docs/advanced/low-precision.md
@@ -17,8 +17,8 @@ up a new model architecture.
 
 | Format | Block layout | Hardware | Models tested | Maturity |
 |---|---|---|---|---|
-| **BF16** | — | All NVIDIA + AMD MI300X / MI325 / MI350 / MI355X | All | Baseline |
-| **FP8 block-wise** (DeepSeek-style) | 128×128, FP32 scales | Hopper (H100 / H200), Blackwell (B200+) | Qwen3-4B, Qwen3-30B-A3B | Generally available |
+| **BF16** | — | All NVIDIA + AMD MI300X / MI325X / MI350X / MI355X | All | Baseline |
+| **FP8 block-wise** (DeepSeek-style) | 128×128, FP32 scales | Hopper (H100 / H200), Blackwell (B200+), AMD MI350X / MI355X | Qwen3-4B, Qwen3-30B-A3B, DeepSeek-V4-Flash | Generally available |
 | **MXFP8** | 1×32, UE8M0 scales | Blackwell only (B200, B300, GB200, GB300) | Qwen3-30B-A3B, DeepSeek-V3.2 | Beta |
 | **NVFP4** (E2M1) | 1×16, two-level (FP8 + FP32) scales | Blackwell only (B200, B300, GB200, GB300) | Qwen3-30B-A3B | Beta |
 
@@ -30,7 +30,7 @@ forward precision. ✅ = supported; ✗ = not supported.
 | Rollout \ Train | BF16 | FP8 block-wise | MXFP8 | NVFP4 |
 |---|---|---|---|---|
 | **BF16**           | ✅ baseline | ✗ | ✗ | ✗ |
-| **FP8 block-wise** | ✅ | ✅ Hopper + Blackwell | ✗ | ✗ |
+| **FP8 block-wise** | ✅ | ✅ Hopper + Blackwell + MI350X / MI355X | ✗ | ✗ |
 | **MXFP8**          | ✅ | ✗ | ✅ Blackwell | ✗ |
 | **NVFP4**          | ✗ | ✗ | ✗ | ✅ Blackwell |
 
@@ -312,13 +312,19 @@ whose contraction axis does not match a one-dimensional scaling layout.
 | NVIDIA H100 / H200 | ✅ | ✅ | ✗ | ✗ |
 | NVIDIA B200 / B300 / GB200 / GB300 | ✅ | ✅ | ✅ | ✅ |
 | NVIDIA A100 | ✅ | ✗ | ✗ | ✗ |
-| AMD MI300X / MI325 / MI350 / MI355X | ✅ | ✗ | ✗ | ✗ |
+| AMD MI350X / MI355X | ✅ | ✅ | ✗ | ✗ |
+| AMD MI300X / MI325X | ✅ | ✗ | ✗ | ✗ |
+
+On MI350X / MI355X, FP8 block-wise is validated through the `scripts/amd/` DeepSeek-V4-Flash
+and Qwen3-30B-A3B recipes; the two ROCm CI tests that exercise it
+(`test_deepseek_v4_flash_4layer_ci.py` for training, `test_amd_moriep_fp8_bridge.py` for
+rollout) are registered but disabled.
 
 ## When BF16 is enough
 
 * Dense models below ~30 B.
 * A100 hardware (no FP8 GEMM).
-* AMD hardware today.
+* AMD MI300X / MI325X (no FP8 block-wise path).
 * Bring-up of a new model architecture, where clean BF16 numerics simplify
   debugging.
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -46,7 +46,8 @@
        "index",
        "getting-started/index",
        "getting-started/installation",
-       "getting-started/quick-start"
+       "getting-started/quick-start",
+       "getting-started/amd"
       ]
      },
      {
@@ -389,7 +390,7 @@
   },
   {
    "source": "/platforms/amd",
-   "destination": "/getting-started/installation",
+   "destination": "/getting-started/amd",
    "permanent": true
   },
   {

--- a/docs/getting-started/amd.md
+++ b/docs/getting-started/amd.md
@@ -1,0 +1,118 @@
+---
+title: AMD ROCm
+description: Run Miles on AMD MI350X / MI355X and MI300X / MI325X with the ROCm images. Docker is the recommended path.
+---
+Miles runs on AMD GPUs through ROCm. The ROCm images ship SGLang, Megatron-LM, and Miles
+preinstalled, with `MILES_HARDWARE_PLATFORM=rocm` already set. The recipes and `train.py`
+flags are the same as on NVIDIA; what changes is the image, the `docker run` flags, and the
+launcher path.
+
+## Images
+
+The two `mi35x` images are built daily from `main` by the sgl-project/sglang nightly
+workflows and published to Docker Hub under
+[`rocm/sgl-dev`](https://hub.docker.com/r/rocm/sgl-dev/tags?name=miles):
+
+| Image | ROCm | GPUs | Notes |
+|---|---|---|---|
+| `rocm/sgl-dev:miles-rocm720-mi35x` | 7.2 | MI350X / MI355X | Python 3.10 — the image the ROCm CI runs |
+| `rocm/sgl-dev:miles-rocm10-mi35x` | 10 | MI350X / MI355X | Python 3.12 |
+| `rocm/sgl-dev:miles-rocm700-mi30x` | 7.0 | MI300X / MI325X | Not rebuilt daily — last built 2026-09-08 |
+
+Each undated tag moves with every build; append `-YYYYMMDD` (e.g.
+`miles-rocm720-mi35x-20260910`) to pin one. The recipes below are validated on
+MI350X / MI355X (`gfx950`); the Qwen3 launchers accept only `MI350X` / `MI355X` in
+`--hardware` and do not run on MI300X / MI325X as shipped.
+
+To build an image yourself, `docker/Dockerfile.rocm` holds the recipe:
+
+```bash
+python docker/build.py --variant rocm720-mi35x --image-tag dev    # or rocm10-mi35x
+```
+
+`dev` writes the undated tag plus a `-YYYYMMDDHHMM` sibling.
+
+## Start the container
+
+On the **host**:
+
+```bash
+docker pull rocm/sgl-dev:miles-rocm720-mi35x
+
+docker run --rm \
+  --device /dev/kfd --device /dev/dri --group-add video --group-add render \
+  --cap-add SYS_PTRACE --security-opt seccomp=unconfined --privileged \
+  --shm-size 128G \
+  --ulimit memlock=-1 --ulimit stack=67108864 \
+  --network=host \
+  -it rocm/sgl-dev:miles-rocm720-mi35x /bin/bash
+```
+
+That drops you into a shell inside the container, with Miles at `/root/miles`, Megatron-LM
+at `/root/Megatron-LM`, and SGLang at `/sgl-workspace/sglang`.
+
+**Everything from here on runs inside the container.**
+
+## Verify
+
+Confirm Miles imports and the GPUs are visible:
+
+```bash
+python -c "import miles; print('Miles import OK')"
+rocm-smi --showproductname
+```
+
+If either command fails, see [Debugging](/developer/debug).
+
+## Launch training
+
+The AMD launchers live under `scripts/amd/` and mirror the CUDA recipes. Download the model
+and data and convert the checkpoint as in the [Quick Start](/getting-started/quick-start)
+(Steps 2 and 3), then launch:
+
+```bash
+cd /root/miles
+python scripts/amd/run_qwen3_4b.py --hardware MI355X    # or MI350X
+```
+
+On the two Qwen3 launchers, `--hardware` sets the GPU count per node and defaults to
+auto-detection, and the launcher exports the Ray HIP visibility variables so Ray and PyTorch
+agree on the device list; `run_qwen3_30b_a3b.py` also takes `--train-fp8` and `--rollout-fp8`.
+The DeepSeek-V4, GLM-5.2, and Inkling launchers take `--num-nodes` and `--num-gpus-per-node`
+and run as subcommands:
+
+```bash
+python scripts/amd/run_deepseek_v4.py train --model-name DeepSeek-V4-Flash-FP8 \
+  --num-nodes 4 --num-gpus-per-node 8
+```
+
+The CUDA launchers under `scripts/` do not accept `MI3xx` in `--hardware`; use the
+`scripts/amd/` counterpart.
+
+| Model | Launcher | Verified on |
+|---|---|---|
+| Qwen3-4B | `scripts/amd/run_qwen3_4b.py` | 1 node × 8 MI350X / MI355X |
+| Qwen3-30B-A3B | `scripts/amd/run_qwen3_30b_a3b.py` | 1 or 2 nodes × 8 MI350X / MI355X |
+| DeepSeek-V4-Flash-FP8 | `scripts/amd/run_deepseek_v4.py` | 4 nodes × 8 MI355X, FP8 block-wise training |
+| Inkling-Small (4-layer slice) | `scripts/amd/run_inkling.py` | 4 GPUs, CI smoke test |
+| GLM-5.2 (5-layer slice) | `scripts/amd/run_glm5_2_744b_a40b.py` | 4 GPUs — ROCm CI test registered but disabled |
+
+Training a different model? See [Models](/models/index) for the per-model recipes; the
+launcher flags carry over, the `--hardware` presets do not.
+
+## CI
+
+Adding the `run-ci-amd` label to a pull request runs the ROCm tests registered with the
+`amd` label in `stage-c-4-gpu-mi350` on the 4-GPU MI350 runners, against
+`rocm/sgl-dev:miles-rocm720-mi35x`; any other `run-ci-<label>` selects the ROCm tests
+carrying that label. The `nightly-stage-c-*-mi350` suites run only in the sgl-project/sglang
+nightly. The daily image builds and MI355X test runs are tracked in
+[`radixark/miles#2256`](https://github.com/radixark/miles/issues/2256); the AMD roadmap is
+[`radixark/miles#2025`](https://github.com/radixark/miles/issues/2025).
+
+## Next steps
+
+- [Quick Start](/getting-started/quick-start) — the same Qwen3-4B run, step by step.
+- [Hardware requirements](/getting-started/installation#hardware-requirements) — per-GPU status.
+- [Low Precision RL](/advanced/low-precision) — FP8 block-wise on MI350X / MI355X.
+- [Docker build](/developer/ci/02-docker-build) — the ROCm Dockerfile, variants, and tags.

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -4,7 +4,7 @@ description: Install Miles and run your first RL training job — the two pages 
 ---
 Two pages take you from a fresh machine to a running RL training job:
 
-- **[Installation](/getting-started/installation)** — Docker (recommended), pip, or building from source on NVIDIA / AMD.
+- **[Installation](/getting-started/installation)** — Docker (recommended), pip, or building from source; AMD GPUs start at [AMD ROCm](/getting-started/amd).
 - **[Quick Start](/getting-started/quick-start)** — `docker pull` to a GRPO run on Qwen3-4B in under an hour, on a single 8-GPU node.
 
 After the loop is running, [Models](/models/index) covers the family-specific recipes and the [User Guide](/user-guide/index) walks through concepts, data, monitoring, and customization.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -22,18 +22,22 @@ versions of SGLang, Megatron-LM, and a few CUDA kernels.
     ```
 
   </Tab>
-  <Tab title="AMD MI300X / MI350X">
+  <Tab title="AMD">
 
     ```bash
-    docker pull rlsys/miles:MI350-355-latest    # or MI300-latest
+    docker pull rocm/sgl-dev:miles-rocm720-mi35x    # or miles-rocm10-mi35x
 
     docker run --rm \
-      --device /dev/dri --device /dev/kfd \
-      --group-add video --ipc=host --shm-size=32g \
-      --cap-add SYS_PTRACE --security-opt seccomp=unconfined \
-      --privileged \
-      -it rlsys/miles:MI350-355-latest /bin/bash
+      --device /dev/kfd --device /dev/dri --group-add video --group-add render \
+      --cap-add SYS_PTRACE --security-opt seccomp=unconfined --privileged \
+      --shm-size 128G \
+      --ulimit memlock=-1 --ulimit stack=67108864 \
+      --network=host \
+      -it rocm/sgl-dev:miles-rocm720-mi35x /bin/bash
     ```
+
+    See [AMD ROCm](/getting-started/amd) for the image variants, the MI300X / MI325X image,
+    and the `scripts/amd/` launchers.
 
   </Tab>
 
@@ -42,8 +46,9 @@ versions of SGLang, Megatron-LM, and a few CUDA kernels.
 The image ships with:
 
 - PyTorch (matching the container's CUDA / ROCm version)
-- Megatron-LM, SGLang, FlashAttention-3, DeepGEMM, Apex
-- Ray, uv, and Miles installed editable at `/root/miles`
+- Megatron-LM, SGLang, TransformerEngine, Apex, and Ray
+- NVIDIA: FlashAttention-3, DeepGEMM, and uv; ROCm: FlashAttention-2 and aiter
+- Miles installed editable at `/root/miles`
 
 See [Hardware requirements](#hardware-requirements) for per-GPU status.
 
@@ -82,7 +87,7 @@ Confirm Miles imports and the GPUs are visible:
 
 ```bash
 python -c "import miles; print('Miles import OK')"
-nvidia-smi
+nvidia-smi    # rocm-smi --showproductname on AMD
 ```
 
 If either command fails, see [Debugging](/developer/debug).
@@ -94,7 +99,8 @@ If either command fails, see [Debugging](/developer/debug).
 | NVIDIA GB300 / GB200 / B300 / B200 | Production |
 | NVIDIA H200 / H100 | Production (CI guarded) |
 | NVIDIA A100 | Supported — FP8 features disabled |
-| AMD MI300X, MI325, MI350X, MI355X | Supported via ROCm |
+| AMD MI350X / MI355X | Supported (CI guarded) |
+| AMD MI300X / MI325X | Supported — image not rebuilt daily |
 
 For multi-node training you also need a high-bandwidth interconnect — InfiniBand, RoCEv2,
 or Slingshot — and 200+ GB/s per node. Single-node jobs run fine over NVLink only.

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -4,9 +4,13 @@ description: Get an RL training job up and running in under an hour.
 ---
 **What you need**
 
-- A node with 8 GPUs (H100 / H200 / B-series).
+- A node with 8 GPUs (H100 / H200 / B-series, or MI350X / MI355X).
 - At least 500 GB of free disk.
 - Docker with GPU access.
+
+On MI350X / MI355X, start from [AMD ROCm](/getting-started/amd): the pre-flight checks and
+the container differ, Steps 2 to 4 are the same, with `scripts/amd/run_qwen3_4b.py` as the
+launcher.
 
 **Pre-flight checks**
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -51,8 +51,8 @@ the largest models all live on Megatron-LM. See
 - **Day-0 model support.** DeepSeek-V4, Kimi-K3, GLM-5.2, Inkling and Nemotron landed on
   release day. Beyond day 0, nearly every frontier model runs on Miles, including Kimi-K2.6
   and Qwen3.5. See [Supported models](#supported-models).
-- **Extensive hardware support.** NVIDIA from H100 through GB300, and AMD MI300X through
-  MI355X via ROCm. See [Supported hardware](#supported-hardware).
+- **Extensive hardware support.** NVIDIA from H100 through GB300, and AMD MI355X, MI350X,
+  MI325X, and MI300X. See [Supported hardware](#supported-hardware).
 - **Wide recipe support.** GRPO, GSPO, PPO and REINFORCE++ for RL, plus SFT and
   [on-policy distillation](/advanced/on-policy-distillation).
 - **Agentic environments.** Train coding and computer-use agents through connectors for
@@ -94,10 +94,10 @@ diffusion recipes and validation details.
 ## Supported hardware
 
 - **NVIDIA**: GB300, GB200, B300, B200, H200, H100, A100.
-- **AMD**: MI300X, MI325, MI350, MI355X (via ROCm).
+- **AMD**: MI355X, MI350X, MI325X, MI300X.
 
 See [Installation](/getting-started/installation#hardware-requirements) for per-GPU status
-and the container images for each.
+and [AMD ROCm](/getting-started/amd) for the ROCm images.
 
 ## News
 
@@ -115,11 +115,12 @@ and the container images for each.
 ## Start here
 
 1. **[Installation](/getting-started/installation)** — Docker, bare metal, AMD.
-2. **[Quick Start](/getting-started/quick-start)** — a training job up and running in under an hour.
-3. **[Core concepts](/user-guide/concepts)** — the four objects in every Miles job.
-4. **[Launch script](/user-guide/launch-script)** — what `python scripts/run_*.py` does
+2. **[AMD ROCm](/getting-started/amd)** — the ROCm images and the `scripts/amd/` launchers.
+3. **[Quick Start](/getting-started/quick-start)** — a training job up and running in under an hour.
+4. **[Core concepts](/user-guide/concepts)** — the four objects in every Miles job.
+5. **[Launch script](/user-guide/launch-script)** — what `python scripts/run_*.py` does
    and how to override a recipe.
-5. **[Training backends](/user-guide/training-backend)** — Megatron-LM and FSDP: parallelism,
+6. **[Training backends](/user-guide/training-backend)** — Megatron-LM and FSDP: parallelism,
    checkpoints, and hooks.
 
 ## Acknowledgment

--- a/docs/models/index.md
+++ b/docs/models/index.md
@@ -23,6 +23,9 @@ Each model name links to its recipe page.
 | **JoyAI** | [JoyAI-LLM-Flash](https://github.com/radixark/miles/blob/main/scripts/run_joy_ai_llm_flash.py) |
 | **GPT-OSS** | [gpt-oss-20b](/models/gpt-oss/gpt-oss) |
 
+Recipes for MI350X / MI355X live under `scripts/amd/`; [AMD ROCm](/getting-started/amd)
+lists them. The CUDA launchers under `scripts/` do not accept `MI3xx` in `--hardware`.
+
 ## Diffusion
 
 | Family | Models |


### PR DESCRIPTION
Co-authored with: @XinyuJiangCMU

## What

- New page `docs/getting-started/amd.md`: the ROCm images, the `docker run` command, a verify step, and one launch command. Added to the Welcome group; the old `/platforms/amd` redirect now points to it.
- Installation: the AMD tab pulled `rlsys/miles:MI350-355-latest`, which stopped updating in May. It now pulls `rocm/sgl-dev:miles-rocm10-mi35x` with the `docker run` flags the ROCm CI uses, and points to the new page for details.
- Low Precision RL: FP8 block-wise is marked available on MI350X / MI355X.
- README: AMD product names and a link to the new page.
- Developer docs: the ROCm notes in `00-stage.md`, `02-docker-build.md`, and `versions.md` now match the workflows. The external nightly is the sglang ROCm 10 workflow, `Dockerfile.rocm` feeds the `rocm/sgl-dev` images rather than `pr-test-rocm.yml`, the ROCm images are rebuilt daily, the `rocm10-mi35x` build args are listed in full, and `mi3xx` is `mi35x`. The `Dockerfile.rocm` header and the `image_inputs.py` comment bound to `02-docker-build.md` are updated in the same change.