### PR TITLE
rollout: add the ReMax advantage estimator (--advantage-estimator remax)

### DIFF
--- a/docs/user-guide/cli-reference.md
+++ b/docs/user-guide/cli-reference.md
@@ -65,7 +65,8 @@ then push up until you OOM.
 
 | Flag | Default | What |
 |---|---|---|
-| `--advantage-estimator` | `grpo` | `grpo`, `gspo`, `ppo`, `reinforce_plus_plus`, `reinforce_plus_plus_baseline`. On-policy distillation is not an estimator — enable it with `--use-opd` on top of any of these. |
+| `--advantage-estimator` | `grpo` | `grpo`, `gspo`, `ppo`, `reinforce_plus_plus`, `reinforce_plus_plus_baseline`, `remax`. On-policy distillation is not an estimator — enable it with `--use-opd` on top of any of these. |
+| `--advantage-estimator remax` | opt-in | One extra greedy (temperature 0) response per prompt supplies the baseline: advantage = reward − greedy reward, without normalization. The greedy response is excluded from training. |
 | `--use-kl-loss` | off | Compute KL against the reference model. |
 | `--kl-loss-coef` | `0.0` | Weight of KL in the loss (0 means monitor only). |
 | `--kl-loss-type` | `k1` | `k1`, `k2`, `k3`, `low_var_kl`. |
@@ -74,6 +75,18 @@ then push up until you OOM.
 | `--eps-clip` | `0.2` | PPO/GRPO low clip. |
 | `--eps-clip-high` | `–` | Asymmetric high clip (DAPO-style). |
 | `--use-tis` | off | Truncated Importance Sampling for train/inference precision mismatch. |
+
+ReMax supports the default class-based and legacy SGLang rollout paths.
+`--n-samples-per-prompt` counts only training responses and can be `1`;
+`--rollout-temperature` continues to control those responses. Reward-normalization
+and GRPO std flags do not affect ReMax. Leave `--normalize-advantages` off.
+Partial rollout, multi-LoRA, fully async rollout, group reward models,
+sample-level rollout submission, and custom reward-postprocessing or train-data
+conversion hooks are unsupported. Custom generation functions must honor the
+sampling parameters and return one sample for the greedy request. Custom rollout
+functions must attach `metadata["remax_baseline_reward"]` to each training sample.
+Dynamic sampling filters see only the training responses and their raw rewards;
+zero-variance filters can discard groups with nonzero ReMax advantages.
 
 ### Sampling
 
@@ -235,7 +248,7 @@ Sections mirror the launch-script argument groups.
 
 | Flag | Type | Default | Notes |
 |---|---|---|---|
-| `--advantage-estimator` | enum | `grpo` | `grpo`, `gspo`, `ppo`, `reinforce_plus_plus`, `reinforce_plus_plus_baseline`. |
+| `--advantage-estimator` | enum | `grpo` | `grpo`, `gspo`, `ppo`, `reinforce_plus_plus`, `reinforce_plus_plus_baseline`, `remax` (reward minus a per-prompt greedy reward; no normalization). |
 | `--use-kl-loss` | flag | off | Compute KL vs. reference. |
 | `--kl-loss-coef` | float | `0.0` | KL weight in loss (0 means monitor). |
 | `--kl-loss-type` | enum | `k1` | `k1`, `k2`, `k3`, `low_var_kl`. |

