### PR TITLE
Batch distributed weight broadcasts with opt-in flattened buckets

### DIFF
--- a/miles/backends/sglang_utils/sglang_api_client.py
+++ b/miles/backends/sglang_utils/sglang_api_client.py
@@ -350,6 +350,7 @@ class SGLangApiClient:
         flush_cache=False,
         weight_version: str | None = None,
         selector: str = "all",
+        load_format: str | None = None,
     ):
         payload = {
             "names": names,
@@ -361,6 +362,8 @@ class SGLangApiClient:
         }
         if weight_version is not None:
             payload["weight_version"] = weight_version
+        if load_format is not None:
+            payload["load_format"] = load_format
         return await self._make_request(
             "update_weights_from_distributed",
             payload,

--- a/miles/backends/training_utils/weight_update/protocol.py
+++ b/miles/backends/training_utils/weight_update/protocol.py
@@ -71,6 +71,10 @@ class WeightTransferProtocol(ABC):
 
 
 def get_weight_transfer_protocol(args: Namespace) -> WeightTransferProtocol:
+    if getattr(args, "update_weight_use_flattened_buckets", False) and (
+        args.colocate or args.update_weight_transfer_mode != "broadcast"
+    ):
+        raise ValueError("--update-weight-use-flattened-buckets requires non-colocated broadcast transfer")
     if args.colocate:
         from miles.backends.training_utils.weight_update.protocols.cuda_ipc import UpdateWeightFromTensor
 

--- a/miles/backends/training_utils/weight_update/protocol.py
+++ b/miles/backends/training_utils/weight_update/protocol.py
@@ -70,11 +70,15 @@ class WeightTransferProtocol(ABC):
         return metrics
 
 
-def get_weight_transfer_protocol(args: Namespace) -> WeightTransferProtocol:
+def validate_flattened_broadcast_args(args: Namespace) -> None:
     if getattr(args, "update_weight_use_flattened_buckets", False) and (
-        args.colocate or args.update_weight_transfer_mode != "broadcast"
+        args.train_backend != "megatron" or args.colocate or args.update_weight_transfer_mode != "broadcast"
     ):
-        raise ValueError("--update-weight-use-flattened-buckets requires non-colocated broadcast transfer")
+        raise ValueError("--update-weight-use-flattened-buckets requires Megatron non-colocated broadcast transfer")
+
+
+def get_weight_transfer_protocol(args: Namespace) -> WeightTransferProtocol:
+    validate_flattened_broadcast_args(args)
     if args.colocate:
         from miles.backends.training_utils.weight_update.protocols.cuda_ipc import UpdateWeightFromTensor
 

--- a/miles/backends/training_utils/weight_update/protocols/broadcast.py
+++ b/miles/backends/training_utils/weight_update/protocols/broadcast.py
@@ -77,6 +77,7 @@ class UpdateWeightFromDistributed(WeightTransferProtocol):
                 self.rollout_engines,
                 bucket,
                 selector=self._selector,
+                use_flattened_buckets=self.args.update_weight_use_flattened_buckets,
             )
             async_utils.wait_futures(futures)
             bucket.clear()
@@ -148,10 +149,20 @@ def update_weights_from_distributed(
     rollout_engines: Sequence[SGLangApiClient],
     converted_named_tensors: Sequence[tuple[str, torch.Tensor]],
     selector: str = "all",
+    use_flattened_buckets: bool = False,
 ) -> list[Future]:
     """
     Send metadata (HTTP), broadcast tensors (NCCL rank 0 → engines).
     """
