### PR TITLE
rm_hub: add --reward-funcs and --reward-weights for composite rewards

### DIFF
--- a/docs/user-guide/cli-reference.md
+++ b/docs/user-guide/cli-reference.md
@@ -272,6 +272,8 @@ Sections mirror the launch-script argument groups.
 | Flag | Type | Default | Notes |
 |---|---|---|---|
 | `--rm-type` | str | – | Built-in reward: `math`, `dapo`, `deepscaler`, `gemma_math`, `f1`, `gpqa`, `ifbench`, `remote_rm`, `random`, `deterministic_random`. A `boxed_` prefix (e.g. `boxed_math`) extracts `\boxed{}` from the response before grading. |
+| `--reward-funcs` | comma-separated str | – | Built-in reward names or dotted custom function paths, scored concurrently per sample and summed with weights. `None` skips a component; all `None` gives `0.0`. Mutually exclusive with `--rm-type` and `--custom-rm-path`. See [Customization](/user-guide/customization#multiple-reward-functions). |
+| `--reward-weights` | comma-separated floats | all `1.0` | Weights in `--reward-funcs` order; requires that flag and a matching number of entries. |
 | `--rm-url` | str | – | Endpoint when `--rm-type remote_rm`. |
 | `--group-rm` | flag | off | Batched reward computation. |
 | `--custom-rm-path` | str | – | Custom reward function (see [Customization](/user-guide/customization)). |

--- a/docs/user-guide/customization.md
+++ b/docs/user-guide/customization.md
@@ -148,6 +148,31 @@ async def batched_custom_rm(args, samples: list[Sample]) -> list[float]:
 Prefixing any of them with `boxed_` (for example `boxed_math`) extracts `\boxed{}`
 from the response before grading.
 
+### Multiple reward functions
+
+Use `--reward-funcs` with a comma-separated list of built-in names or dotted custom
+function paths, and optionally `--reward-weights` in the same order:
+
+```bash
+--reward-funcs math,my_pkg.rewards.format_score --reward-weights 1.0,0.25
+```
+
+Custom functions use `async def format_score(args, sample: Sample, **kwargs) -> float | None`.
+All functions run concurrently per sample. The result is the weighted sum, with
+weights defaulting to `1.0` for every function. Returning `None` skips that function
+for that sample without rescaling the remaining weights; if all return `None`, the
+reward is `0.0`. Unweighted values (including `None`) are stored in
+`sample.metadata["reward_components"]`, keyed by the configured name or dotted path,
+for logging.
+
+For dict-returning built-ins such as `dapo`, set `--reward-key` (for example,
+`--reward-key score`) to select each component's numeric value; the combined reward is
+then stored as `{reward_key: total}` so every `--reward-key` consumer keeps working, and as
+a plain float otherwise. `--reward-funcs` cannot be combined with `--rm-type` or
+`--custom-rm-path`; the number of weights must match the number of functions. A per-sample
+`reward_spec` still overrides the composite for that sample. With `--group-rm`, these
+functions still receive one sample at a time.
+
 ### `--custom-reward-post-process-path`
 
 Hook to normalize rewards differently from the default GRPO normalization.

--- a/miles/rollout/rm_hub/__init__.py
+++ b/miles/rollout/rm_hub/__init__.py
@@ -41,12 +41,47 @@ def _resolve_reward_config(args, sample: Sample) -> tuple[str | None, str]:
 
 
 async def async_rm(args, sample: Sample, **kwargs):
+    # A per-sample reward_spec override still wins over the process-wide --reward-funcs composite.
+    if getattr(args, "reward_funcs", None) and sample.reward_spec is None:
+        return await _async_weighted_rm(args, sample, **kwargs)
+
     custom_rm_path, rm_type = _resolve_reward_config(args, sample)
 
     if custom_rm_path is not None:
         rm_function = load_function(custom_rm_path)
         return await rm_function(args, sample, **kwargs)
 
+    return await _async_builtin_rm(args, sample, rm_type)
+
+
+async def _async_weighted_rm(args, sample: Sample, **kwargs) -> float | dict[str, float]:
+    names = args.reward_funcs
+    weights = args.reward_weights if args.reward_weights is not None else [1.0] * len(names)
+    tasks = [
+        load_function(name)(args, sample, **kwargs) if "." in name else _async_builtin_rm(args, sample, name)
+        for name in names
+    ]
+    values = await asyncio.gather(*tasks)
+    components = {}
+    reward = 0.0
+    for name, weight, value in zip(names, weights, values, strict=True):
+        if isinstance(value, dict):
+            if not args.reward_key or args.reward_key not in value:
+                raise ValueError(
+                    f"Reward function {name!r} returned a dict; set --reward-key to one of {list(value)}."
+                )
+            value = value[args.reward_key]
+        components[name] = value
+        if value is not None:
+            reward += weight * value
+    if sample.metadata is None:
+        sample.metadata = {}
+    sample.metadata["reward_components"] = components
+    # Keep the reward shape --reward-key consumers expect (get_reward_value, eval metrics).
+    return {args.reward_key: reward} if args.reward_key else reward
+
+
+async def _async_builtin_rm(args, sample: Sample, rm_type: str):
     response = sample.response
     label = sample.label
     metadata = sample.metadata if isinstance(sample.metadata, dict) else {}

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -2338,6 +2338,22 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 help="Type of the reward model",
             )
             parser.add_argument(
+                "--reward-funcs",
+                type=str,
+                default=None,
+                help=(
+                    "Comma-separated built-in reward names or dotted custom function paths. "
+                    "Functions run concurrently per sample and may return None to opt out. "
+                    "Mutually exclusive with --rm-type and --custom-rm-path."
+                ),
+            )
+            parser.add_argument(
+                "--reward-weights",
+                type=str,
+                default=None,
+                help="Comma-separated weights for --reward-funcs, in the same order. Defaults to 1.0 for each function.",
+            )
+            parser.add_argument(
                 "--reward-key",
                 type=str,
                 default=None,
@@ -2918,6 +2934,35 @@ def _resolve_mini_ft_controller_enable(args: argparse.Namespace) -> bool:
     return bool(args.ft_components) and args.api_server_port != 0
 
 
+def _validate_reward_args(args):
+    reward_funcs = getattr(args, "reward_funcs", None)
+    reward_weights = getattr(args, "reward_weights", None)
+    if reward_funcs is None:
+        if reward_weights is not None:
+            raise ValueError("--reward-weights requires --reward-funcs")
+        return
+    if args.rm_type is not None or args.custom_rm_path is not None:
+        raise ValueError("--reward-funcs is mutually exclusive with --rm-type and --custom-rm-path")
+    if isinstance(reward_funcs, str):
+        reward_funcs = [name.strip() for name in reward_funcs.split(",")]
+    if not reward_funcs or any(not name for name in reward_funcs):
+        raise ValueError("--reward-funcs must contain non-empty reward names or dotted custom function paths")
+    if reward_weights is None:
+        reward_weights = [1.0] * len(reward_funcs)
+    else:
+        if isinstance(reward_weights, str):
+            reward_weights = reward_weights.split(",")
+        reward_weights = [float(weight) for weight in reward_weights]
+    if len(reward_weights) != len(reward_funcs):
+        raise ValueError("--reward-weights must have the same number of entries as --reward-funcs")
+    eval_reward_key = getattr(args, "eval_reward_key", None)
+    if eval_reward_key and eval_reward_key != args.reward_key:
+        # The composite stores one value, under --reward-key; eval cannot read a different component.
+        raise ValueError("--eval-reward-key must equal --reward-key when --reward-funcs is set")
+    args.reward_funcs = reward_funcs
+    args.reward_weights = reward_weights
+
+
 def miles_validate_args(args):
     if args.custom_config_path:
         data = yaml.safe_load(resolve_file_arg(args.custom_config_path)) or {}
@@ -2926,6 +2971,7 @@ def miles_validate_args(args):
                 logger.info(f"Warning: Argument {k} is already set to {getattr(args, k)}, will override with {v}.")
             setattr(args, k, v)
 
+    _validate_reward_args(args)
     validate_dashboard_args(args)
 
     args.ft_components = _resolve_ft_components(args)

--- a/tests/fast/rollout/rm_hub/test_rm_hub.py
+++ b/tests/fast/rollout/rm_hub/test_rm_hub.py
@@ -1,10 +1,18 @@
+import argparse
+import asyncio
+import importlib
+import sys
+from textwrap import dedent
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
 
 from miles.rollout.rm_hub import async_rm, batched_async_rm
+from miles.utils.arguments import _validate_reward_args, get_miles_extra_args_provider, miles_validate_args
 from miles.utils.async_utils import run
-from miles.utils.types import Sample
+from miles.utils.eval_config import EvalDatasetConfig
+from miles.utils.types import RewardSpec, Sample
 
 
 @pytest.fixture
@@ -13,7 +21,216 @@ def mock_args():
     args.custom_rm_path = None
     args.rm_type = None
     args.rm_url = None
+    args.reward_funcs = None
+    args.reward_weights = None
+    args.reward_key = None
+    args.custom_config_path = None
+    args.eval_reward_key = None
+    args.group_rm = False
+    args.hf_checkpoint = "unused"
+    args.apply_chat_template = False
+    args.chat_template_path = None
+    args.rollout_stop = None
+    args.rollout_stop_token_ids = None
+    args.rollout_skip_special_tokens = True
+    args.sglang_enable_deterministic_inference = False
     return args
+
+
+@pytest.fixture
+def custom_rewards(tmp_path, monkeypatch):
+    module_name = "reward_weight_test_functions"
+    (tmp_path / f"{module_name}.py").write_text(
+        dedent(
+            """\
+            async def score(args, sample, **kwargs):
+                return 2.0 if sample.label == "scored" else None
+
+            async def bonus(args, sample, **kwargs):
+                return kwargs.get("bonus")
+
+            async def wait_for_peer(args, sample, **kwargs):
+                await kwargs["ready"].wait()
+                return 2.0
+
+            async def signal_peer(args, sample, **kwargs):
+                kwargs["ready"].set()
+                return 3.0
+            """
+        )
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+    yield module_name
+    sys.modules.pop(module_name, None)
+
+
+class TestMultipleRewards:
+    @pytest.mark.parametrize("weights,expected", [(None, 5 / 3), ([0.5, 0.75], 1.0), ([0.0, -1.5], -1.0)])
+    def test_weighted_builtins(self, mock_args, weights, expected):
+        mock_args.reward_funcs = ["boxed_f1", "f1"]
+        mock_args.reward_weights = weights
+        sample = Sample(response=r"42 \boxed{42}", label="42")
+        assert run(async_rm(mock_args, sample)) == pytest.approx(expected)
+
+    def test_none_opts_out_per_sample(self, mock_args, custom_rewards):
+        mock_args.reward_funcs = [f"{custom_rewards}.score", f"{custom_rewards}.bonus"]
+        mock_args.reward_weights = [0.25, 2.0]
+        scored = Sample(label="scored")
+        skipped = Sample(label="skipped")
+        assert run(async_rm(mock_args, scored, bonus=3.0)) == 6.5
+        assert run(async_rm(mock_args, skipped, bonus=3.0)) == 6.0
+        assert skipped.metadata["reward_components"] == {
+            f"{custom_rewards}.score": None,
+            f"{custom_rewards}.bonus": 3.0,
+        }
+
+    def test_all_none_returns_zero(self, mock_args, custom_rewards):
+        mock_args.reward_funcs = [f"{custom_rewards}.score", f"{custom_rewards}.bonus"]
+        sample = Sample(label="skipped")
+        assert run(async_rm(mock_args, sample)) == 0.0
+        assert sample.metadata["reward_components"] == {
+            f"{custom_rewards}.score": None,
+            f"{custom_rewards}.bonus": None,
+        }
+
+    @pytest.mark.parametrize("metadata", [None, {"source": "test", "rm_type": "unknown"}])
+    def test_records_unweighted_components(self, mock_args, metadata):
+        mock_args.reward_funcs = ["boxed_f1", "f1"]
+        mock_args.reward_weights = [0.5, 0.75]
+        sample = Sample(response=r"42 \boxed{42}", label="42", metadata=metadata)
+        run(async_rm(mock_args, sample))
+        assert sample.metadata["reward_components"] == {"boxed_f1": 1.0, "f1": pytest.approx(2 / 3)}
+        if metadata is not None:
+            assert sample.metadata["source"] == "test"
+
+    def test_custom_functions_run_concurrently(self, mock_args, custom_rewards):
+        mock_args.reward_funcs = [f"{custom_rewards}.wait_for_peer", f"{custom_rewards}.signal_peer"]
+
+        async def score():
+            return await asyncio.wait_for(async_rm(mock_args, Sample(), ready=asyncio.Event()), timeout=1)
+
+        assert run(score()) == 5.0
+
+    def test_dict_component_and_scalar_reward_value(self, mock_args):
+        mock_args.reward_funcs = ["dapo", "boxed_f1"]
+        mock_args.reward_weights = [0.25, 0.5]
+        mock_args.reward_key = "score"
+        sample = Sample(response=r"Answer: \boxed{42}", label="42")
+        sample.reward = run(async_rm(mock_args, sample))
+        assert sample.reward == {"score": 0.75}
+        assert sample.get_reward_value(mock_args) == 0.75
+        assert sample.metadata["reward_components"] == {"dapo": 1.0, "boxed_f1": 1.0}
+
+    def test_per_sample_reward_spec_overrides_the_composite(self, mock_args):
+        mock_args.reward_funcs = ["boxed_f1", "f1"]
+        mock_args.reward_weights = None
+        sample = Sample(response=r"\boxed{42}", label="42")
+        sample.reward_spec = RewardSpec(rm_type="math")
+        assert run(async_rm(mock_args, sample)) == 1
+        assert not (sample.metadata or {}).get("reward_components")
+
+    @pytest.mark.parametrize("reward_key", [None, "missing"])
+    def test_dict_component_requires_valid_reward_key(self, mock_args, reward_key):
+        mock_args.reward_funcs = ["dapo"]
+        mock_args.reward_key = reward_key
+        with pytest.raises(ValueError, match="dapo.*--reward-key"):
+            run(async_rm(mock_args, Sample(response=r"\boxed{42}", label="42")))
+
+    @pytest.mark.parametrize("legacy", [False, True])
+    @pytest.mark.parametrize("weighted,expected", [(True, -0.25), (False, False)])
+    def test_eval_handles_scalar_and_dict_rewards(self, mock_args, monkeypatch, legacy, weighted, expected):
+        module = importlib.import_module(
+            "miles.rollout.sglang_rollout" if legacy else "miles.rollout.inference_rollout.inference_rollout_eval"
+        )
+        mock_args.reward_key = "score"
+        if weighted:
+            # The composite is stored under --reward-key, so eval reads the same key.
+            mock_args.eval_reward_key = "score"
+            mock_args.reward_funcs = ["dapo", "boxed_f1"]
+            mock_args.reward_weights = [0.25, 0.5]
+        else:
+            mock_args.eval_reward_key = "acc"
+            mock_args.rm_type = "dapo"
+        config = EvalDatasetConfig(name="test", path="unused", n_samples_per_eval_prompt=1)
+        cache_key = config.cache_key + (
+            mock_args.hf_checkpoint,
+            mock_args.apply_chat_template,
+            mock_args.chat_template_path,
+        )
+        cache = {cache_key: SimpleNamespace(samples=[Sample(response=r"\boxed{43}", label="42")])}
+
+        async def generate_and_score(_, sample, **kwargs):
+            sample.reward = await async_rm(mock_args, sample, **kwargs)
+            return sample
+
+        monkeypatch.setattr(module, "generate_and_rm", generate_and_score)
+        monkeypatch.setattr(module, "policy_uses_routing_key", lambda args: False)
+        if legacy:
+            monkeypatch.setattr(module, "EVAL_PROMPT_DATASET", cache)
+            result = run(module.eval_rollout_single_dataset(mock_args, 0, config))
+        else:
+            monkeypatch.setattr(module, "compute_sampling_params", lambda *args, **kwargs: {})
+            result = run(module.eval_rollout_single_dataset(SimpleNamespace(args=mock_args), config, cache))
+        assert result["test"]["rewards"] == [expected]
+
+    def test_batched_rewards_are_set_inplace(self, mock_args, custom_rewards):
+        mock_args.reward_funcs = [f"{custom_rewards}.score", f"{custom_rewards}.bonus"]
+        mock_args.reward_weights = [0.5, 2.0]
+        samples = [Sample(label="scored"), Sample(label="skipped")]
+        run(batched_async_rm(mock_args, samples, inplace_set_reward_field=True, bonus=3.0))
+        assert [sample.reward for sample in samples] == [7.0, 6.0]
+
+
+class TestRewardArgs:
+    @pytest.mark.parametrize("weights", ["0.5", "0.5,1.0,2.0", [0.5]])
+    def test_weights_length_validation(self, mock_args, weights):
+        mock_args.reward_funcs = "math,f1"
+        mock_args.reward_weights = weights
+        with pytest.raises(ValueError, match="--reward-weights.*--reward-funcs"):
+            miles_validate_args(mock_args)
+
+    def test_eval_reward_key_must_match_reward_key(self, mock_args):
+        mock_args.reward_funcs = "dapo,f1"
+        mock_args.reward_key = "score"
+        mock_args.eval_reward_key = "acc"
+        with pytest.raises(ValueError, match="--eval-reward-key must equal --reward-key"):
+            miles_validate_args(mock_args)
+
+    @pytest.mark.parametrize("field,value", [("rm_type", "math"), ("custom_rm_path", "pkg.module.fn")])
+    @pytest.mark.parametrize("via_config", [False, True])
+    def test_mutual_exclusion(self, mock_args, tmp_path, field, value, via_config):
+        mock_args.reward_funcs = "math,f1"
+        if via_config:
+            config = tmp_path / "rewards.yaml"
+            config.write_text(f"{field}: {value}\n")
+            mock_args.custom_config_path = str(config)
+        else:
+            setattr(mock_args, field, value)
+        with pytest.raises(ValueError, match="--reward-funcs.*mutually exclusive"):
+            miles_validate_args(mock_args)
+
+    @pytest.mark.parametrize("weights,expected", [(None, [1.0, 1.0]), ("0.5, -2", [0.5, -2.0])])
+    def test_cli_flags_and_weight_defaults(self, monkeypatch, weights, expected):
+        argv = ["test", "--rollout-batch-size", "2", "--reward-funcs", " math, pkg.module.fn "]
+        if weights is not None:
+            argv += ["--reward-weights", weights]
+        monkeypatch.setattr(sys, "argv", argv)
+        parser = get_miles_extra_args_provider()(argparse.ArgumentParser())
+        args = parser.parse_args(argv[1:])
+        _validate_reward_args(args)
+        assert args.reward_funcs == ["math", "pkg.module.fn"]
+        assert args.reward_weights == expected
+
+    @pytest.mark.parametrize("funcs", ["", "math,", ",f1", []])
+    def test_empty_functions_rejected(self, mock_args, funcs):
+        mock_args.reward_funcs = funcs
+        with pytest.raises(ValueError, match="--reward-funcs"):
+            miles_validate_args(mock_args)
+
+    def test_weights_require_functions(self, mock_args):
+        mock_args.reward_weights = "1.0"
+        with pytest.raises(ValueError, match="--reward-weights requires --reward-funcs"):
+            miles_validate_args(mock_args)
 
 
 class TestAsyncRm:


### PR DESCRIPTION
### What

Adds `--reward-funcs` and `--reward-weights` to `rm_hub`, the TRL `GRPOTrainer(reward_funcs=..., reward_weights=...)` pattern: several reward functions scored per sample and combined as a weighted sum.

- `--reward-funcs` takes a comma-separated list of built-in `rm_type` names (`math`, `dapo`, `f1`, ...) or dotted custom paths with the per-sample signature `async fn(args, sample, **kwargs) -> float | None`. `--reward-weights` is a matching list of floats (default all 1.0).
- `async_rm` scores every function concurrently (`asyncio.gather`), skips entries that return `None` for that sample, and returns the weighted sum of the rest (0.0 if all opt out). The unweighted per-function values are stored on `sample.metadata["reward_components"]` for logging.
- Dict-valued built-ins (`dapo`) contribute their `--reward-key` value; a dict without a usable key is an error. When `--reward-key` is set the composite is stored as `{reward_key: total}` so `get_reward_value` and the eval metrics keep working unchanged; otherwise it is a float.
- A per-sample `reward_spec` override still wins over the composite for that sample. `--reward-funcs` is mutually exclusive with `--rm-type` and `--custom-rm-path`, the weight count must match, and `--eval-reward-key` (if set) must equal `--reward-key` since the composite stores a single value; all validated after the custom-config override. The batch-level `--custom-rm-path` path is unchanged, and so is everything when the flag is unset.

### Test

`tests/fast/rollout/rm_hub/test_rm_hub.py`: weighted sum of two built-ins; a custom function (module written to a temp dir, loaded by dotted path) opting out with `None`; all-`None` gives 0.0; components recorded; a dict-valued built-in with `--reward-key` gives `{key: total}` and `get_reward_value` reads it; a dict without a valid key is rejected; a per-sample `reward_spec` bypasses the composite; concurrency (functions run together, not serially); the validation cases for mutual exclusion and weight count.

### Verification

On a CPU SLURM node: the 54 rm_hub cases pass; `tests/fast/rollout`, `tests/fast/ray/rollout` and `tests/fast/utils/test_arguments.py` pass (1377 passed, 17 skipped); dropping the weight from the sum fails 7 of the new cases; the flags parse; ruff, black and isort clean. Not run on GPU; the change is confined to the CPU-side reward path.

### Scope

Reward hub only. No change to `--group-rm` semantics (functions still receive one sample at a time) or to the batch-level custom reward hook.

cc @fzyzcjy @yueming-yuan