--- a/miles/backends/training_utils/loss.py
+++ b/miles/backends/training_utils/loss.py
@@ -33,7 +33,7 @@ def compute_advantages_and_returns(
 
     This function extracts rewards, log-probs, values, and masks from
     `rollout_data`, computes KL divergences, then applies the chosen advantage
-    estimator. Supported methods: "grpo", "gspo", "ppo", "reinforce_plus_plus",
+    estimator. Supported methods: "grpo", "gspo", "ppo", "remax", "reinforce_plus_plus",
     and "reinforce_plus_plus_baseline". On-policy distillation (OPD) is applied
     orthogonally on top of any estimator via `args.use_opd`. When
     `args.normalize_advantages` is True, advantages are whitened across the

--- a/miles/backends/training_utils/loss_hub/advantages.py
+++ b/miles/backends/training_utils/loss_hub/advantages.py
@@ -56,6 +56,12 @@ def compute_advantages(
         # TODO: is the copy necessary?
         advantages = [r for r in returns]
 
+    elif args.advantage_estimator == "remax":
+        # Rollout reward processing already subtracted the per-prompt greedy reward.
+        rewards = torch.tensor(rewards, dtype=torch.float32, device=kl[0].device)
+        advantages = get_grpo_returns(rewards, kl)
+        returns = advantages
+
     elif args.advantage_estimator == "ppo":
         terminal_rewards = rewards
         token_rewards = []

--- a/miles/ray/rollout/train_data_conversion.py
+++ b/miles/ray/rollout/train_data_conversion.py
@@ -285,6 +285,15 @@ def _post_process_rewards(
         return f(args, samples)
 
     raw_rewards = [sample.get_reward_value(args) for sample in samples]
+    if args.advantage_estimator == "remax":
+        if any(not sample.metadata or sample.metadata.get("remax_baseline_reward") is None for sample in samples):
+            raise ValueError("remax requires remax_baseline_reward metadata on every training sample")
+        # Carry the baseline-adjusted rewards through the existing DP partitioning.
+        return raw_rewards, [
+            reward - sample.metadata["remax_baseline_reward"]
+            for reward, sample in zip(raw_rewards, samples, strict=True)
+        ]
+
     if args.advantage_estimator in ["grpo", "gspo", "reinforce_plus_plus_baseline"] and args.rewards_normalization:
         normalized_rewards = _normalize_rewards_by_rollout(args, samples, raw_rewards, prompt_group_sizes)
         return raw_rewards, normalized_rewards

--- a/miles/rollout/inference_rollout/inference_rollout_common.py
+++ b/miles/rollout/inference_rollout/inference_rollout_common.py
@@ -4,6 +4,7 @@ import uuid
 from argparse import Namespace
 from collections.abc import Callable
 from copy import deepcopy
+from functools import partial
 from typing import Any
 
 from miles.rollout.base_types import (
@@ -20,6 +21,7 @@ from miles.rollout.base_types import (
 from miles.rollout.generate_hub.single_turn import generate
 from miles.rollout.generate_utils.generate_endpoint_utils import policy_uses_routing_key
 from miles.rollout.inference_rollout.compatibility import load_generate_function
+from miles.rollout.remax import generate_remax_baseline
 from miles.rollout.rm_hub import async_rm, batched_async_rm
 from miles.utils.lifecycle import TrajectoryLifecycle
 from miles.utils.processing_utils import load_processor, load_tokenizer
@@ -146,6 +148,10 @@ async def generate_and_rm_group(
 
     if state.aborted:
         return group
+
+    if not evaluation and getattr(args, "advantage_estimator", None) == "remax":
+        if not await generate_remax_baseline(args, group, sampling_params, partial(generate_and_rm, state)):
+            return group
 
     if policy_uses_routing_key(args):
         for sample in group:

--- a/miles/rollout/remax.py
+++ b/miles/rollout/remax.py
@@ -1,0 +1,36 @@
+"""Greedy reward baselines for prompt-group rollout generation."""
+
+import uuid
+from argparse import Namespace
+from collections.abc import Awaitable, Callable
+from copy import deepcopy
+from typing import Any
+
+from miles.utils.types import Sample
+
+
+async def generate_remax_baseline(
+    args: Namespace,
+    group: list[Sample],
+    sampling_params: dict[str, Any],
+    generate_fn: Callable[..., Awaitable[Sample]],
+) -> bool:
+    """Attach one greedy reward to the training samples; reject an unscored group."""
+    baseline = deepcopy(group[0])
+    baseline.reset_for_retry()
+    baseline.index = -(group[0].index or 0) - 1
+    baseline.rollout_id = baseline.index
+    baseline.routing_key = str(uuid.uuid4())
+    baseline.metadata = {**(baseline.metadata or {}), "remax_baseline": True}
+    baseline.remove_sample = True
+    baseline = await generate_fn(baseline, {**sampling_params, "temperature": 0.0})
+    if not isinstance(baseline, Sample):
+        raise ValueError("remax greedy generation must return one Sample")
+    reward = baseline.get_reward_value(args) if baseline.reward is not None else None
+    if baseline.status not in (Sample.Status.COMPLETED, Sample.Status.TRUNCATED) or reward is None:
+        for sample in group:
+            sample.status = Sample.Status.ABORTED
+        return False
+    for sample in group:
+        sample.metadata = {**(sample.metadata or {}), "remax_baseline_reward": reward}
+    return True

--- a/miles/rollout/sglang_rollout.py
+++ b/miles/rollout/sglang_rollout.py
@@ -5,6 +5,7 @@ import uuid
 from argparse import Namespace
 from collections.abc import Callable
 from contextlib import contextmanager
+from functools import partial
 from typing import Any
 
 import numpy as np
@@ -17,6 +18,7 @@ from miles.rollout.base_types import GenerateFnInput, RolloutFnEvalOutput, Rollo
 from miles.rollout.filter_hub.base_types import MetricGatherer
 from miles.rollout.filter_hub.common_filters import apply_preput_filters
 from miles.rollout.inference_rollout.compatibility import load_generate_function
+from miles.rollout.remax import generate_remax_baseline
 from miles.utils import dumper_utils
 from miles.utils.async_utils import run
 from miles.utils.data import Dataset
@@ -363,6 +365,10 @@ async def generate_and_rm_group(
 
     if state.aborted:
         return group
+
+    if not evaluation and getattr(args, "advantage_estimator", None) == "remax":
+        if not await generate_remax_baseline(args, group, sampling_params, partial(generate_and_rm, args)):
+            return group
 
     # Generate a unique routing_key for each sample in the group (routing-key policies only)
     if policy_uses_routing_key(args):

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -82,6 +82,24 @@ def _resolve_rollout_functions(args) -> None:
     args.eval_uses_snapshots = args.eval_num_gpus > 0 or checkpoint_backend
 
 
+def _validate_remax_args(args) -> None:
+    if args.advantage_estimator != "remax":
+        return
+    for option in (
+        "partial_rollout",
+        "multi_lora",
+        "fully_async",
+        "group_rm",
+        "normalize_advantages",
+        "custom_reward_post_process_path",
+        "custom_convert_samples_to_train_data_path",
+    ):
+        if getattr(args, option, None):
+            raise ValueError(f"remax does not support --{option.replace('_', '-')}")
+    if getattr(args, "rollout_submission_granularity", None) == "sample":
+        raise ValueError("remax requires group-level rollout submission")
+
+
 def reset_arg(parser, name, **kwargs):
     """
     Reset the default value of a Megatron argument.
@@ -1472,6 +1490,7 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                     "gspo",
                     "reinforce_plus_plus",
                     "reinforce_plus_plus_baseline",
+                    "remax",
                     "ppo",
                 ],
                 default="grpo",
@@ -3219,6 +3238,7 @@ def miles_validate_args(args):
     from miles.utils.multi_lora import validate_multi_lora_args
 
     validate_multi_lora_args(args)
+    _validate_remax_args(args)
 
     assert not (args.kl_coef != 0 and args.kl_loss_coef != 0), "Only one of kl_coef and kl_loss_coef can be set"
 

--- a/tests/fast/backends/training_utils/loss/test_remax.py
+++ b/tests/fast/backends/training_utils/loss/test_remax.py
@@ -1,0 +1,26 @@
+import pytest
+import torch
+from tests.fast.backends.training_utils.loss.loss_test_utils import make_args
+
+from miles.backends.training_utils.loss_hub.advantages import compute_advantages
+
+
+@pytest.mark.parametrize("local_lengths", [[3, 1, 4], [0, 2, 0]])
+def test_remax_broadcasts_baseline_adjusted_rewards_without_normalization(local_lengths):
+    args = make_args(advantage_estimator="remax", kl_coef=0.0)
+    raw_rewards = [1.0, 5.0, 3.0]
+    fake_baseline = 3.0
+    kl = [torch.zeros(length) for length in local_lengths]
+    advantages, returns = compute_advantages(
+        args,
+        kl=kl,
+        rewards=[reward - fake_baseline for reward in raw_rewards],
+        log_probs=kl,
+        loss_masks=[torch.ones(4) for _ in raw_rewards],
+        total_lengths=[6, 6, 6],
+        response_lengths=[4, 4, 4],
+    )
+
+    for advantage, ret, length, expected in zip(advantages, returns, local_lengths, [-2.0, 2.0, 0.0], strict=True):
+        torch.testing.assert_close(advantage, torch.full((length,), expected))
+        torch.testing.assert_close(ret, advantage)

--- a/tests/fast/ray/rollout/test_remax.py
+++ b/tests/fast/ray/rollout/test_remax.py
@@ -1,0 +1,206 @@
+import asyncio
+from argparse import ArgumentParser
+from contextlib import nullcontext
+from types import SimpleNamespace
+
+import pytest
+from tests.fast.ray.rollout.conftest import make_args, make_samples_grouped
+
+from miles.ray.rollout.train_data_conversion import _post_process_rewards, convert_samples_to_train_data
+from miles.rollout import sglang_rollout
+from miles.rollout.base_types import GenerateFnOutput
+from miles.rollout.filter_hub.common_filters import apply_preput_filters
+from miles.rollout.inference_rollout import inference_rollout_common
+from miles.utils.arguments import _validate_remax_args, get_miles_extra_args_provider
+from miles.utils.lifecycle import TrajectoryLifecycle
+from miles.utils.types import Sample
+
+
+@pytest.fixture(params=[sglang_rollout, inference_rollout_common], ids=["legacy", "class"])
+def rollout_harness(request, monkeypatch):
+    module = request.param
+    args = make_args(
+        advantage_estimator="remax",
+        partial_rollout=False,
+        group_rm=False,
+        custom_generate_function_path=None,
+        sglang_router_policy="consistent_hashing",
+        sglang_enable_deterministic_inference=True,
+        rollout_seed=17,
+    )
+    calls = []
+    state = SimpleNamespace(
+        args=args,
+        aborted=False,
+        semaphore=asyncio.Semaphore(1),
+        generate_fn_semaphore=asyncio.Semaphore(1),
+        dp_rank_context=nullcontext,
+        group_sampling_seeds=[17, 18],
+        baseline_status=Sample.Status.COMPLETED,
+        baseline_rewards=[3.0, 0.5],
+    )
+
+    async def generate(_args, sample, sampling_params):
+        assert sample.reward is None
+        assert not sample.response
+        calls.append((sample, sampling_params.copy()))
+        sample.response = "greedy" if sampling_params["temperature"] == 0 else "sampled"
+        sample.response_length = 2
+        sample.tokens = [10, 11, 12]
+        sample.status = state.baseline_status if sample.metadata.get("remax_baseline") else Sample.Status.COMPLETED
+        return sample
+
+    async def generate_fn(input):
+        return GenerateFnOutput(samples=await generate(input.args, input.sample, input.sampling_params))
+
+    async def reward(_args, sample):
+        score = state.baseline_rewards[sample.group_index] if sample.metadata.get("remax_baseline") else sample.label
+        return {"score": score} if args.reward_key else score
+
+    state.generate_function = generate_fn
+    monkeypatch.setattr(module, "async_rm", reward)
+    monkeypatch.setattr(TrajectoryLifecycle(), "sink", None)
+    if module is sglang_rollout:
+        monkeypatch.setattr(module, "GenerateState", lambda _args: state)
+        monkeypatch.setattr(module, "generate", generate)
+    context = args if module is sglang_rollout else state
+
+    async def run_group(group, sampling_params, evaluation=False):
+        return await module.generate_and_rm_group(context, group, sampling_params, evaluation=evaluation)
+
+    return args, state, calls, run_group
+
+
+def pending_groups(group_size):
+    samples = make_samples_grouped(n_groups=2, group_size=group_size)
+    for i, sample in enumerate(samples):
+        sample.reset_for_retry()
+        sample.label = [1.0, 5.0][i % group_size]
+        sample.metadata = {"dataset": "math"}
+    return [samples[:group_size], samples[group_size:]]
+
+
+@pytest.mark.parametrize("group_size", [1, 2])
+@pytest.mark.parametrize("reward_key", [None, "score"])
+async def test_greedy_baseline_is_per_prompt_and_excluded_from_training(rollout_harness, group_size, reward_key):
+    args, state, calls, run_group = rollout_harness
+    args.n_samples_per_prompt = group_size
+    args.rollout_batch_size = 2
+    args.reward_key = reward_key
+    args.grpo_std_normalization = True
+    params = dict(temperature=0.8, top_p=0.9, top_k=20, max_new_tokens=7, stop=["END"])
+    groups = pending_groups(group_size)
+    outputs = await asyncio.gather(*(run_group(group, params) for group in groups))
+
+    baselines = [(sample, p) for sample, p in calls if sample.metadata.get("remax_baseline")]
+    assert len(baselines) == 2
+    assert len(calls) == 2 * (group_size + 1)
+    assert params["temperature"] == 0.8
+    for baseline, baseline_params in baselines:
+        assert baseline_params == {**params, "temperature": 0.0}
+        assert baseline.response == "greedy"
+        assert baseline.remove_sample
+        assert baseline.index < 0
+        assert baseline.metadata["dataset"] == "math"
+        assert all(baseline.routing_key != sample.routing_key for group in outputs for sample in group)
+
+    for group_index, output in enumerate(outputs):
+        assert len(output) == group_size
+        assert apply_preput_filters(args, None, output).keep
+        assert [s.metadata["remax_baseline_reward"] for s in output] == [[3.0, 0.5][group_index]] * group_size
+        assert all(not s.remove_sample and not s.metadata.get("remax_baseline") for s in output)
+    training_calls = [p for s, p in calls if not s.metadata.get("remax_baseline")]
+    assert all(p["temperature"] == 0.8 for p in training_calls)
+    assert sorted(p["sampling_seed"] for p in training_calls) == sorted([17 + i for i in range(group_size)] * 2)
+    train_data = convert_samples_to_train_data(args, [s for g in outputs for s in g], {}, None, None)
+    expected = [-2.0, 0.5] if group_size == 1 else [-2.0, 2.0, 0.5, 4.5]
+    assert train_data["rewards"] == expected
+    assert train_data["raw_reward"] == [1.0, 5.0][:group_size] * 2
+    assert train_data["loss_masks"] == [[1, 1]] * (2 * group_size)
+    assert train_data["sample_indices"] == list(range(2 * group_size))
+
+
+@pytest.mark.parametrize("evaluation,estimator", [(True, "remax"), (False, "grpo")])
+async def test_evaluation_and_other_estimators_do_not_generate_baselines(rollout_harness, evaluation, estimator):
+    args, _, calls, run_group = rollout_harness
+    args.advantage_estimator = estimator
+    output = await run_group(pending_groups(1)[0], {"temperature": 0.8}, evaluation=evaluation)
+    assert len(calls) == len(output) == 1
+    assert "remax_baseline_reward" not in output[0].metadata
+
+
+@pytest.mark.parametrize("status", [Sample.Status.ABORTED, Sample.Status.FAILED])
+async def test_failed_greedy_baseline_rejects_prompt_group(rollout_harness, status):
+    args, state, calls, run_group = rollout_harness
+    state.baseline_status = status
+    output = await run_group(pending_groups(2)[0], {"temperature": 0.8})
+    assert len(calls) == 1
+    assert len(output) == 2
+    assert not apply_preput_filters(args, None, output).keep
+
+
+@pytest.mark.parametrize("reward_key", [None, "score"])
+async def test_missing_greedy_reward_rejects_prompt_group(rollout_harness, reward_key):
+    args, state, _, run_group = rollout_harness
+    args.reward_key = reward_key
+    state.baseline_rewards[0] = None
+    output = await run_group(pending_groups(1)[0], {"temperature": 0.8})
+    assert not apply_preput_filters(args, None, output).keep
+
+
+async def test_truncated_greedy_response_can_supply_a_baseline(rollout_harness):
+    args, state, _, run_group = rollout_harness
+    state.baseline_status = Sample.Status.TRUNCATED
+    output = await run_group(pending_groups(1)[0], {"temperature": 0.8})
+    assert apply_preput_filters(args, None, output).keep
+    assert output[0].metadata["remax_baseline_reward"] == 3.0
+
+
+@pytest.mark.parametrize("rewards_normalization", [False, True])
+def test_remax_subtraction_does_not_depend_on_reward_normalization_flags(rewards_normalization):
+    args = make_args(
+        advantage_estimator="remax", rewards_normalization=rewards_normalization, grpo_std_normalization=True
+    )
+    samples = make_samples_grouped(n_groups=1, group_size=2, rewards=[1.0, 5.0])
+    for sample in samples:
+        sample.metadata["remax_baseline_reward"] = 3.0
+    raw, adjusted = _post_process_rewards(args, samples[::-1], None)
+    assert raw == [5.0, 1.0]
+    assert adjusted == [2.0, -2.0]
+
+
+def test_remax_requires_baseline_metadata():
+    args = make_args(advantage_estimator="remax")
+    with pytest.raises(ValueError, match="remax_baseline_reward"):
+        _post_process_rewards(args, make_samples_grouped(1, 1), None)
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"partial_rollout": True},
+        {"multi_lora": True},
+        {"fully_async": True},
+        {"group_rm": True},
+        {"normalize_advantages": True},
+        {"rollout_submission_granularity": "sample"},
+        {"custom_reward_post_process_path": "custom.reward"},
+        {"custom_convert_samples_to_train_data_path": "custom.convert"},
+    ],
+)
+def test_remax_rejects_incompatible_options(overrides):
+    with pytest.raises(ValueError, match="remax"):
+        _validate_remax_args(make_args(advantage_estimator="remax", **overrides))
+
+
+def test_remax_accepts_default_options_and_singleton_groups():
+    _validate_remax_args(make_args(advantage_estimator="remax", n_samples_per_prompt=1))
+
+
+def test_cli_accepts_remax_with_singleton_groups():
+    parser = ArgumentParser()
+    get_miles_extra_args_provider()(parser)
+    args = parser.parse_args(["--advantage-estimator", "remax", "--rollout-batch-size", "2"])
+    assert args.advantage_estimator == "remax"
+    assert args.n_samples_per_prompt == 1
+    _validate_remax_args(args)


### PR DESCRIPTION
### What

Adds `--advantage-estimator remax` (Li et al. 2023, verl's `advantage_estimator: remax`): the advantage of each response is `reward - greedy_reward`, where the baseline is the reward of one greedy (temperature 0) response to the same prompt. No group mean or std is used, so it works for singleton groups and for groups where every response scores the same.

- `miles/rollout/remax.py`: `generate_remax_baseline` deep-copies the first sample of a prompt group, resets it, gives it a fresh routing key and a negative index, generates and scores it through the same `generate_and_rm` path at temperature 0 (all other sampling params unchanged), and stores the reward on every group member as `metadata["remax_baseline_reward"]`. The greedy sample itself is never added to the group, so it never reaches training data or metrics. A greedy generation that fails or returns no reward aborts the prompt group.
- Both rollout implementations (`sglang_rollout.py` and the class-based `inference_rollout_common.py`) call the helper before generating the group's training samples: one extra serial generation per prompt group, groups still run concurrently.
- `train_data_conversion._post_process_rewards` yields `reward - baseline`; `loss_hub/advantages.py` carries that through `get_grpo_returns` without normalization; the rest of the loss is untouched.
- Validation rejects combinations that would break the one-baseline-per-group contract: partial rollout, multi-LoRA, fully async, group RM, advantage normalization, custom reward post-process or conversion hooks, and sample-level submission.

### Test

- `tests/fast/ray/rollout/test_remax.py` (10 cases) drives the real `generate_and_rm_group`, `_post_process_rewards` and `compute_advantages` with `generate` and `async_rm` patched: one greedy baseline per prompt, excluded from training and scored via the same reward path; no baseline for evaluation or other estimators; failed or unscored baselines abort the group; a truncated greedy response still supplies a baseline; subtraction is independent of the normalization flags; missing metadata is an error; the incompatible-option rejections; singleton groups accepted from the CLI.
- `tests/fast/backends/training_utils/loss/test_remax.py`: the advantage branch returns the baseline-adjusted rewards unnormalized.

### Verification

On a CPU SLURM node: the 37 new cases pass; `tests/fast/ray/rollout`, `tests/fast/rollout`, `tests/fast/backends/training_utils` and `tests/fast/utils/test_arguments.py` pass (1646 passed, 17 skipped); removing the baseline subtraction fails 10 of the new cases; the flag parses; ruff, black and isort clean. Not run on GPU: the extra greedy generation has not been exercised against a live engine.

### Scope

About 90 production lines. The greedy request still emits a trajectory-lifecycle event (it shows up in the dashboard trajectory stream flagged `remax_baseline`), which is cosmetic. Rejected combinations are listed in the flag's help.

cc @fzyzcjy @yueming-yuan
