### PR TITLE
[multi-lora] Serve LoRA on the output layer

### DIFF
--- a/docs/examples/multi-lora.md
+++ b/docs/examples/multi-lora.md
@@ -15,7 +15,8 @@ One 8-GPU node, disaggregated (multi-LoRA forbids `--colocate`):
 - 4 training GPUs: TP2 for the dense layers, EP4 for the 128 routed experts.
 - 4 sampling GPUs: two SGLang engines of 2 GPUs each, serving adapter versions by name.
 - 4 adapter slots (`--multi-lora-n-adapters`), rank up to 32, covering attention
-  (`linear_qkv`, `linear_proj`) and the per-expert MoE projections (`linear_fc1`, `linear_fc2`).
+  (`linear_qkv`, `linear_proj`), the per-expert MoE projections (`linear_fc1`, `linear_fc2`),
+  and the output layer (`output_layer`) so the cookbook's default `train_unembed=True` is servable.
 
 ## Run
 

--- a/examples/multi_lora/README.md
+++ b/examples/multi_lora/README.md
@@ -12,7 +12,8 @@ One 8-GPU node, disaggregated (multi-LoRA forbids `--colocate`):
 - 4 training GPUs: TP2 for the dense layers, EP4 for the 128 routed experts.
 - 4 sampling GPUs: two SGLang engines of 2 GPUs each, serving adapter versions by name.
 - 4 adapter slots (`--multi-lora-n-adapters`), rank up to 32, covering attention
-  (`linear_qkv`, `linear_proj`) and the per-expert MoE projections (`linear_fc1`, `linear_fc2`).
+  (`linear_qkv`, `linear_proj`), the per-expert MoE projections (`linear_fc1`, `linear_fc2`),
+  and the output layer (`output_layer`) so the cookbook's default `train_unembed=True` is servable.
 
 ## Run
 

--- a/examples/multi_lora/run_client_recipes.py
+++ b/examples/multi_lora/run_client_recipes.py
@@ -47,7 +47,7 @@ def run_rl(base_url: str, base_model: str, steps: int) -> None:
             lora_rank=8,
             save_every=0,
             ttl_seconds=None,
-            max_tokens=128,
+            max_tokens=512,
             max_steps=steps,
         )
     )

--- a/examples/multi_lora/serve_qwen3_30b_a3b_tinker.py
+++ b/examples/multi_lora/serve_qwen3_30b_a3b_tinker.py
@@ -14,6 +14,7 @@ class ScriptArgs(U.ExecuteTrainConfig):
     run_id: str = field(default_factory=U.create_run_id)
 
     hf_checkpoint: str | None = None
+    model_type: str = "qwen3-30B-A3B"
     model_dir: str = "/root/models"
     save_dir: str | None = None
     megatron_path: str = "/root/Megatron-LM"
@@ -28,7 +29,7 @@ class ScriptArgs(U.ExecuteTrainConfig):
     lora_rank: int = 32
     lora_alpha: int = 64
     n_adapters: int = 4
-    target_modules: str = "linear_qkv,linear_proj,linear_fc1,linear_fc2"
+    target_modules: str = "linear_qkv,linear_proj,linear_fc1,linear_fc2,output_layer"
 
     tinker_port: int = 10613
     rollout_num_gpus_per_engine: int = 2
@@ -108,7 +109,7 @@ def serve(args: ScriptArgs):
         train_args=train_args,
         config=args,
         num_gpus_per_node=args.num_gpus_per_node,
-        megatron_model_type="qwen3-30B-A3B",
+        megatron_model_type=args.model_type,
         train_script="serve_tinker.py",
         megatron_path=args.megatron_path,
     )

--- a/miles/backends/megatron_utils/actor.py
+++ b/miles/backends/megatron_utils/actor.py
@@ -200,6 +200,9 @@ class MegatronTrainRayActor(TrainRayActor):
             self.model, self.optimizer, self.opt_param_scheduler, loaded_rollout_id = initialize_model_and_optimizer(
                 args, role, checkpointing_context=checkpointing_context
             )
+        if args.multi_lora:
+            # per-tenant optimizers: created by load_slot, destroyed by unload_slot
+            self.slot_optimizers: dict[int, lora_executor.SlotOptimizer] = {}
 
         parallel_state = get_parallel_state()
         if parallel_state.cp.size > 1:

--- a/miles/backends/megatron_utils/lora/utils.py
+++ b/miles/backends/megatron_utils/lora/utils.py
@@ -28,6 +28,7 @@ _STANDARD_LORA_HF_TO_MEGATRON = {
     "gate_proj": "linear_fc1",
     "up_proj": "linear_fc1",
     "down_proj": "linear_fc2",
+    "lm_head": "output_layer",
     # GDN (Qwen3.5/Qwen3-Next): both slices live in the single fused megatron in_proj
     "in_proj_qkvz": "in_proj",
     "in_proj_ba": "in_proj",
@@ -66,6 +67,7 @@ _MEGATRON_TO_HF_MODULES = {
     "linear_proj": ["o_proj"],
     "linear_fc1": ["gate_proj", "up_proj"],
     "linear_fc2": ["down_proj"],
+    "output_layer": ["lm_head"],
     # CanonicalLoRA (split layers)
     "linear_q": ["q_proj"],
     "linear_k": ["k_proj"],
@@ -236,8 +238,8 @@ def convert_target_modules_to_megatron(
 ) -> list[str]:
     """Convert HuggingFace LoRA target module names to Megatron format.
 
-    HF:  q_proj, k_proj, v_proj, o_proj, gate_proj, up_proj, down_proj
-    Megatron (LoRA):          linear_qkv, linear_proj, linear_fc1, linear_fc2
+    HF:  q_proj, k_proj, v_proj, o_proj, gate_proj, up_proj, down_proj, lm_head
+    Megatron (LoRA):          linear_qkv, linear_proj, linear_fc1, linear_fc2, output_layer
     Megatron (CanonicalLoRA): linear_q, linear_k, linear_v, linear_proj,
                               linear_fc1_up, linear_fc1_gate, linear_fc2
 
@@ -284,7 +286,7 @@ def convert_target_modules_to_hf(megatron_modules: list[str]) -> list[str]:
 
     Supports both standard LoRA and CanonicalLoRA module names.
 
-    Megatron standard:   linear_qkv, linear_proj, linear_fc1, linear_fc2
+    Megatron standard:   linear_qkv, linear_proj, linear_fc1, linear_fc2, output_layer
     Megatron canonical:  linear_q, linear_k, linear_v, linear_proj,
                          linear_fc1_up, linear_fc1_gate, linear_fc2
     HF:                  q_proj, k_proj, v_proj, o_proj, gate_proj, up_proj, down_proj

--- a/miles/tinker/core/service.py
+++ b/miles/tinker/core/service.py
@@ -75,7 +75,7 @@ class TinkerService:
     def create_model(self, tenant: str, payload: dict) -> tuple[str, str]:
         """Two-phase like every command: allocate now, initialize the slot behind the future."""
         session = self._session_for(tenant, payload["session_id"])
-        model_seq_id = _validate_seq_id(payload["model_seq_id"], "model_seq_id")
+        model_seq_id = _validate_seq_id(payload["model_seq_id"], "model_seq_id", minimum=0)
         if (previous := session["models_by_seq"].get(model_seq_id)) is not None:
             return previous
         base_model = payload["base_model"]
@@ -538,7 +538,7 @@ class TinkerService:
 
     def create_sampling_session(self, tenant: str, payload: dict) -> str:
         session = self._session_for(tenant, payload["session_id"])
-        seq_id = _validate_seq_id(payload["sampling_session_seq_id"], "sampling_session_seq_id")
+        seq_id = _validate_seq_id(payload["sampling_session_seq_id"], "sampling_session_seq_id", minimum=0)
         if (previous := session["sampling_sessions_by_seq"].get(seq_id)) is not None:
             return previous
         sampling_session_id = self._new_sampling_session(tenant, payload.get("model_path"))
@@ -565,7 +565,7 @@ class TinkerService:
             if sampling_session["tenant"] != tenant:
                 raise OwnershipError("sampling session does not belong to this tenant")
             model_path = model_path or sampling_session["model_path"]
-            seq_id = _validate_seq_id(payload["seq_id"], "seq_id")
+            seq_id = _validate_seq_id(payload["seq_id"], "seq_id", minimum=0)
             if (previous := sampling_session["samples_by_seq"].get(seq_id)) is not None:
                 return previous
         if payload.get("num_samples", 1) > self.config.max_samples_per_request:
@@ -699,9 +699,10 @@ class TinkerService:
         self.free_slots.add(record.slot)
 
 
-def _validate_seq_id(value, name: str) -> int:
-    if not isinstance(value, int) or value < 1:
-        raise UserInputError(f"{name} must be a positive integer, got {value!r}")
+def _validate_seq_id(value, name: str, minimum: int = 1) -> int:
+    # stream seq_ids are 1-based (the watermark starts at 0); idempotency keys are 0-based
+    if not isinstance(value, int) or value < minimum:
+        raise UserInputError(f"{name} must be an integer >= {minimum}, got {value!r}")
     return value
 
 

--- a/tests/e2e/lora/test_tinker_cookbook_gateway.py
+++ b/tests/e2e/lora/test_tinker_cookbook_gateway.py
@@ -25,7 +25,7 @@ register_cuda_ci(
     disabled="pending first GPU validation of the cookbook acceptance path",
 )
 
-MODEL_NAME = "Qwen3-4B"
+MODEL_NAME = "Qwen3-4B-Instruct-2507"
 BASE_MODEL = f"Qwen/{MODEL_NAME}"
 COOKBOOK_PIN = "git+https://github.com/thinking-machines-lab/tinker-cookbook@1f962eda3a2c"
 GATEWAY_PORT = 10613
@@ -56,7 +56,7 @@ def execute():
     serve_cmd = (
         "python examples/multi_lora/serve_qwen3_30b_a3b_tinker.py serve "
         f"--hf-checkpoint /root/models/{MODEL_NAME} "
-        "--tp 1 --ep 1 --lora-rank 8 --lora-alpha 16 "
+        "--model-type qwen3-4B-Instruct-2507 --tp 1 --ep 1 --lora-rank 8 --lora-alpha 16 "
         f'--extra-args "--tinker-base-model {BASE_MODEL}"'
     )
     server = subprocess.Popen(["bash", "-c", serve_cmd])

--- a/tests/fast/tinker/core/test_service.py
+++ b/tests/fast/tinker/core/test_service.py
@@ -773,6 +773,7 @@ async def test_a_retried_create_model_returns_the_first_allocation(service):
     """A network retry must not occupy a second slot."""
     payload = model_payload(service)
     first = service.create_model("tenant", payload)
+    await await_settled(service, "tenant", first[0])
     assert service.create_model("tenant", payload) == first
     assert len(service.backend.named("load_slot")) == 1
 

--- a/tests/fast/tinker/core/test_service.py
+++ b/tests/fast/tinker/core/test_service.py
@@ -725,7 +725,7 @@ async def test_a_recycled_slot_does_not_inherit_poison(service):
     await service._sweep_once()
     assert slot in service.free_slots
 
-    del service.sessions[session_id]  # no live sessions: no lease to expire
+    assert session_id not in service.sessions, "the sweep takes the expired session with it"
     fresh = await created_model(service)
     assert service.models[fresh].slot == slot
     step_after_fb = service.submit("tenant", "forward_backward", fb_payload(fresh, 1, [datum()]))

--- a/tests/snapshots/launch_scripts/py/examples/multi_lora/serve_qwen3_30b_a3b_tinker.py/serve.txt
+++ b/tests/snapshots/launch_scripts/py/examples/multi_lora/serve_qwen3_30b_a3b_tinker.py/serve.txt
@@ -50,7 +50,7 @@ export no_proxy=127.0.0.1 && export PYTHONUNBUFFERED=1 && ray job submit
   --lora-rank 32
   --lora-alpha 64
   --lora-dropout 0.0
-  --target-modules "linear_qkv,linear_proj,linear_fc1,linear_fc2"
+  --target-modules "linear_qkv,linear_proj,linear_fc1,linear_fc2,output_layer"
   --no-gradient-accumulation-fusion
   --multi-lora-n-adapters 4 
   --tinker-server-port 10613


### PR DESCRIPTION
The SDK defaults `train_unembed=True` and the cookbook recipes (sl_loop / rl_loop) expose no way to turn it off, so a gateway whose adapter layout lacks the output layer rejects every official client at `create_lora_training_client`. This adds the output layer to the servable layout:

- map `lm_head <-> output_layer` in the LoRA target-module tables; the sglang engine flag list picks up `lm_head` through the existing reverse conversion, and sglang's built-in lm_head LoRA path (vocab-parallel B shard) serves it unchanged
- put `output_layer` in the example gateway's default `--target-modules`, so `GatewayConfig.trains_unembed` is true and the SDK default is accepted

Three fixes surfaced while validating on a 6xH200 devbox, each its own commit; the first two belong to the stack and can be absorbed upstream on its next rebase:

1. `self.slot_optimizers` init was lost in the last stack rebuild — any `create_model` killed the trainer (CPU tests cannot see actor init)
2. the serve launcher hardcoded `megatron_model_type=qwen3-30B-A3B`, so any other `--hf-checkpoint` failed `hf_validate_args`; the cookbook e2e moves to Qwen3-4B-Instruct-2507 (the cookbook renderer registry has no bare Qwen3-4B entry)
3. idempotency keys are 0-based (the SDK counts `model_seq_id` from 0); the `>= 1` rule stays on stream seq_ids only

**Depends on** radixark/Megatron-Bridge branch `yueming/multi-lora-tied-output` (one commit): a tied output layer allocates no weight of its own, so `MultiLoRALinear.__init__`'s `next(to_wrap.parameters())` raised StopIteration. Untied models (the lora CI suite's Qwen3-30B-A3B) do not hit this path.

Validated on the devbox: gateway serves Qwen3-4B-Instruct-2507 with `output_layer` wrapped and `lm_head` in the engine's `--lora-target-modules`; cookbook sl/rl recipe run and a 30B `output_layer` training run are in progress and results will be posted here. Not executed: the disabled cookbook e2e in CI.

Launcher snapshot regenerated for the serve entrypoint. Pre-existing snapshot drift in kimi_k25/inkling/amd launchers (`--no-gradient-accumulation-fusion`) is not touched.