### PR TITLE
Test CuTe DSL W4A16 with disjoint 4+4 GPU P2P weight sync

### DIFF
--- a/tests/e2e/megatron/test_glm5_2_744b_a40b_5layer_nvfp4_w4a16.py
+++ b/tests/e2e/megatron/test_glm5_2_744b_a40b_5layer_nvfp4_w4a16.py
@@ -9,7 +9,7 @@ import miles.utils.external_utils.command_utils as U
 register_cuda_ci(
     est_time=3600,
     suite="stage-c-8-gpu-b200",
-    labels=["megatron", "model-scripts"],
+    labels=["megatron", "model-scripts", "weight-update"],
     hardware=["blackwell"],
 )
 
@@ -17,8 +17,8 @@ MODEL_ORG = "Pinaster"
 MODEL_NAME = "GLM-5.2_5layer"
 MODEL_TYPE = "glm5.2-744B-A40B_5layer"
 NUM_GPUS = 8
-ACTOR_NUM_GPUS = NUM_GPUS
-ROLLOUT_NUM_GPUS = NUM_GPUS
+ACTOR_NUM_GPUS = 4
+ROLLOUT_NUM_GPUS = 4
 ROLLOUT_GPUS_PER_ENGINE = 2
 RUN_ID = U.create_run_id()
 
@@ -219,6 +219,7 @@ def execute():
         "--sglang-max-running-requests 512 "
         f"--sglang-chunked-prefill-size {2048 * ROLLOUT_GPUS_PER_ENGINE} "
         "--sglang-watchdog-timeout 3600 "
+        "--sglang-remote-instance-weight-loader-start-seed-via-transfer-engine "
     )
 
     ci_args = "--ci-test --ci-disable-logprobs-checker --ci-disable-weight-update-checker --ci-disable-kl-checker "
@@ -244,7 +245,7 @@ def execute():
         "--allgather-cp "
         "--miles-dsa-topk-backend flashinfer "
         f"--update-weight-buffer-size {2 * 1024 ** 3} "
-        "--colocate "
+        "--update-weight-transfer-mode p2p "
         "--actor-num-nodes 1 "
         f"--actor-num-gpus-per-node {ACTOR_NUM_GPUS} "
         f"--num-gpus-per-node {NUM_GPUS} "


### PR DESCRIPTION
## Summary

@humansand

Run the GLM-5.2 five-layer CuTe DSL NVFP4 W4A16 E2E with separate training and rollout GPUs and P2P weight transfer.

