### PR TITLE
Fix MTP gradient detachment in AutoBridge mode

### DIFF
--- a/miles/backends/megatron_utils/model_provider.py
+++ b/miles/backends/megatron_utils/model_provider.py
@@ -49,6 +49,10 @@ def _apply_bridge_runtime_config(provider, args: argparse.Namespace) -> None:
     provider.calculate_per_token_loss = args.calculate_per_token_loss  # CP>1 VL models assert this
     provider.variable_seq_lengths = args.variable_seq_lengths
 
+    # Match the non-bridge path: MTP must only train its own draft parameters.
+    if getattr(args, "enable_mtp_training", False):
+        provider.mtp_detach_heads = True
+
     # numerics (training infra, not model-defining)
     provider.attention_softmax_in_fp32 = args.attention_softmax_in_fp32
     provider.gradient_accumulation_fusion = args.gradient_accumulation_fusion

--- a/tests/fast/backends/megatron_utils/test_bridge_mtp_detachment.py
+++ b/tests/fast/backends/megatron_utils/test_bridge_mtp_detachment.py
@@ -1,0 +1,84 @@
+"""CPU regression tests for MTP detachment on bridge-built providers."""
+
+import argparse
+import ast
+from collections.abc import Callable
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from tests.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=1, suite="stage-a-cpu", labels=[])
+
+
+@pytest.fixture(scope="module")
+def apply_bridge_runtime_config() -> Callable:
+    # Execute the production helper without importing GPU-only Megatron modules.
+    path = Path(__file__).resolve().parents[4] / "miles/backends/megatron_utils/model_provider.py"
+    tree = ast.parse(path.read_text())
+    function = next(
+        node for node in tree.body if isinstance(node, ast.FunctionDef) and node.name == "_apply_bridge_runtime_config"
+    )
+    namespace = {"argparse": argparse}
+    exec(compile(ast.Module(body=[function], type_ignores=[]), str(path), "exec"), namespace)
+    return namespace["_apply_bridge_runtime_config"]
+
+
+@pytest.fixture
+def runtime_args() -> argparse.Namespace:
+    return argparse.Namespace(
+        tensor_model_parallel_size=1,
+        pipeline_model_parallel_size=1,
+        expert_model_parallel_size=1,
+        expert_tensor_parallel_size=1,
+        sequence_parallel=False,
+        context_parallel_size=1,
+        calculate_per_token_loss=True,
+        variable_seq_lengths=True,
+        attention_softmax_in_fp32=False,
+        gradient_accumulation_fusion=False,
+        fp32_residual_connection=False,
+        deterministic_mode=False,
+        recompute_granularity=None,
+        recompute_method=None,
+        recompute_num_layers=None,
+        recompute_modules=[],
+        cpu_offloading_num_layers=0,
+        distribute_saved_activations=False,
+        tp_comm_overlap=False,
+        fp8=None,
+        fp8_recipe=None,
+        attention_backend="auto",
+        moe_token_dispatcher_type="alltoall",
+    )
+
+
+@pytest.mark.parametrize(
+    ("enabled", "initial_detach", "expected_detach"),
+    [
+        (True, False, True),
+        (True, True, True),
+        (False, False, False),
+        (False, True, True),
+        (None, False, False),
+        (None, True, True),
+    ],
+)
+def test_bridge_mtp_detachment(
+    apply_bridge_runtime_config: Callable,
+    runtime_args: argparse.Namespace,
+    enabled: bool | None,
+    initial_detach: bool,
+    expected_detach: bool,
+) -> None:
+    # A missing flag covers callers that only register Megatron's arguments.
+    if enabled is not None:
+        runtime_args.enable_mtp_training = enabled
+    provider = SimpleNamespace(mtp_num_layers=1, mtp_detach_heads=initial_detach)
+
+    apply_bridge_runtime_config(provider, runtime_args)
+
+    assert provider.mtp_detach_heads is expected_detach
+    assert provider.mtp_num_layers == 1


### PR DESCRIPTION
With `--megatron-to-hf-mode bridge --enable-mtp-training`, the bridge provider retained Megatron's default `mtp_detach_heads=False`, allowing the MTP auxiliary loss to update shared policy weights. Apply the same detachment rule as the regular model provider before finalization, so the auxiliary loss trains only MTP-specific parameters.

The production change is four added lines. The CPU regression test covers enabled, disabled, and missing MTP flags, including preservation of an existing provider setting.

Validation:

- All 6 regression cases pass; unpatched `main` fails the enabled-MTP case.
- All applicable pre-commit checks pass.
- Actual Nemotron Lightning AutoBridge provider construction and finalization on CPU now produces `mtp_detach_heads=True` with MTP training enabled.
- Native Megatron MTP block, embedding, loss, and autoscaler CPU probe: shared backbone/embedding/output auxiliary gradients become zero; draft gradients remain nonzero, and a main-model loss still updates the backbone. This probe uses small CPU layers and mocked pipeline metadata; it is not a full-model GPU training test.

This PR addresses detachment when MTP training is enabled. Environment-variable parsing, auxiliary-loss scaling, and label-mask alignment are separate changes.