+    # Pack before asking receivers to enter their collective, so allocation or
+    # format validation failures cannot leave them waiting for a broadcast.
+    if use_flattened_buckets:
+        tensors = [_flatten_weight_bucket(converted_named_tensors)]
+        load_format = "flattened_bucket"
+    else:
+        tensors = [param.data.contiguous() for _, param in converted_named_tensors]
+        load_format = None
+
     futures = [
         async_utils.submit(
             client.update_weights_from_distributed(
@@ -160,18 +171,34 @@ def update_weights_from_distributed(
                 shapes=[param.shape for _, param in converted_named_tensors],
                 selector=selector,
                 group_name=group_name,
+                load_format=load_format,
             )
         )
         for client in rollout_engines
     ]
 
-    contiguous_tensors = [
-        param.data if param.data.is_contiguous() else param.data.contiguous() for _, param in converted_named_tensors
-    ]
     handles = []
-    for tensor in contiguous_tensors:
+    for tensor in tensors:
         handles.append(dist.broadcast(tensor, 0, group=group, async_op=True))
     for handle in handles:
         handle.wait()
 
     return futures
+
+
+def _flatten_weight_bucket(named_tensors: Sequence[tuple[str, torch.Tensor]]) -> torch.Tensor:
+    # Keep SGLang optional for callers using the existing per-tensor protocol.
+    from sglang.srt.weight_sync.tensor_bucket import FlattenedTensorBucket
+
+    if not getattr(FlattenedTensorBucket, "supports_multi_dtypes", False):
+        raise RuntimeError("Flattened broadcasts require SGLang's mixed-dtype FlattenedTensorBucket")
+
+    # SGLang concatenates raw bytes without padding. Each reconstructed dtype
+    # view requires an aligned offset; preserve names/order and reject unsafe
+    # layouts before allocating or sending metadata instead of casting values.
+    offset = 0
+    for name, tensor in named_tensors:
+        if offset % tensor.element_size():
+            raise ValueError(f"Unaligned flattened weight {name}: byte offset {offset}, dtype {tensor.dtype}")
+        offset += tensor.numel() * tensor.element_size()
+    return FlattenedTensorBucket(named_tensors=list(named_tensors)).get_flattened_tensor()

--- a/miles/backends/training_utils/weight_update/protocols/broadcast.py
+++ b/miles/backends/training_utils/weight_update/protocols/broadcast.py
@@ -77,7 +77,7 @@ class UpdateWeightFromDistributed(WeightTransferProtocol):
                 self.rollout_engines,
                 bucket,
                 selector=self._selector,
-                use_flattened_buckets=self.args.update_weight_use_flattened_buckets,
+                use_flattened_buckets=getattr(self.args, "update_weight_use_flattened_buckets", False),
             )
             async_utils.wait_futures(futures)
             bucket.clear()
