### PR TITLE
fix(tests): scope rollout fixtures to their consumers

### DIFF
--- a/docs/developer/contributor-guide.md
+++ b/docs/developer/contributor-guide.md
@@ -53,6 +53,26 @@ git commit -m "feat(rollout): add partial-rollout buffer"
 git push me feat/awesome && gh pr create
 ```
 
+### Lightweight utility tests
+
+For changes to dependency-light helpers, you can run their tests without installing
+the training image or SGLang. For example, from the repository root:
+
+```bash
+python3.11 -m venv .venv
+source .venv/bin/activate
+python -m pip install pytest pytest-asyncio
+python -m pytest tests/fast/test_conftest_imports.py \
+    tests/fast/utils/test_file_arg_utils.py \
+    tests/fast/utils/test_function_registry.py
+```
+
+This is a small subset, not an environment for all of `tests/fast/`. Other tests
+still require their own dependencies; the full CPU CI environment is defined in
+`.github/workflows/_run-cpu-ci.yml`. Rollout fixtures are registered only where
+they are used, so unrelated utility tests do not import the serving stack during
+collection.
+
 ## Code style
 
 Formatting is not a matter of taste here, it is a hook. `.pre-commit-config.yaml` is the

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,11 +2,6 @@ import os
 
 import pytest
 
-from tests.fast.fixtures.generation_fixtures import generation_env
-from tests.fast.fixtures.rollout_fixtures import rollout_env
-
-_ = rollout_env, generation_env
-
 
 @pytest.fixture(autouse=True)
 def clear_legacy_rollout_gate(monkeypatch):

--- a/tests/fast-gpu/test_semaphore.py
+++ b/tests/fast-gpu/test_semaphore.py
@@ -15,7 +15,10 @@ register_cuda_ci(
 
 import pytest
 
+from tests.fast.fixtures.rollout_fixtures import rollout_env
 from tests.fast.rollout.inference_rollout.integration.utils import integration_env_config, load_and_call_train
+
+_ = rollout_env
 
 _DATA_ROWS = [{"input": f"What is 1+{i}?", "label": str(1 + i)} for i in range(10)]
 _BASE_ARGV = ["--rollout-batch-size", "4", "--n-samples-per-prompt", "2"]

--- a/tests/fast/fixtures/generation_fixtures.py
+++ b/tests/fast/fixtures/generation_fixtures.py
@@ -259,7 +259,7 @@ def with_session_server(
 
 @pytest.fixture
 def generation_env(request, variant):
-    # tests/conftest.py imports this fixture for every test; load the tokenizer-backed helper only when it is used.
+    # Load the tokenizer-backed helper only when the fixture is used, not during test collection.
     from miles.utils.test_utils import mock_tools
 
     SingletonMeta.clear_all_instances()

--- a/tests/fast/rollout/inference_rollout/integration/conftest.py
+++ b/tests/fast/rollout/inference_rollout/integration/conftest.py
@@ -1,0 +1,3 @@
+from tests.fast.fixtures.rollout_fixtures import rollout_env
+
+_ = rollout_env

--- a/tests/fast/test_conftest_imports.py
+++ b/tests/fast/test_conftest_imports.py
@@ -1,0 +1,14 @@
+from tests.fast.import_isolation_utils import modules_imported_by
+
+
+def test_root_conftest_does_not_import_rollout_dependencies():
+    modules = modules_imported_by("tests.conftest")
+
+    unexpected_modules = modules & {
+        "tests.fast.fixtures.generation_fixtures",
+        "tests.fast.fixtures.rollout_fixtures",
+        "torch",
+        "ray",
+        "sglang",
+    }
+    assert not unexpected_modules


### PR DESCRIPTION
# fix(tests): scope rollout fixtures to their consumers

## Problem

Running an unrelated utility test currently imports the rollout/serving stack
through the root `tests/conftest.py`. For example, in a Python environment with
only pytest and pytest-asyncio installed:

```bash
python -m pytest tests/fast/utils/test_file_arg_utils.py
```

fails before collection:

```text
tests/conftest.py -> generation_fixtures.py -> base_types.py -> data_source.py
ModuleNotFoundError: No module named 'torch'
```

The target module and its tests only need the standard library and pytest.
Adding torch is not the underlying fix: the globally imported fixtures also pull
in serving-stack dependencies unrelated to this test.

Related contributor friction is described in #3154. This is a bounded testability
improvement related to #762, not a fix for #2579 or a resolution of the entire
test-enhancements roadmap.

## Change

- Remove unused global generation/rollout fixture registration.
- Register `rollout_env` in the rollout integration directory and explicitly in
  the separate GPU semaphore test.
- Preserve both generation suites' existing explicit fixture registration.
- Add a subprocess regression guarding root-conftest import isolation.
- Document a small utility-test environment without suggesting it supports the
  entire CPU suite.

Production code, fixture implementations, autouse environment cleanup, Ray
initialization, dependency manifests, CI workflows, and test skip policies are
unchanged. The existing disabled semaphore test remains disabled.

## Evidence

In a Python 3.11.14 environment with pytest 8.4.1 and pytest-asyncio 1.0.0:

```bash
python -m pytest tests/fast/test_conftest_imports.py \
    tests/fast/utils/test_file_arg_utils.py \
    tests/fast/utils/test_function_registry.py
```

Result: 20 passed without conftest exclusion, serving-module stubs or model
downloads. The new named regression failed against the original root conftest.

The CPU discovery command includes the new regression:

```bash
PYTHONPATH=. python tests/ci/run_suite.py \
    --hw cpu --suite stage-a-cpu --match-all-labels --list-only
```

All 12 existing test modules consuming these fixtures retain a registration:
two generation, nine rollout integration, and the separate GPU semaphore test.
This was audited statically; the full-stack rollout and GPU tests have not been
run locally and still need the repository's CI environment.

Changed Python files pass the repository-pinned Ruff, Black, isort and autoflake
checks.

## Review focus

This intentionally fixes root-level fixture coupling, not every optional import
in every utility module. The normal full CPU environment remains unchanged.