- **Placement:** four training GPUs (TP4, EP4, ETP1) and four rollout GPUs (two TP2/EP2/DP2 engines) on one eight-GPU node.
- **Transfer:** replace `--colocate` with `--update-weight-transfer-mode p2p`; enable SGLang transfer-engine seeding and add the `weight-update` CI label.
- **Precision:** preserve fake NVFP4 QAT with BF16 TE compute, BF16 shared experts, `flashinfer_cutedsl`, MoE A2A `none`, fused finalize `0`, FP32 LM head, Torch-MM router, and routing replay.
- **Dependency:** the image's `sglang-miles` branch needs the fused DSA indexer mapping from [SGLang #35312](https://github.com/sgl-project/sglang/pull/35312). Otherwise P2P silently skips `indexer.wk` and `indexer.weights_proj`. Validation applies only that PR's `deepseek_v2.py` mapping hunk, not its other registry changes. [SGLang #39139](https://github.com/sgl-project/sglang/pull/39139) adds separate upstream-main W4A16 raw-reload/CUDA-graph regression coverage.

## Validation

- **Hardware/image:** one C2 node, 8× NVIDIA B300 SXM6 AC (275040 MiB each), driver `590.48.01`; `radixark/miles:dev-202609111228`, amd64 manifest `sha256:f774dee95a80a213c30489cf82b13295d8a50338ea39f5aaadb0377d3e4a9bba`. This was the latest timestamped CUDA 13 Miles development image when the bare devbox was requested.
- **Sources:** Miles `4345b3a7dc1721665b0cbff61e140f4a6217b3dc`; image SGLang `32839114c4ada2ae237581405a8ff39dc0db9e25` plus the mapping hunk from `2dc0053d022e02bdad78b4424f41ebdfaea99fa1`; image Megatron `73b54618f7e58e0f25f619bcfecbe2640765475a`.
- **Software:** PyTorch `2.13.0+cu130` / CUDA `13.0`; FlashInfer `0.6.18`; CuTe DSL `4.6.2`; TE `2.17.0`; Mooncake `0.3.13.dev0+g4dbe5a4c`.
- **Workload:** `Pinaster/GLM-5.2_5layer`, DAPO math; 2 rollouts, 8 prompts × 8 samples = 64 trajectories per rollout, global batch 64, response cap 100, temperature 1, 2 GiB weight buckets. Checkpoint conversion and all unchanged test arguments remain in the test.
- **Inherited collective environment:** `NCCL_NVLS_ENABLE=0`, `NCCL_CROSS_NIC=0`, `NCCL_SOCKET_IFNAME=ens3923f0np0`, `GLOO_SOCKET_IFNAME=ens3923f0np0`, and `NCCL_IB_HCA==mlx5_0,mlx5_1,mlx5_4,mlx5_5,mlx5_6,mlx5_11,mlx5_12,mlx5_13` (the value begins with `=` for exact HCA matching).
- **C2 setup:** the bare container needed its hostname mapped to the node IP for torchrun rendezvous. The host has mixed RoCE and IB NICs; propagate `MC_TE_FILTERS=mlx5_0,mlx5_1,mlx5_4,mlx5_5,mlx5_6,mlx5_11,mlx5_12,mlx5_13` and `MC_GID_INDEX=0` to both trainer and rollout Ray workers. NIC names are host-specific. Keep RDMA transport and the default empty device string. A two-process 1 MiB pinned-CPU→GPU RDMA smoke test returned `0` and exact byte equality with this filter.

Apply the existing mapping hunk to the image's SGLang checkout:

```bash
git -C /sgl-workspace/sglang fetch https://github.com/sgl-project/sglang.git \
  2dc0053d022e02bdad78b4424f41ebdfaea99fa1
git -C /sgl-workspace/sglang show --format= \
  2dc0053d022e02bdad78b4424f41ebdfaea99fa1 -- python/sglang/srt/models/deepseek_v2.py \
  | git -C /sgl-workspace/sglang apply
```

From this Miles checkout in the image, reproduce the recipe with the C2 transport environment:

```bash
export PYTHONPATH="$PWD:/root/TransformerEngine:/root/Megatron-LM"
export PYTHONUNBUFFERED=1 RAY_DEDUP_LOGS=0
unset WANDB_API_KEY
python - <<'PY'
import os
import runpy
recipe = runpy.run_path(
    'tests/e2e/megatron/test_glm5_2_744b_a40b_5layer_nvfp4_w4a16.py'
)
recipe['GLM5_ENV'].update({
    'MC_TE_FILTERS': 'mlx5_0,mlx5_1,mlx5_4,mlx5_5,mlx5_6,mlx5_11,mlx5_12,mlx5_13',
    'MC_GID_INDEX': '0',
})
recipe['prepare']()  # Completed once; the validated rerun reused these checkpoints.
for key in ('http_proxy', 'https_proxy', 'HTTP_PROXY', 'HTTPS_PROXY'):
    os.environ.pop(key, None)
recipe['execute']()
PY
```

**Result:** PASS: initial sync, both rollout/training rounds, and final post-training sync completed; all four P2P senders completed three nine-bucket transfers. Every training rank returned twice. Python exit `0` and Ray job succeeded after the final sync. All 432 observed forward/backward routing-replay checks reported zero mismatched tokens under the existing overlap criterion: a token is mismatched only when the recomputed and replayed expert sets have no overlap. This does not assert full top-k identity (442,368 token instances across repeated checks, not unique trajectories).

Complete completion-gate and replay output derived from the raw log:

```json
{
  "recorded_python_exit_code": 0,
  "verdict": "completion_evidence_present",
  "criteria": {
    "recorded_python_exit_zero": true,
    "expected_rollout_ids_present": true,
    "expected_train_step_ids_present": true,
    "observed_train_ranks_are_exactly_0_to_3": true,
    "every_training_rank_returned_each_rollout": true,
    "rank0_completed_initial_and_post_train_syncs": true,
    "final_sync_after_final_train": true,
    "all_four_p2p_senders_have_nonzero_bucket_progress": true,
    "replay_observations_present": true,
    "zero_observed_replay_mismatches": true,
    "ray_success_after_final_sync": true,
    "no_ray_stopped_or_failed_terminal": true,
    "no_rdma_setup_or_connection_retry_errors": true,
    "no_missing_replica_parameters": true,
    "no_swallowed_p2p_failures": true,
    "no_failure_markers_requiring_review": true
  },
  "rank0_sync_completion_count": 3,
  "train_returns_by_rank": {
    "0": 2,
    "1": 2,
    "2": 2,
    "3": 2
  },
  "rollout_ids": [
    0,
    1
  ],
  "train_step_ids": [
    0,
    1
  ],
  "replay_summary": {
    "rank=0,stage=replay_backward": {
      "observations": 36,
      "mismatched_tokens": 0,
      "observed_tokens": 36864,
      "max_mismatch_fraction": 0.0
    },
    "rank=0,stage=replay_forward": {
      "observations": 72,
      "mismatched_tokens": 0,
      "observed_tokens": 73728,
      "max_mismatch_fraction": 0.0
    },
    "rank=1,stage=replay_backward": {
      "observations": 36,
      "mismatched_tokens": 0,
      "observed_tokens": 36864,
      "max_mismatch_fraction": 0.0
    },
    "rank=1,stage=replay_forward": {
      "observations": 72,
      "mismatched_tokens": 0,
      "observed_tokens": 73728,
      "max_mismatch_fraction": 0.0
    },
    "rank=2,stage=replay_backward": {
      "observations": 36,
      "mismatched_tokens": 0,
      "observed_tokens": 36864,
      "max_mismatch_fraction": 0.0
    },
    "rank=2,stage=replay_forward": {
      "observations": 72,
      "mismatched_tokens": 0,
      "observed_tokens": 73728,
      "max_mismatch_fraction": 0.0
    },
    "rank=3,stage=replay_backward": {
      "observations": 36,
      "mismatched_tokens": 0,
      "observed_tokens": 36864,
      "max_mismatch_fraction": 0.0
    },
    "rank=3,stage=replay_forward": {
      "observations": 72,
      "mismatched_tokens": 0,
      "observed_tokens": 73728,
      "max_mismatch_fraction": 0.0
    }
  },
  "p2p_max_buckets_by_sender": {
    "0": 9,
    "1": 9,
    "2": 9,
    "3": 9
  },
  "missing_parameter_warning_count": 0,
  "swallowed_transfer_failure_count": 0,
  "qp_setup_error_count": 0,
  "worker_connection_retry_count": 0
}
```

Raw lifecycle completion records (ANSI color removed):

```text
(MegatronTrainRayActorWithConcurrencyGroups pid=64374) [2026-09-11 22:43:04.011 actor_cell0_rank0] memory_utils.py:41 - [Rank 0] Memory-Usage after update_weights: {'gpu': '0', 'total_GB': 267.69, 'free_GB': 218.32, 'used_GB': 49.37, 'allocated_GB': 32.45, 'reserved_GB': 45.42}
(MegatronTrainRayActorWithConcurrencyGroups pid=64374) [2026-09-11 22:45:52.371 actor_cell0_rank0] structured_log.py:28 - actor cls=MegatronTrainRayActorWithConcurrencyGroups fn=train phase=end ok=true elapsed_s=156.1
(MegatronTrainRayActorWithConcurrencyGroups pid=64375) [2026-09-11 22:46:05.334 actor_cell0_rank1] structured_log.py:28 - actor cls=MegatronTrainRayActorWithConcurrencyGroups fn=train phase=end ok=true elapsed_s=169.0
(MegatronTrainRayActorWithConcurrencyGroups pid=64377) [2026-09-11 22:46:05.627 actor_cell0_rank2] structured_log.py:28 - actor cls=MegatronTrainRayActorWithConcurrencyGroups fn=train phase=end ok=true elapsed_s=169.3
(MegatronTrainRayActorWithConcurrencyGroups pid=64379) [2026-09-11 22:46:05.773 actor_cell0_rank3] structured_log.py:28 - actor cls=MegatronTrainRayActorWithConcurrencyGroups fn=train phase=end ok=true elapsed_s=169.5
(MegatronTrainRayActorWithConcurrencyGroups pid=64374) [2026-09-11 22:46:10.817 actor_cell0_rank0] memory_utils.py:41 - [Rank 0] Memory-Usage after update_weights: {'gpu': '0', 'total_GB': 267.69, 'free_GB': 213.37, 'used_GB': 54.32, 'allocated_GB': 32.75, 'reserved_GB': 45.79}
(MegatronTrainRayActorWithConcurrencyGroups pid=64374) [2026-09-11 22:46:35.944 actor_cell0_rank0] structured_log.py:28 - actor cls=MegatronTrainRayActorWithConcurrencyGroups fn=train phase=end ok=true elapsed_s=24.0
(MegatronTrainRayActorWithConcurrencyGroups pid=64377) [2026-09-11 22:46:43.835 actor_cell0_rank2] structured_log.py:28 - actor cls=MegatronTrainRayActorWithConcurrencyGroups fn=train phase=end ok=true elapsed_s=31.9
(MegatronTrainRayActorWithConcurrencyGroups pid=64375) [2026-09-11 22:46:47.183 actor_cell0_rank1] structured_log.py:28 - actor cls=MegatronTrainRayActorWithConcurrencyGroups fn=train phase=end ok=true elapsed_s=35.2
(MegatronTrainRayActorWithConcurrencyGroups pid=64379) [2026-09-11 22:46:48.507 actor_cell0_rank3] structured_log.py:28 - actor cls=MegatronTrainRayActorWithConcurrencyGroups fn=train phase=end ok=true elapsed_s=36.6
(MegatronTrainRayActorWithConcurrencyGroups pid=64374) [2026-09-11 22:46:53.366 actor_cell0_rank0] memory_utils.py:41 - [Rank 0] Memory-Usage after update_weights: {'gpu': '0', 'total_GB': 267.69, 'free_GB': 213.38, 'used_GB': 54.32, 'allocated_GB': 32.75, 'reserved_GB': 45.79}
2026-09-11 22:46:58,849	SUCC cli.py:67 -- Job 'raysubmit_ksbN2DsUDwqtFvmz' succeeded
```

Complete raw metric records for both rounds (duplicate rank copies removed):

```text
(RolloutExecutor pid=73796) [2026-09-11 22:43:16.263 rollout_executor] metrics.py:89 - perf 0: {'rollout/num_training_samples': 64, 'rollout/episode_raw_reward': 0.0, 'rollout/episode_response_length/mean': 100.0, 'rollout/episode_response_length/median': 100.0, 'rollout/episode_response_length/max': 100, 'rollout/episode_response_length/min': 100, 'rollout/episode_total_response_length/mean': 100.0, 'rollout/response_len/mean': 100.0, 'rollout/response_len/median': 100.0, 'rollout/response_len/max': 100, 'rollout/response_len/min': 100, 'rollout/zero_std/count_0': 8, 'rollout/zero_std/all_zero_percentage': 0.0, 'rollout/zero_std/all_one_percentage': 0.0, 'rollout/prefix_cache_hit_rate': 0.019230769230769232, 'rollout/avg_cached_tokens_per_sample': 3.0, 'rollout/repetition_frac': 0.0, 'rollout/truncated_ratio': 1.0, 'rollout/weight_version/mean': 1.0, 'rollout/weight_version/median': 1.0, 'rollout/weight_version/max': 1, 'rollout/weight_version/min': 1, 'rollout/weight_version/mixed_version_ratio': 0.0, 'perf/rollout_time': 12.219539165496826, 'perf/tokens_per_gpu_per_sec': 130.9378347522115, 'perf/longest_sample_tokens_per_sec': 8.183614672013219, 'perf/effective_tokens_per_gpu_per_sec': 130.9378347522115, 'perf/longest_effective_sample_tokens_per_sec': 8.183614672013219}
(MegatronTrainRayActorWithConcurrencyGroups pid=64374) [2026-09-11 22:44:29.694 actor_cell0_rank0] log_utils.py:126 - rollout 0: {'rollout/response_lengths': 100.0, 'rollout/rewards': 0.0, 'rollout/truncated': 1.0, 'rollout/rollout_log_probs': -10.372714042663574, 'rollout/raw_reward': 0.0, 'rollout/total_lengths': 256.0, 'rollout/ref_log_probs': -10.373340606689453, 'rollout/log_probs': -10.372932434082031, 'rollout/advantages': 0.0, 'rollout/returns': 0.0}
(MegatronTrainRayActorWithConcurrencyGroups pid=64374) [2026-09-11 22:45:52.147 actor_cell0_rank0] log_utils.py:547 - step 0: {'train/loss': 0.0, 'train/pg_loss': 0.0, 'train/entropy_loss': 0.0, 'train/pg_clipfrac': 0.0, 'train/ppo_kl': -0.00015801786503288895, 'train/ess_ratio': 0.9998314380645752, 'train/train_rollout_logprob_abs_diff': 0.011357300914824009, 'train/train_rollout_kl': 0.00010549358557909727, 'train/kl_loss': 0.00017272128025069833, 'train/ois': 1.0002429485321045, 'train/tis': 0.9998875260353088, 'train/tis_clipfrac': 0.0, 'train/tis_abs': 0.01135452650487423, 'train/grad_norm': 0.0, 'train/lr-pg_0': 1e-06, 'train/lr-pg_1': 1e-06, 'train/lr-pg_2': 1e-06, 'train/step': 0}
(RolloutExecutor pid=73796) [2026-09-11 22:46:11.933 rollout_executor] metrics.py:89 - perf 1: {'rollout/num_training_samples': 64, 'rollout/episode_raw_reward': 0.0, 'rollout/episode_response_length/mean': 100.0, 'rollout/episode_response_length/median': 100.0, 'rollout/episode_response_length/max': 100, 'rollout/episode_response_length/min': 100, 'rollout/episode_total_response_length/mean': 100.0, 'rollout/response_len/mean': 100.0, 'rollout/response_len/median': 100.0, 'rollout/response_len/max': 100, 'rollout/response_len/min': 100, 'rollout/zero_std/count_0': 8, 'rollout/zero_std/all_zero_percentage': 0.0, 'rollout/zero_std/all_one_percentage': 0.0, 'rollout/prefix_cache_hit_rate': 0.01991701244813278, 'rollout/avg_cached_tokens_per_sample': 3.0, 'rollout/repetition_frac': 0.0, 'rollout/truncated_ratio': 1.0, 'rollout/weight_version/mean': 2.0, 'rollout/weight_version/median': 2.0, 'rollout/weight_version/max': 2, 'rollout/weight_version/min': 2, 'rollout/weight_version/mixed_version_ratio': 0.0, 'perf/rollout_time': 1.0946002006530762, 'perf/tokens_per_gpu_per_sec': 1461.720908734883, 'perf/longest_sample_tokens_per_sec': 91.3575567959302, 'perf/effective_tokens_per_gpu_per_sec': 1461.720908734883, 'perf/longest_effective_sample_tokens_per_sec': 91.3575567959302}
(MegatronTrainRayActorWithConcurrencyGroups pid=64374) [2026-09-11 22:46:14.145 actor_cell0_rank0] log_utils.py:126 - rollout 1: {'rollout/response_lengths': 100.0, 'rollout/rewards': 0.0, 'rollout/truncated': 1.0, 'rollout/rollout_log_probs': -10.316045761108398, 'rollout/raw_reward': 0.0, 'rollout/total_lengths': 250.625, 'rollout/ref_log_probs': -10.31637191772461, 'rollout/log_probs': -10.316060066223145, 'rollout/advantages': 0.0, 'rollout/returns': 0.0}
(MegatronTrainRayActorWithConcurrencyGroups pid=64374) [2026-09-11 22:46:35.724 actor_cell0_rank0] log_utils.py:547 - step 1: {'train/loss': 0.0, 'train/pg_loss': 0.0, 'train/entropy_loss': 0.0, 'train/pg_clipfrac': 0.0, 'train/ppo_kl': -3.900840238202363e-05, 'train/ess_ratio': 0.9998321533203125, 'train/train_rollout_logprob_abs_diff': 0.01144937053322792, 'train/train_rollout_kl': 0.0001061387883964926, 'train/kl_loss': 0.00019956431060563773, 'train/ois': 1.0001237392425537, 'train/tis': 1.0000923871994019, 'train/tis_clipfrac': 0.0, 'train/tis_abs': 0.01144823431968689, 'train/grad_norm': 0.0, 'train/lr-pg_0': 1e-06, 'train/lr-pg_1': 1e-06, 'train/lr-pg_2': 1e-06, 'train/step': 1}
```

The two train/rollout logprob absolute differences were `0.011357300914824009` and `0.01144937053322792`; these are observations, not gated parity results. Both rounds had zero reward/advantages/gradient norm and 100% truncation. No missing-replica warnings, swallowed transfer exceptions, QP-setup failures, or connection retries occurred. Startup emitted 22 unrelated Qwen3-ASR docstring diagnostics and two caught `/freeze_gc` connection-refused warnings; both rollout engines subsequently became healthy. Four warnings also reported read-only NumPy arrays passed to `torch.from_numpy` for routing replay, without an observed mutation failure.

Full raw E2E log SHA-256: `9c655c857f35c8c70bf9fdd724c6a665f17be4fa215ebfb2c486ab8688c90b3f`. No timing comparison or throughput claim is made.


**Baseline:** deliberately stopped after its first sync: four P2P senders each reached 9 buckets, but emitted 24 missing-parameter warnings over six fused-indexer weights and 22 QP-setup/16 connection-retry messages. Ray's stop command returned zero, so process status alone was not counted as success.

**Limitations:** the existing KL, logprob, and weight-update CI checkers remain disabled. Zero-gradient completion and weight-version counters do not prove changed-weight delivery. This short truncated-response test is integration coverage; it does not establish learning, BF16 numerical parity, multi-node scaling, or P2P performance. The layer-level SGLang regression independently requires exact changed-weight and CUDA-graph behavior, but simulates the raw writes with byte copies.