@@ -158,10 +158,10 @@ def update_weights_from_distributed(
     # format validation failures cannot leave them waiting for a broadcast.
     if use_flattened_buckets:
         tensors = [_flatten_weight_bucket(converted_named_tensors)]
-        load_format = "flattened_bucket"
+        format_kwargs = {"load_format": "flattened_bucket"}
     else:
         tensors = [param.data.contiguous() for _, param in converted_named_tensors]
-        load_format = None
+        format_kwargs = {}
 
     futures = [
         async_utils.submit(
@@ -171,7 +171,7 @@ def update_weights_from_distributed(
                 shapes=[param.shape for _, param in converted_named_tensors],
                 selector=selector,
                 group_name=group_name,
-                load_format=load_format,
+                **format_kwargs,
             )
         )
         for client in rollout_engines

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -9,6 +9,7 @@ from sglang_router.launch_router import RouterArgs
 
 from miles.backends.sglang_utils.arguments import add_sglang_arguments, collect_eval_sglang_overrides
 from miles.backends.sglang_utils.arguments import validate_args as sglang_validate_args
+from miles.backends.training_utils.weight_update.protocol import validate_flattened_broadcast_args
 from miles.dashboard.args import add_dashboard_arguments, validate_dashboard_args
 from miles.rollout.checkpoint_eval import is_checkpoint_eval_fn
 from miles.utils.chat_template_utils.tito_tokenizer import TITOTokenizerType
@@ -826,7 +827,7 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 action="store_true",
                 help=(
                     "Opt in to one packed-byte NCCL broadcast per weight bucket. "
-                    "Requires non-colocated broadcast transfer and SGLang's mixed-dtype flattened-bucket API. "
+                    "Requires Megatron non-colocated broadcast transfer and SGLang's mixed-dtype flattened-bucket API. "
                     "Adds a contiguous bucket allocation on the sender and receivers; "
                     "atomic update units may exceed --update-weight-buffer-size."
                 ),
@@ -2936,6 +2937,7 @@ def miles_validate_args(args):
                 logger.info(f"Warning: Argument {k} is already set to {getattr(args, k)}, will override with {v}.")
             setattr(args, k, v)
 
+    validate_flattened_broadcast_args(args)
     validate_dashboard_args(args)
 
     args.ft_components = _resolve_ft_components(args)

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -822,6 +822,16 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 ),
             )
             parser.add_argument(
+                "--update-weight-use-flattened-buckets",
+                action="store_true",
+                help=(
+                    "Opt in to one packed-byte NCCL broadcast per weight bucket. "
+                    "Requires non-colocated broadcast transfer and SGLang's mixed-dtype flattened-bucket API. "
+                    "Adds a contiguous bucket allocation on the sender and receivers; "
+                    "atomic update units may exceed --update-weight-buffer-size."
+                ),
+            )
+            parser.add_argument(
                 "--update-weights-interval",
                 type=int,
                 default=1,

--- a/tests/fast/backends/sglang_utils/test_sglang_api_client.py
+++ b/tests/fast/backends/sglang_utils/test_sglang_api_client.py
@@ -685,6 +685,29 @@ class TestGetWeightVersion:
 class TestWeightControlPayloads:
     """Optional weight-control fields must be included when given and omitted when not."""
 
+    async def test_distributed_update_forwards_flattened_format_without_losing_version_or_selector(
+        self, client, recorder
+    ):
+        await client.update_weights_from_distributed(
+            names=["expert.weight", "expert.weight_scale_2"],
+            dtypes=["torch.uint8", "torch.float32"],
+            shapes=[[2, 8], []],
+            group_name="g",
+            weight_version="run-7",
+            selector="target",
+            load_format="flattened_bucket",
+        )
+        assert recorder.calls[0][2]["json"] == {
+            "names": ["expert.weight", "expert.weight_scale_2"],
+            "dtypes": ["uint8", "float32"],
+            "shapes": [[2, 8], []],
+            "group_name": "g",
+            "flush_cache": False,
+            "selector": "target",
+            "weight_version": "run-7",
+            "load_format": "flattened_bucket",
+        }
+
     async def test_tensor_update_forwards_a_weight_version_and_a_non_default_selector(self, client, recorder):
         """Multi-model engines address one submodel at a time and stamp the resulting version."""
         await client.update_weights_from_tensor(

--- a/tests/fast/backends/training_utils/weight_update/test_broadcast_buckets.py
+++ b/tests/fast/backends/training_utils/weight_update/test_broadcast_buckets.py
@@ -1,0 +1,189 @@
+"""CPU wire-format checks against the actual SGLang bucket implementation."""
+
+import importlib.util
+import os
+import sys
+import weakref
+from argparse import Namespace
+from contextlib import nullcontext
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+import torch
+
+from miles.backends.training_utils.weight_update.protocols import broadcast
+from miles.backends.training_utils.weight_update.protocol import get_weight_transfer_protocol
+from tests.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=30, suite="stage-a-cpu", labels=[])
+
+
+@pytest.fixture
+def bucket_class(monkeypatch):
+    # CPU CI supplies SGLANG_SOURCE_ROOT. Load this pure-Torch module directly
+    # so format tests do not require SGLang's unrelated GPU runtime imports.
+    root = os.environ.get("SGLANG_SOURCE_ROOT")
+    if root is None:
+        from sglang.srt.weight_sync.tensor_bucket import FlattenedTensorBucket
+
+        return FlattenedTensorBucket
+    name = "sglang.srt.weight_sync.tensor_bucket"
+    spec = importlib.util.spec_from_file_location(name, Path(root) / "sglang/srt/weight_sync/tensor_bucket.py")
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, name, module)
+    spec.loader.exec_module(module)
+    return module.FlattenedTensorBucket
+
+
+def _weights():
+    return [
+        ("expert.weight", torch.arange(16, dtype=torch.uint8).reshape(2, 8).T),
+        ("expert.weight_scale", torch.tensor([0, 128, 126, 255], dtype=torch.uint8).view(torch.float8_e4m3fn)),
+        ("expert.weight_scale_2", torch.tensor(-0.0, dtype=torch.float32)),
+        ("dense.weight", torch.arange(8, dtype=torch.bfloat16).reshape(2, 4).T),
+        ("empty", torch.empty((0, 2), dtype=torch.float32)),
+    ]
+
+
+def _assert_same_bytes(expected, actual):
+    assert [name for name, _ in actual] == [name for name, _ in expected]
+    for (_, original), (_, received) in zip(expected, actual, strict=True):
+        assert original.shape == received.shape
+        assert original.dtype == received.dtype
+        assert torch.equal(original.flatten().view(torch.uint8), received.flatten().view(torch.uint8))
+
+
+@pytest.mark.parametrize("packed", [False, True])
+def test_broadcast_roundtrip_preserves_mixed_dtype_bytes_and_scalar_shape(monkeypatch, bucket_class, packed):
+    weights = _weights()
+    original = [(name, tensor.clone()) for name, tensor in weights]
+    clients = [SimpleNamespace(update_weights_from_distributed=Mock(return_value=object())) for _ in range(2)]
+    monkeypatch.setattr(broadcast.async_utils, "submit", lambda future: future)
+    sent = []
+    waits = []
+    group = object()
+
+    def send(tensor, src, *, group, async_op):
+        assert src == 0 and async_op
+        assert tensor.is_contiguous()
+        sent.append(tensor.clone())
+        return SimpleNamespace(wait=lambda: waits.append(tensor.numel()))
+
+    monkeypatch.setattr(broadcast.dist, "broadcast", send)
+    futures = broadcast.update_weights_from_distributed("test-group", group, clients, weights, "target", packed)
+    assert futures == [client.update_weights_from_distributed.return_value for client in clients]
+    assert len(sent) == len(waits) == (1 if packed else len(weights))
+    for client in clients:
+        metadata = client.update_weights_from_distributed.call_args.kwargs
+        assert metadata == {
+            "names": [name for name, _ in weights],
+            "dtypes": [tensor.dtype for _, tensor in weights],
+            "shapes": [tensor.shape for _, tensor in weights],
+            "selector": "target",
+            "group_name": "test-group",
+            "load_format": "flattened_bucket" if packed else None,
+        }
+    if packed:
+        assert sent[0].dtype == torch.uint8
+        assert sent[0].numel() == sum(t.numel() * t.element_size() for _, t in weights)
+        # Reproduce SGLang's existing distributed receiver with the transmitted
+        # metadata: allocate empty tensors, form its bucket, receive, reconstruct.
+        receiver = bucket_class(
+            named_tensors=[
+                (n, torch.empty(s, dtype=d))
+                for n, d, s in zip(metadata["names"], metadata["dtypes"], metadata["shapes"], strict=True)
+            ]
+        )
+        receiver.get_flattened_tensor().copy_(sent[0])
+        received = receiver.reconstruct_tensors()
+    else:
+        received = [(name, tensor) for (name, _), tensor in zip(weights, sent, strict=True)]
+    _assert_same_bytes(original, received)
+    _assert_same_bytes(original, weights)
+
+
+def test_unaligned_dtype_offset_is_rejected_before_receivers_enter_collectives(monkeypatch, bucket_class):
+    client = SimpleNamespace(update_weights_from_distributed=Mock())
+    collective = Mock()
+    monkeypatch.setattr(broadcast.dist, "broadcast", collective)
+    weights = [("byte", torch.ones(3, dtype=torch.uint8)), ("scale", torch.tensor(1.0))]
+    with pytest.raises(ValueError, match=r"Unaligned flattened weight scale: byte offset 3"):
+        broadcast.update_weights_from_distributed("g", object(), [client], weights, use_flattened_buckets=True)
+    client.update_weights_from_distributed.assert_not_called()
+    collective.assert_not_called()
+
+
+def test_unsupported_bucket_api_is_rejected_before_receiver_dispatch(monkeypatch, bucket_class):
+    monkeypatch.setattr(bucket_class, "supports_multi_dtypes", False)
+    client = SimpleNamespace(update_weights_from_distributed=Mock())
+    collective = Mock()
+    monkeypatch.setattr(broadcast.dist, "broadcast", collective)
+    with pytest.raises(RuntimeError, match="mixed-dtype FlattenedTensorBucket"):
+        broadcast.update_weights_from_distributed("g", object(), [client], _weights(), use_flattened_buckets=True)
+    client.update_weights_from_distributed.assert_not_called()
+    collective.assert_not_called()
+
+
+def test_pack_allocation_failure_does_not_dispatch_receivers(monkeypatch, bucket_class):
+    def fail(*args, **kwargs):
+        raise MemoryError("bucket allocation")
+
+    monkeypatch.setattr(bucket_class, "__init__", fail)
+    client = SimpleNamespace(update_weights_from_distributed=Mock())
+    collective = Mock()
+    monkeypatch.setattr(broadcast.dist, "broadcast", collective)
+    with pytest.raises(MemoryError, match="bucket allocation"):
+        broadcast.update_weights_from_distributed("g", object(), [client], _weights(), use_flattened_buckets=True)
+    client.update_weights_from_distributed.assert_not_called()
+    collective.assert_not_called()
+
+
+def test_backing_buffer_lives_through_collective_wait_and_bucket_clears_after_receiver_completion(
+    monkeypatch, bucket_class
+):
+    weights = _weights()
+    events = []
+    buffers = []
+    client = SimpleNamespace(update_weights_from_distributed=Mock(return_value=object()))
+    monkeypatch.setattr(broadcast.async_utils, "submit", lambda future: future)
+
+    def send(tensor, *args, **kwargs):
+        ref = weakref.ref(tensor)
+        buffers.append(ref)
+
+        def wait():
+            assert ref() is not None
+            assert weights
+            events.append("collective_complete")
+
+        return SimpleNamespace(wait=wait)
+
+    def wait_receivers(futures):
+        assert futures == [client.update_weights_from_distributed.return_value]
+        assert weights
+        assert events == ["collective_complete"]
+        events.append("receivers_complete")
+
+    monkeypatch.setattr(broadcast.dist, "broadcast", send)
+    monkeypatch.setattr(broadcast.async_utils, "wait_futures", wait_receivers)
+    updater = broadcast.UpdateWeightFromDistributed.__new__(broadcast.UpdateWeightFromDistributed)
+    updater.args = Namespace(update_weight_use_flattened_buckets=True)
+    updater._engine_lock = nullcontext()
+    updater.group_name = "g"
+    updater._model_update_groups = object()
+    updater.rollout_engines = [client]
+    updater._selector = "target"
+    updater.send_bucket(weights)
+    assert len(buffers) == 1
+    assert events == ["collective_complete", "receivers_complete"]
+    assert not weights
+    assert client.update_weights_from_distributed.call_args.kwargs["load_format"] == "flattened_bucket"
+
+
+@pytest.mark.parametrize("colocate,mode", [(True, "broadcast"), (False, "p2p"), (False, "disk-delta")])
+def test_opt_in_rejects_protocols_that_would_ignore_it(colocate, mode):
+    args = Namespace(colocate=colocate, update_weight_transfer_mode=mode, update_weight_use_flattened_buckets=True)
+    with pytest.raises(ValueError, match="requires non-colocated broadcast transfer"):
+        get_weight_transfer_protocol(args)

