### PR TITLE
fix: align MTP loss masks with input tokens before context-parallel slicing

### DIFF
--- a/miles/backends/megatron_utils/model.py
+++ b/miles/backends/megatron_utils/model.py
@@ -329,6 +329,7 @@ def forward_only(
             args.data_pad_size_multiplier,
             args.qkv_format,
             allgather_cp=args.allgather_cp,
+            get_input_loss_masks=args.enable_mtp_training,
         )
         unconcat_tokens = batch["unconcat_tokens"]
         tokens = batch["tokens"]
@@ -347,7 +348,7 @@ def forward_only(
             attention_mask=None,
             labels=None,
             packed_seq_params=packed_seq_params,
-            loss_mask=batch["full_loss_masks"],
+            loss_mask=batch["input_loss_masks"] if args.enable_mtp_training else batch["full_loss_masks"],
             **(filter_keys(batch, ["witness_ids"]) if args.enable_witness else {}),
             **(batch["multimodal_train_inputs"] if batch["multimodal_train_inputs"] is not None else {}),
             fp32_output=fp32_output,
@@ -512,6 +513,7 @@ def train_one_step(
             args.data_pad_size_multiplier,
             args.qkv_format,
             allgather_cp=args.allgather_cp,
+            get_input_loss_masks=args.enable_mtp_training,
         )
 
         if "adapter_token_counts" in batch:
@@ -543,7 +545,8 @@ def train_one_step(
                 "attention_mask": None,
                 "labels": None,
                 "packed_seq_params": get_packed_seq_params(batch, args),
-                "loss_mask": batch["full_loss_masks"],
+                # With labels=None, Megatron derives MTP labels and shifts this mask.
+                "loss_mask": batch["input_loss_masks"] if args.enable_mtp_training else batch["full_loss_masks"],
                 **(filter_keys(batch, ["witness_ids"]) if args.enable_witness else {}),
             }
 

--- a/miles/backends/training_utils/data.py
+++ b/miles/backends/training_utils/data.py
@@ -121,6 +121,52 @@ def get_rollout_data(
     return rollout_data, store_get_result
 
 
+def _prepare_loss_masks(
+    loss_masks: Sequence[torch.Tensor],
+    total_lengths: Sequence[int],
+    response_lengths: Sequence[int],
+    *,
+    qkv_format: str,
+    max_seqlen: int,
+    pad: int,
+    allgather_cp: bool,
+    input_aligned: bool,
+) -> torch.Tensor:
+    """Align response masks before packing and CP slicing.
+
+    The main loss uses next-token/prediction alignment. Megatron MTP with
+    ``labels=None`` instead requires input-token alignment: it derives labels
+    and shifts the supplied mask itself. Shifting an already CP-sharded mask
+    cannot recover the values across shard or packed-sequence boundaries.
+    """
+    parallel_state = get_parallel_state()
+    cp_size = parallel_state.cp.size
+    cp_rank = parallel_state.cp.rank
+    shift = 0 if input_aligned else 1
+    aligned_masks = []
+    for loss_mask, total_length, response_length in zip(loss_masks, total_lengths, response_lengths, strict=True):
+        prompt_length = total_length - response_length
+        loss_mask = F.pad(loss_mask, (prompt_length - shift, shift), value=0)
+        if not allgather_cp:
+            loss_mask = slice_with_cp(loss_mask, 0, qkv_format, max_seqlen)
+        aligned_masks.append(loss_mask)
+
+    if qkv_format == "bshd":
+        if allgather_cp:
+            local_len = max_seqlen // cp_size
+            start = cp_rank * local_len
+            aligned_masks = [
+                F.pad(mask, (0, max_seqlen - mask.size(0)), value=0)[start : start + local_len]
+                for mask in aligned_masks
+            ]
+        return torch.stack(aligned_masks)
+
+    loss_mask = F.pad(torch.cat(aligned_masks), (0, pad), value=0)
+    if allgather_cp:
+        loss_mask = loss_mask.chunk(cp_size, dim=0)[cp_rank]
+    return loss_mask.unsqueeze(0)
+
+
 def get_batch(
     data_iterator: "DataIterator",
     keys: Sequence[str],
@@ -128,6 +174,7 @@ def get_batch(
     qkv_format: str = "thd",
     get_position_ids: bool = False,
     allgather_cp: bool = False,
+    get_input_loss_masks: bool = False,
 ) -> dict[str, torch.Tensor | list[torch.Tensor] | None]:
     """
     Generate a CP-ready micro-batch with packed sequence parameters.
@@ -142,11 +189,15 @@ def get_batch(
         data_iterator: Iterator providing micro-batch data.
         keys: List of keys to fetch from the iterator.
         pad_multiplier: Multiplier for padding size calculation (default: 128).
+        get_input_loss_masks: Also return input-aligned masks for consumers that
+            derive next-token labels themselves (Megatron MTP with labels=None).
 
     Returns a dict including:
     - "tokens": torch.LongTensor of shape [1, T_padded] on the current CUDA device
     - "unconcat_tokens": list[torch.LongTensor] for the micro-batch before CP slicing/concat
     - "packed_seq_params": PackedSeqParams with T-H-D settings (cu_seqlens on CUDA, dtype=int)
+    - "full_loss_masks": next-token/prediction-aligned masks, unchanged by get_input_loss_masks
+    - "input_loss_masks": optional masks aligned with input tokens, before any prediction shift
     Plus any other requested keys forwarded from the iterator.
     """
 
@@ -169,6 +220,7 @@ def get_batch(
     # use 0 as the pad token id should be fine?
     pad_token_id = 0
     pad_size = parallel_state.tp.size * pad_multiplier
+    pad = 0
 
     # for cp, we need all tokens to calculate logprob
     batch["unconcat_tokens"] = tokens
@@ -287,43 +339,22 @@ def get_batch(
     if (witness_ids := batch.get("witness_ids")) is not None:
         batch["witness_ids"] = _compute_transform_like_token_ids(witness_ids)
 
-    # loss masks
-    loss_masks = []
-    for loss_mask, total_length, response_length in zip(
-        batch["loss_masks"],
-        batch["total_lengths"],
-        batch["response_lengths"],
-        strict=True,
-    ):
-        prompt_length = total_length - response_length
-        # Align mask to token stream positions (prompt_length-1 left pad, 1 right pad)
-        loss_mask = F.pad(loss_mask, (prompt_length - 1, 1), value=0)
-        if allgather_cp:
-            loss_masks.append(loss_mask)
-            continue
-        loss_mask = slice_with_cp(loss_mask, 0, qkv_format, max_seqlen)
-        loss_masks.append(loss_mask)
-
-    if qkv_format == "bshd":
-        if allgather_cp:
-            local_len = max_seqlen // cp_size
-            start = parallel_state.cp.rank * local_len
-            loss_masks = [
-                F.pad(lm, (0, max_seqlen - lm.size(0)), value=0)[start : start + local_len] for lm in loss_masks
-            ]
-        loss_masks = torch.stack(loss_masks)
-    elif qkv_format == "thd" and allgather_cp:
-        # DSA: concatenate first (same as tokens), pad globally (same pad as above), then slice once.
-        loss_masks = torch.cat(loss_masks, dim=0)
-        if pad != 0:
-            loss_masks = F.pad(loss_masks, (0, pad), value=0)
-        loss_masks = loss_masks.chunk(cp_size, dim=0)[cp_rank].unsqueeze(0)
-    elif qkv_format == "thd":
-        loss_masks = torch.cat(loss_masks)
-        loss_masks = F.pad(loss_masks, (0, pad), value=0).unsqueeze(0)
-
-    assert loss_masks.shape == tokens.shape, f"loss_masks.shape: {loss_masks.shape}, tokens.shape: {tokens.shape}"
-    batch["full_loss_masks"] = loss_masks
+    mask_alignments = {"full_loss_masks": False}
+    if get_input_loss_masks:
+        mask_alignments["input_loss_masks"] = True
+    for key, input_aligned in mask_alignments.items():
+        mask = _prepare_loss_masks(
+            batch["loss_masks"],
+            batch["total_lengths"],
+            batch["response_lengths"],
+            qkv_format=qkv_format,
+            max_seqlen=max_seqlen,
+            pad=pad,
+            allgather_cp=allgather_cp,
+            input_aligned=input_aligned,
+        )
+        assert mask.shape == tokens.shape, f"{key}.shape: {mask.shape}, tokens.shape: {tokens.shape}"
+        batch[key] = mask
 
     # Process multimodal training tensors if present
     multimodal_train_inputs = batch.get("multimodal_train_inputs", None)

--- a/tests/fast/backends/megatron_utils/test_mtp_loss_mask_alignment.py
+++ b/tests/fast/backends/megatron_utils/test_mtp_loss_mask_alignment.py
@@ -1,0 +1,111 @@
+"""Exercise Miles masks through the real, optional Megatron MTP loss consumer."""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+from tests.ci.ci_register import register_cpu_ci
+
+from miles.backends.training_utils import cp_utils
+from miles.backends.training_utils import data as data_utils
+from miles.backends.training_utils.parallel import GroupInfo, ParallelState
+
+mtp = pytest.importorskip("megatron.core.transformer.multi_token_prediction")
+packed_seq = pytest.importorskip("megatron.core.packed_seq_params")
+
+register_cpu_ci(est_time=10, suite="stage-a-cpu", labels=[])
+
+
+@pytest.mark.parametrize("num_layers", [1, 2])
+@pytest.mark.parametrize("labels_provided", [False, True])
+@pytest.mark.parametrize("all_masked", [False, True])
+def test_actual_mtp_loss_selects_intended_targets(
+    monkeypatch: pytest.MonkeyPatch,
+    num_layers: int,
+    labels_provided: bool,
+    all_masked: bool,
+) -> None:
+    group = GroupInfo(rank=0, size=1, group=None)
+    state = ParallelState(
+        intra_dp=group, intra_dp_cp=group, cp=group, tp=group, pp=group, ep=group, etp=group, indep_dp=group
+    )
+    monkeypatch.setattr(data_utils, "get_parallel_state", lambda: state)
+    monkeypatch.setattr(cp_utils, "get_parallel_state", lambda: state)
+    monkeypatch.setattr(torch.cuda, "current_device", lambda: torch.device("cpu"))
+    monkeypatch.setattr(torch.Tensor, "cuda", lambda self, *args, **kwargs: self)
+    monkeypatch.setattr(mtp.parallel_state, "get_context_parallel_world_size", lambda: 1)
+    monkeypatch.setattr(mtp.MTPLossAutoScaler, "main_loss_backward_scale", torch.tensor(1.0))
+
+    token_ids = [torch.arange(1, 13), torch.arange(101, 111)]
+    mask_values = [[0, 0, 1, 1, 1, 1, 1, 0, 0], [1, 0, 1, 1, 1, 0, 1]]
+    masks = [torch.tensor(values) * int(not all_masked) for values in mask_values]
+    rollout = {
+        "tokens": token_ids,
+        "loss_masks": masks,
+        "total_lengths": [len(t) for t in token_ids],
+        "response_lengths": [len(mask) for mask in masks],
+    }
+    batch = data_utils.get_batch(
+        data_utils.DataIterator(rollout, micro_batch_size=2),
+        list(rollout),
+        pad_multiplier=8,
+        get_input_loss_masks=True,
+    )
+    targets = []
+    losses = []
+
+    def output_layer(hidden: torch.Tensor, *, labels: torch.Tensor, **kwargs: object) -> torch.Tensor:
+        # Only the expensive model projection/CE is replaced. Real Megatron
+        # rolling, masking, normalization and autograd injection run unchanged.
+        targets.append(labels)
+        loss = torch.ones_like(labels, dtype=torch.float32, requires_grad=True)
+        losses.append(loss)
+        return loss
+
+    next_tokens = {0: 0}
+    expected_targets = []
+    for tokens, mask in zip(token_ids, masks, strict=True):
+        ids = tokens.tolist()
+        next_tokens.update({token_id: ids[i + 1] if i + 1 < len(ids) else 0 for i, token_id in enumerate(ids)})
+        expected_targets.extend(
+            token_id for token_id, selected in zip(ids[3:], mask.tolist(), strict=True) if selected
+        )
+    labels = torch.tensor([[next_tokens[token_id] for token_id in batch["tokens"][0].tolist()]])
+    config = SimpleNamespace(
+        mtp_num_layers=num_layers,
+        mtp_detach_heads=False,
+        calculate_per_token_loss=True,
+        cross_entropy_loss_fusion=True,
+        cross_entropy_fusion_impl="linear",
+        mtp_loss_scaling_factor=0.2,
+    )
+    mask = batch["full_loss_masks"] if labels_provided else batch["input_loss_masks"]
+    original_mask = mask.clone()
+    hidden = torch.zeros((num_layers + 1) * batch["tokens"].numel(), 1, 1, requires_grad=True)
+    output = mtp.process_mtp_loss(
+        hidden_states=hidden,
+        labels=labels if labels_provided else None,
+        loss_mask=mask,
+        output_layer=output_layer,
+        output_weight=None,
+        runtime_gather_output=False,
+        is_training=False,
+        compute_language_model_loss=None,
+        config=config,
+        cp_group=None,
+        tp_group=None,
+        packed_seq_params=packed_seq.PackedSeqParams(
+            qkv_format="thd",
+            cu_seqlens_q=batch["cu_seqlens"],
+            cu_seqlens_kv=batch["cu_seqlens"],
+            max_seqlen_q=batch["max_seqlen"],
+            max_seqlen_kv=batch["max_seqlen"],
+        ),
+        input_ids=batch["tokens"],
+    )
+    output.sum().backward()
+    for target, loss in zip(targets, losses, strict=True):
+        assert loss.grad is not None
+        assert torch.isfinite(loss.grad).all()
+        assert target[loss.grad != 0].tolist() == expected_targets
+    torch.testing.assert_close(mask, original_mask)

--- a/tests/fast/backends/megatron_utils/test_mtp_loss_mask_alignment.py
+++ b/tests/fast/backends/megatron_utils/test_mtp_loss_mask_alignment.py
@@ -19,11 +19,15 @@ register_cpu_ci(est_time=10, suite="stage-a-cpu", labels=[])
 @pytest.mark.parametrize("num_layers", [1, 2])
 @pytest.mark.parametrize("labels_provided", [False, True])
 @pytest.mark.parametrize("all_masked", [False, True])
+@pytest.mark.parametrize("per_token_loss", [False, True])
+@pytest.mark.parametrize("qkv_format", ["thd", "bshd"])
 def test_actual_mtp_loss_selects_intended_targets(
     monkeypatch: pytest.MonkeyPatch,
     num_layers: int,
     labels_provided: bool,
     all_masked: bool,
+    per_token_loss: bool,
+    qkv_format: str,
 ) -> None:
     group = GroupInfo(rank=0, size=1, group=None)
     state = ParallelState(
@@ -44,11 +48,13 @@ def test_actual_mtp_loss_selects_intended_targets(
         "loss_masks": masks,
         "total_lengths": [len(t) for t in token_ids],
         "response_lengths": [len(mask) for mask in masks],
+        "max_seq_lens": [24, 24],
     }
     batch = data_utils.get_batch(
         data_utils.DataIterator(rollout, micro_batch_size=2),
         list(rollout),
         pad_multiplier=8,
+        qkv_format=qkv_format,
         get_input_loss_masks=True,
     )
     targets = []
@@ -70,18 +76,28 @@ def test_actual_mtp_loss_selects_intended_targets(
         expected_targets.extend(
             token_id for token_id, selected in zip(ids[3:], mask.tolist(), strict=True) if selected
         )
-    labels = torch.tensor([[next_tokens[token_id] for token_id in batch["tokens"][0].tolist()]])
+    labels = torch.tensor([[next_tokens[token_id] for token_id in row] for row in batch["tokens"].tolist()])
     config = SimpleNamespace(
         mtp_num_layers=num_layers,
         mtp_detach_heads=False,
-        calculate_per_token_loss=True,
+        calculate_per_token_loss=per_token_loss,
         cross_entropy_loss_fusion=True,
         cross_entropy_fusion_impl="linear",
         mtp_loss_scaling_factor=0.2,
     )
     mask = batch["full_loss_masks"] if labels_provided else batch["input_loss_masks"]
     original_mask = mask.clone()
-    hidden = torch.zeros((num_layers + 1) * batch["tokens"].numel(), 1, 1, requires_grad=True)
+    batch_size, seq_len = batch["tokens"].shape
+    hidden = torch.zeros((num_layers + 1) * seq_len, batch_size, 1, requires_grad=True)
+    packed_params = None
+    if qkv_format == "thd":
+        packed_params = packed_seq.PackedSeqParams(
+            qkv_format="thd",
+            cu_seqlens_q=batch["cu_seqlens"],
+            cu_seqlens_kv=batch["cu_seqlens"],
+            max_seqlen_q=batch["max_seqlen"],
+            max_seqlen_kv=batch["max_seqlen"],
+        )
     output = mtp.process_mtp_loss(
         hidden_states=hidden,
         labels=labels if labels_provided else None,
@@ -94,13 +110,7 @@ def test_actual_mtp_loss_selects_intended_targets(
         config=config,
         cp_group=None,
         tp_group=None,
-        packed_seq_params=packed_seq.PackedSeqParams(
-            qkv_format="thd",
-            cu_seqlens_q=batch["cu_seqlens"],
-            cu_seqlens_kv=batch["cu_seqlens"],
-            max_seqlen_q=batch["max_seqlen"],
-            max_seqlen_kv=batch["max_seqlen"],
-        ),
+        packed_seq_params=packed_params,
         input_ids=batch["tokens"],
     )
     output.sum().backward()

--- a/tests/fast/backends/megatron_utils/test_mtp_loss_mask_alignment.py
+++ b/tests/fast/backends/megatron_utils/test_mtp_loss_mask_alignment.py
@@ -4,7 +4,6 @@ from types import SimpleNamespace
 
 import pytest
 import torch
-from tests.ci.ci_register import register_cpu_ci
 
 from miles.backends.training_utils import cp_utils
 from miles.backends.training_utils import data as data_utils
@@ -12,8 +11,6 @@ from miles.backends.training_utils.parallel import GroupInfo, ParallelState
 
 mtp = pytest.importorskip("megatron.core.transformer.multi_token_prediction")
 packed_seq = pytest.importorskip("megatron.core.packed_seq_params")
-
-register_cpu_ci(est_time=10, suite="stage-a-cpu", labels=[])
 
 
 @pytest.mark.parametrize("num_layers", [1, 2])

--- a/tests/fast/backends/training_utils/test_input_loss_masks.py
+++ b/tests/fast/backends/training_utils/test_input_loss_masks.py
@@ -1,0 +1,99 @@
+"""Mask alignment must be established before packing and context-parallel slicing."""
+
+import pytest
+import torch
+from tests.ci.ci_register import register_cpu_ci
+
+from miles.backends.training_utils import cp_utils
+from miles.backends.training_utils import data as data_utils
+from miles.backends.training_utils.parallel import GroupInfo, ParallelState
+
+register_cpu_ci(est_time=10, suite="stage-a-cpu", labels=[])
+
+
+def _parallel_state(cp_size: int, cp_rank: int) -> ParallelState:
+    group = GroupInfo(rank=0, size=1, group=None)
+    cp_group = GroupInfo(rank=cp_rank, size=cp_size, group=None)
+    return ParallelState(
+        intra_dp=group,
+        intra_dp_cp=cp_group,
+        cp=cp_group,
+        tp=GroupInfo(rank=0, size=2, group=None),
+        pp=group,
+        ep=group,
+        etp=group,
+        indep_dp=group,
+    )
+
+
+@pytest.mark.parametrize("qkv_format", ["thd", "bshd"])
+@pytest.mark.parametrize("allgather_cp", [False, True])
+@pytest.mark.parametrize("cp_size", [1, 2, 4])
+@pytest.mark.parametrize("get_input_loss_masks", [False, True])
+@pytest.mark.parametrize("dtype", [torch.int64, torch.float32])
+def test_mask_alignment_survives_packing_and_cp(
+    monkeypatch: pytest.MonkeyPatch,
+    qkv_format: str,
+    allgather_cp: bool,
+    cp_size: int,
+    get_input_loss_masks: bool,
+    dtype: torch.dtype,
+) -> None:
+    # Different lengths, multiple assistant spans, an empty response, a masked
+    # response, and a prompt-free sample. Token IDs uniquely identify positions.
+    tokens = [torch.arange(100 * i + 1, 100 * i + n + 1) for i, n in enumerate([13, 11, 5, 9, 7, 1])]
+    masks = [
+        torch.tensor(values, dtype=dtype)
+        for values in ([1, 1, 0, 0, 1, 0, 1, 1, 1], [0, 1, 1, 0, 1, 1, 1], [], [0] * 6, [1] * 7, [1])
+    ]
+    original_masks = [mask.clone() for mask in masks]
+    rollout = {
+        "tokens": tokens,
+        "loss_masks": masks,
+        "total_lengths": [len(t) for t in tokens],
+        "response_lengths": [len(mask) for mask in masks],
+        "max_seq_lens": [24] * len(tokens),
+    }
+    # Independent oracle keyed by the actual input token at each position;
+    # neither the collator's padding helper nor its CP slicing builds it.
+    input_weights = {0: 0}
+    prediction_weights = {0: 0}
+    for token_ids, mask in zip(tokens, masks, strict=True):
+        weights = [0] * (len(token_ids) - len(mask)) + mask.tolist()
+        for position, token_id in enumerate(token_ids.tolist()):
+            input_weights[token_id] = weights[position]
+            prediction_weights[token_id] = weights[position + 1] if position + 1 < len(weights) else 0
+
+    monkeypatch.setattr(torch.cuda, "current_device", lambda: torch.device("cpu"))
+    monkeypatch.setattr(torch.Tensor, "cuda", lambda self, *args, **kwargs: self)
+    totals = {"full_loss_masks": 0.0, "input_loss_masks": 0.0}
+    seen_tokens = []
+    for cp_rank in range(cp_size):
+        state = _parallel_state(cp_size, cp_rank)
+        monkeypatch.setattr(data_utils, "get_parallel_state", lambda state=state: state)
+        monkeypatch.setattr(cp_utils, "get_parallel_state", lambda state=state: state)
+        batch = data_utils.get_batch(
+            data_utils.DataIterator(rollout, micro_batch_size=len(tokens)),
+            list(rollout),
+            pad_multiplier=7,
+            qkv_format=qkv_format,
+            allgather_cp=allgather_cp,
+            get_input_loss_masks=get_input_loss_masks,
+        )
+        assert ("input_loss_masks" in batch) == get_input_loss_masks
+        flat_tokens = batch["tokens"].flatten().tolist()
+        seen_tokens.extend(token_id for token_id in flat_tokens if token_id != 0)
+        for key, weights in (("full_loss_masks", prediction_weights), ("input_loss_masks", input_weights)):
+            if key not in batch:
+                continue
+            expected = torch.tensor([weights[token_id] for token_id in flat_tokens], dtype=dtype)
+            torch.testing.assert_close(batch[key].flatten(), expected)
+            assert batch[key].shape == batch["tokens"].shape
+            totals[key] += batch[key].sum().item()
+
+    assert sorted(seen_tokens) == sorted(torch.cat(tokens).tolist())
+    assert totals["full_loss_masks"] == sum(prediction_weights.values())
+    if get_input_loss_masks:
+        assert totals["input_loss_masks"] == sum(input_weights.values())
+    for mask, original in zip(masks, original_masks, strict=True):
+        torch.testing.assert_close(mask, original)

--- a/tests/fast/backends/training_utils/test_input_loss_masks.py
+++ b/tests/fast/backends/training_utils/test_input_loss_masks.py
@@ -2,13 +2,10 @@
 
 import pytest
 import torch
-from tests.ci.ci_register import register_cpu_ci
 
 from miles.backends.training_utils import cp_utils
 from miles.backends.training_utils import data as data_utils
 from miles.backends.training_utils.parallel import GroupInfo, ParallelState
-
-register_cpu_ci(est_time=10, suite="stage-a-cpu", labels=[])
 
 
 def _parallel_state(cp_size: int, cp_rank: int) -> ParallelState:


### PR DESCRIPTION
## Summary

Fix auxiliary multi-token-prediction (MTP) supervision using Miles changes only. Megatron is unchanged, and the main SFT/policy loss keeps its existing mask.

## Bug

Miles builds `full_loss_masks` in next-token/prediction alignment, but calls Megatron with `labels=None`. Megatron's MTP path derives next-token labels from `input_ids` and shifts the supplied mask along with them before applying the additional MTP-depth shift. Passing an already prediction-aligned mask therefore advances the mask one token too far relative to the MTP targets.

For example, an intended supervised target span at positions 4–8 can instead select 3–7 for the auxiliary loss. The targets themselves are not relabeled; the wrong boundary positions receive loss. This does not demonstrate a downstream accuracy impact or a problem with the main SFT loss.

## Changes

- Add opt-in `get_input_loss_masks` to the shared batch builder. It returns a separate `input_loss_masks` tensor without changing `full_loss_masks`.
- Construct alignment from the original response mask before padding, packing, or context-parallel slicing. A local roll after sharding would not correctly handle shard/packed-sequence boundaries.
- Pass the input-aligned mask to Megatron in training and forward-only calls when MTP training is enabled. Non-MTP consumers and the combined schedule-plan path retain their previous behavior.
- Add an independent token-position oracle for both supported layouts, zigzag/contiguous CP, CP sizes 1/2/4, padding, multiple supervised spans, empty/all-zero responses, and prompt-free inputs.
- Exercise the real optional Megatron `process_mtp_loss`, sequence rolling, normalization, and `MTPLossAutoScaler.backward` on CPU. Only the expensive output projection/CE is replaced with differentiable per-token losses; the tests inspect which target positions receive gradients. Covers supplied/inferred labels, one/two MTP layers, both layouts and normalization modes, and all-masked inputs.

## Validation

- **80 focused cases passed** (0.72 s): 48 batch/layout/CP mask cases and 32 cases through the real Megatron MTP loss/backward consumer.
- **324 training-utility cases passed** (177.85 s), including the 48 new batch cases and existing distributed CP2 loss/advantage checks. There are **356 distinct passing cases** across these two commands.
- All changed files passed pre-commit (including Ruff, isort, Black and secret checks) and `git diff --check`.
- Negative control: replacing the new input-aligned mask with the old prediction-aligned mask reproduces a failing target-gradient assertion in the real Megatron consumer; no source file was changed for this control.
- Megatron consumer validation used unchanged `radixark/Megatron-LM` commit `235952df607b3820716e5e67728a5ab470ca33ae`. The optional consumer tests skip if Megatron is not installed; they actually ran in this validation.
- Scope: CPU mask/gradient validation, simulated CP1/2/4 batch layouts, and neighboring distributed CPU tests. No full-model GPU retraining or downstream benchmark comparison was performed.

```sh
python -m pytest tests/fast/backends/training_utils -q --durations=5
python -m pytest tests/fast/backends/training_utils/test_input_loss_masks.py \
  tests/fast/backends/megatron_utils/test_mtp_loss_mask_alignment.py -q --durations=5
```

No new dependency or user-facing launch flag is required. The batch-builder docstring documents the internal alignment contract; no README change is needed.
