### PR TITLE
fix(rollout): handle malformed tool arguments

### DIFF
--- a/miles/rollout/generate_utils/tool_call_utils.py
+++ b/miles/rollout/generate_utils/tool_call_utils.py
@@ -17,6 +17,7 @@ from miles.rollout.generate_utils.sampling_mask import append_forced_sampling_to
 from miles.utils.types import Sample
 
 _DUMMY_USER = {"role": "user", "content": "dummy"}
+_INVALID_TOOL_ARGUMENTS = "Invalid tool arguments: expected a JSON object. The tool was not executed."
 
 
 def create_tool_call_parser(tool_specs, tool_call_parser):
@@ -41,19 +42,38 @@ async def _execute_tool_call(
 ) -> dict[str, Any]:
     if isinstance(call, ChatCompletionMessageToolCall):
         name = call.function.name
-        params = json.loads(call.function.arguments) if call.function.arguments else {}
+        arguments = call.function.arguments
         tool_call_id = call.id
     elif isinstance(call, ToolCallItem):
         name = call.name
-        params = json.loads(call.parameters) if call.parameters else {}
+        arguments = call.parameters
         tool_call_id = f"call_{uuid.uuid4().hex[:24]}"
     else:
         raise TypeError(f"Unsupported tool call type: {type(call)}")
+
+    params = _parse_tool_arguments(arguments)
+    if params is None:
+        return {
+            "role": "tool",
+            "tool_call_id": tool_call_id,
+            "content": _INVALID_TOOL_ARGUMENTS,
+            "name": name,
+        }
 
     result = await execute_one(name, params)
     assert isinstance(result, str)
 
     return {"role": "tool", "tool_call_id": tool_call_id, "content": result, "name": name}
+
+
+def _parse_tool_arguments(arguments: str) -> dict[str, Any] | None:
+    if not arguments:
+        return {}
+    try:
+        params = json.loads(arguments)
+    except json.JSONDecodeError:
+        return None
+    return params if isinstance(params, dict) else None
 
 
 def update_sample_with_tool_responses(sample: Sample, tool_messages: list[dict[str, Any]], tokenizer):

--- a/tests/fast/rollout/generate_hub/test_tool_call_utils.py
+++ b/tests/fast/rollout/generate_hub/test_tool_call_utils.py
@@ -1,6 +1,14 @@
 import pytest
+from openai.types.chat import ChatCompletionMessageToolCall
+from sglang.srt.function_call.core_types import ToolCallItem
 
-from miles.rollout.generate_utils.tool_call_utils import _DUMMY_USER, _build_dummy_assistant, tokenize_tool_responses
+from miles.rollout.generate_utils.tool_call_utils import (
+    _DUMMY_USER,
+    _build_dummy_assistant,
+    _execute_tool_call,
+    execute_tool_calls,
+    tokenize_tool_responses,
+)
 from miles.utils.processing_utils import load_tokenizer
 
 TOOL_CALL_TEST_MODELS = [
@@ -57,6 +65,83 @@ SAMPLE_TOOL_RESPONSES = [
         "name": "get_temperature",
     },
 ]
+
+
+@pytest.mark.parametrize(
+    "arguments",
+    ['{"cmd": "pytest"', "[1, 2]", "42", '"pytest"', "null"],
+)
+async def test_invalid_tool_arguments_return_an_error_without_execution(arguments):
+    calls = []
+
+    async def execute_one(name, params):
+        calls.append((name, params))
+        return "ok"
+
+    message = await _execute_tool_call(ToolCallItem(tool_index=0, name="bash", parameters=arguments), execute_one)
+
+    assert calls == []
+    assert message["role"] == "tool"
+    assert message["name"] == "bash"
+    assert message["tool_call_id"].startswith("call_")
+    assert message["content"] == ("Invalid tool arguments: expected a JSON object. The tool was not executed.")
+
+
+async def test_openai_tool_call_preserves_id_when_arguments_are_invalid():
+    async def execute_one(name, params):
+        pytest.fail(f"executor called with {name=} and {params=}")
+
+    call = ChatCompletionMessageToolCall(
+        id="call_known",
+        function={"name": "bash", "arguments": "{"},
+        type="function",
+    )
+
+    message = await _execute_tool_call(call, execute_one)
+
+    assert message == {
+        "role": "tool",
+        "tool_call_id": "call_known",
+        "content": "Invalid tool arguments: expected a JSON object. The tool was not executed.",
+        "name": "bash",
+    }
+
+
+@pytest.mark.parametrize("arguments", ["", '{"cmd": "pytest"}'])
+async def test_valid_tool_arguments_reach_the_executor(arguments):
+    calls = []
+
+    async def execute_one(name, params):
+        calls.append((name, params))
+        return "ok"
+
+    message = await _execute_tool_call(ToolCallItem(tool_index=0, name="bash", parameters=arguments), execute_one)
+
+    expected_params = {} if not arguments else {"cmd": "pytest"}
+    assert calls == [("bash", expected_params)]
+    assert message["content"] == "ok"
+
+
+async def test_invalid_arguments_do_not_skip_later_tool_calls():
+    calls = []
+
+    async def execute_one(name, params):
+        calls.append((name, params))
+        return f"ran {name}"
+
+    messages = await execute_tool_calls(
+        [
+            ToolCallItem(tool_index=0, name="broken", parameters="{"),
+            ToolCallItem(tool_index=1, name="bash", parameters='{"cmd": "pytest"}'),
+        ],
+        execute_one,
+    )
+
+    assert calls == [("bash", {"cmd": "pytest"})]
+    assert [message["content"] for message in messages] == [
+        "Invalid tool arguments: expected a JSON object. The tool was not executed.",
+        "ran bash",
+    ]
 
 
 class TestTokenizeToolResponses:


### PR DESCRIPTION
Fixes #2689.

Model-generated tool arguments are now validated before the executor is called. Malformed JSON and valid JSON values that are not objects produce a deterministic tool response instead of escaping the rollout or reaching an executor with the wrong type. A bad call also no longer prevents later valid calls in the same turn from running.

Valid JSON objects and empty arguments keep their existing behavior. OpenAI tool call IDs are preserved in the error response.

Validation:

- 9 focused pytest cases passed on Python 3.12. The run used the real `ToolCallItem` from SGLang v0.5.19. Unrelated parser and protocol imports were stubbed because the local Windows host does not have the full GPU and Ray stack. The 31 tokenizer-dependent cases in the file were not selected.
- All applicable pre commit hooks passed for the two changed files.
- `git diff --check` passed.