--- a/tests/fast/backends/training_utils/weight_update/test_broadcast_buckets.py
+++ b/tests/fast/backends/training_utils/weight_update/test_broadcast_buckets.py
@@ -14,7 +14,10 @@ import pytest
 import torch
 
 from miles.backends.training_utils.weight_update.protocols import broadcast
-from miles.backends.training_utils.weight_update.protocol import get_weight_transfer_protocol
+from miles.backends.training_utils.weight_update.protocol import (
+    get_weight_transfer_protocol,
+    validate_flattened_broadcast_args,
+)
 from tests.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=30, suite="stage-a-cpu", labels=[])
@@ -83,7 +86,7 @@ def test_broadcast_roundtrip_preserves_mixed_dtype_bytes_and_scalar_shape(monkey
             "shapes": [tensor.shape for _, tensor in weights],
             "selector": "target",
             "group_name": "test-group",
-            "load_format": "flattened_bucket" if packed else None,
+            **({"load_format": "flattened_bucket"} if packed else {}),
         }
     if packed:
         assert sent[0].dtype == torch.uint8
@@ -182,8 +185,42 @@ def test_backing_buffer_lives_through_collective_wait_and_bucket_clears_after_re
     assert client.update_weights_from_distributed.call_args.kwargs["load_format"] == "flattened_bucket"
 
 
-@pytest.mark.parametrize("colocate,mode", [(True, "broadcast"), (False, "p2p"), (False, "disk-delta")])
-def test_opt_in_rejects_protocols_that_would_ignore_it(colocate, mode):
-    args = Namespace(colocate=colocate, update_weight_transfer_mode=mode, update_weight_use_flattened_buckets=True)
-    with pytest.raises(ValueError, match="requires non-colocated broadcast transfer"):
-        get_weight_transfer_protocol(args)
+@pytest.mark.parametrize("validator", [validate_flattened_broadcast_args, get_weight_transfer_protocol])
+@pytest.mark.parametrize(
+    "backend,colocate,mode",
+    [
+        ("megatron", True, "broadcast"),
+        ("megatron", False, "p2p"),
+        ("megatron", False, "disk-delta"),
+        ("fsdp", False, "broadcast"),
+        ("fsdp", True, "broadcast"),
+    ],
+)
+def test_opt_in_rejects_backends_and_protocols_that_would_ignore_it(validator, backend, colocate, mode):
+    args = Namespace(
+        train_backend=backend,
+        colocate=colocate,
+        update_weight_transfer_mode=mode,
+        update_weight_use_flattened_buckets=True,
+    )
+    with pytest.raises(ValueError, match="requires Megatron non-colocated broadcast transfer"):
+        validator(args)
+
+
+@pytest.mark.parametrize("flag", [None, False])
+def test_existing_fsdp_arguments_are_unchanged_without_the_opt_in(flag):
+    args = Namespace(train_backend="fsdp", colocate=False, update_weight_transfer_mode="broadcast")
+    if flag is not None:
+        args.update_weight_use_flattened_buckets = flag
+    validate_flattened_broadcast_args(args)
+
+
+def test_megatron_non_colocated_broadcast_accepts_the_opt_in():
+    validate_flattened_broadcast_args(
+        Namespace(
+            train_backend="megatron",
+            colocate=False,
+            update_weight_transfer_mode="broadcast",
+            update_weight_use_flattened_buckets=True,
+        )
+    )

--- a/tests/fast/backends/training_utils/weight_update/test_broadcast_engine_lock.py
+++ b/tests/fast/backends/training_utils/weight_update/test_broadcast_engine_lock.py
@@ -85,6 +85,7 @@ class TestSendBucketUnderTheEngineLock:
     @staticmethod
     def _make_self(store: HashStore) -> SimpleNamespace:
         return SimpleNamespace(
+            args=Namespace(),
             _engine_lock=StoreTicketLock(store=store, prefix=_PREFIX, poll_interval=0.001),
             group_name="miles-pp_0",
             _model_update_groups=MagicMock(name="nccl_group"),
@@ -125,6 +126,7 @@ class TestSendBucketUnderTheEngineLock:
             fake_self.rollout_engines,
             bucket,
             selector="all",
+            use_flattened_buckets=False,
         )
         wait_futures.assert_called_once_with(broadcast.return_value)
         assert bucket == []


### PR DESCRIPTION
## Summary

@humansand

Add an opt-in packed format for non-colocated Megatron policy-weight publication. The existing sender launches one NCCL broadcast per tensor, including each four-byte NVFP4 global scale; the opt-in sends each existing weight bucket as one byte tensor through SGLang's existing `flattened_bucket` API.

- **Reuse:** add `load_format` forwarding to `SGLangApiClient` and reuse SGLang's `FlattenedTensorBucket`. Keep names, tensor order, shapes, dtypes, target/draft selector, version fields and the existing update-session lifecycle. No new transport or quantization arithmetic.
- **Opt-in:** `--update-weight-use-flattened-buckets`; the default remains per-tensor broadcasts. Reject the flag with FSDP, colocated/hybrid IPC, P2P or disk-delta instead of silently ignoring it.
- **Byte contract:** pack raw bytes without dtype conversion. Preserve zero-dimensional FP32 scales, negative zero, FP8 bit patterns, empty tensor shapes and noncontiguous inputs. SGLang does not pad between dtype views; reject unaligned byte offsets before dispatching receiver requests. Require its mixed-dtype bucket API.
- **Failure/lifetime:** finish local packing before receivers enter their collectives. Keep the packed tensor alive until all broadcast work handles have been waited, and wait for receiver futures before clearing the original bucket.
- **Memory:** packing adds a contiguous allocation/copy at the sender. The existing SGLang receiver also allocates individual tensors and a packed buffer. Atomic update units may exceed `--update-weight-buffer-size`; this remains opt-in until GPU peak-memory and publication timing are checked.
- **Scope:** observed publication host latency motivated this batching candidate. CPU tests validate the byte contract and dispatch reduction, **not** a GPU speedup. Quantization, gather topology, model loaders and receiver allocation strategy are unchanged. This draft adds no GPU performance result.

## Compatibility

Checked SGLang `sglang-miles` at `02b5e123c490c988d21526d0dd7837fefdd0e1da` and main at `6ba96d329fb838d7028b5f3db4f5dbc3fb8e366d`. Their actual bucket implementations are identical (SHA256 `fc50064ea51c338262394ff0b7a849100e7c46761099e27a4478e9db0ea08cc2`), and both distributed receiver paths support `load_format="flattened_bucket"`. No SGLang code change is required for this format.

End-to-end Miles integration still targets `sglang-miles`: main lacks that branch's selector/session extensions. Passing the byte-format tests against main does not establish full Miles runtime compatibility with main.

## Validation

Miles base `3ccc2cb37eac2fc51844ac1b4cd4282e923708c1`; tested candidate `e4de022ae65291b9433aa425b0a8512937a6f876`. CPU-only macOS, Python 3.12.12, PyTorch 2.14.0, pytest 9.1.1. No GPU allocation, NCCL execution or model serving occurred.

- **sglang-miles expanded regressions: 125 passed, 1 skipped.** Includes existing broadcast, engine-lock, connection, lifecycle, metadata-value, fan-out and LoRA tests, plus the new bucket tests and full API-client suite. The one existing colocated IPC check skips because this lightweight environment does not import the complete SGLang runtime.
- **SGLang main byte-format control: 85 passed.** Nineteen bucket/validation cases plus 66 API-client cases. The byte transform and receiver reconstruction use the actual bucket class from the selected source revision; HTTP/collectives are local recorders. Tests cover exact mixed-dtype bytes, scalar shape, noncontiguous input, offset rejection, unsupported API rejection, allocation failure before receiver dispatch, backing-buffer lifetime, selector/version/format forwarding and backend/protocol selection, including FSDP rejection.
- **Independent CPU distributed-lock suite: 33 passed**, including actual local TCPStore/Gloo processes.
- **Default compatibility:** the distributed client receives no new keyword when the opt-in is off, the HTTP payload omits `load_format`, and older Namespace instances without the flag keep per-tensor behavior.
- **Control-flow observation:** the five-tensor fixture takes five per-tensor broadcast calls or one packed call. This is a mock-transport count, not NCCL latency.
- **Static checks:** Ruff, Black and `git diff --check` passed.
- **Not run:** GPU peak-memory, multi-node NCCL, two-step RL or publication-performance validation. No before/after speedup is claimed.

From the Miles checkout with CPU test dependencies installed:

```bash
git clone https://github.com/sgl-project/sglang.git ../sglang-packed-test
git -C ../sglang-packed-test checkout 02b5e123c490c988d21526d0dd7837fefdd0e1da
export SGLANG_SOURCE_ROOT="$PWD/../sglang-packed-test/python"
python -m pytest --confcutdir=tests/fast/backends -q -rs \
  tests/fast/backends/training_utils/weight_update/test_broadcast.py \
  tests/fast/backends/training_utils/weight_update/test_broadcast_engine_lock.py \
  tests/fast/backends/training_utils/weight_update/test_connection_contract.py \
  tests/fast/backends/training_utils/weight_update/test_dist_weight_update_lifecycle.py \
  tests/fast/backends/training_utils/weight_update/test_weight_update_call_values.py \
  tests/fast/backends/training_utils/weight_update/test_weight_update_fan_out.py \
  tests/fast/backends/training_utils/weight_update/test_lora_update_weight.py \
  tests/fast/backends/training_utils/weight_update/test_broadcast_buckets.py \
  tests/fast/backends/sglang_utils/test_sglang_api_client.py
python -m pytest --confcutdir=tests/fast/utils -q tests/fast/utils/test_distributed_lock.py

git -C ../sglang-packed-test checkout 6ba96d329fb838d7028b5f3db4f5dbc3fb8e366d
python -m pytest --confcutdir=tests/fast/backends -q \
  tests/fast/backends/training_utils/weight_update/test_broadcast_buckets.py \
  tests/fast/backends/sglang_utils/test_sglang_api_client.py
```

`--confcutdir` excludes unrelated rollout fixtures from these focused CPU checks. Hosted CPU CI installs `requirements.txt` and `tests/ci/requirements-ci-cpu.txt`; local execution used the versions stated above. Tests load the pure-Torch SGLang bucket module directly from `SGLANG_SOURCE_ROOT`, so byte-format coverage does not require its server imports or a model checkpoint.

## Complete CPU test output

Only the local workspace path is shortened below.

<details><summary>sglang-miles expanded regressions</summary>

```text
============================= test session starts ==============================
platform darwin -- Python 3.12.12, pytest-9.1.1, pluggy-1.6.0
rootdir: <local Miles checkout>
configfile: pyproject.toml
plugins: asyncio-1.4.0, anyio-4.15.1
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 126 items

tests/fast/backends/training_utils/weight_update/test_broadcast.py ....  [  3%]
tests/fast/backends/training_utils/weight_update/test_broadcast_engine_lock.py . [  3%]
.............                                                            [ 14%]
tests/fast/backends/training_utils/weight_update/test_connection_contract.py . [ 15%]
                                                                         [ 15%]
tests/fast/backends/training_utils/weight_update/test_dist_weight_update_lifecycle.py . [ 15%]
........                                                                 [ 22%]
tests/fast/backends/training_utils/weight_update/test_weight_update_call_values.py . [ 23%]
s                                                                        [ 23%]
tests/fast/backends/training_utils/weight_update/test_weight_update_fan_out.py . [ 24%]
...                                                                      [ 26%]
tests/fast/backends/training_utils/weight_update/test_lora_update_weight.py . [ 27%]
......                                                                   [ 32%]
tests/fast/backends/training_utils/weight_update/test_broadcast_buckets.py . [ 33%]
..................                                                       [ 47%]
tests/fast/backends/sglang_utils/test_sglang_api_client.py ............. [ 57%]
.....................................................                    [100%]

============================== slowest durations ===============================
0.05s call     tests/fast/backends/training_utils/weight_update/test_broadcast.py::TestDisconnectRolloutEnginesFromDistributed::test_disconnect_awaits_engine_cleanup_when_local_destroy_fails
0.01s call     tests/fast/backends/training_utils/weight_update/test_dist_weight_update_lifecycle.py::TestWeightUpdateSessionFrame::test_every_engine_walks_the_frame_in_order[retract]

(376 durations < 0.005s hidden.  Use -vv to show these durations.)
=========================== short test summary info ============================
SKIPPED [1] tests/fast/backends/training_utils/weight_update/test_weight_update_call_values.py:50: could not import 'sglang': No module named 'sglang'
======================== 125 passed, 1 skipped in 0.86s ========================
```

</details>

<details><summary>SGLang main byte-format control</summary>

```text
============================= test session starts ==============================
platform darwin -- Python 3.12.12, pytest-9.1.1, pluggy-1.6.0
rootdir: <local Miles checkout>
configfile: pyproject.toml
plugins: asyncio-1.4.0, anyio-4.15.1
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 85 items

tests/fast/backends/training_utils/weight_update/test_broadcast_buckets.py . [  1%]
..................                                                       [ 22%]
tests/fast/backends/sglang_utils/test_sglang_api_client.py ............. [ 37%]
.....................................................                    [100%]

============================== slowest durations ===============================

(255 durations < 0.005s hidden.  Use -vv to show these durations.)
============================== 85 passed in 0.89s ==============================
```

</details>

<details><summary>CPU TCP/Gloo distributed locks</summary>

```text
============================= test session starts ==============================
platform darwin -- Python 3.12.12, pytest-9.1.1, pluggy-1.6.0
rootdir: <local Miles checkout>
configfile: pyproject.toml
plugins: asyncio-1.4.0, anyio-4.15.1
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 33 items

tests/fast/utils/test_distributed_lock.py .............................. [ 90%]
...                                                                      [100%]

============================== slowest durations ===============================
1.88s call     tests/fast/utils/test_distributed_lock.py::TestCreateWorldTicketLock::test_a_rank_that_does_not_contend_joins_the_broadcast_but_holds_no_lock
1.36s call     tests/fast/utils/test_distributed_lock.py::TestCreateWorldTicketLock::test_every_rank_shares_the_store_hosted_by_rank_zero
1.14s call     tests/fast/utils/test_distributed_lock.py::TestStoreTicketLockOverTcpStore::test_a_waiter_fails_fast_when_the_host_dies_while_it_polls
0.77s call     tests/fast/utils/test_distributed_lock.py::TestStoreTicketLockOverTcpStore::test_acquire_fails_fast_once_the_host_process_is_gone
0.36s call     tests/fast/utils/test_distributed_lock.py::TestStoreTicketLockOverTcpStore::test_a_holder_connection_that_disappears_keeps_holding_its_ticket
0.32s call     tests/fast/utils/test_distributed_lock.py::TestStoreTicketLockOverTcpStore::test_separate_connections_to_one_store_form_a_single_queue
0.31s call     tests/fast/utils/test_distributed_lock.py::TestStoreTicketLock::test_a_holder_that_never_releases_stalls_the_queue
0.21s call     tests/fast/utils/test_distributed_lock.py::TestStoreTicketLock::test_acquire_blocks_until_the_previous_holder_releases
0.07s call     tests/fast/utils/test_distributed_lock.py::TestStoreTicketLockContention::test_the_critical_section_runs_alone
0.01s call     tests/fast/utils/test_distributed_lock.py::TestStoreTicketLock::test_a_long_wait_is_logged_periodically

(89 durations < 0.005s hidden.  Use -vv to show these durations.)
============================== 33 passed in 7.25s ==============================
```

</details>
